### PR TITLE
fix bug related to accessing wrong mapping data for global coarsening MG

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -325,7 +325,33 @@ MultigridPreconditionerBase<dim, Number>::initialize_coarse_grid_triangulations(
 
       coarse_grid_triangulations =
         MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(*tria);
+
+      // We also need separate mappings for the coarse grid triangulations
+      unsigned int const n_h_levels = coarse_grid_triangulations.size();
+      coarse_grid_mappings.resize(n_h_levels - 1);
+      for(unsigned int h_level = 0; h_level < coarse_grid_mappings.size(); ++h_level)
+      {
+        // TODO
+        coarse_grid_mappings[h_level].reset(new MappingQGeneric<dim>(1));
+      }
     }
+  }
+}
+
+template<int dim, typename Number>
+Mapping<dim> const &
+MultigridPreconditionerBase<dim, Number>::get_mapping(unsigned int const h_level) const
+{
+  if(data.use_global_coarsening)
+  {
+    if(data.involves_h_transfer() && h_level < coarse_grid_mappings.size())
+      return *(coarse_grid_mappings[h_level]);
+    else
+      return *mapping;
+  }
+  else
+  {
+    return *mapping;
   }
 }
 
@@ -496,7 +522,8 @@ MultigridPreconditionerBase<dim, Number>::initialize_matrix_free()
 
     matrix_free_objects[level].reset(new MatrixFree<dim, MultigridNumber>());
 
-    matrix_free_objects[level]->reinit(*mapping,
+    auto const & mg_level_info = level_info[level];
+    matrix_free_objects[level]->reinit(get_mapping(mg_level_info.h_level()),
                                        matrix_free_data_objects[level]->get_dof_handler_vector(),
                                        matrix_free_data_objects[level]->get_constraint_vector(),
                                        matrix_free_data_objects[level]->get_quadrature_vector(),
@@ -509,7 +536,7 @@ void
 MultigridPreconditionerBase<dim, Number>::update_matrix_free()
 {
   for(unsigned int level = coarse_level; level <= fine_level; level++)
-    matrix_free_objects[level]->update_mapping(*mapping);
+    matrix_free_objects[level]->update_mapping(get_mapping(level_info[level].h_level()));
 }
 
 template<int dim, typename Number>
@@ -575,11 +602,14 @@ MultigridPreconditionerBase<dim, Number>::initialize_affine_constraints(
 
   DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints);
   for(auto & it : dirichlet_bc)
-    VectorTools::interpolate_boundary_values(*mapping,
+  {
+    MappingQGeneric<dim> mapping_dummy(MappingQGeneric<dim>(1));
+    VectorTools::interpolate_boundary_values(mapping_dummy,
                                              dof_handler,
                                              it.first,
                                              Functions::ZeroFunction<dim, MultigridNumber>(),
                                              affine_constraints);
+  }
   affine_constraints.close();
 }
 
@@ -861,7 +891,8 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_transfer_operators(
   {
     auto tmp = std::make_shared<MGTransferGlobalCoarsening<dim, MultigridNumber, VectorTypeMG>>();
 
-    tmp->reinit(*mapping, matrix_free_objects, constraints, constrained_dofs, dof_index);
+    MappingQGeneric<dim> mapping_dummy(MappingQGeneric<dim>(1));
+    tmp->reinit(mapping_dummy, matrix_free_objects, constraints, constrained_dofs, dof_index);
 
     transfers = tmp;
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -603,7 +603,7 @@ MultigridPreconditionerBase<dim, Number>::initialize_affine_constraints(
   DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints);
   for(auto & it : dirichlet_bc)
   {
-    MappingQGeneric<dim> mapping_dummy(MappingQGeneric<dim>(1));
+    MappingQGeneric<dim> mapping_dummy(1);
     VectorTools::interpolate_boundary_values(mapping_dummy,
                                              dof_handler,
                                              it.first,
@@ -891,7 +891,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_transfer_operators(
   {
     auto tmp = std::make_shared<MGTransferGlobalCoarsening<dim, MultigridNumber, VectorTypeMG>>();
 
-    MappingQGeneric<dim> mapping_dummy(MappingQGeneric<dim>(1));
+    MappingQGeneric<dim> mapping_dummy(1);
     tmp->reinit(mapping_dummy, matrix_free_objects, constraints, constrained_dofs, dof_index);
 
     transfers = tmp;

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -891,7 +891,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_transfer_operators(
   {
     auto tmp = std::make_shared<MGTransferGlobalCoarsening<dim, MultigridNumber, VectorTypeMG>>();
 
-    tmp->reinit(matrix_free_objects, constraints, constrained_dofs, dof_index);
+    tmp->reinit(matrix_free_objects, constraints, dof_index);
 
     transfers = tmp;
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -891,8 +891,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_transfer_operators(
   {
     auto tmp = std::make_shared<MGTransferGlobalCoarsening<dim, MultigridNumber, VectorTypeMG>>();
 
-    MappingQGeneric<dim> mapping_dummy(1);
-    tmp->reinit(mapping_dummy, matrix_free_objects, constraints, constrained_dofs, dof_index);
+    tmp->reinit(matrix_free_objects, constraints, constrained_dofs, dof_index);
 
     transfers = tmp;
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -228,6 +228,12 @@ private:
   initialize_coarse_grid_triangulations(parallel::TriangulationBase<dim> const * tria);
 
   /*
+   * Returns the correct mapping depending on the multigrid transfer type and the current h-level.
+   */
+  Mapping<dim> const &
+  get_mapping(unsigned int const h_level) const;
+
+  /*
    * Constrained dofs. This function is required for MGTransfer_MGLevelObject.
    */
   virtual void
@@ -297,8 +303,16 @@ private:
 
   MultigridData data;
 
-  Mapping<dim> const *                                   mapping;
+  // Only relevant for global coarsening, where this vector contains coarse level triangulations,
+  // and the fine level triangulation as the last element of the vector.
   std::vector<std::shared_ptr<Triangulation<dim> const>> coarse_grid_triangulations;
+
+  // In case of global coarsening, this is the mapping associated to the fine level triangulation.
+  Mapping<dim> const * mapping;
+
+  // Only relevant for global coarsening, where this vector contains only the mappings for
+  // triangulations coarser than the fine level triangulation.
+  std::vector<std::shared_ptr<Mapping<dim> const>> coarse_grid_mappings;
 
   typedef SmootherBase<VectorTypeMG>       SMOOTHER;
   MGLevelObject<std::shared_ptr<SMOOTHER>> smoothers;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.cpp
@@ -48,13 +48,11 @@ MGTransferGlobalCoarsening<dim, Number, VectorType>::prolongate(unsigned int con
 template<int dim, typename Number, typename VectorType>
 void
 MGTransferGlobalCoarsening<dim, Number, VectorType>::reinit(
-  Mapping<dim> const &                                        mapping,
   MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
   MGLevelObject<std::shared_ptr<AffineConstraints<Number>>> & mg_constraints,
   MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &         mg_constrained_dofs,
   unsigned int const                                          dof_handler_index)
 {
-  (void)mapping;
   (void)mg_constrained_dofs;
   {
     std::vector<MGLevelInfo>            global_levels;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.h
@@ -47,7 +47,6 @@ public:
   void
   reinit(MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
          MGLevelObject<std::shared_ptr<AffineConstraints<Number>>> & mg_constraints,
-         MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &         mg_constrained_dofs,
          unsigned int const                                          dof_handler_index = 0);
 
   void

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfer/mg_transfer_global_coarsening.h
@@ -45,8 +45,7 @@ public:
   }
 
   void
-  reinit(Mapping<dim> const &                                        mapping,
-         MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
+  reinit(MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
          MGLevelObject<std::shared_ptr<AffineConstraints<Number>>> & mg_constraints,
          MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &         mg_constrained_dofs,
          unsigned int const                                          dof_handler_index = 0);


### PR DESCRIPTION
The "Mg with hanging nodes" merge request did not support global coarsening multigrid for mappings such as `MappingQCache`. This is fixed in the present pull request.

A TODO is added to the code since a correct transfer of mapping information to coarser multigrid levels still needs to be done. Currently, `MappingQGeneric<dim>(1)` is used as default and in order to avoid a crash of the simulation.