### PR TITLE
fix bug in OperatorBase::add_diagonal()

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -400,6 +400,10 @@ OperatorBase<dim, Number, n_components>::add_diagonal(VectorType & diagonal) con
       *matrix_free,
       diagonal,
       [&](auto & integrator) -> void {
+        // TODO this line is currently needed as bugfix, but should be
+        // removed because reinit is now done twice
+        this->reinit_cell(integrator.get_current_cell_index());
+
         integrator.evaluate(integrator_flags.cell_evaluate.value,
                             integrator_flags.cell_evaluate.gradient,
                             integrator_flags.cell_evaluate.hessian);


### PR DESCRIPTION
The new diagonal computation introduced in MR !384 (Mg with hanging nodes) (gitlab) introduced a bug. I guess the newly introduced tests have not been run ;)

This PR is a bugfix. 

Independently from this PR, the ``dealii::MatrixFreeTools::compute_diagonal()`` function needs to be extended by another lambda that takes ``ExaDG::OperatorBase::reinit_cell()`` as argument, so that classes derived from ``OperatorBase`` can do the setup that they need, e.g., nonlinear operators.