### PR TITLE
reduce compile time for multigrid by forward declarations

### DIFF
--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -27,6 +27,7 @@
 #include <exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h>
 #include <exadg/convection_diffusion/spatial_discretization/operator.h>
 #include <exadg/convection_diffusion/spatial_discretization/project_velocity.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h>

--- a/include/exadg/grid/moving_mesh_elasticity.h
+++ b/include/exadg/grid/moving_mesh_elasticity.h
@@ -22,6 +22,10 @@
 #ifndef INCLUDE_EXADG_GRID_MOVING_MESH_ELASTICITY_H_
 #define INCLUDE_EXADG_GRID_MOVING_MESH_ELASTICITY_H_
 
+// deal.II
+#include <deal.II/base/timer.h>
+
+// ExaDG
 #include <exadg/grid/moving_mesh_base.h>
 #include <exadg/structure/spatial_discretization/operator.h>
 #include <exadg/utilities/print_solver_results.h>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -23,7 +23,9 @@
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h>
 #include <exadg/poisson/preconditioner/multigrid_preconditioner.h>
 #include <exadg/poisson/spatial_discretization/laplace_operator.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/inverse_mass_preconditioner.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/util/check_multigrid.h>
 
 namespace ExaDG

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -21,6 +21,7 @@
 
 #include <exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/jacobi_preconditioner.h>
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -21,6 +21,7 @@
 
 #include <exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/jacobi_preconditioner.h>
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -21,6 +21,7 @@
 
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h>
 #include <exadg/poisson/preconditioner/multigrid_preconditioner.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/util/check_multigrid.h>
 
 namespace ExaDG

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -25,6 +25,7 @@
 // ExaDG
 #include <exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/jacobi_preconditioner.h>
 #include <exadg/time_integration/time_step_calculation.h>

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -28,6 +28,7 @@
 // ExaDG
 #include <exadg/poisson/preconditioner/multigrid_preconditioner.h>
 #include <exadg/poisson/spatial_discretization/operator.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioner/jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h>

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -28,14 +28,16 @@
 
 // ExaDG
 #include <exadg/matrix_free/categorization.h>
-#include <exadg/operators/operator_base.h>
+#include <exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h>
 #include <exadg/solvers_and_preconditioners/multigrid/constraints.h>
+#include <exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h>
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h>
-#include <exadg/solvers_and_preconditioners/preconditioner/preconditioner_amg.h>
+#include <exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.h>
+#include <exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_mg_level_object.h>
 #include <exadg/solvers_and_preconditioners/util/compute_eigenvalues.h>
 
 namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -22,15 +22,38 @@
 #ifndef INCLUDE_SOLVERS_AND_PRECONDITIONERS_MULTIGRID_PRECONDITIONER_ADAPTER_BASE_H_
 #define INCLUDE_SOLVERS_AND_PRECONDITIONERS_MULTIGRID_PRECONDITIONER_ADAPTER_BASE_H_
 
+// deal.II
+#include <deal.II/base/mg_level_object.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/multigrid/mg_constrained_dofs.h>
+
+// ExaDG
 #include <exadg/matrix_free/matrix_free_wrapper.h>
 #include <exadg/operators/multigrid_operator_base.h>
-#include <exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h>
 #include <exadg/solvers_and_preconditioners/multigrid/levels_hybrid_multigrid.h>
-#include <exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h>
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h>
-#include <exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.h>
-#include <exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_mg_level_object.h>
+#include <exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer.h>
+#include <exadg/solvers_and_preconditioners/preconditioner/preconditioner_base.h>
+
+// forward declarations
+namespace ExaDG
+{
+template<typename VectorType, typename Operator, typename Smoother>
+class MultigridPreconditioner;
+
+template<int dim, typename Number, typename VectorType>
+class MGTransferGlobalCoarsening;
+
+template<int dim, typename Number, typename VectorType>
+class MGTransfer_MGLevelObject;
+} // namespace ExaDG
+
+namespace dealii
+{
+template<typename VectorType>
+class MGCoarseGridBase;
+}
 
 namespace ExaDG
 {


### PR DESCRIPTION
as pointed out by @peterrum, compilation of ExaDG takes unnecessarily long when making changes to multigrid ingredients.