### PR TITLE
Remove Assert in compute_performance_metrics()

### DIFF
--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -223,7 +223,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
 
   unsigned int const N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
 
-  double const t_10 = solve_time * n_10 / iterations;
+  double const t_10 = iterations > 0 ? solve_time * double(n_10) / double(iterations) : solve_time;
 
   if(not(is_test))
   {

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -406,9 +406,6 @@ template<int dim, typename Number, int n_components>
 double
 Operator<dim, Number, n_components>::get_n10() const
 {
-  AssertThrow(iterative_solver->n10 != 0,
-              ExcMessage("Make sure to activate param.compute_performance_metrics!"));
-
   return iterative_solver->n10;
 }
 

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -34,8 +34,7 @@ template<typename VectorType>
 class IterativeSolverBase
 {
 public:
-  IterativeSolverBase()
-    : performance_metrics_available(false), l2_0(1.0), l2_n(1.0), n(0), rho(0.0), /*r(0.0),*/ n10(0)
+  IterativeSolverBase() : l2_0(1.0), l2_n(1.0), n(0), rho(0.0), n10(0)
   {
   }
 
@@ -50,8 +49,6 @@ public:
   void
   compute_performance_metrics(Control const & solver_control) const
   {
-    performance_metrics_available = true;
-
     // get some statistics related to convergence
     this->l2_0 = solver_control.initial_value();
     this->l2_n = solver_control.last_value();
@@ -61,19 +58,16 @@ public:
     if(n > 0)
     {
       this->rho = std::pow(l2_n / l2_0, 1.0 / n);
-      //    this->r   = -std::log(rho) / std::log(10.0);
       this->n10 = -10.0 * std::log(10.0) / std::log(rho);
     }
   }
 
   // performance metrics
-  mutable bool         performance_metrics_available;
   mutable double       l2_0; // norm of initial residual
   mutable double       l2_n; // norm of final residual
   mutable unsigned int n;    // number of iterations
   mutable double       rho;  // average convergence rate
-                             //  mutable double       r;    // logarithmic convergence rate
-  mutable double n10;        // number of iterations needed to reduce the residual by 1e10
+  mutable double       n10;  // number of iterations needed to reduce the residual by 1e10
 };
 
 struct CGSolverData

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -35,7 +35,7 @@ class IterativeSolverBase
 {
 public:
   IterativeSolverBase()
-    : performance_metrics_available(false), l2_0(1.0), l2_n(1.0), n(0), rho(1.0), r(1.0), n10(0)
+    : performance_metrics_available(false), l2_0(1.0), l2_n(1.0), n(0), rho(0.0), /*r(0.0),*/ n10(0)
   {
   }
 
@@ -58,10 +58,12 @@ public:
     this->n    = solver_control.last_step();
 
     // compute some derived performance metrics
-    AssertThrow(n != 0, ExcMessage("Division by zero."));
-    this->rho = std::pow(l2_n / l2_0, 1.0 / n);
-    this->r   = -std::log(rho) / std::log(10.0);
-    this->n10 = -10.0 * std::log(10.0) / std::log(rho);
+    if(n > 0)
+    {
+      this->rho = std::pow(l2_n / l2_0, 1.0 / n);
+      //    this->r   = -std::log(rho) / std::log(10.0);
+      this->n10 = -10.0 * std::log(10.0) / std::log(rho);
+    }
   }
 
   // performance metrics
@@ -70,8 +72,8 @@ public:
   mutable double       l2_n; // norm of final residual
   mutable unsigned int n;    // number of iterations
   mutable double       rho;  // average convergence rate
-  mutable double       r;    // logarithmic convergence rate
-  mutable double       n10;  // number of iterations needed to reduce the residual by 1e10
+                             //  mutable double       r;    // logarithmic convergence rate
+  mutable double n10;        // number of iterations needed to reduce the residual by 1e10
 };
 
 struct CGSolverData
@@ -149,13 +151,6 @@ output_eigenvalues(const std::vector<NUMBER> & eigenvalues,
                    const std::string &         text,
                    MPI_Comm const &            mpi_comm)
 {
-  //    deallog << text << std::endl;
-  //    for (unsigned int j = 0; j < eigenvalues.size(); ++j)
-  //      {
-  //        deallog << ' ' << eigenvalues.at(j) << std::endl;
-  //      }
-  //    deallog << std::endl;
-
   if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
   {
     std::cout << text << std::endl;


### PR DESCRIPTION
It might happen that the number of linear iterations is 0, e.g., for trivial initial and boundary conditions, in which case the solver should not terminate but instead use reasonable default values.