### PR TITLE
Multigrid refactoring

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.cpp
@@ -233,4 +233,15 @@ MultigridData::involves_h_transfer() const
   else
     return false;
 }
+
+bool
+MultigridData::involves_c_transfer() const
+{
+  if(type == MultigridType::hMG || type == MultigridType::pMG || type == MultigridType::hpMG ||
+     type == MultigridType::phMG)
+    return false;
+  else
+    return true;
+}
+
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h
@@ -308,6 +308,9 @@ struct MultigridData
   bool
   involves_h_transfer() const;
 
+  bool
+  involves_c_transfer() const;
+
   // Multigrid type: p-MG vs. h-MG
   MultigridType type;
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -300,6 +300,33 @@ MultigridPreconditionerBase<dim, Number>::check_levels(std::vector<MGLevelInfo> 
 
 template<int dim, typename Number>
 void
+MultigridPreconditionerBase<dim, Number>::initialize_coarse_grid_triangulations(
+  parallel::TriangulationBase<dim> const * tria)
+{
+  // coarse grid triangulations are only required in case of the multigrid transfer
+  // with global coarsening
+  if(data.use_global_coarsening)
+  {
+    if(data.involves_h_transfer())
+    {
+      AssertThrow(tria->n_global_levels() == 1 ||
+                    dynamic_cast<parallel::fullydistributed::Triangulation<dim> const *>(tria) ==
+                      nullptr,
+                  ExcMessage(
+                    "h-transfer is currently not supported for the option use_global_coarsening "
+                    "in combination with a parallel::fullydistributed::Triangulation that "
+                    "contains refinements. Either use a parallel::fullydistributed::Triangulation "
+                    "without refinements, a parallel::distributed::Triangulation, or a "
+                    "MultigridType without h-transfer."));
+
+      coarse_grid_triangulations =
+        MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(*tria);
+    }
+  }
+}
+
+template<int dim, typename Number>
+void
 MultigridPreconditionerBase<dim, Number>::initialize_dof_handler_and_constraints(
   bool const                               operator_is_singular,
   PeriodicFacePairs *                      periodic_face_pairs_in,
@@ -361,25 +388,6 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
   // this type of transfer has to be used for triangulations with hanging nodes
   if(data.use_global_coarsening)
   {
-    // create coarse grid triangulations only once
-    if(data.involves_h_transfer() && coarse_grid_triangulations.empty())
-    {
-      AssertThrow(tria->n_global_levels() == 1 ||
-                    dynamic_cast<parallel::fullydistributed::Triangulation<dim> const *>(tria) ==
-                      nullptr,
-                  ExcMessage(
-                    "h-transfer is currently not supported for the option use_global_coarsening "
-                    "in combination with a parallel::fullydistributed::Triangulation that "
-                    "contains refinements. Either use a parallel::fullydistributed::Triangulation "
-                    "without refinements, a parallel::distributed::Triangulation, or a "
-                    "MultigridType without h-transfer."));
-
-      coarse_grid_triangulations =
-        MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(*tria);
-    }
-
-    unsigned int const n_components = fe.n_components();
-
     // setup dof-handler and constrained dofs for all multigrid levels
     for(unsigned int i = 0; i < level_info.size(); i++)
     {
@@ -388,15 +396,15 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
       auto dof_handler = new DoFHandler<dim>((level.h_level() + 1 == tria->n_global_levels()) ?
                                                *(dynamic_cast<Triangulation<dim> const *>(tria)) :
                                                *coarse_grid_triangulations[level.h_level()]);
-      // ... create FE and distribute it
+
       if(level.is_dg())
-        dof_handler->distribute_dofs(FESystem<dim>(FE_DGQ<dim>(level.degree()), n_components));
+        dof_handler->distribute_dofs(FESystem<dim>(FE_DGQ<dim>(level.degree()), fe.n_components()));
       else
-        dof_handler->distribute_dofs(FESystem<dim>(FE_Q<dim>(level.degree()), n_components));
+        dof_handler->distribute_dofs(FESystem<dim>(FE_Q<dim>(level.degree()), fe.n_components()));
 
       dof_handlers[i].reset(dof_handler);
 
-      auto affine_constraints_own = new AffineConstraints<MultigridNumber>;
+      auto affine_constraints_own = new AffineConstraints<MultigridNumber>();
 
       // TODO: integrate periodic constraints into initialize_affine_constraints
       initialize_affine_constraints(*dof_handler, *affine_constraints_own, dirichlet_bc);
@@ -405,6 +413,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
       AssertThrow(periodic_face_pairs.empty(),
                   ExcMessage("Multigrid transfer option use_global_coarsening "
                              "is currently not available for problems with periodic boundaries."));
+
       constraints[i].reset(affine_constraints_own);
     }
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -44,7 +44,7 @@ using namespace dealii;
 
 template<int dim, typename Number>
 MultigridPreconditionerBase<dim, Number>::MultigridPreconditionerBase(MPI_Comm const & comm)
-  : mapping(nullptr), n_levels(1), coarse_level(0), fine_level(0), mpi_comm(comm)
+  : n_levels(1), coarse_level(0), fine_level(0), mpi_comm(comm), mapping(nullptr)
 {
 }
 
@@ -290,10 +290,11 @@ MultigridPreconditionerBase<dim, Number>::check_levels(std::vector<MGLevelInfo> 
     auto fine   = level_info[l];
     auto coarse = level_info[l - 1];
 
-    AssertThrow((fine.h_level() != coarse.h_level()) ^ (fine.degree() != coarse.degree()) ^
-                  (fine.is_dg() != coarse.is_dg()),
-                ExcMessage(
-                  "Between levels there is only ONE change allowed: either in h- or p-level!"));
+    AssertThrow(
+      (fine.h_level() != coarse.h_level()) xor (fine.degree() != coarse.degree()) xor
+        (fine.is_dg() != coarse.is_dg()),
+      ExcMessage(
+        "Between two consecutive multigrid levels, only one type of transfer is allowed."));
   }
 }
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -299,19 +299,6 @@ MultigridPreconditionerBase<dim, Number>::check_levels(std::vector<MGLevelInfo> 
 }
 
 template<int dim, typename Number>
-bool
-MultigridPreconditionerBase<dim, Number>::mg_transfer_to_continuous_elements() const
-{
-  MultigridType const mg_type = data.type;
-
-  if(mg_type == MultigridType::hMG || mg_type == MultigridType::pMG ||
-     mg_type == MultigridType::hpMG || mg_type == MultigridType::phMG)
-    return false;
-  else
-    return true;
-}
-
-template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::initialize_dof_handler_and_constraints(
   bool const                               operator_is_singular,
@@ -320,11 +307,11 @@ MultigridPreconditionerBase<dim, Number>::initialize_dof_handler_and_constraints
   parallel::TriangulationBase<dim> const * tria,
   Map const *                              dirichlet_bc_in)
 {
-  bool const is_dg = fe.dofs_per_vertex == 0;
+  bool const is_dg = (fe.dofs_per_vertex == 0);
 
   if(data.coarse_problem.preconditioner == MultigridCoarseGridPreconditioner::AMG ||
      data.coarse_problem.solver == MultigridCoarseGridSolver::AMG || !is_dg ||
-     this->mg_transfer_to_continuous_elements())
+     data.involves_c_transfer())
   {
     AssertThrow(
       dirichlet_bc_in != nullptr && periodic_face_pairs_in != nullptr,
@@ -340,7 +327,6 @@ MultigridPreconditionerBase<dim, Number>::initialize_dof_handler_and_constraints
   PeriodicFacePairs periodic_face_pairs;
   if(dirichlet_bc_in != nullptr)
     periodic_face_pairs = *periodic_face_pairs_in;
-
 
   this->do_initialize_dof_handler_and_constraints(operator_is_singular,
                                                   periodic_face_pairs,

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -187,9 +187,6 @@ protected:
   unsigned int                        fine_level;
 
 private:
-  bool
-  mg_transfer_to_continuous_elements() const;
-
   /*
    * Multigrid levels (i.e. coarsening strategy, h-/p-/hp-/ph-MG).
    */

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -274,8 +274,8 @@ private:
 
   MultigridData data;
 
-  Mapping<dim> const *                             mapping;
-  std::vector<std::shared_ptr<Triangulation<dim>>> coarse_grid_triangulations;
+  Mapping<dim> const *                                   mapping;
+  std::vector<std::shared_ptr<Triangulation<dim> const>> coarse_grid_triangulations;
 
   typedef SmootherBase<VectorTypeMG>       SMOOTHER;
   MGLevelObject<std::shared_ptr<SMOOTHER>> smoothers;

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -198,15 +198,23 @@ private:
   void
   check_levels(std::vector<MGLevelInfo> const & level_info);
 
+  /*
+   * Coarse grid triangulations in case of global coarsening transfer type.
+   */
+  void
+  initialize_coarse_grid_triangulations(parallel::TriangulationBase<dim> const * tria);
 
   /*
-   * Constrained dofs.
+   * Constrained dofs. This function is required for MGTransfer_MGLevelObject.
    */
   virtual void
-  initialize_constrained_dofs(DoFHandler<dim> const &,
-                              MGConstrainedDoFs &,
-                              Map const & dirichlet_bc);
+  initialize_constrained_dofs(DoFHandler<dim> const & dof_handler,
+                              MGConstrainedDoFs &     constrained_dofs,
+                              Map const &             dirichlet_bc);
 
+  /*
+   * Constrained dofs. This function is required for MGTransferGlobalCoarsening.
+   */
   void
   initialize_affine_constraints(DoFHandler<dim> const &              dof_handler,
                                 AffineConstraints<MultigridNumber> & affine_contraints,

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -179,9 +179,6 @@ protected:
   MGLevelObject<std::shared_ptr<MatrixFree<dim, MultigridNumber>>>     matrix_free_objects;
   MGLevelObject<std::shared_ptr<Operator>>                             operators;
   std::shared_ptr<MGTransfer<VectorTypeMG>>                            transfers;
-  std::vector<std::shared_ptr<Triangulation<dim>>>                     coarse_grid_triangulations;
-
-  Mapping<dim> const * mapping;
 
   std::vector<MGDoFHandlerIdentifier> p_levels;
   std::vector<MGLevelInfo>            level_info;
@@ -271,6 +268,9 @@ private:
   MPI_Comm const & mpi_comm;
 
   MultigridData data;
+
+  Mapping<dim> const *                             mapping;
+  std::vector<std::shared_ptr<Triangulation<dim>>> coarse_grid_triangulations;
 
   typedef SmootherBase<VectorTypeMG>       SMOOTHER;
   MGLevelObject<std::shared_ptr<SMOOTHER>> smoothers;


### PR DESCRIPTION
Changes mainly affecting `MultigridPreconditionerBase`:
- member variables `mapping` and `coarse_grid_triangulations` should be private

- The question whether c-transfer is involved should be answered by `MultigridData`, not `MultigridPreconditionerBase` (single-responsibility principle).

- The coarse grid triangulations are currently created in a function (`ìnitialize_dof_handler_and_constraints()`) that may be called several times, which is why this function has an if-statement (`if(coarse_grid_triangulations.empty()){...}`). However, this is difficult to understand and I think it is better to do this in a separate function. Another reason is that the function name `ìnitialize_dof_handler_and_constraints()` does not give an idea that this function currently also creates coarse grid triangulations.

- Some other minor refactoring steps have also been done.