### PR TITLE
Optimizations for interface to PETSc/BoomerAMG preconditioner

### DIFF
--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -483,11 +483,11 @@ Operator<dim, Number, n_components>::vmult_matrix_based(
 {
   apply_petsc_operation(dst,
                         src,
+                        system_matrix.get_mpi_communicator(),
                         [&](PETScWrappers::VectorBase &       petsc_dst,
                             PETScWrappers::VectorBase const & petsc_src) {
                           system_matrix.vmult(petsc_dst, petsc_src);
-                        },
-                        system_matrix.get_mpi_communicator());
+                        });
 }
 #endif
 

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -486,7 +486,8 @@ Operator<dim, Number, n_components>::vmult_matrix_based(
                         [&](PETScWrappers::VectorBase &       petsc_dst,
                             PETScWrappers::VectorBase const & petsc_src) {
                           system_matrix.vmult(petsc_dst, petsc_src);
-                        });
+                        },
+                        system_matrix.get_mpi_communicator());
 }
 #endif
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -247,7 +247,10 @@ public:
             {
               AssertThrow(false, ExcMessage("Not implemented."));
             }
-          });
+          },
+          std::dynamic_pointer_cast<PreconditionerBoomerAMG<Operator, NumberAMG>>(
+            preconditioner_amg)
+            ->system_matrix.get_mpi_communicator());
 #endif
       }
       else

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -218,6 +218,9 @@ public:
         apply_petsc_operation(
           dst,
           src,
+          std::dynamic_pointer_cast<PreconditionerBoomerAMG<Operator, NumberAMG>>(
+            preconditioner_amg)
+            ->system_matrix.get_mpi_communicator(),
           [&](PETScWrappers::VectorBase & petsc_dst, PETScWrappers::VectorBase const & petsc_src) {
             std::shared_ptr<PreconditionerBoomerAMG<Operator, NumberAMG>> coarse_operator =
               std::dynamic_pointer_cast<PreconditionerBoomerAMG<Operator, NumberAMG>>(
@@ -247,10 +250,7 @@ public:
             {
               AssertThrow(false, ExcMessage("Not implemented."));
             }
-          },
-          std::dynamic_pointer_cast<PreconditionerBoomerAMG<Operator, NumberAMG>>(
-            preconditioner_amg)
-            ->system_matrix.get_mpi_communicator());
+          });
 #endif
       }
       else

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -235,8 +235,8 @@ private:
 
 #ifdef DEAL_II_WITH_PETSC
   // PETSc vector objects to avoid re-allocation in every vmult() operation
-  mutable Vec petsc_vector_src;
-  mutable Vec petsc_vector_dst;
+  mutable VectorTypePETSc petsc_vector_src;
+  mutable VectorTypePETSc petsc_vector_dst;
 #endif
 };
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -146,6 +146,16 @@ public:
     calculate_preconditioner();
   }
 
+  ~PreconditionerBoomerAMG()
+  {
+#ifdef DEAL_II_WITH_PETSC
+    PetscErrorCode ierr = VecDestroy(&petsc_vector_dst);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+    ierr = VecDestroy(&petsc_vector_src);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+#endif
+  }
+
 #ifdef DEAL_II_WITH_PETSC
   PETScWrappers::MPI::SparseMatrix const &
   get_system_matrix()
@@ -159,7 +169,8 @@ public:
   {
 #ifdef DEAL_II_WITH_PETSC
     // clear content of matrix since the next calculate_system_matrix-commands add their result
-    system_matrix = 0.0;
+    if(system_matrix.m() > 0)
+      system_matrix = 0.0;
 #endif
 
     calculate_preconditioner();
@@ -169,12 +180,15 @@ public:
   vmult(VectorType & dst, VectorType const & src) const override
   {
 #ifdef DEAL_II_WITH_PETSC
-    apply_petsc_operation(dst,
-                          src,
-                          [&](PETScWrappers::VectorBase &       petsc_dst,
-                              PETScWrappers::VectorBase const & petsc_src) {
-                            amg.vmult(petsc_dst, petsc_src);
-                          });
+    if(system_matrix.m() > 0)
+      apply_petsc_operation(dst,
+                            src,
+                            [&](PETScWrappers::VectorBase &       petsc_dst,
+                                PETScWrappers::VectorBase const & petsc_src) {
+                              amg.vmult(petsc_dst, petsc_src);
+                            },
+                            petsc_vector_dst,
+                            petsc_vector_src);
 #else
     (void)dst;
     (void)src;
@@ -188,9 +202,24 @@ private:
   {
 #ifdef DEAL_II_WITH_PETSC
     // calculate_matrix
-    pde_operator.calculate_system_matrix(system_matrix);
+    if(system_matrix.m() > 0)
+    {
+      pde_operator.calculate_system_matrix(system_matrix);
 
-    amg.initialize(system_matrix, boomer_data);
+      amg.initialize(system_matrix, boomer_data);
+
+      // get vector partitioner
+      LinearAlgebra::distributed::Vector<typename Operator::value_type> vector;
+      pde_operator.initialize_dof_vector(vector);
+      VecCreateMPI(system_matrix.get_mpi_communicator(),
+                   vector.get_partitioner()->local_size(),
+                   PETSC_DETERMINE,
+                   &petsc_vector_dst);
+      VecCreateMPI(system_matrix.get_mpi_communicator(),
+                   vector.get_partitioner()->local_size(),
+                   PETSC_DETERMINE,
+                   &petsc_vector_src);
+    }
 #else
     AssertThrow(false, ExcMessage("deal.II is not compiled with PETSc!"));
 #endif
@@ -200,6 +229,12 @@ private:
   Operator const & pde_operator;
 
   BoomerData boomer_data;
+
+#ifdef DEAL_II_WITH_PETSC
+  // PETSc vector objects to avoid re-allocation in every vmult() operation
+  mutable Vec petsc_vector_src;
+  mutable Vec petsc_vector_dst;
+#endif
 };
 } // namespace ExaDG
 

--- a/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
@@ -30,7 +30,8 @@ using namespace dealii;
 
 /*
  *  This function wraps the copy of a PETSc object (sparse matrix,
- *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector.
+ *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector, taking
+ *  pre-allocated PETSc vector objects for the temporary operations
  */
 #ifdef DEAL_II_WITH_PETSC
 template<typename VectorType>
@@ -38,28 +39,20 @@ void
 apply_petsc_operation(VectorType &                                           dst,
                       VectorType const &                                     src,
                       std::function<void(PETScWrappers::VectorBase &,
-                                         PETScWrappers::VectorBase const &)> petsc_operation)
+                                         PETScWrappers::VectorBase const &)> petsc_operation,
+                      Vec &                                                  petsc_vector_dst,
+                      Vec &                                                  petsc_vector_src)
 {
-  // copy to petsc internal vector type because there is currently no such
-  // function in deal.II (and the transition via ReadWriteVector is too
-  // slow/poorly tested)
-  Vec vector_dst, vector_src;
-  VecCreateMPI(dst.get_mpi_communicator(),
-               dst.get_partitioner()->local_size(),
-               PETSC_DETERMINE,
-               &vector_dst);
-  VecCreateMPI(src.get_mpi_communicator(),
-               src.get_partitioner()->local_size(),
-               PETSC_DETERMINE,
-               &vector_src);
-
   {
+    // copy to petsc internal vector type because there is currently no such
+    // function in deal.II (and the transition via ReadWriteVector is too
+    // slow/poorly tested)
     PetscInt       begin, end;
-    PetscErrorCode ierr = VecGetOwnershipRange(vector_src, &begin, &end);
+    PetscErrorCode ierr = VecGetOwnershipRange(petsc_vector_src, &begin, &end);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     PetscScalar * ptr;
-    ierr = VecGetArray(vector_src, &ptr);
+    ierr = VecGetArray(petsc_vector_src, &ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     const PetscInt local_size = src.get_partitioner()->local_size();
@@ -69,23 +62,23 @@ apply_petsc_operation(VectorType &                                           dst
       ptr[i] = src.local_element(i);
     }
 
-    ierr = VecRestoreArray(vector_src, &ptr);
+    ierr = VecRestoreArray(petsc_vector_src, &ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
   // wrap `Vec` into VectorBase (without copying data)
-  PETScWrappers::VectorBase petsc_dst(vector_dst);
-  PETScWrappers::VectorBase petsc_src(vector_src);
+  PETScWrappers::VectorBase petsc_dst(petsc_vector_dst);
+  PETScWrappers::VectorBase petsc_src(petsc_vector_src);
 
   petsc_operation(petsc_dst, petsc_src);
 
   {
     PetscInt       begin, end;
-    PetscErrorCode ierr = VecGetOwnershipRange(vector_dst, &begin, &end);
+    PetscErrorCode ierr = VecGetOwnershipRange(petsc_vector_dst, &begin, &end);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     PetscScalar * ptr;
-    ierr = VecGetArray(vector_dst, &ptr);
+    ierr = VecGetArray(petsc_vector_dst, &ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     const PetscInt local_size = dst.get_partitioner()->local_size();
@@ -96,9 +89,35 @@ apply_petsc_operation(VectorType &                                           dst
       dst.local_element(i) = ptr[i];
     }
 
-    ierr = VecRestoreArray(vector_dst, &ptr);
+    ierr = VecRestoreArray(petsc_vector_dst, &ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
+}
+
+/*
+ *  This function wraps the copy of a PETSc object (sparse matrix,
+ *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector,
+ *  allocating a PETSc vectors and then calling the other function
+ */
+template<typename VectorType>
+void
+apply_petsc_operation(VectorType &                                           dst,
+                      VectorType const &                                     src,
+                      std::function<void(PETScWrappers::VectorBase &,
+                                         PETScWrappers::VectorBase const &)> petsc_operation,
+                      MPI_Comm const &                                       petsc_mpi_communicator)
+{
+  Vec vector_dst, vector_src;
+  VecCreateMPI(petsc_mpi_communicator,
+               dst.get_partitioner()->local_size(),
+               PETSC_DETERMINE,
+               &vector_dst);
+  VecCreateMPI(petsc_mpi_communicator,
+               src.get_partitioner()->local_size(),
+               PETSC_DETERMINE,
+               &vector_src);
+
+  apply_petsc_operation(dst, src, petsc_operation, vector_dst, vector_src);
 
   PetscErrorCode ierr = VecDestroy(&vector_dst);
   AssertThrow(ierr == 0, ExcPETScError(ierr));

--- a/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
@@ -37,8 +37,8 @@ typedef Vec VectorTypePETSc;
 /*
  *  This function wraps the copy of a PETSc object (sparse matrix,
  *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector, taking
- *  pre-allocated PETSc vector objects (with struct name `Vec) for the
- *  temporary operations
+ *  pre-allocated PETSc vector objects (with struct name `Vec`, aka
+ *  VectorTypePETSc) for the temporary operations
  */
 template<typename VectorType>
 void


### PR DESCRIPTION
This is the next set of optimizations. This PR does two things:
- Enable the PETSc infrastructure to run on a communicator with fewer processes, i.e., the communicator for the PETSc matrices can be only a subset of all MPI processes; this forces us to pass in the relevant communicator into `apply_petsc_operation`
- Pre-allocate the vectors needed for the `apply_petsc_operation` for the BoomerAMG preconditioner, to avoid setting them up over and over again.