### PR TITLE
Drop MPI processes from coarser grid level in global coarsening

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -444,9 +444,10 @@ create_geometric_coarsening_sequence(Triangulation<dim, spacedim> const & fine_t
     // polynomials, resulting in small run times in preliminary studies. This
     // could be generalized by a parameter to set in the application files.
     unsigned int n_cells_per_process = 400;
-    for(unsigned int level = fine_triangulation->n_global_levels() - 1;
-        level > 0 && tria_copy.n_global_active_cells() / Utilities::MPI::n_mpi_processes(mpi_comm) >
-                       n_cells_per_process;
+    for(int level = fine_triangulation->n_global_levels() - 2;
+        level >= 0 &&
+        tria_copy.n_global_active_cells() / Utilities::MPI::n_mpi_processes(mpi_comm) >
+          n_cells_per_process;
         --level)
     {
       // extract relevant information from distributed triangulation
@@ -464,9 +465,9 @@ create_geometric_coarsening_sequence(Triangulation<dim, spacedim> const & fine_t
 
       level_tria->create_triangulation(construction_data);
 
-      coarse_grid_triangulations[level - 1] = level_tria;
+      coarse_grid_triangulations[level] = level_tria;
 
-      if(level > 1)
+      if(level > 0)
         tria_copy.coarsen_global();
     }
 
@@ -487,7 +488,7 @@ create_geometric_coarsening_sequence(Triangulation<dim, spacedim> const & fine_t
     // Continue as above but with the serial triangulation that gets
     // distributed
     unsigned int n_partitions = Utilities::MPI::n_mpi_processes(mpi_comm);
-    for(unsigned int level = tria_copy.n_global_levels(); level > 0; --level)
+    for(int level = tria_copy.n_global_levels() - 1; level >= 0; --level)
     {
       // reduce the number of MPI ranks per coarsening step by at most a
       // factor of 8, in order to avoid too much transfer out of a single MPI
@@ -522,10 +523,10 @@ create_geometric_coarsening_sequence(Triangulation<dim, spacedim> const & fine_t
       level_tria->create_triangulation(construction_data);
 
       // save mesh
-      coarse_grid_triangulations[level - 1] = level_tria;
+      coarse_grid_triangulations[level] = level_tria;
 
       // coarsen mesh
-      if(is_first_process_on_node && level > 1)
+      if(is_first_process_on_node && level > 0)
         serial_tria.coarsen_global();
     }
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -355,8 +355,7 @@ replicate_distributed_triangulation_on_node(
   {
     // collect refinement flags from the complete distributed triangulation on
     // global rank 0 by an MPI_Gather step
-    std::vector<std::vector<std::vector<CellId>>> refinement_flags(
-      n_levels - 1);
+    std::vector<std::vector<std::vector<CellId>>> refinement_flags(n_levels - 1);
     {
       for(unsigned int l = 0; l < n_levels - 1; ++l)
       {

--- a/include/exadg/utilities/mpi.h
+++ b/include/exadg/utilities/mpi.h
@@ -19,8 +19,8 @@
  *  ______________________________________________________________________
  */
 
-#ifndef DYNAMIC_CONVERGENCE_TABLE
-#define DYNAMIC_CONVERGENCE_TABLE
+#ifndef INCLUDE_UTILITIES_MPI_H_
+#define INCLUDE_UTILITIES_MPI_H_
 
 namespace ExaDG
 {
@@ -44,8 +44,8 @@ identify_first_process_on_node(MPI_Comm const & mpi_comm)
   MPI_Comm_free(&comm_shared);
 
   AssertThrow(size_shared == Utilities::MPI::max(size_shared, mpi_comm),
-              ExcMessage("The mesh coarsening with shared memory only works if all nodes "
-                         "are populated with the same number of MPI ranks!"));
+              ExcMessage("The identification of MPI process groups in terms of compute nodes only "
+                         "works if all nodes are populated with the same number of MPI ranks!"));
   return {rank % size_shared == 0, size_shared};
 }
 

--- a/include/exadg/utilities/mpi.h
+++ b/include/exadg/utilities/mpi.h
@@ -1,0 +1,54 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef DYNAMIC_CONVERGENCE_TABLE
+#define DYNAMIC_CONVERGENCE_TABLE
+
+namespace ExaDG
+{
+/*
+ * Return whether the current MPI process is the first on a compute node,
+ * defined as the ranks which share the same memory
+ * (`MPI_COMM_TYPE_SHARED`). The second argument returns the number of
+ * processes per node, in case it is needed in the algorithm.
+ */
+std::tuple<bool, unsigned int>
+identify_first_process_on_node(MPI_Comm const & mpi_comm)
+{
+  int rank;
+  MPI_Comm_rank(mpi_comm, &rank);
+
+  MPI_Comm comm_shared;
+  MPI_Comm_split_type(mpi_comm, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, &comm_shared);
+
+  int size_shared;
+  MPI_Comm_size(comm_shared, &size_shared);
+  MPI_Comm_free(&comm_shared);
+
+  AssertThrow(size_shared == Utilities::MPI::max(size_shared, mpi_comm),
+              ExcMessage("The mesh coarsening with shared memory only works if all nodes "
+                         "are populated with the same number of MPI ranks!"));
+  return {rank % size_shared == 0, size_shared};
+}
+
+} // namespace ExaDG
+
+#endif


### PR DESCRIPTION
This was done in close collaboration with @peterrum - the goal of this rather involved code is to drop MPI processes as we pass to coarser levels in multigrid. We should at some point integrate this feature into deal.II (combined with the ability to directly coarsen `parallel::fullydistributed::Triangulation` for the setup of multigrid), but until deal.II catches up on this topic we need to implement a brute-force strategy here in ExaDG to be able to run with 100k+ MPI processes and complicated coarse meshes.