### PR TITLE
simplify interface in MovingMeshBase

### DIFF
--- a/include/exadg/grid/moving_mesh_base.h
+++ b/include/exadg/grid/moving_mesh_base.h
@@ -155,13 +155,12 @@ public:
 
 protected:
   void
-  initialize_mapping_q_cache(Mapping<dim> const &           mapping,
-                             Triangulation<dim> const &     triangulation,
+  initialize_mapping_q_cache(Triangulation<dim> const &     triangulation,
                              std::shared_ptr<Function<dim>> displacement_function)
   {
     // dummy FE for compatibility with interface of FEValues
     FE_Nothing<dim> dummy_fe;
-    FEValues<dim>   fe_values(mapping,
+    FEValues<dim>   fe_values(*this->mapping,
                             dummy_fe,
                             QGaussLobatto<dim>(this->mapping_ale->get_degree() + 1),
                             update_quadrature_points);
@@ -192,9 +191,7 @@ protected:
   }
 
   void
-  initialize_mapping_q_cache(Mapping<dim> const &    mapping,
-                             DoFHandler<dim> const & dof_handler,
-                             VectorType const &      dof_vector)
+  initialize_mapping_q_cache(DoFHandler<dim> const & dof_handler, VectorType const & dof_vector)
   {
     // we have to project the solution onto all coarse levels of the triangulation
     // (required for initialization of MappingQCache)
@@ -224,7 +221,7 @@ protected:
                 ExcMessage("Expected finite element with dim components."));
 
     FE_Nothing<dim> dummy_fe;
-    FEValues<dim>   fe_values(mapping,
+    FEValues<dim>   fe_values(*this->mapping,
                             dummy_fe,
                             QGaussLobatto<dim>(fe.degree + 1),
                             update_quadrature_points);
@@ -278,9 +275,8 @@ protected:
   std::vector<unsigned int>           hierarchic_to_lexicographic_numbering;
   std::vector<unsigned int>           lexicographic_to_hierarchic_numbering;
 
-private:
   // MPI communicator
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 };
 
 } // namespace ExaDG

--- a/include/exadg/grid/moving_mesh_elasticity.h
+++ b/include/exadg/grid/moving_mesh_elasticity.h
@@ -54,7 +54,7 @@ public:
     pde_operator->initialize_dof_vector(displacement);
 
     // make sure that the mapping is initialized
-    this->initialize_mapping_q_cache(*this->mapping, pde_operator->get_dof_handler(), displacement);
+    this->initialize_mapping_q_cache(pde_operator->get_dof_handler(), displacement);
   }
 
   void
@@ -100,7 +100,7 @@ public:
       }
     }
 
-    this->initialize_mapping_q_cache(*this->mapping, pde_operator->get_dof_handler(), displacement);
+    this->initialize_mapping_q_cache(pde_operator->get_dof_handler(), displacement);
   }
 
   void

--- a/include/exadg/grid/moving_mesh_function.h
+++ b/include/exadg/grid/moving_mesh_function.h
@@ -58,7 +58,7 @@ public:
 
     mesh_movement_function->set_time(time);
 
-    this->initialize_mapping_q_cache(*this->mapping, triangulation, mesh_movement_function);
+    this->initialize_mapping_q_cache(triangulation, mesh_movement_function);
   }
 
 private:

--- a/include/exadg/grid/moving_mesh_poisson.h
+++ b/include/exadg/grid/moving_mesh_poisson.h
@@ -56,7 +56,7 @@ public:
     poisson->initialize_dof_vector(displacement);
 
     // make sure that the mapping is initialized
-    this->initialize_mapping_q_cache(*this->mapping, poisson->get_dof_handler(), displacement);
+    this->initialize_mapping_q_cache(poisson->get_dof_handler(), displacement);
   }
 
   void
@@ -81,7 +81,7 @@ public:
       print_solver_info_linear(pcout, n_iter, timer.wall_time(), print_wall_times);
     }
 
-    this->initialize_mapping_q_cache(*this->mapping, poisson->get_dof_handler(), displacement);
+    this->initialize_mapping_q_cache(poisson->get_dof_handler(), displacement);
   }
 
   void


### PR DESCRIPTION
@kronbichler related to our discussion, we can simplify the interface in `MovingMeshBase` a bit. Currently, all derived classes pass the same `this->mapping` to the member function of this class, which is unnecessarily comlex.