### PR TITLE
Avoid compile warnings with clang-12 compiler

### DIFF
--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_data.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_data.h
@@ -221,7 +221,7 @@ struct LinePlotData
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(ConditionalOStream &)
   {
     // TODO: add output for basic line plot data
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
@@ -107,7 +107,7 @@ public:
   void
   step(VectorType & dst, VectorType const & src) const
   {
-    IterationNumberControl control(data.number_of_iterations, 1.e-20, 1.e-10);
+    IterationNumberControl control(data.number_of_iterations, 1.e-20);
 
     SolverCG<VectorType> solver(control);
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
@@ -108,7 +108,7 @@ public:
   void
   step(VectorType & dst, VectorType const & src) const
   {
-    IterationNumberControl control(data.number_of_iterations, 1.e-20, 1.e-10);
+    IterationNumberControl control(data.number_of_iterations, 1.e-20);
 
     typename SolverGMRES<VectorType>::AdditionalData additional_data;
     additional_data.right_preconditioning = true;

--- a/include/exadg/time_integration/time_int_bdf_base.h
+++ b/include/exadg/time_integration/time_int_bdf_base.h
@@ -221,12 +221,6 @@ private:
   prepare_vectors_for_next_timestep() = 0;
 
   /*
-   * Solve the current time step.
-   */
-  virtual void
-  solve_timestep() = 0;
-
-  /*
    * Solve for a steady-state solution using pseudo-time-stepping.
    */
   virtual void


### PR DESCRIPTION
These are the warnings extracted from #45 that do not belong to the virual/override/final category.