### PR TITLE
adjust comments related to new multigrid transfer variant

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h
@@ -314,7 +314,8 @@ struct MultigridData
   // Sequence of polynomial degrees during p-multigrid
   PSequenceType p_sequence;
 
-  // enable global coarsening
+  // Enable this option in order to invoke a multigrid transfer implementation that can deal with
+  // hanging nodes
   bool use_global_coarsening;
 
   // Smoother data

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -393,7 +393,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
 
     unsigned int const n_components = fe.n_components();
 
-    // setup dof-handler and constrained dofs for each p-level
+    // setup dof-handler and constrained dofs for all multigrid levels
     for(unsigned int i = 0; i < level_info.size(); i++)
     {
       auto const & level = level_info[i];


### PR DESCRIPTION
@peterrum, @bergbauer Related to the discussion in PR #20, I added a comment that explains that `use_global_coarsening` has to be activated in order to deal with hanging nodes. I also voted for renaming this variable (e.g. `enable_hanging_nodes`), but would only do that in case you agree on that. 