### PR TITLE
MG constraints setup: call interpolate_boundary_values only once

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -702,15 +702,21 @@ MultigridPreconditionerBase<dim, Number>::initialize_affine_constraints(
   affine_constraints.reinit(locally_relevant_dofs);
 
   DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints);
+
+  // collect all boundary functions and translate to format understood by
+  // deal.II to cover all boundaries at once
+  Functions::ZeroFunction<dim, MultigridNumber>                        zero_function;
+  std::map<types::boundary_id, Function<dim, MultigridNumber> const *> boundary_functions;
   for(auto & it : dirichlet_bc)
   {
-    MappingQGeneric<dim> mapping_dummy(1);
-    VectorTools::interpolate_boundary_values(mapping_dummy,
-                                             dof_handler,
-                                             it.first,
-                                             Functions::ZeroFunction<dim, MultigridNumber>(),
-                                             affine_constraints);
+    boundary_functions[it.first] = &zero_function;
   }
+
+  MappingQGeneric<dim> mapping_dummy(1);
+  VectorTools::interpolate_boundary_values(mapping_dummy,
+                                           dof_handler,
+                                           boundary_functions,
+                                           affine_constraints);
   affine_constraints.close();
 }
 


### PR DESCRIPTION
I noticed that the setup of the multigrid preconditioner took a long time for lung simulations with many generation (outlets). As a first improvement, I found out that the `VectorTools::interpolate_boundary_values` was called for every boundary id separately. As that is a rather expensive function because it iterates over the whole mesh in each call (including the coarse artificial cells), this pull request allows me to reduce the time in the setup for 11 generations and 1 global refinement on 16 nodes from 610 seconds to 594 seconds. (I'm still looking into the other big consumers.)