### PR TITLE
fix bug related to *Mg with hanging nodes* MR

### DIFF
--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -220,9 +220,9 @@ MultigridPreconditioner<dim, Number>::initialize_dof_handler_and_constraints(
                                                     dirichlet_bc_velocity,
                                                     this->level_info,
                                                     this->p_levels,
-                                                    this->dof_handlers_velocity,
-                                                    this->constrained_dofs_velocity,
-                                                    this->constraints_velocity);
+                                                    dof_handlers_velocity,
+                                                    constrained_dofs_velocity,
+                                                    constraints_velocity);
   }
 }
 
@@ -235,11 +235,11 @@ MultigridPreconditioner<dim, Number>::initialize_transfer_operators()
   if(data.convective_problem &&
      data.convective_kernel_data.velocity_type == TypeVelocityField::DoFVector)
   {
-    this->transfers_velocity.reinit(*this->mapping,
-                                    this->matrix_free_objects,
-                                    this->constraints_velocity,
-                                    this->constrained_dofs_velocity,
-                                    1);
+    unsigned int const dof_index = 1;
+    this->do_initialize_transfer_operators(transfers_velocity,
+                                           constraints_velocity,
+                                           constrained_dofs_velocity,
+                                           dof_index);
   }
 }
 
@@ -289,7 +289,7 @@ MultigridPreconditioner<dim, Number>::set_velocity(VectorTypeMG const & velocity
   {
     auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
     auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
-    transfers_velocity.interpolate(level, vector_coarse_level, vector_fine_level);
+    transfers_velocity->interpolate(level, vector_coarse_level, vector_fine_level);
     this->get_operator(level - 1)->set_velocity_copy(vector_coarse_level);
   }
 }

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -150,7 +150,7 @@ private:
   std::shared_ptr<PDEOperatorMG>
   get_operator(unsigned int level) const;
 
-  MGTransfer_MGLevelObject<dim, MultigridNumber, VectorTypeMG> transfers_velocity;
+  std::shared_ptr<MGTransfer<VectorTypeMG>> transfers_velocity;
 
   MGLevelObject<std::shared_ptr<DoFHandler<dim> const>>              dof_handlers_velocity;
   MGLevelObject<std::shared_ptr<MGConstrainedDoFs>>                  constrained_dofs_velocity;

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -165,6 +165,13 @@ protected:
   virtual void
   initialize_transfer_operators();
 
+  void
+  do_initialize_transfer_operators(
+    std::shared_ptr<MGTransfer<VectorTypeMG>> &                          transfers,
+    MGLevelObject<std::shared_ptr<AffineConstraints<MultigridNumber>>> & constraints,
+    MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &                  constrained_dofs,
+    unsigned int const                                                   dof_index);
+
   MGLevelObject<std::shared_ptr<DoFHandler<dim> const>>                dof_handlers;
   MGLevelObject<std::shared_ptr<MGConstrainedDoFs>>                    constrained_dofs;
   MGLevelObject<std::shared_ptr<AffineConstraints<MultigridNumber>>>   constraints;


### PR DESCRIPTION
The "Mg with hanging nodes* MR did not implement the switch between the two multigrid transfer options for the ConvDiff module. The behavior is therefore unexpected for the user, and can be considered a bug in the current form since it ignores the multigrid parameter `use_global_coarsening`.

The problem is solved by introducing a member function in the base class that needs to be called by all derived classes whenever initializing transfer operators.