### PR TITLE
implement transfer of mapping for multigrid with global coarsening

### DIFF
--- a/include/exadg/grid/moving_mesh_base.h
+++ b/include/exadg/grid/moving_mesh_base.h
@@ -41,11 +41,16 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshBase(std::shared_ptr<Mapping<dim>> mapping,
-                 unsigned int const            mapping_degree_q_cache,
-                 Triangulation<dim> const &    triangulation)
-    : MappingDoFVector<dim, Number>(mapping, mapping_degree_q_cache, triangulation)
+  MovingMeshBase(std::shared_ptr<Mapping<dim> const> mapping_undeformed,
+                 unsigned int const                  mapping_degree_q_cache)
+    : MappingDoFVector<dim, Number>(mapping_degree_q_cache), mapping_undeformed(mapping_undeformed)
   {
+    // Make sure that MappingQCache is initialized correctly. An empty dof-vector is used and,
+    // hence, no displacements are added to the reference configuration described by
+    // mapping_undeformed.
+    DoFHandler<dim> dof_handler;
+    VectorType      displacement_vector;
+    this->initialize(mapping_undeformed, displacement_vector, dof_handler);
   }
 
   /**
@@ -69,6 +74,10 @@ public:
   {
     AssertThrow(false, ExcMessage("Has to be overwritten by derived classes."));
   }
+
+protected:
+  // mapping describing undeformed reference state
+  std::shared_ptr<Mapping<dim> const> mapping_undeformed;
 };
 
 } // namespace ExaDG

--- a/include/exadg/grid/moving_mesh_elasticity.h
+++ b/include/exadg/grid/moving_mesh_elasticity.h
@@ -46,13 +46,12 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshElasticity(std::shared_ptr<Mapping<dim>>                     mapping,
+  MovingMeshElasticity(std::shared_ptr<Mapping<dim>>                     mapping_undeformed,
                        std::shared_ptr<Structure::Operator<dim, Number>> structure_operator,
                        Structure::InputParameters const &                structure_parameters)
-    : MovingMeshBase<dim, Number>(mapping,
+    : MovingMeshBase<dim, Number>(mapping_undeformed,
                                   // extract mapping_degree_moving from elasticity operator
-                                  structure_operator->get_dof_handler().get_fe().degree,
-                                  structure_operator->get_dof_handler().get_triangulation()),
+                                  structure_operator->get_dof_handler().get_fe().degree),
       pde_operator(structure_operator),
       param(structure_parameters),
       pcout(std::cout,
@@ -109,7 +108,7 @@ public:
       }
     }
 
-    this->initialize(displacement, pde_operator->get_dof_handler());
+    this->initialize(this->mapping_undeformed, displacement, pde_operator->get_dof_handler());
   }
 
   /**

--- a/include/exadg/grid/moving_mesh_function.h
+++ b/include/exadg/grid/moving_mesh_function.h
@@ -41,12 +41,12 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshFunction(std::shared_ptr<Mapping<dim>>        mapping,
+  MovingMeshFunction(std::shared_ptr<Mapping<dim> const>  mapping_undeformed,
                      unsigned int const                   mapping_degree_q_cache,
                      Triangulation<dim> const &           triangulation,
                      std::shared_ptr<Function<dim>> const mesh_movement_function,
                      double const                         start_time)
-    : MovingMeshBase<dim, Number>(mapping, mapping_degree_q_cache, triangulation),
+    : MovingMeshBase<dim, Number>(mapping_undeformed, mapping_degree_q_cache),
       mesh_movement_function(mesh_movement_function),
       triangulation(triangulation)
   {
@@ -80,7 +80,7 @@ public:
 
     // dummy FE for compatibility with interface of FEValues
     FE_Nothing<dim> dummy_fe;
-    FEValues<dim>   fe_values(*this->mapping,
+    FEValues<dim>   fe_values(*this->mapping_undeformed,
                             dummy_fe,
                             QGaussLobatto<dim>(this->get_degree() + 1),
                             update_quadrature_points);

--- a/include/exadg/grid/moving_mesh_poisson.h
+++ b/include/exadg/grid/moving_mesh_poisson.h
@@ -46,12 +46,11 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshPoisson(std::shared_ptr<Mapping<dim>>                        mapping,
+  MovingMeshPoisson(std::shared_ptr<Mapping<dim> const>                  mapping_undeformed,
                     std::shared_ptr<Poisson::Operator<dim, Number, dim>> poisson_operator)
-    : MovingMeshBase<dim, Number>(mapping,
+    : MovingMeshBase<dim, Number>(mapping_undeformed,
                                   // extract mapping_degree_moving from Poisson operator
-                                  poisson_operator->get_dof_handler().get_fe().degree,
-                                  poisson_operator->get_dof_handler().get_triangulation()),
+                                  poisson_operator->get_dof_handler().get_fe().degree),
       poisson(poisson_operator),
       pcout(std::cout,
             Utilities::MPI::this_mpi_process(
@@ -86,7 +85,7 @@ public:
       print_solver_info_linear(pcout, n_iter, timer.wall_time(), print_wall_times);
     }
 
-    this->initialize(displacement, poisson->get_dof_handler());
+    this->initialize(this->mapping_undeformed, displacement, poisson->get_dof_handler());
   }
 
   /**

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -318,7 +318,7 @@ private:
 
   // Only relevant for global coarsening,where this vector contains coarse level mappings,
   // and the fine level mapping as the last element of the vector.
-  std::vector<std::shared_ptr<Mapping<dim> const>> coarse_grid_mappings;
+  std::vector<std::shared_ptr<MappingDoFVector<dim, Number>>> coarse_grid_mappings;
 
   // Only relevant for global refinement and in case that a mapping of type MappingDoFVector is
   // used.

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.cpp
@@ -123,10 +123,7 @@ MGTransferGlobalCoarsening<dim, Number, VectorType>::interpolate(unsigned int co
                                                                  VectorType &       dst,
                                                                  VectorType const & src) const
 {
-  (void)level;
-  (void)dst;
-  (void)src;
-  AssertThrow(false, ExcNotImplemented());
+  transfers[level].interpolate(dst, src);
 }
 
 typedef dealii::LinearAlgebra::distributed::Vector<float>  VectorTypeFloat;


### PR DESCRIPTION
closes #33

the interfaces of `MappingDoFVector` have been generalized since this class is now used for both ALE and multigrid functionalities.