### PR TITLE
Avoid warning regarding overriden virtual functions

### DIFF
--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
@@ -64,11 +64,13 @@ public:
 
   virtual ~PostProcessor();
 
-  virtual void
-  setup(Operator<dim, Number> const & pde_operator);
+  void
+  setup(Operator<dim, Number> const & pde_operator) override;
 
-  virtual void
-  do_postprocessing(VectorType const & solution, double const time, int const time_step_number);
+  void
+  do_postprocessing(VectorType const & solution,
+                    double const       time,
+                    int const          time_step_number) override;
 
 protected:
   // DoF vectors for derived quantities: (p, u, T)

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor.h
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor.h
@@ -60,17 +60,13 @@ protected:
 public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
-  virtual ~PostProcessor()
-  {
-  }
-
   void
   setup(Operator<dim, Number> const & pde_operator, Mapping<dim> const & mapping) override;
 
-  virtual void
+  void
   do_postprocessing(VectorType const & solution,
                     double const       time             = 0.0,
-                    int const          time_step_number = -1);
+                    int const          time_step_number = -1) override;
 
 protected:
   MPI_Comm const mpi_comm;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -70,14 +70,14 @@ public:
 
   virtual ~PostProcessor();
 
-  virtual void
-  setup(Operator const & pde_operator);
+  void
+  setup(Operator const & pde_operator) override;
 
-  virtual void
+  void
   do_postprocessing(VectorType const & velocity,
                     VectorType const & pressure,
                     double const       time             = 0.0,
-                    int const          time_step_number = -1);
+                    int const          time_step_number = -1) override;
 
 protected:
   MPI_Comm const mpi_comm;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -69,12 +69,12 @@ public:
    * Calls setup() function of base class and additionally initializes the pressure Poisson operator
    * needed for projection-type methods.
    */
-  virtual void
+  void
   setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
         std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data,
-        std::string const &                          dof_index_temperature = "");
+        std::string const &                          dof_index_temperature = "") override;
 
-  virtual void
+  void
   update_after_mesh_movement() override;
 
   /*

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -101,22 +101,22 @@ public:
   print_iterations() const = 0;
 
   bool
-  print_solver_info() const;
+  print_solver_info() const final;
 
 protected:
-  virtual void
+  void
   allocate_vectors() override;
 
-  virtual void
+  void
   setup_derived() override;
 
-  virtual void
+  void
   read_restart_vectors(boost::archive::binary_iarchive & ia) override;
 
-  virtual void
+  void
   write_restart_vectors(boost::archive::binary_oarchive & oa) const override;
 
-  virtual void
+  void
   prepare_vectors_for_next_timestep() override;
 
   /*
@@ -126,7 +126,7 @@ protected:
   void
   calculate_sum_alphai_ui_oif_substepping(VectorType & sum_alphai_ui,
                                           double const cfl,
-                                          double const cfl_oif);
+                                          double const cfl_oif) final;
 
   void
   move_mesh(double const time) const;
@@ -162,30 +162,27 @@ private:
   initialize_vec_convective_term();
 
   void
-  initialize_oif();
+  initialize_oif() final;
 
   void
-  initialize_solution_oif_substepping(VectorType & solution_tilde_m, unsigned int i);
+  initialize_solution_oif_substepping(VectorType & solution_tilde_m, unsigned int i) final;
 
   void
   update_sum_alphai_ui_oif_substepping(VectorType &       sum_alphai_ui,
                                        VectorType const & u_tilde_i,
-                                       unsigned int       i);
+                                       unsigned int       i) final;
 
   void
   do_timestep_oif_substepping(VectorType & solution_tilde_mp,
                               VectorType & solution_tilde_m,
                               double const start_time,
-                              double const time_step_size);
+                              double const time_step_size) final;
 
   double
-  calculate_time_step_size();
+  calculate_time_step_size() final;
 
   double
-  recalculate_time_step_size() const;
-
-  virtual void
-  solve_steady_problem() = 0;
+  recalculate_time_step_size() const final;
 
   virtual VectorType const &
   get_velocity(unsigned int i /* t_{n-i} */) const = 0;
@@ -200,7 +197,7 @@ private:
   set_pressure(VectorType const & pressure, unsigned int const i /* t_{n-i} */) = 0;
 
   void
-  postprocessing() const;
+  postprocessing() const final;
 
   // Operator-integration-factor splitting for convective term
   std::shared_ptr<OperatorOIF<dim, Number>> convective_operator_OIF;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -64,32 +64,32 @@ public:
   postprocessing_stability_analysis();
 
   void
-  print_iterations() const;
+  print_iterations() const final;
 
   VectorType const &
-  get_velocity_np() const;
+  get_velocity_np() const final;
 
   VectorType const &
-  get_pressure_np() const;
+  get_pressure_np() const final;
 
 private:
   void
-  setup_derived() override;
+  setup_derived() final;
 
   void
-  allocate_vectors() override;
+  allocate_vectors() final;
 
   void
-  initialize_current_solution();
+  initialize_current_solution() final;
 
   void
-  initialize_former_solutions();
+  initialize_former_solutions() final;
 
   void
-  solve_timestep() override;
+  solve_timestep() final;
 
   void
-  solve_steady_problem();
+  solve_steady_problem() final;
 
   double
   evaluate_residual();
@@ -98,22 +98,22 @@ private:
   penalty_step();
 
   void
-  prepare_vectors_for_next_timestep() override;
+  prepare_vectors_for_next_timestep() final;
 
   VectorType const &
-  get_velocity() const;
+  get_velocity() const final;
 
   VectorType const &
-  get_velocity(unsigned int i /* t_{n-i} */) const;
+  get_velocity(unsigned int i /* t_{n-i} */) const final;
 
   VectorType const &
-  get_pressure(unsigned int i /* t_{n-i} */) const;
+  get_pressure(unsigned int i /* t_{n-i} */) const final;
 
   void
-  set_velocity(VectorType const & velocity, unsigned int const i /* t_{n-i} */);
+  set_velocity(VectorType const & velocity, unsigned int const i /* t_{n-i} */) final;
 
   void
-  set_pressure(VectorType const & pressure, unsigned int const i /* t_{n-i} */);
+  set_pressure(VectorType const & pressure, unsigned int const i /* t_{n-i} */) final;
 
   std::shared_ptr<Operator> pde_operator;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -62,32 +62,32 @@ public:
   postprocessing_stability_analysis();
 
   void
-  print_iterations() const;
+  print_iterations() const final;
 
   VectorType const &
-  get_velocity_np() const;
+  get_velocity_np() const final;
 
   VectorType const &
-  get_pressure_np() const;
+  get_pressure_np() const final;
 
 private:
   void
-  setup_derived() override;
-
-  virtual void
-  read_restart_vectors(boost::archive::binary_iarchive & ia) override;
-
-  virtual void
-  write_restart_vectors(boost::archive::binary_oarchive & oa) const override;
+  setup_derived() final;
 
   void
-  solve_timestep() override;
+  read_restart_vectors(boost::archive::binary_iarchive & ia) final;
 
   void
-  allocate_vectors() override;
+  write_restart_vectors(boost::archive::binary_oarchive & oa) const final;
 
   void
-  prepare_vectors_for_next_timestep() override;
+  solve_timestep() final;
+
+  void
+  allocate_vectors() final;
+
+  void
+  prepare_vectors_for_next_timestep() final;
 
   void
   update_velocity_dbc();
@@ -99,13 +99,13 @@ private:
   evaluate_convective_term();
 
   void
-  update_time_integrator_constants();
+  update_time_integrator_constants() final;
 
   void
-  initialize_current_solution() override;
+  initialize_current_solution() final;
 
   void
-  initialize_former_solutions() override;
+  initialize_former_solutions() final;
 
   void
   initialize_acceleration_and_velocity_on_boundary();
@@ -132,25 +132,25 @@ private:
   rhs_viscous(VectorType & rhs) const;
 
   void
-  solve_steady_problem();
+  solve_steady_problem() final;
 
   double
   evaluate_residual();
 
   VectorType const &
-  get_velocity() const;
+  get_velocity() const final;
 
   VectorType const &
-  get_velocity(unsigned int i /* t_{n-i} */) const;
+  get_velocity(unsigned int i /* t_{n-i} */) const final;
 
   VectorType const &
-  get_pressure(unsigned int i /* t_{n-i} */) const;
+  get_pressure(unsigned int i /* t_{n-i} */) const final;
 
   void
-  set_velocity(VectorType const & velocity, unsigned int const i /* t_{n-i} */);
+  set_velocity(VectorType const & velocity, unsigned int const i /* t_{n-i} */) final;
 
   void
-  set_pressure(VectorType const & pressure, unsigned int const i /* t_{n-i} */);
+  set_pressure(VectorType const & pressure, unsigned int const i /* t_{n-i} */) final;
 
   std::shared_ptr<Operator> pde_operator;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -63,44 +63,44 @@ public:
   postprocessing_stability_analysis();
 
   void
-  print_iterations() const;
+  print_iterations() const final;
 
   VectorType const &
-  get_velocity_np() const;
+  get_velocity_np() const final;
 
   VectorType const &
-  get_pressure_np() const;
+  get_pressure_np() const final;
 
 private:
   void
-  update_time_integrator_constants();
+  update_time_integrator_constants() final;
 
   void
-  allocate_vectors() override;
+  allocate_vectors() final;
 
   void
-  initialize_current_solution();
+  initialize_current_solution() final;
 
   void
-  initialize_former_solutions();
+  initialize_former_solutions() final;
 
   void
-  setup_derived() override;
+  setup_derived() final;
 
-  virtual void
-  read_restart_vectors(boost::archive::binary_iarchive & ia) override;
+  void
+  read_restart_vectors(boost::archive::binary_iarchive & ia) final;
 
-  virtual void
-  write_restart_vectors(boost::archive::binary_oarchive & oa) const override;
+  void
+  write_restart_vectors(boost::archive::binary_oarchive & oa) const final;
 
   void
   initialize_pressure_on_boundary();
 
   void
-  solve_timestep() override;
+  solve_timestep() final;
 
   void
-  solve_steady_problem();
+  solve_steady_problem() final;
 
   double
   evaluate_residual();
@@ -133,22 +133,22 @@ private:
   rhs_pressure(VectorType & rhs) const;
 
   void
-  prepare_vectors_for_next_timestep() override;
+  prepare_vectors_for_next_timestep() final;
 
   VectorType const &
-  get_velocity() const;
+  get_velocity() const final;
 
   VectorType const &
-  get_velocity(unsigned int i /* t_{n-i} */) const;
+  get_velocity(unsigned int i /* t_{n-i} */) const final;
 
   VectorType const &
-  get_pressure(unsigned int i /* t_{n-i} */) const;
+  get_pressure(unsigned int i /* t_{n-i} */) const final;
 
   void
-  set_velocity(VectorType const & velocity, unsigned int const i /* t_{n-i} */);
+  set_velocity(VectorType const & velocity, unsigned int const i /* t_{n-i} */) final;
 
   void
-  set_pressure(VectorType const & pressure, unsigned int const i /* t_{n-i} */);
+  set_pressure(VectorType const & pressure, unsigned int const i /* t_{n-i} */) final;
 
   std::shared_ptr<Operator> pde_operator;
 

--- a/include/exadg/poisson/postprocessor/postprocessor.h
+++ b/include/exadg/poisson/postprocessor/postprocessor.h
@@ -62,10 +62,10 @@ public:
   void
   setup(DoFHandler<dim, dim> const & dof_handler, Mapping<dim> const & mapping) override;
 
-  virtual void
+  void
   do_postprocessing(VectorType const & solution,
                     double const       time             = 0.0,
-                    int const          time_step_number = -1);
+                    int const          time_step_number = -1) override;
 
 protected:
   MPI_Comm const mpi_comm;

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -76,7 +76,7 @@ private:
   void
   fill_matrix_free_data(MatrixFreeData<dim, MultigridNumber> & matrix_free_data,
                         unsigned int const                     level,
-                        unsigned int const                     h_level);
+                        unsigned int const                     h_level) override;
 
   /*
    * Has to be overwritten since we want to use ComponentMask here

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -253,36 +253,36 @@ public:
 
   // continuous FE: This function sets the constrained Dirichlet boundary values.
   void
-  set_constrained_values(VectorType & solution, double const time) const override;
+  set_constrained_values(VectorType & solution, double const time) const final;
 
 private:
   void
-  reinit_face(unsigned int const face) const;
+  reinit_face(unsigned int const face) const final;
 
   void
-  reinit_boundary_face(unsigned int const face) const;
+  reinit_boundary_face(unsigned int const face) const final;
 
   void
   reinit_face_cell_based(unsigned int const       cell,
                          unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+                         types::boundary_id const boundary_id) const final;
 
   void
-  do_cell_integral(IntegratorCell & integrator) const;
+  do_cell_integral(IntegratorCell & integrator) const final;
 
   void
-  do_face_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
+  do_face_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const final;
 
   void
-  do_face_int_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
+  do_face_int_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const final;
 
   void
-  do_face_ext_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
+  do_face_ext_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const final;
 
   void
   do_boundary_integral(IntegratorFace &           integrator_m,
                        OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+                       types::boundary_id const & boundary_id) const final;
 
   void
   cell_loop_empty(MatrixFree<dim, Number> const & matrix_free,
@@ -313,7 +313,7 @@ private:
   // continuous FE: calculates Neumann boundary integral
   void
   do_boundary_integral_continuous(IntegratorFace &           integrator_m,
-                                  types::boundary_id const & boundary_id) const;
+                                  types::boundary_id const & boundary_id) const final;
 
   LaplaceOperatorData<rank, dim> operator_data;
 

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -108,8 +108,8 @@ public:
   set_constrained_values(VectorType & dst, double const time) const override;
 
 protected:
-  virtual void
-  reinit_cell(unsigned int const cell) const;
+  void
+  reinit_cell(unsigned int const cell) const override;
 
   OperatorData<dim> operator_data;
 

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.h
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.h
@@ -64,7 +64,7 @@ public:
                   bool const                                   is_test_);
 
   void
-  setup(bool const do_restart) override;
+  setup(bool const do_restart) final;
 
   void
   print_iterations() const;
@@ -92,22 +92,22 @@ public:
 
 private:
   void
-  solve_timestep() override;
+  solve_timestep() final;
 
   void
-  prepare_vectors_for_next_timestep() override;
+  prepare_vectors_for_next_timestep() final;
 
   void
-  do_write_restart(std::string const & filename) const override;
+  do_write_restart(std::string const & filename) const final;
 
   void
-  do_read_restart(std::ifstream & in) override;
+  do_read_restart(std::ifstream & in) final;
 
   void
-  postprocessing() const override;
+  postprocessing() const final;
 
   bool
-  print_solver_info() const;
+  print_solver_info() const final;
 
   std::shared_ptr<Interface::Operator<Number>> pde_operator;
 

--- a/include/exadg/time_integration/time_int_bdf_base.h
+++ b/include/exadg/time_integration/time_int_bdf_base.h
@@ -108,7 +108,7 @@ protected:
    * Do one time step including different updates before and after the actual solution of the
    * current time step.
    */
-  virtual void
+  void
   do_timestep_pre_solve(bool const print_header) override;
 
   void
@@ -236,7 +236,7 @@ private:
    * Restart: read solution vectors (has to be implemented in derived classes).
    */
   void
-  do_read_restart(std::ifstream & in);
+  do_read_restart(std::ifstream & in) override;
 
   void
   read_restart_preamble(boost::archive::binary_iarchive & ia);
@@ -249,7 +249,7 @@ private:
    * state.
    */
   void
-  do_write_restart(std::string const & filename) const;
+  do_write_restart(std::string const & filename) const override;
 
   void
   write_restart_preamble(boost::archive::binary_oarchive & oa) const;

--- a/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
+++ b/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
@@ -67,10 +67,10 @@ protected:
 
 private:
   void
-  do_timestep_pre_solve(bool const print_header);
+  do_timestep_pre_solve(bool const print_header) override;
 
   void
-  do_timestep_post_solve();
+  do_timestep_post_solve() override;
 
   void
   prepare_vectors_for_next_timestep();


### PR DESCRIPTION
The clang-12 compiler I am using to compile exadg reports warnings when we override virtual functions but do not add the `override` attribute. I tried to fix most of those warnings with this PR. I am not entirely sure if I fixed all already, but since I cannot immediately recheck, I wanted to post it now.

One thing I was undecided about is whether we want to report the `virtual` keyword on those overriden functions. We use both variants within exadg, and I have a slight preference for adding it nonetheless, but I am happy to get convinced the other way around as well.

(I fixed two other small warnings that I will point out by separate posts in a minute so that they don't get overlooked.)