### PR TITLE
consistently use Triangulation instead of parallel::TriangulationBase

### DIFF
--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -182,11 +182,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     std::vector<unsigned int> repetitions({2, 1});
     Point<dim>                point1(0.0, 0.0), point2(L, H);

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -261,11 +261,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -423,11 +423,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     // hypercube volume is [left,right]^dim
     double const left = -1.0, right = 0.5;

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -176,11 +176,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -186,11 +186,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -221,11 +221,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     double const pi   = numbers::PI;
     double const left = -pi * L, right = pi * L;

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -72,11 +72,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)triangulation;
     (void)periodic_faces;

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -315,11 +315,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     Tensor<1, dim> dimensions;
     dimensions[0] = DIMENSIONS_X1;

--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -142,11 +142,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -189,11 +189,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -203,11 +203,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -160,11 +160,11 @@ public:
   /**************************************************************************************/
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -182,11 +182,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -135,11 +135,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -72,11 +72,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)triangulation;
     (void)periodic_faces;

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -140,11 +140,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -414,11 +414,11 @@ public:
   }
 
   void
-  create_grid_fluid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                    PeriodicFaces &                                   periodic_faces,
-                    unsigned int const                                n_refine_space,
-                    std::shared_ptr<Mapping<dim>> &                   mapping,
-                    unsigned int const                                mapping_degree)
+  create_grid_fluid(std::shared_ptr<Triangulation<dim>> triangulation,
+                    PeriodicFaces &                     periodic_faces,
+                    unsigned int const                  n_refine_space,
+                    std::shared_ptr<Mapping<dim>> &     mapping,
+                    unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 
@@ -749,11 +749,11 @@ public:
   }
 
   void
-  create_grid_structure(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree)
+  create_grid_structure(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -407,11 +407,11 @@ public:
   }
 
   void
-  create_grid_fluid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                    PeriodicFaces &                                   periodic_faces,
-                    unsigned int const                                n_refine_space,
-                    std::shared_ptr<Mapping<dim>> &                   mapping,
-                    unsigned int const                                mapping_degree)
+  create_grid_fluid(std::shared_ptr<Triangulation<dim>> triangulation,
+                    PeriodicFaces &                     periodic_faces,
+                    unsigned int const                  n_refine_space,
+                    std::shared_ptr<Mapping<dim>> &     mapping,
+                    unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 
@@ -889,11 +889,11 @@ public:
   }
 
   void
-  create_grid_structure(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree)
+  create_grid_structure(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -273,11 +273,11 @@ public:
   }
 
   void
-  create_grid_fluid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                    PeriodicFaces &                                   periodic_faces,
-                    unsigned int const                                n_refine_space,
-                    std::shared_ptr<Mapping<dim>> &                   mapping,
-                    unsigned int const                                mapping_degree)
+  create_grid_fluid(std::shared_ptr<Triangulation<dim>> triangulation,
+                    PeriodicFaces &                     periodic_faces,
+                    unsigned int const                  n_refine_space,
+                    std::shared_ptr<Mapping<dim>> &     mapping,
+                    unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 
@@ -620,11 +620,11 @@ public:
   }
 
   void
-  create_grid_structure(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree)
+  create_grid_structure(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -81,11 +81,11 @@ public:
   }
 
   void
-  create_grid_fluid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                    PeriodicFaces &                                   periodic_faces,
-                    unsigned int const                                n_refine_space,
-                    std::shared_ptr<Mapping<dim>> &                   mapping,
-                    unsigned int const                                mapping_degree)
+  create_grid_fluid(std::shared_ptr<Triangulation<dim>> triangulation,
+                    PeriodicFaces &                     periodic_faces,
+                    unsigned int const                  n_refine_space,
+                    std::shared_ptr<Mapping<dim>> &     mapping,
+                    unsigned int const                  mapping_degree)
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;
@@ -190,11 +190,11 @@ public:
   }
 
   void
-  create_grid_structure(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree)
+  create_grid_structure(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree)
   {
     (void)triangulation;
     (void)periodic_faces;

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -313,11 +313,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -335,11 +335,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -311,11 +311,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     if(dim == 2)
     {

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -323,11 +323,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -86,11 +86,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -383,11 +383,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     Geometry::create_grid(triangulation, n_refine_space, periodic_faces);
 
@@ -395,11 +395,11 @@ public:
   }
 
   void
-  create_grid_precursor(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree)
+  create_grid_precursor(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree)
   {
     Geometry::create_grid_precursor(triangulation,
                                     n_refine_space + additional_refinements_precursor,

--- a/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
@@ -161,8 +161,8 @@ public:
 
 template<int dim>
 void
-create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-            unsigned int const                                n_refine_space,
+create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+            unsigned int const                  n_refine_space,
             std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
               periodic_faces)
 {
@@ -243,8 +243,8 @@ create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
 template<int dim>
 void
 create_grid_precursor(
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-  unsigned int const                                n_refine_space,
+  std::shared_ptr<Triangulation<dim>> triangulation,
+  unsigned int const                  n_refine_space,
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
     periodic_faces)
 {

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -250,11 +250,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -216,11 +216,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -187,11 +187,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -440,11 +440,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     FDANozzle::create_grid_and_set_boundary_ids_nozzle(triangulation,
                                                        n_refine_space,
@@ -454,11 +454,11 @@ public:
   }
 
   void
-  create_grid_precursor(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree)
+  create_grid_precursor(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree)
   {
     Triangulation<2> tria_2d;
     GridGenerator::hyper_ball(tria_2d, Point<2>(), FDANozzle::R_OUTER);

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -75,11 +75,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     FDANozzle::create_grid_and_set_boundary_ids_nozzle(triangulation,
                                                        n_refine_space,

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/grid.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/grid.h
@@ -98,8 +98,8 @@ radius_function(double const z)
 template<int dim>
 void
 create_grid_and_set_boundary_ids_nozzle(
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-  unsigned int const                                n_refine_space,
+  std::shared_ptr<Triangulation<dim>> triangulation,
+  unsigned int const                  n_refine_space,
   std::vector<
     GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> & /*periodic_faces*/)
 {

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -465,11 +465,11 @@ public:
 
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     this->refine_level = n_refine_space;
 

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -254,11 +254,11 @@ public:
 
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -209,11 +209,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     AssertThrow(dim == 2, ExcMessage("This application is only implemented for dim=2."));
 

--- a/applications/incompressible_navier_stokes/kovasznay/application.h
+++ b/applications/incompressible_navier_stokes/kovasznay/application.h
@@ -266,11 +266,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -326,11 +326,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     std::vector<unsigned int> repetitions({1, 1});
     Point<dim>                point1(0.0, -H), point2(L, H);

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -264,11 +264,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     Point<dim> p_1;
     p_1[0] = 0.;

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -352,11 +352,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     double const              y_upper = apply_symmetry_bc ? 0.0 : H / 2.;
     Point<dim>                point1(0.0, -H / 2.), point2(L, y_upper);

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -176,11 +176,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     double const left = 0.0, right = 1.0;
     GridGenerator::hyper_cube(*triangulation, left, right);

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -288,11 +288,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -348,11 +348,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     this->refine_level = n_refine_space;
 

--- a/applications/incompressible_navier_stokes/template/application.h
+++ b/applications/incompressible_navier_stokes/template/application.h
@@ -72,11 +72,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;

--- a/applications/incompressible_navier_stokes/template_precursor/application.h
+++ b/applications/incompressible_navier_stokes/template_precursor/application.h
@@ -55,11 +55,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)triangulation;
     (void)periodic_faces;
@@ -69,11 +69,11 @@ public:
   }
 
   void
-  create_grid_precursor(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree)
+  create_grid_precursor(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree)
   {
     (void)triangulation;
     (void)periodic_faces;

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -172,11 +172,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -393,11 +393,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     Tensor<1, dim> dimensions;
     dimensions[0] = DIMENSIONS_X1;

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -477,11 +477,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/incompressible_navier_stokes/vortex/vortex_backup.h
+++ b/applications/incompressible_navier_stokes/vortex/vortex_backup.h
@@ -465,8 +465,8 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              unsigned int const                                n_refine_space,
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              unsigned int const                  n_refine_space,
               std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
                 periodic_faces)
   {

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -243,11 +243,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -178,11 +178,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -77,11 +77,11 @@ public:
 
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/poisson/template/application.h
+++ b/applications/poisson/template/application.h
@@ -72,11 +72,11 @@ public:
 
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -96,11 +96,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -252,11 +252,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -194,11 +194,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -185,11 +185,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     AssertThrow(dim == 3, ExcMessage("This application only makes sense for dim=3."));
 

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -359,11 +359,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)periodic_faces;
 

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -61,11 +61,11 @@ public:
   }
 
   void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree)
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree)
   {
     (void)triangulation;
     (void)periodic_faces;

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -146,7 +146,7 @@ private:
   InputParameters param;
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation;
+  std::shared_ptr<Triangulation<dim>> triangulation;
 
   // mapping
   std::shared_ptr<Mapping<dim>> mapping;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -35,7 +35,7 @@ using namespace dealii;
 
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
-  parallel::TriangulationBase<dim> const &       triangulation_in,
+  Triangulation<dim> const &                     triangulation_in,
   std::shared_ptr<Mapping<dim> const>            mapping_in,
   unsigned int const                             degree_in,
   std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -51,7 +51,7 @@ private:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
-  Operator(parallel::TriangulationBase<dim> const &       triangulation_in,
+  Operator(Triangulation<dim> const &                     triangulation_in,
            std::shared_ptr<Mapping<dim> const>            mapping_in,
            unsigned int const                             degree_in,
            std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -76,11 +76,11 @@ public:
   set_input_parameters(InputParameters & parameters) = 0;
 
   virtual void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree) = 0;
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree) = 0;
 
   virtual void
   set_boundary_conditions(

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -148,7 +148,7 @@ private:
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation;
+  std::shared_ptr<Triangulation<dim>> triangulation;
 
   // static mapping
   std::shared_ptr<Mapping<dim>> static_mapping;

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -44,11 +44,11 @@ MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & m
 
 template<int dim, typename Number>
 void
-MultigridPreconditioner<dim, Number>::initialize(MultigridData const &                    mg_data,
-                                                 parallel::TriangulationBase<dim> const * tria,
-                                                 FiniteElement<dim> const &               fe,
-                                                 std::shared_ptr<Mapping<dim> const>      mapping,
-                                                 PDEOperator const &           pde_operator,
+MultigridPreconditioner<dim, Number>::initialize(MultigridData const &               mg_data,
+                                                 Triangulation<dim> const *          tria,
+                                                 FiniteElement<dim> const &          fe,
+                                                 std::shared_ptr<Mapping<dim> const> mapping,
+                                                 PDEOperator const &                 pde_operator,
                                                  MultigridOperatorType const & mg_operator_type,
                                                  bool const                    mesh_is_moving,
                                                  Map const *                   dirichlet_bc,
@@ -201,11 +201,11 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
 template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize_dof_handler_and_constraints(
-  bool const                               operator_is_singular,
-  PeriodicFacePairs *                      periodic_face_pairs,
-  FiniteElement<dim> const &               fe,
-  parallel::TriangulationBase<dim> const * tria,
-  Map const *                              dirichlet_bc)
+  bool const                 operator_is_singular,
+  PeriodicFacePairs *        periodic_face_pairs,
+  FiniteElement<dim> const & fe,
+  Triangulation<dim> const * tria,
+  Map const *                dirichlet_bc)
 {
   Base::initialize_dof_handler_and_constraints(
     operator_is_singular, periodic_face_pairs, fe, tria, dirichlet_bc);

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -65,15 +65,15 @@ public:
    *  This function initializes the multigrid preconditioner.
    */
   void
-  initialize(MultigridData const &                    mg_data,
-             parallel::TriangulationBase<dim> const * tria,
-             FiniteElement<dim> const &               fe,
-             std::shared_ptr<Mapping<dim> const>      mapping,
-             PDEOperator const &                      pde_operator,
-             MultigridOperatorType const &            mg_operator_type,
-             bool const                               mesh_is_moving,
-             Map const *                              dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                      periodic_face_pairs = nullptr);
+  initialize(MultigridData const &               mg_data,
+             Triangulation<dim> const *          tria,
+             FiniteElement<dim> const &          fe,
+             std::shared_ptr<Mapping<dim> const> mapping,
+             PDEOperator const &                 pde_operator,
+             MultigridOperatorType const &       mg_operator_type,
+             bool const                          mesh_is_moving,
+             Map const *                         dirichlet_bc        = nullptr,
+             PeriodicFacePairs *                 periodic_face_pairs = nullptr);
 
   /*
    *  This function updates the multigrid preconditioner.
@@ -94,8 +94,8 @@ private:
   initialize_dof_handler_and_constraints(bool const                 operator_is_singular,
                                          PeriodicFacePairs *        periodic_face_pairs,
                                          FiniteElement<dim> const & fe,
-                                         parallel::TriangulationBase<dim> const * tria,
-                                         Map const * dirichlet_bc) override;
+                                         Triangulation<dim> const * tria,
+                                         Map const *                dirichlet_bc) override;
 
   void
   initialize_transfer_operators() override;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -58,7 +58,7 @@ public:
   /*
    * Constructor.
    */
-  Operator(parallel::TriangulationBase<dim> const &       triangulation,
+  Operator(Triangulation<dim> const &                     triangulation,
            std::shared_ptr<Mapping<dim> const>            mapping,
            unsigned int const                             degree,
            PeriodicFaces const                            periodic_face_pairs,

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -71,11 +71,11 @@ public:
   set_input_parameters(InputParameters & parameters) = 0;
 
   virtual void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree) = 0;
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree) = 0;
 
   virtual std::shared_ptr<Function<dim>>
   set_mesh_movement_function()

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -318,7 +318,7 @@ private:
   Structure::InputParameters structure_param;
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> structure_triangulation;
+  std::shared_ptr<Triangulation<dim>> structure_triangulation;
 
   // mapping
   std::shared_ptr<Mapping<dim>> structure_mapping;
@@ -355,7 +355,7 @@ private:
   /****************************************** FLUID *******************************************/
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> fluid_triangulation;
+  std::shared_ptr<Triangulation<dim>> fluid_triangulation;
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
     fluid_periodic_faces;
 

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -90,11 +90,11 @@ public:
   set_input_parameters_fluid(IncNS::InputParameters & parameters) = 0;
 
   virtual void
-  create_grid_fluid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                    PeriodicFaces &                                   periodic_faces,
-                    unsigned int const                                n_refine_space,
-                    std::shared_ptr<Mapping<dim>> &                   mapping,
-                    unsigned int const                                mapping_degree) = 0;
+  create_grid_fluid(std::shared_ptr<Triangulation<dim>> triangulation,
+                    PeriodicFaces &                     periodic_faces,
+                    unsigned int const                  n_refine_space,
+                    std::shared_ptr<Mapping<dim>> &     mapping,
+                    unsigned int const                  mapping_degree) = 0;
 
   // currently required for test cases with analytical mesh movement
   virtual std::shared_ptr<Function<dim>>
@@ -148,11 +148,11 @@ public:
   set_input_parameters_structure(Structure::InputParameters & parameters) = 0;
 
   virtual void
-  create_grid_structure(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree) = 0;
+  create_grid_structure(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree) = 0;
 
   virtual void
   set_boundary_conditions_structure(

--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.h
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.h
@@ -47,12 +47,12 @@ public:
   /*
    * Constructor.
    */
-  InterfaceCommunicator(const std::vector<Point<spacedim>> &               quadrature_points,
-                        const parallel::TriangulationBase<dim, spacedim> & tria,
-                        const Mapping<dim, spacedim> &                     mapping,
-                        double const                                       tolerance,
-                        const std::vector<bool> &                          marked_vertices,
-                        std::shared_ptr<GridTools::Cache<dim, dim>> const  cache)
+  InterfaceCommunicator(const std::vector<Point<spacedim>> &              quadrature_points,
+                        const Triangulation<dim, spacedim> &              tria,
+                        const Mapping<dim, spacedim> &                    mapping,
+                        double const                                      tolerance,
+                        const std::vector<bool> &                         marked_vertices,
+                        std::shared_ptr<GridTools::Cache<dim, dim>> const cache)
     : comm(tria.get_communicator())
   {
     // create bounding boxed of local active cells
@@ -430,15 +430,15 @@ public:
   }
 
   void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>                matrix_free_dst_in,
-        unsigned int const                                      dof_index_dst_in,
-        std::vector<quad_index> const &                         quad_indices_dst_in,
-        MapBoundaryCondition const &                            map_bc_in,
-        std::shared_ptr<parallel::TriangulationBase<dim>> const triangulation_src_in,
-        DoFHandler<dim> const &                                 dof_handler_src_in,
-        Mapping<dim> const &                                    mapping_src_in,
-        VectorType const &                                      dof_vector_src_in,
-        double const                                            tolerance)
+  setup(std::shared_ptr<MatrixFree<dim, Number>>  matrix_free_dst_in,
+        unsigned int const                        dof_index_dst_in,
+        std::vector<quad_index> const &           quad_indices_dst_in,
+        MapBoundaryCondition const &              map_bc_in,
+        std::shared_ptr<Triangulation<dim>> const triangulation_src_in,
+        DoFHandler<dim> const &                   dof_handler_src_in,
+        Mapping<dim> const &                      mapping_src_in,
+        VectorType const &                        dof_vector_src_in,
+        double const                              tolerance)
   {
     matrix_free_dst   = matrix_free_dst_in;
     dof_index_dst     = dof_index_dst_in;
@@ -695,9 +695,9 @@ private:
   /*
    * src-side
    */
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation_src;
-  DoFHandler<dim> const *                           dof_handler_src;
-  Mapping<dim> const *                              mapping_src;
+  std::shared_ptr<Triangulation<dim>> triangulation_src;
+  DoFHandler<dim> const *             dof_handler_src;
+  Mapping<dim> const *                mapping_src;
 
   mutable std::map<quad_index, std::map<mpi_rank, ArrayQuadraturePoints>> map_q_points_src;
   mutable std::map<quad_index, std::map<mpi_rank, ArrayVectorCache>>      map_cache_src;

--- a/include/exadg/grid/moving_mesh_function.h
+++ b/include/exadg/grid/moving_mesh_function.h
@@ -41,11 +41,11 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshFunction(std::shared_ptr<Mapping<dim>>            mapping,
-                     unsigned int const                       mapping_degree_q_cache,
-                     parallel::TriangulationBase<dim> const & triangulation,
-                     std::shared_ptr<Function<dim>> const     mesh_movement_function,
-                     double const                             start_time)
+  MovingMeshFunction(std::shared_ptr<Mapping<dim>>        mapping,
+                     unsigned int const                   mapping_degree_q_cache,
+                     Triangulation<dim> const &           triangulation,
+                     std::shared_ptr<Function<dim>> const mesh_movement_function,
+                     double const                         start_time)
     : MovingMeshBase<dim, Number>(mapping, mapping_degree_q_cache, triangulation),
       mesh_movement_function(mesh_movement_function),
       triangulation(triangulation)

--- a/include/exadg/grid/periodic_box.h
+++ b/include/exadg/grid/periodic_box.h
@@ -37,8 +37,8 @@ using namespace dealii;
 template<int dim>
 void
 create_periodic_box(
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-  unsigned int const                                n_refine_space,
+  std::shared_ptr<Triangulation<dim>> triangulation,
+  unsigned int const                  n_refine_space,
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
                      periodic_faces,
   unsigned int const n_subdivisions,

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -104,7 +104,7 @@ private:
    */
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation;
+  std::shared_ptr<Triangulation<dim>> triangulation;
 
   // mapping
   std::shared_ptr<Mapping<dim>> static_mapping;

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -214,7 +214,7 @@ private:
    */
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation;
+  std::shared_ptr<Triangulation<dim>> triangulation;
 
   // static mapping
   std::shared_ptr<Mapping<dim>> static_mapping;

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.h
@@ -80,7 +80,7 @@ private:
    */
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation_pre, triangulation;
+  std::shared_ptr<Triangulation<dim>> triangulation_pre, triangulation;
 
   // mapping
   std::shared_ptr<Mapping<dim>> mapping_pre, mapping;

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -38,11 +38,11 @@ MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & c
 
 template<int dim, typename Number>
 void
-MultigridPreconditioner<dim, Number>::initialize(MultigridData const &                    mg_data,
-                                                 parallel::TriangulationBase<dim> const * tria,
-                                                 FiniteElement<dim> const &               fe,
-                                                 std::shared_ptr<Mapping<dim> const>      mapping,
-                                                 PDEOperator const &           pde_operator,
+MultigridPreconditioner<dim, Number>::initialize(MultigridData const &               mg_data,
+                                                 Triangulation<dim> const *          tria,
+                                                 FiniteElement<dim> const &          fe,
+                                                 std::shared_ptr<Mapping<dim> const> mapping,
+                                                 PDEOperator const &                 pde_operator,
                                                  MultigridOperatorType const & mg_operator_type,
                                                  bool const                    mesh_is_moving,
                                                  Map const *                   dirichlet_bc,

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -59,15 +59,15 @@ public:
   MultigridPreconditioner(MPI_Comm const & comm);
 
   void
-  initialize(MultigridData const &                    mg_data,
-             parallel::TriangulationBase<dim> const * tria,
-             FiniteElement<dim> const &               fe,
-             std::shared_ptr<Mapping<dim> const>      mapping,
-             PDEOperator const &                      pde_operator,
-             MultigridOperatorType const &            mg_operator_type,
-             bool const                               mesh_is_moving,
-             Map const *                              dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                      periodic_face_pairs = nullptr);
+  initialize(MultigridData const &               mg_data,
+             Triangulation<dim> const *          tria,
+             FiniteElement<dim> const &          fe,
+             std::shared_ptr<Mapping<dim> const> mapping,
+             PDEOperator const &                 pde_operator,
+             MultigridOperatorType const &       mg_operator_type,
+             bool const                          mesh_is_moving,
+             Map const *                         dirichlet_bc        = nullptr,
+             PeriodicFacePairs *                 periodic_face_pairs = nullptr);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -38,14 +38,14 @@ MultigridPreconditionerProjection<dim, Number>::MultigridPreconditionerProjectio
 template<int dim, typename Number>
 void
 MultigridPreconditionerProjection<dim, Number>::initialize(
-  MultigridData const &                    mg_data,
-  parallel::TriangulationBase<dim> const * tria,
-  FiniteElement<dim> const &               fe,
-  std::shared_ptr<Mapping<dim> const>      mapping,
-  PDEOperator const &                      pde_operator,
-  bool const                               mesh_is_moving,
-  Map const *                              dirichlet_bc,
-  PeriodicFacePairs *                      periodic_face_pairs)
+  MultigridData const &               mg_data,
+  Triangulation<dim> const *          tria,
+  FiniteElement<dim> const &          fe,
+  std::shared_ptr<Mapping<dim> const> mapping,
+  PDEOperator const &                 pde_operator,
+  bool const                          mesh_is_moving,
+  Map const *                         dirichlet_bc,
+  PeriodicFacePairs *                 periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
@@ -59,14 +59,14 @@ public:
   MultigridPreconditionerProjection(MPI_Comm const & mpi_comm);
 
   void
-  initialize(MultigridData const &                    mg_data,
-             parallel::TriangulationBase<dim> const * tria,
-             FiniteElement<dim> const &               fe,
-             std::shared_ptr<Mapping<dim> const>      mapping,
-             PDEOperator const &                      pde_operator,
-             bool const                               mesh_is_moving,
-             Map const *                              dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                      periodic_face_pairs = nullptr);
+  initialize(MultigridData const &               mg_data,
+             Triangulation<dim> const *          tria,
+             FiniteElement<dim> const &          fe,
+             std::shared_ptr<Mapping<dim> const> mapping,
+             PDEOperator const &                 pde_operator,
+             bool const                          mesh_is_moving,
+             Map const *                         dirichlet_bc        = nullptr,
+             PeriodicFacePairs *                 periodic_face_pairs = nullptr);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -36,9 +36,9 @@ using namespace dealii;
 
 template<int dim, typename Number>
 OperatorCoupled<dim, Number>::OperatorCoupled(
-  parallel::TriangulationBase<dim> const & triangulation_in,
-  std::shared_ptr<Mapping<dim> const>      mapping_in,
-  unsigned int const                       degree_u_in,
+  Triangulation<dim> const &          triangulation_in,
+  std::shared_ptr<Mapping<dim> const> mapping_in,
+  unsigned int const                  degree_u_in,
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                   periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
@@ -478,14 +478,9 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_momentum()
     std::dynamic_pointer_cast<MULTIGRID>(preconditioner_momentum);
 
   auto & dof_handler = this->get_dof_handler_u();
-
-  parallel::TriangulationBase<dim> const * tria =
-    dynamic_cast<parallel::TriangulationBase<dim> const *>(&dof_handler.get_triangulation());
-  FiniteElement<dim> const & fe = dof_handler.get_fe();
-
   mg_preconditioner->initialize(this->param.multigrid_data_velocity_block,
-                                tria,
-                                fe,
+                                &dof_handler.get_triangulation(),
+                                dof_handler.get_fe(),
                                 this->mapping,
                                 this->momentum_operator,
                                 this->param.multigrid_operator_type_velocity_block,
@@ -609,14 +604,9 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_schur_complement()
     std::dynamic_pointer_cast<MultigridPoisson>(multigrid_preconditioner_schur_complement);
 
   auto & dof_handler = this->get_dof_handler_p();
-
-  parallel::TriangulationBase<dim> const * tria =
-    dynamic_cast<const parallel::TriangulationBase<dim> *>(&dof_handler.get_triangulation());
-  const FiniteElement<dim> & fe = dof_handler.get_fe();
-
   mg_preconditioner->initialize(mg_data,
-                                tria,
-                                fe,
+                                &dof_handler.get_triangulation(),
+                                dof_handler.get_fe(),
                                 this->mapping,
                                 laplace_operator_data,
                                 this->param.ale_formulation,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -189,9 +189,9 @@ public:
    * Constructor.
    */
   OperatorCoupled(
-    parallel::TriangulationBase<dim> const & triangulation_in,
-    std::shared_ptr<Mapping<dim> const>      mapping_in,
-    unsigned int const                       degree_u_in,
+    Triangulation<dim> const &          triangulation_in,
+    std::shared_ptr<Mapping<dim> const> mapping_in,
+    unsigned int const                  degree_u_in,
     std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                     periodic_face_pairs_in,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -33,9 +33,9 @@ using namespace dealii;
 
 template<int dim, typename Number>
 OperatorDualSplitting<dim, Number>::OperatorDualSplitting(
-  parallel::TriangulationBase<dim> const & triangulation_in,
-  std::shared_ptr<Mapping<dim> const>      mapping_in,
-  unsigned int const                       degree_u_in,
+  Triangulation<dim> const &          triangulation_in,
+  std::shared_ptr<Mapping<dim> const> mapping_in,
+  unsigned int const                  degree_u_in,
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                   periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
@@ -124,15 +124,9 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
       std::dynamic_pointer_cast<MULTIGRID>(helmholtz_preconditioner);
 
     auto & dof_handler = this->get_dof_handler_u();
-
-    parallel::TriangulationBase<dim> const * tria =
-      dynamic_cast<const parallel::TriangulationBase<dim> *>(&dof_handler.get_triangulation());
-
-    const FiniteElement<dim> & fe = dof_handler.get_fe();
-
     mg_preconditioner->initialize(this->param.multigrid_data_viscous,
-                                  tria,
-                                  fe,
+                                  &dof_handler.get_triangulation(),
+                                  dof_handler.get_fe(),
                                   this->mapping,
                                   this->momentum_operator,
                                   MultigridOperatorType::ReactionDiffusion,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
@@ -56,9 +56,9 @@ public:
    * Constructor.
    */
   OperatorDualSplitting(
-    parallel::TriangulationBase<dim> const & triangulation,
-    std::shared_ptr<Mapping<dim> const>      mapping,
-    unsigned int const                       degree_u,
+    Triangulation<dim> const &          triangulation,
+    std::shared_ptr<Mapping<dim> const> mapping,
+    unsigned int const                  degree_u,
     std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                     periodic_face_pairs,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -33,9 +33,9 @@ using namespace dealii;
 
 template<int dim, typename Number>
 OperatorPressureCorrection<dim, Number>::OperatorPressureCorrection(
-  parallel::TriangulationBase<dim> const & triangulation_in,
-  std::shared_ptr<Mapping<dim> const>      mapping_in,
-  unsigned int const                       degree_u_in,
+  Triangulation<dim> const &          triangulation_in,
+  std::shared_ptr<Mapping<dim> const> mapping_in,
+  unsigned int const                  degree_u_in,
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                   periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
@@ -132,15 +132,9 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
       std::dynamic_pointer_cast<Multigrid>(momentum_preconditioner);
 
     auto & dof_handler = this->get_dof_handler_u();
-
-    parallel::TriangulationBase<dim> const * tria =
-      dynamic_cast<const parallel::TriangulationBase<dim> *>(&dof_handler.get_triangulation());
-
-    const FiniteElement<dim> & fe = dof_handler.get_fe();
-
     mg_preconditioner->initialize(this->param.multigrid_data_momentum,
-                                  tria,
-                                  fe,
+                                  &dof_handler.get_triangulation(),
+                                  dof_handler.get_fe(),
                                   this->mapping,
                                   this->momentum_operator,
                                   this->param.multigrid_operator_type_momentum,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
@@ -105,9 +105,9 @@ public:
    * Constructor.
    */
   OperatorPressureCorrection(
-    parallel::TriangulationBase<dim> const & triangulation,
-    std::shared_ptr<Mapping<dim> const>      mapping,
-    unsigned int const                       degree_u,
+    Triangulation<dim> const &          triangulation,
+    std::shared_ptr<Mapping<dim> const> mapping,
+    unsigned int const                  degree_u,
     std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                     periodic_face_pairs,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -32,9 +32,9 @@ using namespace dealii;
 
 template<int dim, typename Number>
 OperatorProjectionMethods<dim, Number>::OperatorProjectionMethods(
-  parallel::TriangulationBase<dim> const & triangulation_in,
-  std::shared_ptr<Mapping<dim> const>      mapping_in,
-  unsigned int const                       degree_u_in,
+  Triangulation<dim> const &          triangulation_in,
+  std::shared_ptr<Mapping<dim> const> mapping_in,
+  unsigned int const                  degree_u_in,
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                   periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
@@ -183,14 +183,10 @@ OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poiss
     std::shared_ptr<Multigrid> mg_preconditioner =
       std::dynamic_pointer_cast<Multigrid>(preconditioner_pressure_poisson);
 
-    parallel::TriangulationBase<dim> const * tria =
-      dynamic_cast<const parallel::TriangulationBase<dim> *>(
-        &this->get_dof_handler_p().get_triangulation());
-    const FiniteElement<dim> & fe = this->get_dof_handler_p().get_fe();
-
+    auto & dof_handler = this->get_dof_handler_p();
     mg_preconditioner->initialize(mg_data,
-                                  tria,
-                                  fe,
+                                  &dof_handler.get_triangulation(),
+                                  dof_handler.get_fe(),
                                   this->mapping,
                                   laplace_operator.get_data(),
                                   this->param.ale_formulation,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -48,9 +48,9 @@ public:
    * Constructor.
    */
   OperatorProjectionMethods(
-    parallel::TriangulationBase<dim> const & triangulation,
-    std::shared_ptr<Mapping<dim> const>      mapping,
-    unsigned int const                       degree_u,
+    Triangulation<dim> const &          triangulation,
+    std::shared_ptr<Mapping<dim> const> mapping,
+    unsigned int const                  degree_u,
     std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                     periodic_face_pairs,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -38,9 +38,9 @@ using namespace dealii;
 
 template<int dim, typename Number>
 SpatialOperatorBase<dim, Number>::SpatialOperatorBase(
-  parallel::TriangulationBase<dim> const & triangulation_in,
-  std::shared_ptr<Mapping<dim> const>      mapping_in,
-  unsigned int const                       degree_u_in,
+  Triangulation<dim> const &          triangulation_in,
+  std::shared_ptr<Mapping<dim> const> mapping_in,
+  unsigned int const                  degree_u_in,
   std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                   periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
@@ -1125,14 +1125,9 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
   // explicit copy needed since function is called on const
   auto periodic_face_pairs = this->periodic_face_pairs;
 
-  parallel::TriangulationBase<dim> const * tria =
-    dynamic_cast<const parallel::TriangulationBase<dim> *>(
-      &dof_handler_u_scalar.get_triangulation());
-  const FiniteElement<dim> & fe = dof_handler_u_scalar.get_fe();
-
   mg_preconditioner->initialize(mg_data,
-                                tria,
-                                fe,
+                                &dof_handler_u_scalar.get_triangulation(),
+                                dof_handler_u_scalar.get_fe(),
                                 mapping,
                                 laplace_operator.get_data(),
                                 this->param.ale_formulation,
@@ -1443,15 +1438,9 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
         std::dynamic_pointer_cast<MULTIGRID>(preconditioner_projection);
 
       auto const & dof_handler = this->get_dof_handler_u();
-
-      parallel::TriangulationBase<dim> const * tria =
-        dynamic_cast<parallel::TriangulationBase<dim> const *>(&dof_handler.get_triangulation());
-
-      FiniteElement<dim> const & fe = dof_handler.get_fe();
-
       mg_preconditioner->initialize(this->param.multigrid_data_projection,
-                                    tria,
-                                    fe,
+                                    &dof_handler.get_triangulation(),
+                                    dof_handler.get_fe(),
                                     this->mapping,
                                     *this->projection_operator,
                                     this->param.ale_formulation,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -144,9 +144,9 @@ public:
    * Constructor.
    */
   SpatialOperatorBase(
-    parallel::TriangulationBase<dim> const & triangulation,
-    std::shared_ptr<Mapping<dim> const>      mapping,
-    unsigned int const                       degree_u,
+    Triangulation<dim> const &          triangulation,
+    std::shared_ptr<Mapping<dim> const> mapping,
+    unsigned int const                  degree_u,
     std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
                                                     periodic_face_pairs,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
@@ -474,7 +474,7 @@ protected:
   /*
    * Triangulation
    */
-  parallel::TriangulationBase<dim> const & triangulation;
+  Triangulation<dim> const & triangulation;
 
   /*
    * Mapping

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -81,11 +81,11 @@ public:
   set_input_parameters(InputParameters & parameters) = 0;
 
   virtual void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree) = 0;
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree) = 0;
 
   virtual void
   set_boundary_conditions(
@@ -174,11 +174,11 @@ public:
   set_input_parameters_precursor(InputParameters & parameters) = 0;
 
   virtual void
-  create_grid_precursor(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-                        PeriodicFaces &                                   periodic_faces,
-                        unsigned int const                                n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &                   mapping,
-                        unsigned int const                                mapping_degree) = 0;
+  create_grid_precursor(std::shared_ptr<Triangulation<dim>> triangulation,
+                        PeriodicFaces &                     periodic_faces,
+                        unsigned int const                  n_refine_space,
+                        std::shared_ptr<Mapping<dim>> &     mapping,
+                        unsigned int const                  mapping_degree) = 0;
 
   virtual void
   set_boundary_conditions_precursor(

--- a/include/exadg/matrix_free/categorization.h
+++ b/include/exadg/matrix_free/categorization.h
@@ -37,9 +37,9 @@ using namespace dealii;
  */
 template<int dim, typename AdditionalData>
 void
-do_cell_based_loops(const parallel::TriangulationBase<dim> & tria,
-                    AdditionalData &                         data,
-                    unsigned int const                       level = numbers::invalid_unsigned_int)
+do_cell_based_loops(const Triangulation<dim> & tria,
+                    AdditionalData &           data,
+                    unsigned int const         level = numbers::invalid_unsigned_int)
 {
   bool is_mg = (level != numbers::invalid_unsigned_int);
 

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -146,7 +146,7 @@ private:
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation;
+  std::shared_ptr<Triangulation<dim>> triangulation;
 
   // mapping
   std::shared_ptr<Mapping<dim>> mapping;

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -37,14 +37,14 @@ MultigridPreconditioner<dim, Number, n_components>::MultigridPreconditioner(
 template<int dim, typename Number, int n_components>
 void
 MultigridPreconditioner<dim, Number, n_components>::initialize(
-  MultigridData const &                    mg_data,
-  const parallel::TriangulationBase<dim> * tria,
-  const FiniteElement<dim> &               fe,
-  std::shared_ptr<Mapping<dim> const>      mapping,
-  LaplaceOperatorData<rank, dim> const &   data_in,
-  bool const                               mesh_is_moving,
-  Map const *                              dirichlet_bc,
-  PeriodicFacePairs *                      periodic_face_pairs)
+  MultigridData const &                  mg_data,
+  const Triangulation<dim> *             tria,
+  const FiniteElement<dim> &             fe,
+  std::shared_ptr<Mapping<dim> const>    mapping,
+  LaplaceOperatorData<rank, dim> const & data_in,
+  bool const                             mesh_is_moving,
+  Map const *                            dirichlet_bc,
+  PeriodicFacePairs *                    periodic_face_pairs)
 {
   data = data_in;
 

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -60,14 +60,14 @@ public:
   MultigridPreconditioner(MPI_Comm const & mpi_comm);
 
   void
-  initialize(MultigridData const &                    mg_data,
-             const parallel::TriangulationBase<dim> * tria,
-             const FiniteElement<dim> &               fe,
-             std::shared_ptr<Mapping<dim> const>      mapping,
-             LaplaceOperatorData<rank, dim> const &   data_in,
-             bool const                               mesh_is_moving,
-             Map const *                              dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                      periodic_face_pairs = nullptr);
+  initialize(MultigridData const &                  mg_data,
+             const Triangulation<dim> *             tria,
+             const FiniteElement<dim> &             fe,
+             std::shared_ptr<Mapping<dim> const>    mapping,
+             LaplaceOperatorData<rank, dim> const & data_in,
+             bool const                             mesh_is_moving,
+             Map const *                            dirichlet_bc        = nullptr,
+             PeriodicFacePairs *                    periodic_face_pairs = nullptr);
 
   void
   update() override;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -42,7 +42,7 @@ using namespace dealii;
 
 template<int dim, typename Number, int n_components>
 Operator<dim, Number, n_components>::Operator(
-  parallel::TriangulationBase<dim> const &             triangulation_in,
+  Triangulation<dim> const &                           triangulation_in,
   std::shared_ptr<Mapping<dim> const>                  mapping_in,
   unsigned int const                                   degree_in,
   PeriodicFaces const                                  periodic_face_pairs_in,
@@ -253,19 +253,14 @@ Operator<dim, Number, n_components>::setup_solver()
     std::shared_ptr<Multigrid> mg_preconditioner =
       std::dynamic_pointer_cast<Multigrid>(preconditioner);
 
-    parallel::TriangulationBase<dim> const * tria =
-      dynamic_cast<const parallel::TriangulationBase<dim> *>(
-        &this->dof_handler.get_triangulation());
-    const FiniteElement<dim> & fe = this->dof_handler.get_fe();
-
     mg_preconditioner->initialize(mg_data,
-                                  tria,
-                                  fe,
+                                  &dof_handler.get_triangulation(),
+                                  dof_handler.get_fe(),
                                   mapping,
                                   laplace_operator.get_data(),
                                   false /* moving_mesh */,
                                   &laplace_operator.get_data().bc->dirichlet_bc,
-                                  &this->periodic_face_pairs);
+                                  &periodic_face_pairs);
   }
   else
   {

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -65,7 +65,7 @@ private:
     PeriodicFaces;
 
 public:
-  Operator(parallel::TriangulationBase<dim> const &             triangulation,
+  Operator(Triangulation<dim> const &                           triangulation,
            std::shared_ptr<Mapping<dim> const>                  mapping,
            unsigned int const                                   degree,
            PeriodicFaces const                                  periodic_face_pairs,

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -75,11 +75,11 @@ public:
   set_input_parameters(InputParameters & parameters) = 0;
 
   virtual void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree) = 0;
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree) = 0;
 
   virtual void
     set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor) = 0;

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.h
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.h
@@ -142,10 +142,10 @@ private:
 
   SmartPointer<DoFHandler<dim> const> dof_handler;
 
-  std::shared_ptr<VectorType>                       velocity_full;
-  std::shared_ptr<parallel::TriangulationBase<dim>> tria_full;
-  std::shared_ptr<FESystem<dim>>                    fe_full;
-  std::shared_ptr<DoFHandler<dim>>                  dof_handler_full;
+  std::shared_ptr<VectorType>         velocity_full;
+  std::shared_ptr<Triangulation<dim>> tria_full;
+  std::shared_ptr<FESystem<dim>>      fe_full;
+  std::shared_ptr<DoFHandler<dim>>    dof_handler_full;
 };
 } // namespace ExaDG
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -53,9 +53,9 @@ MultigridPreconditionerBase<dim, Number>::MultigridPreconditionerBase(MPI_Comm c
 
 template<int dim, typename Number>
 void
-MultigridPreconditionerBase<dim, Number>::initialize(MultigridData const &                    data,
-                                                     parallel::TriangulationBase<dim> const * tria,
-                                                     FiniteElement<dim> const &               fe,
+MultigridPreconditionerBase<dim, Number>::initialize(MultigridData const &               data,
+                                                     Triangulation<dim> const *          tria,
+                                                     FiniteElement<dim> const &          fe,
                                                      std::shared_ptr<Mapping<dim> const> mapping,
                                                      bool const          operator_is_singular,
                                                      Map const *         dirichlet_bc,
@@ -127,10 +127,9 @@ MultigridPreconditionerBase<dim, Number>::initialize(MultigridData const &      
 
 template<int dim, typename Number>
 void
-MultigridPreconditionerBase<dim, Number>::initialize_levels(
-  parallel::TriangulationBase<dim> const * tria,
-  unsigned int const                       degree,
-  bool const                               is_dg)
+MultigridPreconditionerBase<dim, Number>::initialize_levels(Triangulation<dim> const * tria,
+                                                            unsigned int const         degree,
+                                                            bool const                 is_dg)
 {
   MultigridType const mg_type = data.type;
 
@@ -310,7 +309,7 @@ MultigridPreconditionerBase<dim, Number>::check_levels(std::vector<MGLevelInfo> 
 template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::initialize_coarse_grid_triangulations(
-  parallel::TriangulationBase<dim> const * tria)
+  Triangulation<dim> const * tria)
 {
   // coarse grid triangulations are only required in case of the multigrid transfer
   // with global coarsening
@@ -403,11 +402,11 @@ MultigridPreconditionerBase<dim, Number>::get_mapping(unsigned int const h_level
 template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::initialize_dof_handler_and_constraints(
-  bool const                               operator_is_singular,
-  PeriodicFacePairs *                      periodic_face_pairs_in,
-  FiniteElement<dim> const &               fe,
-  parallel::TriangulationBase<dim> const * tria,
-  Map const *                              dirichlet_bc_in)
+  bool const                 operator_is_singular,
+  PeriodicFacePairs *        periodic_face_pairs_in,
+  FiniteElement<dim> const & fe,
+  Triangulation<dim> const * tria,
+  Map const *                dirichlet_bc_in)
 {
   bool const is_dg = (fe.dofs_per_vertex == 0);
 
@@ -448,7 +447,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
   bool                                                                 is_singular,
   PeriodicFacePairs &                                                  periodic_face_pairs,
   FiniteElement<dim> const &                                           fe,
-  parallel::TriangulationBase<dim> const *                             tria,
+  Triangulation<dim> const *                                           tria,
   Map const &                                                          dirichlet_bc,
   std::vector<MGLevelInfo> &                                           level_info,
   std::vector<MGDoFHandlerIdentifier> &                                p_levels,

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -94,13 +94,13 @@ public:
    * Initialization function.
    */
   void
-  initialize(MultigridData const &                    data,
-             parallel::TriangulationBase<dim> const * tria,
-             FiniteElement<dim> const &               fe,
-             std::shared_ptr<Mapping<dim> const>      mapping,
-             bool const                               operator_is_singular = false,
-             Map const *                              dirichlet_bc         = nullptr,
-             PeriodicFacePairs *                      periodic_face_pairs  = nullptr);
+  initialize(MultigridData const &               data,
+             Triangulation<dim> const *          tria,
+             FiniteElement<dim> const &          fe,
+             std::shared_ptr<Mapping<dim> const> mapping,
+             bool const                          operator_is_singular = false,
+             Map const *                         dirichlet_bc         = nullptr,
+             PeriodicFacePairs *                 periodic_face_pairs  = nullptr);
 
   /*
    * This function applies the multigrid preconditioner dst = P^{-1} src.
@@ -172,15 +172,15 @@ protected:
   initialize_dof_handler_and_constraints(bool                       is_singular,
                                          PeriodicFacePairs *        periodic_face_pairs,
                                          FiniteElement<dim> const & fe,
-                                         parallel::TriangulationBase<dim> const * tria,
-                                         Map const *                              dirichlet_bc);
+                                         Triangulation<dim> const * tria,
+                                         Map const *                dirichlet_bc);
 
   void
   do_initialize_dof_handler_and_constraints(
     bool                                                                 is_singular,
     PeriodicFacePairs &                                                  periodic_face_pairs,
     FiniteElement<dim> const &                                           fe,
-    parallel::TriangulationBase<dim> const *                             tria,
+    Triangulation<dim> const *                                           tria,
     Map const &                                                          dirichlet_bc,
     std::vector<MGLevelInfo> &                                           level_info,
     std::vector<MGDoFHandlerIdentifier> &                                p_levels,
@@ -220,9 +220,7 @@ private:
    * Multigrid levels (i.e. coarsening strategy, h-/p-/hp-/ph-MG).
    */
   void
-  initialize_levels(parallel::TriangulationBase<dim> const * tria,
-                    unsigned int const                       degree,
-                    bool const                               is_dg);
+  initialize_levels(Triangulation<dim> const * tria, unsigned int const degree, bool const is_dg);
 
   void
   check_levels(std::vector<MGLevelInfo> const & level_info);
@@ -231,7 +229,7 @@ private:
    * Coarse grid triangulations in case of global coarsening transfer type.
    */
   void
-  initialize_coarse_grid_triangulations(parallel::TriangulationBase<dim> const * tria);
+  initialize_coarse_grid_triangulations(Triangulation<dim> const * tria);
 
   /*
    * Returns the correct mapping depending on the multigrid transfer type and the current h-level.
@@ -309,7 +307,7 @@ private:
 
   MultigridData data;
 
-  parallel::TriangulationBase<dim> const * triangulation;
+  Triangulation<dim> const * triangulation;
 
   // Only relevant for global coarsening, where this vector contains coarse level triangulations,
   // and the fine level triangulation as the last element of the vector.

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -131,7 +131,7 @@ private:
   InputParameters param;
 
   // triangulation
-  std::shared_ptr<parallel::TriangulationBase<dim>> triangulation;
+  std::shared_ptr<Triangulation<dim>> triangulation;
 
   // mapping
   std::shared_ptr<Mapping<dim>> mapping;

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -37,7 +37,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize(
   MultigridData const &                       mg_data,
-  parallel::TriangulationBase<dim> const *    tria,
+  Triangulation<dim> const *                  tria,
   FiniteElement<dim> const &                  fe,
   std::shared_ptr<Mapping<dim> const>         mapping,
   ElasticityOperatorBase<dim, Number> const & pde_operator,

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -62,7 +62,7 @@ public:
 
   void
   initialize(MultigridData const &                       mg_data,
-             parallel::TriangulationBase<dim> const *    tria,
+             Triangulation<dim> const *                  tria,
              FiniteElement<dim> const &                  fe,
              std::shared_ptr<Mapping<dim> const>         mapping,
              ElasticityOperatorBase<dim, Number> const & pde_operator,

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -39,7 +39,7 @@ using namespace dealii;
 
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
-  parallel::TriangulationBase<dim> &             triangulation_in,
+  Triangulation<dim> &                           triangulation_in,
   std::shared_ptr<Mapping<dim> const>            mapping_in,
   unsigned int const &                           degree_in,
   PeriodicFaces const &                          periodic_face_pairs_in,
@@ -339,10 +339,6 @@ Operator<dim, Number>::initialize_preconditioner()
   }
   else if(param.preconditioner == Preconditioner::Multigrid)
   {
-    parallel::TriangulationBase<dim> const * tria =
-      dynamic_cast<const parallel::TriangulationBase<dim> *>(&dof_handler.get_triangulation());
-    const FiniteElement<dim> & fe = dof_handler.get_fe();
-
     if(param.large_deformation)
     {
       typedef MultigridPreconditioner<dim, Number> Multigrid;
@@ -352,8 +348,8 @@ Operator<dim, Number>::initialize_preconditioner()
         std::dynamic_pointer_cast<Multigrid>(preconditioner);
 
       mg_preconditioner->initialize(param.multigrid_data,
-                                    tria,
-                                    fe,
+                                    &dof_handler.get_triangulation(),
+                                    dof_handler.get_fe(),
                                     mapping,
                                     elasticity_operator_nonlinear,
                                     true,
@@ -369,8 +365,8 @@ Operator<dim, Number>::initialize_preconditioner()
         std::dynamic_pointer_cast<Multigrid>(preconditioner);
 
       mg_preconditioner->initialize(param.multigrid_data,
-                                    tria,
-                                    fe,
+                                    &dof_handler.get_triangulation(),
+                                    dof_handler.get_fe(),
                                     mapping,
                                     elasticity_operator_linear,
                                     false,

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -176,7 +176,7 @@ public:
   /*
    * Constructor.
    */
-  Operator(parallel::TriangulationBase<dim> &             triangulation_in,
+  Operator(Triangulation<dim> &                           triangulation_in,
            std::shared_ptr<Mapping<dim> const>            mapping_in,
            unsigned int const &                           degree_in,
            PeriodicFaces const &                          periodic_face_pairs_in,

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -73,11 +73,11 @@ public:
   set_input_parameters(InputParameters & parameters) = 0;
 
   virtual void
-  create_grid(std::shared_ptr<parallel::TriangulationBase<dim>> triangulation,
-              PeriodicFaces &                                   periodic_faces,
-              unsigned int const                                n_refine_space,
-              std::shared_ptr<Mapping<dim>> &                   mapping,
-              unsigned int const                                mapping_degree) = 0;
+  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
+              PeriodicFaces &                     periodic_faces,
+              unsigned int const                  n_refine_space,
+              std::shared_ptr<Mapping<dim>> &     mapping,
+              unsigned int const                  mapping_degree) = 0;
 
 
   virtual void

--- a/include/exadg/utilities/print_general_infos.h
+++ b/include/exadg/utilities/print_general_infos.h
@@ -118,9 +118,9 @@ print_matrixfree_info(ConditionalOStream const & pcout)
 // print grid info
 template<int dim>
 inline void
-print_grid_data(ConditionalOStream const &               pcout,
-                unsigned int const                       n_refine_space,
-                parallel::TriangulationBase<dim> const & triangulation)
+print_grid_data(ConditionalOStream const & pcout,
+                unsigned int const         n_refine_space,
+                Triangulation<dim> const & triangulation)
 {
   pcout << std::endl
         << "Generating grid for " << dim << "-dimensional problem:" << std::endl


### PR DESCRIPTION
Recent changes of deal.II allow us to avoid dynamic casts related to triangulation classes