### PR TITLE
Optimize matrix-vector product in OperatorBase

### DIFF
--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -642,8 +642,9 @@ private:
   /*
    * for CG
    */
-  std::vector<unsigned int>                      constrained_indices;
-  mutable std::vector<std::pair<Number, Number>> constrained_values;
+  std::vector<unsigned int>   constrained_indices;
+  mutable std::vector<Number> constrained_values_src;
+  mutable std::vector<Number> constrained_values_dst;
 };
 } // namespace ExaDG
 


### PR DESCRIPTION
This is another (modest) optimization I played with during the code analysis last month: We might want to run the vector-zero within `MatrixFree::loop` to save one access to the result vector. In the `apply` function, we can then only manipulate in one of the `dst/src` vectors. To make more clear where the constrained values that we put aside come from, I tried to give them more intuitive names.