### PR TITLE
Fix memory leak in PETSc operation

### DIFF
--- a/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
@@ -99,6 +99,11 @@ apply_petsc_operation(VectorType &                                           dst
     ierr = VecRestoreArray(vector_dst, &ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
+
+  PetscErrorCode ierr = VecDestroy(&vector_dst);
+  AssertThrow(ierr == 0, ExcPETScError(ierr));
+  ierr = VecDestroy(&vector_src);
+  AssertThrow(ierr == 0, ExcPETScError(ierr));
 }
 #endif
 


### PR DESCRIPTION
PETSc's vector `Vec` is a C struct without destructor, so I need to explicitly deallocate the memory I have reserved to avoid a memory leak. I observed this from incompressible simulations that ran out of memory after a few hundreds of time steps.