### PR TITLE
Implement BoomerAMG via PETSc

### DIFF
--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -52,113 +52,113 @@ public:
     return pde_operator;
   }
 
-  AffineConstraints<typename Operator::value_type> const &
-  get_affine_constraints() const override
+  virtual AffineConstraints<typename Operator::value_type> const &
+  get_affine_constraints() const
   {
     return pde_operator->get_affine_constraints();
   }
 
-  MatrixFree<dim, Number> const &
-  get_matrix_free() const override
+  virtual MatrixFree<dim, Number> const &
+  get_matrix_free() const
   {
     return pde_operator->get_matrix_free();
   }
 
-  unsigned int
-  get_dof_index() const override
+  virtual unsigned int
+  get_dof_index() const
   {
     return pde_operator->get_dof_index();
   }
 
-  types::global_dof_index
-  m() const override
+  virtual types::global_dof_index
+  m() const
   {
     return pde_operator->m();
   }
 
-  types::global_dof_index
-  n() const override
+  virtual types::global_dof_index
+  n() const
   {
     return pde_operator->n();
   }
 
-  Number
-  el(unsigned int const i, const unsigned int j) const override
+  virtual Number
+  el(unsigned int const i, const unsigned int j) const
   {
     return pde_operator->el(i, j);
   }
 
-  void
-  initialize_dof_vector(VectorType & vector) const override
+  virtual void
+  initialize_dof_vector(VectorType & vector) const
   {
     pde_operator->initialize_dof_vector(vector);
   }
 
-  void
-  vmult(VectorType & dst, VectorType const & src) const override
+  virtual void
+  vmult(VectorType & dst, VectorType const & src) const
   {
     pde_operator->vmult(dst, src);
   }
 
-  void
-  vmult_add(VectorType & dst, VectorType const & src) const override
+  virtual void
+  vmult_add(VectorType & dst, VectorType const & src) const
   {
     pde_operator->vmult_add(dst, src);
   }
 
-  void
-  vmult_interface_down(VectorType & dst, VectorType const & src) const override
+  virtual void
+  vmult_interface_down(VectorType & dst, VectorType const & src) const
   {
     pde_operator->vmult_interface_down(dst, src);
   }
 
-  void
-  vmult_add_interface_up(VectorType & dst, VectorType const & src) const override
+  virtual void
+  vmult_add_interface_up(VectorType & dst, VectorType const & src) const
   {
     pde_operator->vmult_add_interface_up(dst, src);
   }
 
-  void
-  calculate_inverse_diagonal(VectorType & inverse_diagonal_entries) const override
+  virtual void
+  calculate_inverse_diagonal(VectorType & inverse_diagonal_entries) const
   {
     pde_operator->calculate_inverse_diagonal(inverse_diagonal_entries);
   }
 
-  void
-  update_block_diagonal_preconditioner() const override
+  virtual void
+  update_block_diagonal_preconditioner() const
   {
     pde_operator->update_block_diagonal_preconditioner();
   }
 
-  void
-  apply_inverse_block_diagonal(VectorType & dst, VectorType const & src) const override
+  virtual void
+  apply_inverse_block_diagonal(VectorType & dst, VectorType const & src) const
   {
     pde_operator->apply_inverse_block_diagonal(dst, src);
   }
 
 #ifdef DEAL_II_WITH_TRILINOS
-  void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const override
+  virtual void
+  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const
   {
     pde_operator->init_system_matrix(system_matrix);
   }
 
-  void
-  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const override
+  virtual void
+  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const
   {
     pde_operator->calculate_system_matrix(system_matrix);
   }
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
-  void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const override
+  virtual void
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
   {
     pde_operator->init_system_matrix(system_matrix);
   }
 
-  void
-  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const override
+  virtual void
+  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
   {
     pde_operator->calculate_system_matrix(system_matrix);
   }

--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -150,6 +150,20 @@ public:
   }
 #endif
 
+#ifdef DEAL_II_WITH_PETSC
+  virtual void
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
+  {
+    pde_operator->init_system_matrix(system_matrix);
+  }
+
+  virtual void
+  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
+  {
+    pde_operator->calculate_system_matrix(system_matrix);
+  }
+#endif
+
 private:
   std::shared_ptr<Operator> pde_operator;
 };

--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -52,113 +52,113 @@ public:
     return pde_operator;
   }
 
-  virtual AffineConstraints<typename Operator::value_type> const &
-  get_affine_constraints() const
+  AffineConstraints<typename Operator::value_type> const &
+  get_affine_constraints() const override
   {
     return pde_operator->get_affine_constraints();
   }
 
-  virtual MatrixFree<dim, Number> const &
-  get_matrix_free() const
+  MatrixFree<dim, Number> const &
+  get_matrix_free() const override
   {
     return pde_operator->get_matrix_free();
   }
 
-  virtual unsigned int
-  get_dof_index() const
+  unsigned int
+  get_dof_index() const override
   {
     return pde_operator->get_dof_index();
   }
 
-  virtual types::global_dof_index
-  m() const
+  types::global_dof_index
+  m() const override
   {
     return pde_operator->m();
   }
 
-  virtual types::global_dof_index
-  n() const
+  types::global_dof_index
+  n() const override
   {
     return pde_operator->n();
   }
 
-  virtual Number
-  el(unsigned int const i, const unsigned int j) const
+  Number
+  el(unsigned int const i, const unsigned int j) const override
   {
     return pde_operator->el(i, j);
   }
 
-  virtual void
-  initialize_dof_vector(VectorType & vector) const
+  void
+  initialize_dof_vector(VectorType & vector) const override
   {
     pde_operator->initialize_dof_vector(vector);
   }
 
-  virtual void
-  vmult(VectorType & dst, VectorType const & src) const
+  void
+  vmult(VectorType & dst, VectorType const & src) const override
   {
     pde_operator->vmult(dst, src);
   }
 
-  virtual void
-  vmult_add(VectorType & dst, VectorType const & src) const
+  void
+  vmult_add(VectorType & dst, VectorType const & src) const override
   {
     pde_operator->vmult_add(dst, src);
   }
 
-  virtual void
-  vmult_interface_down(VectorType & dst, VectorType const & src) const
+  void
+  vmult_interface_down(VectorType & dst, VectorType const & src) const override
   {
     pde_operator->vmult_interface_down(dst, src);
   }
 
-  virtual void
-  vmult_add_interface_up(VectorType & dst, VectorType const & src) const
+  void
+  vmult_add_interface_up(VectorType & dst, VectorType const & src) const override
   {
     pde_operator->vmult_add_interface_up(dst, src);
   }
 
-  virtual void
-  calculate_inverse_diagonal(VectorType & inverse_diagonal_entries) const
+  void
+  calculate_inverse_diagonal(VectorType & inverse_diagonal_entries) const override
   {
     pde_operator->calculate_inverse_diagonal(inverse_diagonal_entries);
   }
 
-  virtual void
-  update_block_diagonal_preconditioner() const
+  void
+  update_block_diagonal_preconditioner() const override
   {
     pde_operator->update_block_diagonal_preconditioner();
   }
 
-  virtual void
-  apply_inverse_block_diagonal(VectorType & dst, VectorType const & src) const
+  void
+  apply_inverse_block_diagonal(VectorType & dst, VectorType const & src) const override
   {
     pde_operator->apply_inverse_block_diagonal(dst, src);
   }
 
 #ifdef DEAL_II_WITH_TRILINOS
-  virtual void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const
+  void
+  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const override
   {
     pde_operator->init_system_matrix(system_matrix);
   }
 
-  virtual void
-  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const
+  void
+  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const override
   {
     pde_operator->calculate_system_matrix(system_matrix);
   }
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
-  virtual void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
+  void
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const override
   {
     pde_operator->init_system_matrix(system_matrix);
   }
 
-  virtual void
-  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
+  void
+  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const override
   {
     pde_operator->calculate_system_matrix(system_matrix);
   }

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -22,7 +22,7 @@
 #ifndef OPERATOR_PRECONDITIONABLE_H
 #define OPERATOR_PRECONDITIONABLE_H
 
-#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/matrix_free/matrix_free.h>
 

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -22,6 +22,8 @@
 #ifndef OPERATOR_PRECONDITIONABLE_H
 #define OPERATOR_PRECONDITIONABLE_H
 
+#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/matrix_free/matrix_free.h>
 
 namespace ExaDG
@@ -91,6 +93,14 @@ public:
 
   virtual void
   calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const = 0;
+#endif
+
+#ifdef DEAL_II_WITH_PETSC
+  virtual void
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const = 0;
+
+  virtual void
+  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const = 0;
 #endif
 };
 

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -789,7 +789,11 @@ OperatorBase<dim, Number, n_components>::internal_calculate_system_matrix(
   // communicate overlapping matrix parts
   system_matrix.compress(VectorOperation::add);
 
-  if(!is_dg)
+  if(!is_dg
+#ifdef DEAL_II_WITH_TRILINOS
+     && std::is_same<SparseMatrix, TrilinosWrappers::SparseMatrix>::value
+#endif
+  )
   {
     // make zero entries on diagonal (due to constrained dofs) to one:
     auto p = system_matrix.local_range();

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -659,7 +659,6 @@ OperatorBase<dim, Number, n_components>::update_block_diagonal_preconditioner() 
   }
 }
 
-#ifdef DEAL_II_WITH_TRILINOS
 
 namespace
 {
@@ -691,35 +690,83 @@ make_sparsity_pattern(const DoFHandler<dim, spacedim> & dof,
 }
 } // namespace
 
+#ifdef DEAL_II_WITH_TRILINOS
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::init_system_matrix(SparseMatrix & system_matrix) const
+OperatorBase<dim, Number, n_components>::init_system_matrix(
+  TrilinosWrappers::SparseMatrix & system_matrix) const
+{
+  internal_init_system_matrix(system_matrix);
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::calculate_system_matrix(
+  TrilinosWrappers::SparseMatrix & system_matrix) const
+{
+  internal_calculate_system_matrix(system_matrix);
+}
+#endif
+
+#ifdef DEAL_II_WITH_PETSC
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::init_system_matrix(
+  PETScWrappers::MPI::SparseMatrix & system_matrix) const
+{
+  internal_init_system_matrix(system_matrix);
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::calculate_system_matrix(
+  PETScWrappers::MPI::SparseMatrix & system_matrix) const
+{
+  internal_calculate_system_matrix(system_matrix);
+}
+#endif
+
+template<int dim, typename Number, int n_components>
+template<typename SparseMatrix>
+void
+OperatorBase<dim, Number, n_components>::internal_init_system_matrix(
+  SparseMatrix & system_matrix) const
 {
   DoFHandler<dim> const & dof_handler = this->matrix_free->get_dof_handler(this->data.dof_index);
 
-  TrilinosWrappers::SparsityPattern dsp(is_mg ? dof_handler.locally_owned_mg_dofs(this->level) :
-                                                dof_handler.locally_owned_dofs(),
-                                        dof_handler.get_communicator());
+  IndexSet const & owned_dofs =
+    is_mg ? dof_handler.locally_owned_mg_dofs(this->level) : dof_handler.locally_owned_dofs();
+  IndexSet relevant_dofs;
+  if(is_mg)
+    DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, relevant_dofs);
+  else
+    DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+  DynamicSparsityPattern dsp(relevant_dofs);
 
   if(is_dg && is_mg)
     MGTools::make_flux_sparsity_pattern(dof_handler, dsp, this->level);
   else if(is_dg && !is_mg)
     DoFTools::make_flux_sparsity_pattern(dof_handler, dsp);
   else if(/*!is_dg &&*/ is_mg)
-    make_sparsity_pattern<dim, dim, TrilinosWrappers::SparsityPattern, Number>(dof_handler,
-                                                                               dsp,
-                                                                               this->level,
-                                                                               *this->constraint);
+    make_sparsity_pattern<dim, dim, DynamicSparsityPattern, Number>(dof_handler,
+                                                                    dsp,
+                                                                    this->level,
+                                                                    *this->constraint);
   else /* if (!is_dg && !is_mg)*/
     DoFTools::make_sparsity_pattern(dof_handler, dsp, *this->constraint);
 
-  dsp.compress();
-  system_matrix.reinit(dsp);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             owned_dofs,
+                                             dof_handler.get_communicator(),
+                                             relevant_dofs);
+  system_matrix.reinit(owned_dofs, owned_dofs, dsp, dof_handler.get_communicator());
 }
 
 template<int dim, typename Number, int n_components>
+template<typename SparseMatrix>
 void
-OperatorBase<dim, Number, n_components>::calculate_system_matrix(SparseMatrix & system_matrix) const
+OperatorBase<dim, Number, n_components>::internal_calculate_system_matrix(
+  SparseMatrix & system_matrix) const
 {
   // assemble matrix locally on each process
   if(evaluate_face_integrals() && is_dg)
@@ -751,7 +798,6 @@ OperatorBase<dim, Number, n_components>::calculate_system_matrix(SparseMatrix & 
         system_matrix.add(i, i, 1);
   } // nothing to do for dg
 }
-#endif
 
 template<int dim, typename Number, int n_components>
 void
@@ -1652,8 +1698,8 @@ OperatorBase<dim, Number, n_components>::cell_based_loop_block_diagonal(
   }
 }
 
-#ifdef DEAL_II_WITH_TRILINOS
 template<int dim, typename Number, int n_components>
+template<typename SparseMatrix>
 void
 OperatorBase<dim, Number, n_components>::cell_loop_calculate_system_matrix(
   MatrixFree<dim, Number> const & matrix_free,
@@ -1722,6 +1768,7 @@ OperatorBase<dim, Number, n_components>::cell_loop_calculate_system_matrix(
 }
 
 template<int dim, typename Number, int n_components>
+template<typename SparseMatrix>
 void
 OperatorBase<dim, Number, n_components>::face_loop_calculate_system_matrix(
   MatrixFree<dim, Number> const & matrix_free,
@@ -1893,6 +1940,7 @@ OperatorBase<dim, Number, n_components>::face_loop_calculate_system_matrix(
 }
 
 template<int dim, typename Number, int n_components>
+template<typename SparseMatrix>
 void
 OperatorBase<dim, Number, n_components>::boundary_face_loop_calculate_system_matrix(
   MatrixFree<dim, Number> const & matrix_free,
@@ -1951,7 +1999,6 @@ OperatorBase<dim, Number, n_components>::boundary_face_loop_calculate_system_mat
     }
   }
 }
-#endif
 
 template<int dim, typename Number, int n_components>
 void

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -32,7 +32,7 @@
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #endif
 #ifdef DEAL_II_WITH_PETSC
-#  include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#  include <deal.II/lac/petsc_sparse_matrix.h>
 #endif
 #include <deal.II/matrix_free/matrix_free.h>
 

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -31,6 +31,9 @@
 #ifdef DEAL_II_WITH_TRILINOS
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #endif
+#ifdef DEAL_II_WITH_PETSC
+#  include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#endif
 #include <deal.II/matrix_free/matrix_free.h>
 
 // ExaDG
@@ -99,10 +102,7 @@ public:
 
   typedef std::vector<LAPACKFullMatrix<Number>> BlockMatrix;
 
-#ifdef DEAL_II_WITH_TRILINOS
-  typedef FullMatrix<TrilinosScalar>     FullMatrix_;
-  typedef TrilinosWrappers::SparseMatrix SparseMatrix;
-#endif
+  typedef FullMatrix<TrilinosScalar> FullMatrix_;
 
   OperatorBase();
 
@@ -193,10 +193,21 @@ public:
    */
 #ifdef DEAL_II_WITH_TRILINOS
   void
-  init_system_matrix(SparseMatrix & system_matrix) const;
+  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
 
   void
-  calculate_system_matrix(SparseMatrix & system_matrix) const;
+  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
+#endif
+
+  /*
+   * Algebraic multigrid (AMG): sparse matrix (PETSc) methods
+   */
+#ifdef DEAL_II_WITH_PETSC
+  void
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
+
+  void
+  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
 #endif
 
   /*
@@ -554,28 +565,41 @@ private:
                                                       VectorType const &              src,
                                                       Range const &                   range) const;
 
-#ifdef DEAL_II_WITH_TRILINOS
+  /*
+   * Set up sparse matrix internally for templated matrix type (Trilinos or
+   * PETSc matrices)
+   */
+  template<typename SparseMatrix>
+  void
+  internal_init_system_matrix(SparseMatrix & system_matrix) const;
+
+  template<typename SparseMatrix>
+  void
+  internal_calculate_system_matrix(SparseMatrix & system_matrix) const;
+
   /*
    * Calculate sparse matrix.
    */
+  template<typename SparseMatrix>
   void
   cell_loop_calculate_system_matrix(MatrixFree<dim, Number> const & matrix_free,
                                     SparseMatrix &                  dst,
                                     SparseMatrix const &            src,
                                     Range const &                   range) const;
 
+  template<typename SparseMatrix>
   void
   face_loop_calculate_system_matrix(MatrixFree<dim, Number> const & matrix_free,
                                     SparseMatrix &                  dst,
                                     SparseMatrix const &            src,
                                     Range const &                   range) const;
 
+  template<typename SparseMatrix>
   void
   boundary_face_loop_calculate_system_matrix(MatrixFree<dim, Number> const & matrix_free,
                                              SparseMatrix &                  dst,
                                              SparseMatrix const &            src,
                                              Range const &                   range) const;
-#endif
 
   /*
    * This function sets entries in the diagonal corresponding to constraint DoFs to one.

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -140,6 +140,19 @@ public:
                      VectorTypeDouble const &               src) const;
 #endif
 
+#ifdef DEAL_II_WITH_PETSC
+  void
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
+
+  void
+  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
+
+  void
+  vmult_matrix_based(VectorTypeDouble &                       dst,
+                     PETScWrappers::MPI::SparseMatrix const & system_matrix,
+                     VectorTypeDouble const &                 src) const;
+#endif
+
 private:
   std::string
   get_dof_name() const;

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -167,7 +167,6 @@ public:
     if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::AMG ||
        additional_data.preconditioner == MultigridCoarseGridPreconditioner::BoomerAMG)
     {
-#ifdef DEAL_II_WITH_TRILINOS
       // create temporal vectors of type TrilinosNumber (double)
       VectorTypeTrilinos dst_tri;
       dst_tri.reinit(dst, false);
@@ -206,7 +205,6 @@ public:
 
       // convert TrilinosNumber (double) -> MultigridNumber (float)
       dst.copy_locally_owned_data_from(dst_tri);
-#endif
     }
     else
     {

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -224,7 +224,7 @@ public:
                          petsc_src,
                          coarse_operator->amg);
           }
-          else if(additional_data.solver_type == KrylovSolverType::CG)
+          else if(additional_data.solver_type == KrylovSolverType::GMRES)
           {
             PETScWrappers::SolverGMRES solver(solver_control);
             solver.solve(coarse_operator->system_matrix,

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -24,6 +24,7 @@
 
 // deal.II
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/petsc_solver.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/solver_gmres.h>
@@ -36,6 +37,7 @@
 #include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
 #include <exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h>
 #include <exadg/solvers_and_preconditioners/solvers/solver_data.h>
+#include <exadg/solvers_and_preconditioners/utilities/petsc_operation.h>
 
 namespace ExaDG
 {
@@ -52,13 +54,13 @@ class MGCoarseKrylov
   : public MGCoarseGridBase<LinearAlgebra::distributed::Vector<typename Operator::value_type>>
 {
 public:
-  typedef double TrilinosNumber;
+  typedef double NumberAMG;
 
   typedef typename Operator::value_type MultigridNumber;
 
   typedef LinearAlgebra::distributed::Vector<MultigridNumber> VectorType;
 
-  typedef LinearAlgebra::distributed::Vector<TrilinosNumber> VectorTypeTrilinos;
+  typedef LinearAlgebra::distributed::Vector<NumberAMG> VectorTypeAMG;
 
   struct AdditionalData
   {
@@ -110,13 +112,13 @@ public:
     }
     else if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::AMG)
     {
-      preconditioner_trilinos.reset(
-        new PreconditionerAMG<Operator, TrilinosNumber>(matrix, additional_data.amg_data));
+      preconditioner_amg.reset(
+        new PreconditionerAMG<Operator, NumberAMG>(matrix, additional_data.amg_data));
     }
     else if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::BoomerAMG)
     {
-      preconditioner_trilinos.reset(
-        new PreconditionerBoomerAMG<Operator, TrilinosNumber>(matrix, additional_data.amg_data));
+      preconditioner_amg.reset(
+        new PreconditionerBoomerAMG<Operator, NumberAMG>(matrix, additional_data.amg_data));
     }
     else
     {
@@ -149,7 +151,7 @@ public:
     else if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::AMG ||
             additional_data.preconditioner == MultigridCoarseGridPreconditioner::BoomerAMG)
     {
-      preconditioner_trilinos->update();
+      preconditioner_amg->update();
     }
     else
     {
@@ -164,47 +166,78 @@ public:
     if(additional_data.operator_is_singular)
       set_zero_mean_value(r);
 
-    if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::AMG ||
-       additional_data.preconditioner == MultigridCoarseGridPreconditioner::BoomerAMG)
+    if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::AMG)
     {
-      // create temporal vectors of type TrilinosNumber (double)
-      VectorTypeTrilinos dst_tri;
+      // create temporal vectors of type NumberAMG (double)
+      VectorTypeAMG dst_tri;
       dst_tri.reinit(dst, false);
-      VectorTypeTrilinos src_tri;
+      VectorTypeAMG src_tri;
       src_tri.reinit(r, true);
       src_tri.copy_locally_owned_data_from(r);
 
       ReductionControl solver_control(additional_data.solver_data.max_iter,
                                       additional_data.solver_data.abs_tol,
                                       additional_data.solver_data.rel_tol);
+      std::shared_ptr<PreconditionerAMG<Operator, NumberAMG>> coarse_operator =
+        std::dynamic_pointer_cast<PreconditionerAMG<Operator, NumberAMG>>(preconditioner_amg);
 
       if(additional_data.solver_type == KrylovSolverType::CG)
       {
-        SolverCG<VectorTypeTrilinos>                                 solver(solver_control);
-        std::shared_ptr<PreconditionerAMG<Operator, TrilinosNumber>> coarse_operator =
-          std::dynamic_pointer_cast<PreconditionerAMG<Operator, TrilinosNumber>>(
-            preconditioner_trilinos);
-        solver.solve(coarse_operator->system_matrix, dst_tri, src_tri, *preconditioner_trilinos);
+        SolverCG<VectorTypeAMG> solver(solver_control);
+        solver.solve(coarse_operator->system_matrix, dst_tri, src_tri, *preconditioner_amg);
       }
       else if(additional_data.solver_type == KrylovSolverType::GMRES)
       {
-        typename SolverGMRES<VectorTypeTrilinos>::AdditionalData gmres_data;
+        typename SolverGMRES<VectorTypeAMG>::AdditionalData gmres_data;
         gmres_data.max_n_tmp_vectors     = additional_data.solver_data.max_krylov_size;
         gmres_data.right_preconditioning = true;
 
-        SolverGMRES<VectorTypeTrilinos> solver(solver_control, gmres_data);
-        std::shared_ptr<PreconditionerAMG<Operator, TrilinosNumber>> coarse_operator =
-          std::dynamic_pointer_cast<PreconditionerAMG<Operator, TrilinosNumber>>(
-            preconditioner_trilinos);
-        solver.solve(coarse_operator->system_matrix, dst_tri, src_tri, *preconditioner_trilinos);
+        SolverGMRES<VectorTypeAMG> solver(solver_control, gmres_data);
+        solver.solve(coarse_operator->system_matrix, dst_tri, src_tri, *preconditioner_amg);
       }
       else
       {
         AssertThrow(false, ExcMessage("Not implemented."));
       }
 
-      // convert TrilinosNumber (double) -> MultigridNumber (float)
+      // convert NumberAMG (double) -> MultigridNumber (float)
       dst.copy_locally_owned_data_from(dst_tri);
+    }
+    else if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::BoomerAMG)
+    {
+#ifdef DEAL_II_WITH_PETSC
+      apply_petsc_operation(
+        dst,
+        src,
+        [&](PETScWrappers::VectorBase & petsc_dst, PETScWrappers::VectorBase const & petsc_src) {
+          std::shared_ptr<PreconditionerBoomerAMG<Operator, NumberAMG>> coarse_operator =
+            std::dynamic_pointer_cast<PreconditionerBoomerAMG<Operator, NumberAMG>>(
+              preconditioner_amg);
+          ReductionControl solver_control(additional_data.solver_data.max_iter,
+                                          additional_data.solver_data.abs_tol,
+                                          additional_data.solver_data.rel_tol);
+          if(additional_data.solver_type == KrylovSolverType::CG)
+          {
+            PETScWrappers::SolverCG solver(solver_control);
+            solver.solve(coarse_operator->system_matrix,
+                         petsc_dst,
+                         petsc_src,
+                         coarse_operator->amg);
+          }
+          else if(additional_data.solver_type == KrylovSolverType::CG)
+          {
+            PETScWrappers::SolverGMRES solver(solver_control);
+            solver.solve(coarse_operator->system_matrix,
+                         petsc_dst,
+                         petsc_src,
+                         coarse_operator->amg);
+          }
+          else
+          {
+            AssertThrow(false, ExcMessage("Not implemented."));
+          }
+        });
+#endif
     }
     else
     {
@@ -277,8 +310,8 @@ private:
 
   std::shared_ptr<PreconditionerBase<MultigridNumber>> preconditioner;
 
-  // we need a separate object here because Trilinos needs double precision
-  std::shared_ptr<PreconditionerBase<TrilinosNumber>> preconditioner_trilinos;
+  // we need a separate object here because the AMG preconditioners need double precision
+  std::shared_ptr<PreconditionerBase<NumberAMG>> preconditioner_amg;
 
   AdditionalData additional_data;
 
@@ -317,9 +350,9 @@ class MGCoarseAMG
   : public MGCoarseGridBase<LinearAlgebra::distributed::Vector<typename Operator::value_type>>
 {
 private:
-  typedef double TrilinosNumber;
+  typedef double NumberAMG;
 
-  typedef LinearAlgebra::distributed::Vector<TrilinosNumber> VectorTypeTrilinos;
+  typedef LinearAlgebra::distributed::Vector<NumberAMG> VectorTypeAMG;
 
   typedef LinearAlgebra::distributed::Vector<typename Operator::value_type> VectorTypeMultigrid;
 
@@ -327,9 +360,9 @@ public:
   MGCoarseAMG(Operator const & op, bool const use_boomer_amg, AMGData data = AMGData())
   {
     if(use_boomer_amg)
-      amg_preconditioner.reset(new PreconditionerBoomerAMG<Operator, TrilinosNumber>(op, data));
+      amg_preconditioner.reset(new PreconditionerBoomerAMG<Operator, NumberAMG>(op, data));
     else
-      amg_preconditioner.reset(new PreconditionerAMG<Operator, TrilinosNumber>(op, data));
+      amg_preconditioner.reset(new PreconditionerAMG<Operator, NumberAMG>(op, data));
   }
 
   void
@@ -343,24 +376,24 @@ public:
              VectorTypeMultigrid &       dst,
              VectorTypeMultigrid const & src) const
   {
-    // create temporal vectors of type VectorTypeTrilinos (double)
-    VectorTypeTrilinos dst_trilinos;
+    // create temporal vectors of type VectorTypeAMG (double)
+    VectorTypeAMG dst_trilinos;
     dst_trilinos.reinit(dst, false);
-    VectorTypeTrilinos src_trilinos;
+    VectorTypeAMG src_trilinos;
     src_trilinos.reinit(src, true);
 
-    // convert: VectorTypeMultigrid -> VectorTypeTrilinos
+    // convert: VectorTypeMultigrid -> VectorTypeAMG
     src_trilinos.copy_locally_owned_data_from(src);
 
     // use Trilinos to perform AMG
     amg_preconditioner->vmult(dst_trilinos, src_trilinos);
 
-    // convert: VectorTypeTrilinos -> VectorTypeMultigrid
+    // convert: VectorTypeAMG -> VectorTypeMultigrid
     dst.copy_locally_owned_data_from(dst_trilinos);
   }
 
 private:
-  std::shared_ptr<PreconditionerBase<TrilinosNumber>> amg_preconditioner;
+  std::shared_ptr<PreconditionerBase<NumberAMG>> amg_preconditioner;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.cpp
@@ -162,6 +162,9 @@ enum_to_string(MultigridCoarseGridSolver const enum_type)
     case MultigridCoarseGridSolver::AMG:
       string_type = "AMG";
       break;
+    case MultigridCoarseGridSolver::BoomerAMG:
+      string_type = "BoomerAMG";
+      break;
     default:
       AssertThrow(false, ExcMessage("Not implemented."));
       break;
@@ -189,6 +192,9 @@ enum_to_string(MultigridCoarseGridPreconditioner const enum_type)
       break;
     case MultigridCoarseGridPreconditioner::AMG:
       string_type = "AMG";
+      break;
+    case MultigridCoarseGridPreconditioner::BoomerAMG:
+      string_type = "BoomerAMG";
       break;
     default:
       AssertThrow(false, ExcMessage("Not implemented."));

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h
@@ -140,7 +140,8 @@ enum class MultigridCoarseGridSolver
   Chebyshev,
   CG,
   GMRES,
-  AMG
+  AMG,
+  BoomerAMG
 };
 
 std::string
@@ -152,7 +153,8 @@ enum class MultigridCoarseGridPreconditioner
   None,
   PointJacobi,
   BlockJacobi,
-  AMG
+  AMG,
+  BoomerAMG
 };
 
 std::string

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -892,7 +892,13 @@ MultigridPreconditionerBase<dim, Number>::initialize_coarse_solver(bool const op
     case MultigridCoarseGridSolver::AMG:
     {
       coarse_grid_solver.reset(
-        new MGCoarseAMG<Operator>(coarse_operator, data.coarse_problem.amg_data));
+        new MGCoarseAMG<Operator>(coarse_operator, false, data.coarse_problem.amg_data));
+      return;
+    }
+    case MultigridCoarseGridSolver::BoomerAMG:
+    {
+      coarse_grid_solver.reset(
+        new MGCoarseAMG<Operator>(coarse_operator, true, data.coarse_problem.amg_data));
       return;
     }
     default:

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -118,43 +118,30 @@ private:
 /*
  * Wrapper class for BoomerAMG from Hypre
  */
-template<typename Operator, typename PreconditionerNumber>
-class PreconditionerBoomerAMG : public PreconditionerBase<PreconditionerNumber>
+template<typename Operator, typename Number>
+class PreconditionerBoomerAMG : public PreconditionerBase<Number>
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<PreconditionerNumber> VectorType;
+  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
 
 #ifdef DEAL_II_WITH_PETSC
 public:
   // distributed sparse system matrix
   PETScWrappers::MPI::SparseMatrix system_matrix;
 
-private:
+  // amg preconditioner for access by PETSc solver
   PETScWrappers::PreconditionBoomerAMG amg;
 #endif
 
-public:
   PreconditionerBoomerAMG(Operator const & op, AMGData data = AMGData())
     : pde_operator(op), amg_data(data)
   {
 #ifdef DEAL_II_WITH_PETSC
     // initialize system matrix
     pde_operator.init_system_matrix(system_matrix);
-
-    // calculate_matrix
-    pde_operator.calculate_system_matrix(system_matrix);
-
-    // initialize the Boomer AMG data structures, translate from Trilinos
-    // settings; right now we must skip most parameters because there does not
-    // appear to be a setting available in deal.II
-    PETScWrappers::PreconditionBoomerAMG::AdditionalData boomer_data;
-    boomer_data.symmetric_operator               = amg_data.data.elliptic;
-    boomer_data.strong_threshold                 = 0.25;
-    boomer_data.aggressive_coarsening_num_levels = 2;
-    amg.initialize(system_matrix, boomer_data);
-#else
-    AssertThrow(false, ExcMessage("deal.II is not compiled with PETSc!"));
 #endif
+
+    calculate_preconditioner();
   }
 
 #ifdef DEAL_II_WITH_PETSC
@@ -170,19 +157,10 @@ public:
   {
 #ifdef DEAL_II_WITH_PETSC
     // clear content of matrix since the next calculate_system_matrix-commands add their result
-    system_matrix *= 0.0;
-
-    // re-calculate matrix
-    pde_operator.calculate_system_matrix(system_matrix);
-
-    PETScWrappers::PreconditionBoomerAMG::AdditionalData boomer_data;
-    boomer_data.symmetric_operator               = amg_data.data.elliptic;
-    boomer_data.strong_threshold                 = 0.25;
-    boomer_data.aggressive_coarsening_num_levels = 2;
-    amg.initialize(system_matrix, boomer_data);
-#else
-    AssertThrow(false, ExcMessage("deal.II is not compiled with PETSc!"));
+    system_matrix = 0.0;
 #endif
+
+    calculate_preconditioner();
   }
 
   void
@@ -199,6 +177,26 @@ public:
   }
 
 private:
+  void
+  calculate_preconditioner()
+  {
+#ifdef DEAL_II_WITH_PETSC
+    // calculate_matrix
+    pde_operator.calculate_system_matrix(system_matrix);
+
+    // initialize the Boomer AMG data structures, translate from Trilinos
+    // settings; right now we must skip most parameters because there does not
+    // appear to be a setting available in deal.II
+    PETScWrappers::PreconditionBoomerAMG::AdditionalData boomer_data;
+    boomer_data.symmetric_operator               = amg_data.data.elliptic;
+    boomer_data.strong_threshold                 = 0.25;
+    boomer_data.aggressive_coarsening_num_levels = 2;
+    amg.initialize(system_matrix, boomer_data);
+#else
+    AssertThrow(false, ExcMessage("deal.II is not compiled with PETSc!"));
+#endif
+  }
+
   // reference to matrix-free operator
   Operator const & pde_operator;
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -23,8 +23,8 @@
 #define PRECONDITIONER_AMG
 
 #include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_precondition.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -23,6 +23,8 @@
 #define PRECONDITIONER_AMG
 
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_precondition.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 
@@ -76,7 +78,7 @@ public:
 #endif
 
   void
-  update()
+  update() override
   {
 #ifdef DEAL_II_WITH_TRILINOS
     // clear content of matrix since the next calculate_system_matrix-commands add their result
@@ -93,7 +95,7 @@ public:
   }
 
   void
-  vmult(VectorTypeTrilinos & dst, VectorTypeTrilinos const & src) const
+  vmult(VectorTypeTrilinos & dst, VectorTypeTrilinos const & src) const override
   {
 #ifdef DEAL_II_WITH_TRILINOS
     amg.vmult(dst, src);
@@ -101,6 +103,148 @@ public:
     (void)dst;
     (void)src;
     AssertThrow(false, ExcMessage("deal.II is not compiled with Trilinos!"));
+#endif
+  }
+
+private:
+  // reference to matrix-free operator
+  Operator const & pde_operator;
+
+  AMGData amg_data;
+};
+
+
+/*
+ * Wrapper class for BoomerAMG from Hypre
+ */
+template<typename Operator, typename PreconditionerNumber>
+class PreconditionerBoomerAMG : public PreconditionerBase<PreconditionerNumber>
+{
+private:
+  typedef LinearAlgebra::distributed::Vector<PreconditionerNumber> VectorType;
+
+#ifdef DEAL_II_WITH_PETSC
+public:
+  // distributed sparse system matrix
+  PETScWrappers::MPI::SparseMatrix system_matrix;
+
+private:
+  PETScWrappers::PreconditionBoomerAMG amg;
+#endif
+
+public:
+  PreconditionerBoomerAMG(Operator const & op, AMGData data = AMGData())
+    : pde_operator(op), amg_data(data)
+  {
+#ifdef DEAL_II_WITH_PETSC
+    // initialize system matrix
+    pde_operator.init_system_matrix(system_matrix);
+
+    // calculate_matrix
+    pde_operator.calculate_system_matrix(system_matrix);
+
+    // initialize the Boomer AMG data structures, translate from Trilinos
+    // settings; right now we must skip most parameters because there does not
+    // appear to be a setting available in deal.II
+    PETScWrappers::PreconditionBoomerAMG::AdditionalData boomer_data;
+    boomer_data.symmetric_operator               = amg_data.data.elliptic;
+    boomer_data.strong_threshold                 = 0.25;
+    boomer_data.aggressive_coarsening_num_levels = 2;
+    amg.initialize(system_matrix, boomer_data);
+#else
+    AssertThrow(false, ExcMessage("deal.II is not compiled with PETSc!"));
+#endif
+  }
+
+#ifdef DEAL_II_WITH_PETSC
+  PETScWrappers::MPI::SparseMatrix const &
+  get_system_matrix()
+  {
+    return system_matrix;
+  }
+#endif
+
+  void
+  update() override
+  {
+#ifdef DEAL_II_WITH_PETSC
+    // clear content of matrix since the next calculate_system_matrix-commands add their result
+    system_matrix *= 0.0;
+
+    // re-calculate matrix
+    pde_operator.calculate_system_matrix(system_matrix);
+
+    PETScWrappers::PreconditionBoomerAMG::AdditionalData boomer_data;
+    boomer_data.symmetric_operator               = amg_data.data.elliptic;
+    boomer_data.strong_threshold                 = 0.25;
+    boomer_data.aggressive_coarsening_num_levels = 2;
+    amg.initialize(system_matrix, boomer_data);
+#else
+    AssertThrow(false, ExcMessage("deal.II is not compiled with PETSc!"));
+#endif
+  }
+
+  void
+  vmult(VectorType & dst, VectorType const & src) const override
+  {
+#ifdef DEAL_II_WITH_PETSC
+    // copy to petsc internal vector type because there is currently no such
+    // function in deal.II (and the transition via ReadWriteVector is too
+    // slow/poorly tested)
+    Vec vector_dst, vector_src;
+    VecCreateMPI(dst.get_mpi_communicator(),
+                 dst.get_partitioner()->local_size(),
+                 PETSC_DETERMINE,
+                 &vector_dst);
+    VecCreateMPI(src.get_mpi_communicator(),
+                 src.get_partitioner()->local_size(),
+                 PETSC_DETERMINE,
+                 &vector_src);
+
+    {
+      PetscInt       begin, end;
+      PetscErrorCode ierr = VecGetOwnershipRange(vector_src, &begin, &end);
+      AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+      PetscScalar * ptr;
+      ierr = VecGetArray(vector_src, &ptr);
+      AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+      const PetscInt local_size = src.get_partitioner()->local_size();
+      AssertDimension(local_size, static_cast<unsigned int>(end - begin));
+      for(PetscInt i = 0; i < local_size; ++i)
+      {
+        ptr[i] = src.local_element(i);
+      }
+
+      ierr = VecRestoreArray(vector_src, &ptr);
+    }
+
+    PETScWrappers::VectorBase petsc_dst(vector_dst);
+    amg.vmult(petsc_dst, PETScWrappers::VectorBase(vector_src));
+
+    {
+      PetscInt       begin, end;
+      PetscErrorCode ierr = VecGetOwnershipRange(vector_dst, &begin, &end);
+      AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+      PetscScalar * ptr;
+      ierr = VecGetArray(vector_dst, &ptr);
+      AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+      const PetscInt local_size = dst.get_partitioner()->local_size();
+      AssertDimension(local_size, static_cast<unsigned int>(end - begin));
+      for(PetscInt i = 0; i < local_size; ++i)
+      {
+        dst.local_element(i) = ptr[i];
+      }
+
+      ierr = VecRestoreArray(vector_dst, &ptr);
+    }
+#else
+    (void)dst;
+    (void)src;
+    AssertThrow(false, ExcMessage("deal.II is not compiled with PETSC!"));
 #endif
   }
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -23,7 +23,7 @@
 #define PRECONDITIONER_AMG
 
 #include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_precondition.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>

--- a/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
@@ -1,0 +1,105 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_SOLVERS_AND_PRECONDITIONERS_PETSCOPERATION_H_
+#define INCLUDE_SOLVERS_AND_PRECONDITIONERS_PETSCOPERATION_H_
+
+#include <deal.II/lac/petsc_vector.h>
+
+namespace ExaDG
+{
+using namespace dealii;
+
+/*
+ *  This function wraps the copy of a PETSc object (sparse matrix,
+ *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector.
+ */
+template<typename VectorType>
+void
+apply_petsc_operation(VectorType &                                           dst,
+                      VectorType const &                                     src,
+                      std::function<void(PETScWrappers::VectorBase &,
+                                         PETScWrappers::VectorBase const &)> petsc_operation)
+{
+  // copy to petsc internal vector type because there is currently no such
+  // function in deal.II (and the transition via ReadWriteVector is too
+  // slow/poorly tested)
+  Vec vector_dst, vector_src;
+  VecCreateMPI(dst.get_mpi_communicator(),
+               dst.get_partitioner()->local_size(),
+               PETSC_DETERMINE,
+               &vector_dst);
+  VecCreateMPI(src.get_mpi_communicator(),
+               src.get_partitioner()->local_size(),
+               PETSC_DETERMINE,
+               &vector_src);
+
+  {
+    PetscInt       begin, end;
+    PetscErrorCode ierr = VecGetOwnershipRange(vector_src, &begin, &end);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    PetscScalar * ptr;
+    ierr = VecGetArray(vector_src, &ptr);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    const PetscInt local_size = src.get_partitioner()->local_size();
+    AssertDimension(local_size, static_cast<unsigned int>(end - begin));
+    for(PetscInt i = 0; i < local_size; ++i)
+    {
+      ptr[i] = src.local_element(i);
+    }
+
+    ierr = VecRestoreArray(vector_src, &ptr);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+  }
+
+  // wrap `Vec` into VectorBase (without copying data)
+  PETScWrappers::VectorBase petsc_dst(vector_dst);
+  PETScWrappers::VectorBase petsc_src(vector_src);
+
+  petsc_operation(petsc_dst, petsc_src);
+
+  {
+    PetscInt       begin, end;
+    PetscErrorCode ierr = VecGetOwnershipRange(vector_dst, &begin, &end);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    PetscScalar * ptr;
+    ierr = VecGetArray(vector_dst, &ptr);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    const PetscInt local_size = dst.get_partitioner()->local_size();
+    AssertDimension(local_size, static_cast<unsigned int>(end - begin));
+
+    for(PetscInt i = 0; i < local_size; ++i)
+    {
+      dst.local_element(i) = ptr[i];
+    }
+
+    ierr = VecRestoreArray(vector_dst, &ptr);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+  }
+}
+
+} // namespace ExaDG
+
+#endif /* INCLUDE_SOLVERS_AND_PRECONDITIONERS_INVERTDIAGONAL_H_ */

--- a/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
@@ -32,6 +32,7 @@ using namespace dealii;
  *  This function wraps the copy of a PETSc object (sparse matrix,
  *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector.
  */
+#ifdef DEAL_II_WITH_PETSC
 template<typename VectorType>
 void
 apply_petsc_operation(VectorType &                                           dst,
@@ -99,6 +100,7 @@ apply_petsc_operation(VectorType &                                           dst
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 }
+#endif
 
 } // namespace ExaDG
 


### PR DESCRIPTION
This PR implements the BoomerAMG preconditioner from the HYPRE package, available through the deal.II/PETSc interface. I had to implement a second matrix infrastructure for PETSc matrices in the base operator, and then I added another preconditioner class for BoomerAMG. The current interface is somewhat wasteful because:
* we copy the vectors two times, once for `MultigridNumber` -> `TrilinosNumber` and then again from `LinearAlgebra::distributed::Vector` into PETSc's own vector type, because we need the latter for `PETScWrappers::SparseMatrix::vmult`. If we think it is important, we might get around with a single copy.
* ~~if we use a CG solver around multigrid (or GMRES for that matter), we might want to consider to use a Krylov solver directly from PETSc, rather than `SolverCG` from deal.II. This might help to get around the inefficiencies in transitioning data types.~~ I now use PETSc's solver directly.

Given that we only do expensive operations within the wrapped function (apart from vmult tests), I think the first point should not matter too much.