### PR TITLE
MappingDoFVector: change order of parameters for consistency

### DIFF
--- a/include/exadg/grid/mapping_dof_vector.h
+++ b/include/exadg/grid/mapping_dof_vector.h
@@ -71,7 +71,7 @@ public:
     DoFHandler<dim> dof_handler(triangulation);
     dof_handler.distribute_dofs(fe);
     VectorType displacement_vector;
-    initialize(dof_handler, displacement_vector);
+    initialize(displacement_vector, dof_handler);
   }
 
   /**
@@ -175,11 +175,11 @@ public:
    * Initializes the MappingQCache object by providing a displacement dof-vector (with a
    * corresponding DoFHandler object) that describes the displacement of the mesh compared to an
    * undeformed reference configuration. If the displacement dof-vector is empty or uninitialized,
-   * this implies that no displacements will be added to the grid coordinates described by the
-   * static mapping.
+   * this implies that no displacements will be added to the grid coordinates of the reference
+   * configuration.
    */
   void
-  initialize(DoFHandler<dim> const & dof_handler, VectorType const & displacement_vector)
+  initialize(VectorType const & displacement_vector, DoFHandler<dim> const & dof_handler)
   {
     AssertThrow(MultithreadInfo::n_threads() == 1, ExcNotImplemented());
 

--- a/include/exadg/grid/moving_mesh_elasticity.h
+++ b/include/exadg/grid/moving_mesh_elasticity.h
@@ -109,7 +109,7 @@ public:
       }
     }
 
-    this->initialize(pde_operator->get_dof_handler(), displacement);
+    this->initialize(displacement, pde_operator->get_dof_handler());
   }
 
   /**

--- a/include/exadg/grid/moving_mesh_poisson.h
+++ b/include/exadg/grid/moving_mesh_poisson.h
@@ -86,7 +86,7 @@ public:
       print_solver_info_linear(pcout, n_iter, timer.wall_time(), print_wall_times);
     }
 
-    this->initialize(poisson->get_dof_handler(), displacement);
+    this->initialize(displacement, poisson->get_dof_handler());
   }
 
   /**


### PR DESCRIPTION
The function `fill_grid_coordinates_vector()` uses a different order of parameters, which appears somewhat inconsistent in the doxygen docu.