### PR TITLE
Fix a few more occurrences of virtual/override

### DIFF
--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -138,7 +138,7 @@ public:
   double const end_time   = 10.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.equation_type   = EquationType::NavierStokes;
@@ -186,7 +186,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     std::vector<unsigned int> repetitions({2, 1});
     Point<dim>                point1(0.0, 0.0), point2(L, H);
@@ -276,7 +276,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
@@ -285,7 +285,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output      = this->write_output;

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -217,7 +217,7 @@ public:
   double const end_time   = 1.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.equation_type   = EquationType::Euler;
@@ -265,7 +265,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -297,7 +297,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
@@ -306,7 +306,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output      = this->write_output;

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -371,7 +371,7 @@ public:
   double const end_time   = 0.75;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.equation_type   = EquationType::NavierStokes;
@@ -427,7 +427,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     // hypercube volume is [left,right]^dim
     double const left = -1.0, right = 0.5;
@@ -480,7 +480,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side_density.reset(new RightHandSideDensity<dim>());
@@ -489,7 +489,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output      = this->write_output;

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -132,7 +132,7 @@ public:
   double const end_time   = 25.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.equation_type   = EquationType::NavierStokes;
@@ -180,7 +180,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -246,7 +246,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new InitialSolution<dim>());
     field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
@@ -255,7 +255,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -142,7 +142,7 @@ public:
   double const end_time   = 10.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.equation_type   = EquationType::NavierStokes;
@@ -190,7 +190,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -223,7 +223,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
@@ -232,7 +232,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -146,7 +146,7 @@ public:
   double const end_time   = 20.0 * CHARACTERISTIC_TIME;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.equation_type   = EquationType::NavierStokes;
@@ -225,7 +225,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     double const pi   = numbers::PI;
     double const left = -pi * L, right = pi * L;
@@ -267,7 +267,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new InitialSolution<dim>());
     field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
@@ -276,7 +276,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -63,7 +63,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     (void)param;
 
@@ -76,7 +76,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)triangulation;
     (void)periodic_faces;
@@ -107,7 +107,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     // these lines show exemplarily how the field functions are filled
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(dim + 2));
@@ -117,7 +117,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -118,7 +118,7 @@ public:
    *  point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const override
+  push_forward(Point<dim> const & xi) const final
   {
     Point<dim> x;
 
@@ -136,7 +136,7 @@ public:
    *  to point xi in reference coordinates [0,1]^d
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const override
+  pull_back(Point<dim> const & x) const final
   {
     Point<dim> xi;
 
@@ -150,7 +150,7 @@ public:
   }
 
   std::unique_ptr<Manifold<dim>>
-  clone() const override
+  clone() const final
   {
     return std::make_unique<ManifoldTurbulentChannel<dim>>(dimensions);
   }
@@ -270,7 +270,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.equation_type   = EquationType::NavierStokes;
@@ -319,7 +319,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     Tensor<1, dim> dimensions;
     dimensions[0] = DIMENSIONS_X1;
@@ -392,7 +392,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<CompNS::FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<CompNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new InitialSolution<dim>());
     field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
@@ -403,7 +403,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -118,7 +118,7 @@ public:
    *  point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const
+  push_forward(Point<dim> const & xi) const override
   {
     Point<dim> x;
 
@@ -136,7 +136,7 @@ public:
    *  to point xi in reference coordinates [0,1]^d
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const
+  pull_back(Point<dim> const & x) const override
   {
     Point<dim> xi;
 

--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -79,7 +79,7 @@ public:
   double const end_time   = 1.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type              = ProblemType::Steady;
@@ -146,7 +146,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -174,7 +174,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -183,7 +183,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
@@ -193,7 +193,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -113,7 +113,7 @@ public:
   double const end_time   = 1.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type              = ProblemType::Steady;
@@ -193,7 +193,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -205,7 +205,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -213,7 +213,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new Functions::ConstantFunction<dim>(1.0, 1));
@@ -221,7 +221,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -144,7 +144,7 @@ public:
   double const end_time   = 1.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type    = ProblemType::Unsteady;
@@ -207,7 +207,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -220,7 +220,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -240,7 +240,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>(diffusivity));
     field_functions->right_hand_side.reset(new RightHandSide<dim>(diffusivity));
@@ -248,7 +248,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -101,7 +101,7 @@ public:
   double const end_time   = 1.0; // increase end_time for larger deformations of the hill
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type              = ProblemType::Unsteady;
@@ -164,7 +164,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -175,7 +175,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -184,7 +184,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
@@ -192,7 +192,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -96,7 +96,7 @@ public:
   double const right = +1.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type              = ProblemType::Unsteady;
@@ -186,7 +186,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -197,7 +197,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -206,7 +206,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
@@ -214,7 +214,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -76,7 +76,7 @@ public:
   bool const ale = false;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) override
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -139,7 +139,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) override
   {
     (void)periodic_faces;
 
@@ -180,7 +180,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) override
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -190,7 +190,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
@@ -200,7 +200,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -76,7 +76,7 @@ public:
   bool const ale = false;
 
   void
-  set_input_parameters(InputParameters & param) override
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -139,7 +139,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) override
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -160,7 +160,7 @@ public:
   }
 
   std::shared_ptr<Function<dim>>
-  set_mesh_movement_function() override
+  set_mesh_movement_function() final
   {
     std::shared_ptr<Function<dim>> mesh_motion;
 
@@ -180,7 +180,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) override
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -190,7 +190,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Solution<dim>());
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
@@ -200,7 +200,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -65,7 +65,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     (void)param;
     // TODO fill parameters
@@ -76,7 +76,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)triangulation;
     (void)periodic_faces;
@@ -86,14 +86,14 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     boundary_descriptor->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
@@ -101,7 +101,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -94,7 +94,7 @@ public:
   MeshType    mesh_type        = MeshType::Cartesian;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type    = ProblemType::Unsteady;
@@ -144,7 +144,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;
@@ -176,14 +176,14 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     (void)boundary_descriptor;
   }
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     // these lines show exemplarily how the field functions are filled
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
@@ -199,7 +199,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -132,7 +132,7 @@ public:
   }
 
   void
-  set_input_parameters_fluid(IncNS::InputParameters & param)
+  set_input_parameters_fluid(IncNS::InputParameters & param) final
   {
     using namespace IncNS;
 
@@ -553,7 +553,7 @@ public:
 
 
   void
-  set_input_parameters_ale(Poisson::InputParameters & param)
+  set_input_parameters_ale(Poisson::InputParameters & param) final
   {
     using namespace Poisson;
 
@@ -618,7 +618,7 @@ public:
   }
 
   void
-  set_input_parameters_ale(Structure::InputParameters & parameters)
+  set_input_parameters_ale(Structure::InputParameters & parameters) final
   {
     using namespace Structure;
 
@@ -709,7 +709,7 @@ public:
 
   // Structure
   void
-  set_input_parameters_structure(Structure::InputParameters & parameters)
+  set_input_parameters_structure(Structure::InputParameters & parameters) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -418,7 +418,7 @@ public:
                     PeriodicFaces &                     periodic_faces,
                     unsigned int const                  n_refine_space,
                     std::shared_ptr<Mapping<dim>> &     mapping,
-                    unsigned int const                  mapping_degree)
+                    unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -472,7 +472,7 @@ public:
   void
   set_boundary_conditions_fluid(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
@@ -516,7 +516,7 @@ public:
   }
 
   void
-  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -525,7 +525,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -578,7 +578,7 @@ public:
   }
 
   void set_boundary_conditions_ale(
-    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor)
+    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -611,7 +611,7 @@ public:
 
 
   void
-  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
@@ -649,7 +649,7 @@ public:
 
   void
   set_boundary_conditions_ale(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -699,7 +699,7 @@ public:
   }
 
   void
-  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
@@ -753,7 +753,7 @@ public:
                         PeriodicFaces &                     periodic_faces,
                         unsigned int const                  n_refine_space,
                         std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree)
+                        unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -803,7 +803,7 @@ public:
 
   void
   set_boundary_conditions_structure(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -837,7 +837,8 @@ public:
   }
 
   void
-  set_field_functions_structure(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_structure(
+    std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
@@ -845,7 +846,7 @@ public:
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -681,7 +681,7 @@ public:
   }
 
   void
-  set_material_ale(Structure::MaterialDescriptor & material_descriptor)
+  set_material_ale(Structure::MaterialDescriptor & material_descriptor) final
   {
     using namespace Structure;
 
@@ -823,7 +823,7 @@ public:
   }
 
   void
-  set_material_structure(Structure::MaterialDescriptor & material_descriptor)
+  set_material_structure(Structure::MaterialDescriptor & material_descriptor) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -687,7 +687,7 @@ public:
   }
 
   void
-  set_material_ale(Structure::MaterialDescriptor & material_descriptor)
+  set_material_ale(Structure::MaterialDescriptor & material_descriptor) final
   {
     using namespace Structure;
 
@@ -1011,7 +1011,7 @@ public:
   }
 
   void
-  set_material_structure(Structure::MaterialDescriptor & material_descriptor)
+  set_material_structure(Structure::MaterialDescriptor & material_descriptor) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -163,7 +163,7 @@ public:
   }
 
   void
-  set_input_parameters_fluid(IncNS::InputParameters & param)
+  set_input_parameters_fluid(IncNS::InputParameters & param) final
   {
     using namespace IncNS;
 
@@ -571,7 +571,7 @@ public:
   }
 
   void
-  set_input_parameters_ale(Poisson::InputParameters & param)
+  set_input_parameters_ale(Poisson::InputParameters & param) final
   {
     using namespace Poisson;
 
@@ -625,7 +625,7 @@ public:
   }
 
   void
-  set_input_parameters_ale(Structure::InputParameters & parameters)
+  set_input_parameters_ale(Structure::InputParameters & parameters) final
   {
     using namespace Structure;
 
@@ -714,7 +714,7 @@ public:
 
   // Structure
   void
-  set_input_parameters_structure(Structure::InputParameters & parameters)
+  set_input_parameters_structure(Structure::InputParameters & parameters) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -411,7 +411,7 @@ public:
                     PeriodicFaces &                     periodic_faces,
                     unsigned int const                  n_refine_space,
                     std::shared_ptr<Mapping<dim>> &     mapping,
-                    unsigned int const                  mapping_degree)
+                    unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -507,7 +507,7 @@ public:
   void
   set_boundary_conditions_fluid(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
@@ -540,7 +540,7 @@ public:
   }
 
   void
-  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -549,7 +549,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -596,7 +596,7 @@ public:
   }
 
   void set_boundary_conditions_ale(
-    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor)
+    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
@@ -618,7 +618,7 @@ public:
 
 
   void
-  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
@@ -656,7 +656,7 @@ public:
 
   void
   set_boundary_conditions_ale(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -705,7 +705,7 @@ public:
   }
 
   void
-  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
@@ -893,7 +893,7 @@ public:
                         PeriodicFaces &                     periodic_faces,
                         unsigned int const                  n_refine_space,
                         std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree)
+                        unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -982,7 +982,7 @@ public:
 
   void
   set_boundary_conditions_structure(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -1001,7 +1001,8 @@ public:
   }
 
   void
-  set_field_functions_structure(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_structure(
+    std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
 
@@ -1024,7 +1025,7 @@ public:
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -107,7 +107,7 @@ public:
   }
 
   void
-  set_input_parameters_fluid(IncNS::InputParameters & param)
+  set_input_parameters_fluid(IncNS::InputParameters & param) final
   {
     using namespace IncNS;
 
@@ -438,7 +438,7 @@ public:
 
 
   void
-  set_input_parameters_ale(Poisson::InputParameters & param)
+  set_input_parameters_ale(Poisson::InputParameters & param) final
   {
     using namespace Poisson;
 
@@ -497,7 +497,7 @@ public:
   }
 
   void
-  set_input_parameters_ale(Structure::InputParameters & parameters)
+  set_input_parameters_ale(Structure::InputParameters & parameters) final
   {
     using namespace Structure;
 
@@ -580,7 +580,7 @@ public:
 
   // Structure
   void
-  set_input_parameters_structure(Structure::InputParameters & parameters)
+  set_input_parameters_structure(Structure::InputParameters & parameters) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -554,7 +554,7 @@ public:
   }
 
   void
-  set_material_ale(Structure::MaterialDescriptor & material_descriptor)
+  set_material_ale(Structure::MaterialDescriptor & material_descriptor) final
   {
     using namespace Structure;
 
@@ -716,7 +716,7 @@ public:
   }
 
   void
-  set_material_structure(Structure::MaterialDescriptor & material_descriptor)
+  set_material_structure(Structure::MaterialDescriptor & material_descriptor) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -277,7 +277,7 @@ public:
                     PeriodicFaces &                     periodic_faces,
                     unsigned int const                  n_refine_space,
                     std::shared_ptr<Mapping<dim>> &     mapping,
-                    unsigned int const                  mapping_degree)
+                    unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -365,7 +365,7 @@ public:
   void
   set_boundary_conditions_fluid(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
@@ -401,7 +401,7 @@ public:
   }
 
   void
-  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -410,7 +410,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -463,7 +463,7 @@ public:
   }
 
   void set_boundary_conditions_ale(
-    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor)
+    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -490,7 +490,7 @@ public:
 
 
   void
-  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
@@ -528,7 +528,7 @@ public:
 
   void
   set_boundary_conditions_ale(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -570,7 +570,7 @@ public:
   }
 
   void
-  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
@@ -624,7 +624,7 @@ public:
                         PeriodicFaces &                     periodic_faces,
                         unsigned int const                  n_refine_space,
                         std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree)
+                        unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -687,7 +687,7 @@ public:
 
   void
   set_boundary_conditions_structure(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -730,7 +730,8 @@ public:
   }
 
   void
-  set_field_functions_structure(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_structure(
+    std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
@@ -738,7 +739,7 @@ public:
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -85,7 +85,7 @@ public:
                     PeriodicFaces &                     periodic_faces,
                     unsigned int const                  n_refine_space,
                     std::shared_ptr<Mapping<dim>> &     mapping,
-                    unsigned int const                  mapping_degree)
+                    unsigned int const                  mapping_degree) final
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;
@@ -98,7 +98,7 @@ public:
   void
   set_boundary_conditions_fluid(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -115,7 +115,7 @@ public:
   }
 
   void
-  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     // these lines show exemplarily how the field functions are filled
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
@@ -125,7 +125,7 @@ public:
   }
 
   void set_boundary_conditions_ale(
-    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor)
+    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -135,7 +135,7 @@ public:
   }
 
   void
-  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) final
   {
     // these lines show exemplarily how the field functions are filled
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
@@ -150,7 +150,7 @@ public:
 
   void
   set_boundary_conditions_ale(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     (void)boundary_descriptor;
   }
@@ -162,14 +162,14 @@ public:
   }
 
   void
-  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_ale(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     (void)field_functions;
   }
 
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 
@@ -194,7 +194,7 @@ public:
                         PeriodicFaces &                     periodic_faces,
                         unsigned int const                  n_refine_space,
                         std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree)
+                        unsigned int const                  mapping_degree) final
   {
     (void)triangulation;
     (void)periodic_faces;
@@ -205,7 +205,7 @@ public:
 
   void
   set_boundary_conditions_structure(
-    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor)
+    std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     (void)boundary_descriptor;
   }
@@ -217,13 +217,14 @@ public:
   }
 
   void
-  set_field_functions_structure(std::shared_ptr<Structure::FieldFunctions<dim>> field_functions)
+  set_field_functions_structure(
+    std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) final
   {
     (void)field_functions;
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -156,7 +156,7 @@ public:
   }
 
   void
-  set_material_ale(Structure::MaterialDescriptor & material_descriptor)
+  set_material_ale(Structure::MaterialDescriptor & material_descriptor) final
   {
     (void)material_descriptor;
   }
@@ -211,7 +211,7 @@ public:
   }
 
   void
-  set_material_structure(Structure::MaterialDescriptor & material_descriptor)
+  set_material_structure(Structure::MaterialDescriptor & material_descriptor) final
   {
     (void)material_descriptor;
   }

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -63,7 +63,7 @@ public:
   }
 
   void
-  set_input_parameters_fluid(IncNS::InputParameters & param)
+  set_input_parameters_fluid(IncNS::InputParameters & param) final
   {
     (void)param;
 
@@ -72,7 +72,7 @@ public:
   }
 
   void
-  set_input_parameters_ale(Poisson::InputParameters & param)
+  set_input_parameters_ale(Poisson::InputParameters & param) final
   {
     (void)param;
 
@@ -143,7 +143,7 @@ public:
   }
 
   void
-  set_input_parameters_ale(Structure::InputParameters & parameters)
+  set_input_parameters_ale(Structure::InputParameters & parameters) final
   {
     (void)parameters;
   }
@@ -184,7 +184,7 @@ public:
 
   // Structure
   void
-  set_input_parameters_structure(Structure::InputParameters & parameters)
+  set_input_parameters_structure(Structure::InputParameters & parameters) final
   {
     (void)parameters;
   }

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -348,7 +348,7 @@ public:
   }
 
   std::shared_ptr<Function<dim>>
-  set_mesh_movement_function()
+  set_mesh_movement_function() final
   {
     std::shared_ptr<Function<dim>> mesh_motion;
 

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -317,7 +317,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -369,7 +369,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -388,7 +388,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -400,7 +400,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -88,7 +88,7 @@ public:
   double const REL_TOL_LINEAR = 1.e-2;
 
   void
-  set_input_parameters(IncNS::InputParameters & param)
+  set_input_parameters(IncNS::InputParameters & param) final
   {
     using namespace IncNS;
 
@@ -237,7 +237,8 @@ public:
   }
 
   void
-  set_input_parameters_scalar(ConvDiff::InputParameters & param, unsigned int const scalar_index)
+  set_input_parameters_scalar(ConvDiff::InputParameters & param,
+                              unsigned int const          scalar_index) final
   {
     using namespace ConvDiff;
 
@@ -423,7 +424,7 @@ public:
   void
   set_boundary_conditions_scalar(
     std::shared_ptr<ConvDiff::BoundaryDescriptor<dim>> boundary_descriptor,
-    unsigned int                                       scalar_index = 0)
+    unsigned int                                       scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -437,7 +438,7 @@ public:
 
   void
   set_field_functions_scalar(std::shared_ptr<ConvDiff::FieldFunctions<dim>> field_functions,
-                             unsigned int                                   scalar_index = 0)
+                             unsigned int                                   scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -449,7 +450,7 @@ public:
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
   construct_postprocessor_scalar(unsigned int const degree,
                                  MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index)
+                                 unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -339,7 +339,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -371,7 +371,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -387,7 +387,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -397,7 +397,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -134,7 +134,7 @@ public:
   double const output_interval_time = (end_time - start_time) / 200.0;
 
   void
-  set_input_parameters(IncNS::InputParameters & param)
+  set_input_parameters(IncNS::InputParameters & param) final
   {
     using namespace IncNS;
 
@@ -268,7 +268,8 @@ public:
   }
 
   void
-  set_input_parameters_scalar(ConvDiff::InputParameters & param, unsigned int const scalar_index)
+  set_input_parameters_scalar(ConvDiff::InputParameters & param,
+                              unsigned int const          scalar_index) final
   {
     (void)scalar_index;
 
@@ -420,7 +421,7 @@ public:
   void
   set_boundary_conditions_scalar(
     std::shared_ptr<ConvDiff::BoundaryDescriptor<dim>> boundary_descriptor,
-    unsigned int                                       scalar_index = 0)
+    unsigned int                                       scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -433,7 +434,7 @@ public:
 
   void
   set_field_functions_scalar(std::shared_ptr<ConvDiff::FieldFunctions<dim>> field_functions,
-                             unsigned int                                   scalar_index = 0)
+                             unsigned int                                   scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -445,7 +446,7 @@ public:
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
   construct_postprocessor_scalar(unsigned int const degree,
                                  MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index)
+                                 unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -315,7 +315,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     if(dim == 2)
     {
@@ -374,7 +374,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -390,7 +390,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -402,7 +402,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -107,7 +107,7 @@ public:
   double const output_interval_time = (end_time - start_time) / 100.0;
 
   void
-  set_input_parameters(IncNS::InputParameters & param)
+  set_input_parameters(IncNS::InputParameters & param) final
   {
     using namespace IncNS;
 
@@ -240,7 +240,8 @@ public:
   }
 
   void
-  set_input_parameters_scalar(ConvDiff::InputParameters & param, unsigned int const scalar_index)
+  set_input_parameters_scalar(ConvDiff::InputParameters & param,
+                              unsigned int const          scalar_index) final
   {
     (void)scalar_index;
 
@@ -426,7 +427,7 @@ public:
   void
   set_boundary_conditions_scalar(
     std::shared_ptr<ConvDiff::BoundaryDescriptor<dim>> boundary_descriptor,
-    unsigned int                                       scalar_index = 0)
+    unsigned int                                       scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -439,7 +440,7 @@ public:
 
   void
   set_field_functions_scalar(std::shared_ptr<ConvDiff::FieldFunctions<dim>> field_functions,
-                             unsigned int                                   scalar_index = 0)
+                             unsigned int                                   scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -451,7 +452,7 @@ public:
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
   construct_postprocessor_scalar(unsigned int const degree,
                                  MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index)
+                                 unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -110,7 +110,7 @@ public:
   double const REL_TOL_LINEAR = 1.e-2;
 
   void
-  set_input_parameters(IncNS::InputParameters & param)
+  set_input_parameters(IncNS::InputParameters & param) final
   {
     using namespace IncNS;
 
@@ -251,7 +251,8 @@ public:
   }
 
   void
-  set_input_parameters_scalar(ConvDiff::InputParameters & param, unsigned int const scalar_index)
+  set_input_parameters_scalar(ConvDiff::InputParameters & param,
+                              unsigned int const          scalar_index) final
   {
     (void)scalar_index;
 
@@ -402,7 +403,7 @@ public:
   void
   set_boundary_conditions_scalar(
     std::shared_ptr<ConvDiff::BoundaryDescriptor<dim>> boundary_descriptor,
-    unsigned int                                       scalar_index = 0)
+    unsigned int                                       scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -413,7 +414,7 @@ public:
 
   void
   set_field_functions_scalar(std::shared_ptr<ConvDiff::FieldFunctions<dim>> field_functions,
-                             unsigned int                                   scalar_index = 0)
+                             unsigned int                                   scalar_index = 0) final
   {
     (void)scalar_index; // only one scalar quantity considered
 
@@ -425,7 +426,7 @@ public:
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
   construct_postprocessor_scalar(unsigned int const degree,
                                  MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index)
+                                 unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -327,7 +327,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -355,7 +355,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -368,7 +368,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -380,7 +380,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -63,7 +63,7 @@ public:
   }
 
   void
-  set_input_parameters(IncNS::InputParameters & param)
+  set_input_parameters(IncNS::InputParameters & param) final
   {
     (void)param;
 
@@ -74,7 +74,8 @@ public:
   }
 
   void
-  set_input_parameters_scalar(ConvDiff::InputParameters & param, unsigned int const scalar_index)
+  set_input_parameters_scalar(ConvDiff::InputParameters & param,
+                              unsigned int const          scalar_index) final
   {
     (void)param;
     (void)scalar_index;
@@ -142,7 +143,7 @@ public:
   void
   set_boundary_conditions_scalar(
     std::shared_ptr<ConvDiff::BoundaryDescriptor<dim>> boundary_descriptor,
-    unsigned int const                                 scalar_index = 0)
+    unsigned int const                                 scalar_index = 0) final
   {
     (void)scalar_index;
 
@@ -155,7 +156,7 @@ public:
 
   void
   set_field_functions_scalar(std::shared_ptr<ConvDiff::FieldFunctions<dim>> field_functions,
-                             unsigned int const                             scalar_index = 0)
+                             unsigned int const                             scalar_index = 0) final
   {
     (void)scalar_index;
 
@@ -167,7 +168,7 @@ public:
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
   construct_postprocessor_scalar(unsigned int const degree,
                                  MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index)
+                                 unsigned int const scalar_index) final
   {
     (void)degree;
     (void)scalar_index;

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -90,7 +90,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;
@@ -103,7 +103,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<IncNS::BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -118,7 +118,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -127,7 +127,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -371,7 +371,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     do_set_input_parameters(param);
   }
@@ -387,7 +387,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     Geometry::create_grid(triangulation, n_refine_space, periodic_faces);
 
@@ -399,7 +399,7 @@ public:
                         PeriodicFaces &                     periodic_faces,
                         unsigned int const                  n_refine_space,
                         std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree)
+                        unsigned int const                  mapping_degree) final
   {
     Geometry::create_grid_precursor(triangulation,
                                     n_refine_space + additional_refinements_precursor,
@@ -409,8 +409,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -443,7 +444,7 @@ public:
   void
   set_boundary_conditions_precursor(
     std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -458,7 +459,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(centerline_velocity,
@@ -472,7 +473,7 @@ public:
   }
 
   void
-  set_field_functions_precursor(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions_precursor(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(centerline_velocity,
@@ -485,7 +486,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 
@@ -733,7 +734,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 

--- a/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
@@ -131,7 +131,7 @@ public:
    *  to point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const override
+  push_forward(Point<dim> const & xi) const final
   {
     Point<dim> x = xi;
     x[1]         = grid_transform_y(xi[1]);
@@ -144,7 +144,7 @@ public:
    *  to point xi in reference coordinates
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const override
+  pull_back(Point<dim> const & x) const final
   {
     Point<dim> xi = x;
     xi[1]         = inverse_grid_transform_y(x[1]);
@@ -153,7 +153,7 @@ public:
   }
 
   std::unique_ptr<Manifold<dim>>
-  clone() const override
+  clone() const final
   {
     return std::make_unique<MyManifold<dim>>();
   }

--- a/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
@@ -131,7 +131,7 @@ public:
    *  to point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const
+  push_forward(Point<dim> const & xi) const override
   {
     Point<dim> x = xi;
     x[1]         = grid_transform_y(xi[1]);
@@ -144,7 +144,7 @@ public:
    *  to point xi in reference coordinates
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const
+  pull_back(Point<dim> const & x) const override
   {
     Point<dim> xi = x;
     xi[1]         = inverse_grid_transform_y(x[1]);

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -142,7 +142,7 @@ public:
   double const end_time   = 1.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -254,7 +254,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -266,8 +266,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     // set boundary conditions
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
@@ -279,7 +280,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new AnalyticalSolutionVelocity<dim>(viscosity));
@@ -291,7 +292,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -48,7 +48,7 @@ public:
   double const end_time   = 10.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Steady;
@@ -220,7 +220,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -243,8 +243,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     // all boundaries have ID = 0 by default -> Dirichlet boundaries
 
@@ -264,7 +265,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -273,7 +274,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -74,7 +74,7 @@ public:
   double const end_time   = 10.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type             = ProblemType::Steady; // Unsteady;
@@ -191,7 +191,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -227,8 +227,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -243,7 +244,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -252,7 +253,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -428,7 +428,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     do_set_input_parameters(param);
   }
@@ -444,7 +444,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     FDANozzle::create_grid_and_set_boundary_ids_nozzle(triangulation,
                                                        n_refine_space,
@@ -458,7 +458,7 @@ public:
                         PeriodicFaces &                     periodic_faces,
                         unsigned int const                  n_refine_space,
                         std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree)
+                        unsigned int const                  mapping_degree) final
   {
     Triangulation<2> tria_2d;
     GridGenerator::hyper_ball(tria_2d, Point<2>(), FDANozzle::R_OUTER);
@@ -551,8 +551,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     /*
      *  FILL BOUNDARY DESCRIPTORS
@@ -588,7 +589,7 @@ public:
   void
   set_boundary_conditions_precursor(
     std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     /*
      *  FILL BOUNDARY DESCRIPTORS
@@ -606,7 +607,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(max_velocity));
@@ -616,7 +617,7 @@ public:
   }
 
   void
-  set_field_functions_precursor(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions_precursor(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(max_velocity));
@@ -627,7 +628,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 
@@ -829,7 +830,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -238,7 +238,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -294,7 +294,7 @@ public:
   double const REL_TOL_LINEAR = 1.e-2;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = problem_type;
@@ -469,7 +469,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     this->refine_level = n_refine_space;
 
@@ -508,8 +508,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -531,7 +532,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -540,7 +541,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -64,7 +64,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(ParameterHandler & prm) override
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -87,7 +87,7 @@ public:
   bool ALE = true;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) override
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -258,7 +258,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) override
   {
     (void)periodic_faces;
 
@@ -290,8 +290,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -304,7 +305,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
   {
     field_functions->initial_solution_velocity.reset(new AnalyticalSolutionVelocity<dim>());
     field_functions->initial_solution_pressure.reset(new AnalyticalSolutionPressure<dim>());
@@ -313,7 +314,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -64,7 +64,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm) override
+  add_parameters(ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -87,7 +87,7 @@ public:
   bool ALE = true;
 
   void
-  set_input_parameters(InputParameters & param) override
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -258,7 +258,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) override
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -270,7 +270,7 @@ public:
   }
 
   std::shared_ptr<Function<dim>>
-  set_mesh_movement_function() override
+  set_mesh_movement_function() final
   {
     std::shared_ptr<Function<dim>> mesh_motion;
 
@@ -292,7 +292,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -305,7 +305,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new AnalyticalSolutionVelocity<dim>());
     field_functions->initial_solution_pressure.reset(new AnalyticalSolutionPressure<dim>());
@@ -314,7 +314,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -96,7 +96,7 @@ public:
   double const end_time   = 400.0 * T;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type             = ProblemType::Unsteady;
@@ -213,7 +213,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     AssertThrow(dim == 2, ExcMessage("This application is only implemented for dim=2."));
 
@@ -243,8 +243,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -256,7 +257,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(DELTA_0, U_INF, C_N));
@@ -266,7 +267,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/kovasznay/application.h
+++ b/applications/incompressible_navier_stokes/kovasznay/application.h
@@ -154,7 +154,7 @@ public:
   double const end_time   = 1.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -270,7 +270,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -293,8 +293,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -312,7 +313,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     std::shared_ptr<Function<dim>> initial_solution_velocity;
     std::shared_ptr<Function<dim>> initial_solution_pressure;
@@ -335,7 +336,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -208,7 +208,7 @@ public:
   double       end_time   = 2.0 * t0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -330,7 +330,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     std::vector<unsigned int> repetitions({1, 1});
     Point<dim>                point1(0.0, -H), point2(L, H);
@@ -358,8 +358,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -370,7 +371,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new AnalyticalSolutionVelocity<dim>(H, MAX_VELOCITY, ALPHA, EPSILON, FE, OMEGA, EIG_VEC));
@@ -380,7 +381,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -120,7 +120,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(ParameterHandler & prm) override
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -177,7 +177,7 @@ public:
   unsigned int points_per_line        = 20;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) override
   {
     // MATHEMATICAL MODEL
     param.problem_type = ProblemType::Unsteady;
@@ -268,7 +268,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) override
   {
     Point<dim> p_1;
     p_1[0] = 0.;
@@ -335,8 +335,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
   {
     // set boundary conditions
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
@@ -350,7 +351,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
   {
     field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(bulk_velocity, H, height));
@@ -360,7 +361,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -120,7 +120,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm) override
+  add_parameters(ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -177,7 +177,7 @@ public:
   unsigned int points_per_line        = 20;
 
   void
-  set_input_parameters(InputParameters & param) override
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type = ProblemType::Unsteady;
@@ -268,7 +268,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) override
+              unsigned int const                  mapping_degree) final
   {
     Point<dim> p_1;
     p_1[0] = 0.;
@@ -337,7 +337,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     // set boundary conditions
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
@@ -351,7 +351,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(bulk_velocity, H, height));
@@ -361,7 +361,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/periodic_hill/include/manifold.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/manifold.h
@@ -94,7 +94,7 @@ public:
   }
 
   Point<dim>
-  push_forward(Point<dim> const & xi) const override
+  push_forward(Point<dim> const & xi) const final
   {
     Point<dim> x = xi;
 
@@ -108,7 +108,7 @@ public:
   }
 
   Point<dim>
-  pull_back(Point<dim> const & x) const override
+  pull_back(Point<dim> const & x) const final
   {
     Point<dim> xi = x;
 
@@ -122,7 +122,7 @@ public:
   }
 
   std::unique_ptr<Manifold<dim>>
-  clone() const override
+  clone() const final
   {
     return std::make_unique<PeriodicHillManifold<dim>>(H, LENGTH, HEIGHT, GRID_STRETCH_FAC);
   }

--- a/applications/incompressible_navier_stokes/periodic_hill/include/manifold.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/manifold.h
@@ -94,7 +94,7 @@ public:
   }
 
   Point<dim>
-  push_forward(Point<dim> const & xi) const
+  push_forward(Point<dim> const & xi) const override
   {
     Point<dim> x = xi;
 
@@ -108,7 +108,7 @@ public:
   }
 
   Point<dim>
-  pull_back(Point<dim> const & x) const
+  pull_back(Point<dim> const & x) const override
   {
     Point<dim> xi = x;
 

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -191,7 +191,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -227,7 +227,7 @@ public:
   double const end_time   = 100.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                   = ProblemType::Unsteady;
@@ -356,7 +356,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     double const              y_upper = apply_symmetry_bc ? 0.0 : H / 2.;
     Point<dim>                point1(0.0, -H / 2.), point2(L, y_upper);
@@ -393,8 +393,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -476,7 +477,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -489,7 +490,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -82,7 +82,7 @@ public:
   double const end_time   = 4.0;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type = ProblemType::Unsteady;
@@ -180,7 +180,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     double const left = 0.0, right = 1.0;
     GridGenerator::hyper_cube(*triangulation, left, right);
@@ -204,8 +204,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     (void)boundary_descriptor_velocity;
     (void)boundary_descriptor_pressure;
@@ -213,7 +214,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new InitialSolutionVelocity<dim>(rho, delta));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -222,7 +223,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -166,7 +166,7 @@ public:
   double const end_time   = 1.0e-1;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type             = ProblemType::Unsteady;
@@ -292,7 +292,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -304,8 +304,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     // test case with pure Dirichlet boundary conditions for velocity
     // all boundaries have ID = 0 by default
@@ -321,7 +322,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new AnalyticalSolutionVelocity<dim>(viscosity));
@@ -333,7 +334,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -119,7 +119,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm) override
+  add_parameters(ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -179,7 +179,7 @@ public:
   double const REL_TOL_LINEAR = 1.e-2;
 
   void
-  set_input_parameters(InputParameters & param) override
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type = ProblemType::Unsteady;
@@ -352,7 +352,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) override
+              unsigned int const                  mapping_degree) final
   {
     this->refine_level = n_refine_space;
 
@@ -428,7 +428,7 @@ public:
   }
 
   std::shared_ptr<Function<dim>>
-  set_mesh_movement_function() override
+  set_mesh_movement_function() final
   {
     std::shared_ptr<Function<dim>> mesh_motion;
 
@@ -451,7 +451,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     if(exploit_symmetry)
     {
@@ -471,7 +471,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new InitialSolutionVelocity<dim>(V_0, L));
     field_functions->initial_solution_pressure.reset(new InitialSolutionPressure<dim>(V_0, L, p_0));
@@ -480,7 +480,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -119,7 +119,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(ParameterHandler & prm) override
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -179,7 +179,7 @@ public:
   double const REL_TOL_LINEAR = 1.e-2;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) override
   {
     // MATHEMATICAL MODEL
     param.problem_type = ProblemType::Unsteady;
@@ -352,7 +352,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) override
   {
     this->refine_level = n_refine_space;
 
@@ -449,8 +449,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
   {
     if(exploit_symmetry)
     {
@@ -470,7 +471,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
   {
     field_functions->initial_solution_velocity.reset(new InitialSolutionVelocity<dim>(V_0, L));
     field_functions->initial_solution_pressure.reset(new InitialSolutionPressure<dim>(V_0, L, p_0));
@@ -479,7 +480,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/template/application.h
+++ b/applications/incompressible_navier_stokes/template/application.h
@@ -63,7 +63,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     (void)param;
 
@@ -76,7 +76,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;
@@ -87,8 +87,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -105,7 +106,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     // these lines show how the field functions are filled
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
@@ -115,7 +116,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_navier_stokes/template_precursor/application.h
+++ b/applications/incompressible_navier_stokes/template_precursor/application.h
@@ -43,7 +43,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     (void)param;
   }
@@ -59,7 +59,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)triangulation;
     (void)periodic_faces;
@@ -73,7 +73,7 @@ public:
                         PeriodicFaces &                     periodic_faces,
                         unsigned int const                  n_refine_space,
                         std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree)
+                        unsigned int const                  mapping_degree) final
   {
     (void)triangulation;
     (void)periodic_faces;
@@ -83,8 +83,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -95,7 +96,7 @@ public:
   void
   set_boundary_conditions_precursor(
     std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -104,7 +105,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -113,7 +114,7 @@ public:
   }
 
   void
-  set_field_functions_precursor(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions_precursor(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -122,7 +123,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 
@@ -135,7 +136,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -62,7 +62,7 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -77,7 +77,7 @@ public:
   MeshType    mesh_type        = MeshType::Cartesian;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -176,7 +176,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;
@@ -216,7 +216,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(dim));
@@ -225,7 +225,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -112,7 +112,7 @@ public:
    *  point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const override
+  push_forward(Point<dim> const & xi) const final
   {
     Point<dim> x;
 
@@ -130,7 +130,7 @@ public:
    *  to point xi in reference coordinates [0,1]^d
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const override
+  pull_back(Point<dim> const & x) const final
   {
     Point<dim> xi;
 
@@ -144,7 +144,7 @@ public:
   }
 
   std::unique_ptr<Manifold<dim>>
-  clone() const override
+  clone() const final
   {
     return std::make_unique<ManifoldTurbulentChannel<dim>>(dimensions);
   }
@@ -255,7 +255,7 @@ public:
   double const REL_TOL_LINEAR = 1.e-2;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -397,7 +397,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     Tensor<1, dim> dimensions;
     dimensions[0] = DIMENSIONS_X1;
@@ -444,8 +444,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -456,7 +457,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(new InitialSolutionVelocity<dim>());
     field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
@@ -467,7 +468,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -112,7 +112,7 @@ public:
    *  point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const
+  push_forward(Point<dim> const & xi) const override
   {
     Point<dim> x;
 
@@ -130,7 +130,7 @@ public:
    *  to point xi in reference coordinates [0,1]^d
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const
+  pull_back(Point<dim> const & x) const override
   {
     Point<dim> xi;
 

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -291,7 +291,7 @@ public:
   bool const ALE = true;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) override
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -481,7 +481,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) override
   {
     (void)periodic_faces;
 
@@ -635,8 +635,9 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure)
+  set_boundary_conditions(
+    std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -658,7 +659,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
   {
     field_functions->initial_solution_velocity.reset(
       new AnalyticalSolutionVelocity<dim>(u_x_max, viscosity));
@@ -740,7 +741,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -291,7 +291,7 @@ public:
   bool const ALE = true;
 
   void
-  set_input_parameters(InputParameters & param) override
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.problem_type                = ProblemType::Unsteady;
@@ -481,7 +481,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) override
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -637,7 +637,7 @@ public:
   void
   set_boundary_conditions(
     std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) override
+    std::shared_ptr<BoundaryDescriptorP<dim>> boundary_descriptor_pressure) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -659,7 +659,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) override
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution_velocity.reset(
       new AnalyticalSolutionVelocity<dim>(u_x_max, viscosity));
@@ -671,7 +671,7 @@ public:
   }
 
   std::shared_ptr<Function<dim>>
-  set_mesh_movement_function() override
+  set_mesh_movement_function() final
   {
     std::shared_ptr<Function<dim>> mesh_motion;
 
@@ -691,7 +691,7 @@ public:
   }
 
   void
-  set_input_parameters_poisson(Poisson::InputParameters & param) override
+  set_input_parameters_poisson(Poisson::InputParameters & param) final
   {
     using namespace Poisson;
 
@@ -723,7 +723,7 @@ public:
   }
 
   void set_boundary_conditions_poisson(
-    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) override
+    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -733,15 +733,14 @@ public:
   }
 
   void
-  set_field_functions_poisson(
-    std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) override
+  set_field_functions_poisson(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) override
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/vortex/vortex_backup.h
+++ b/applications/incompressible_navier_stokes/vortex/vortex_backup.h
@@ -655,7 +655,7 @@ public:
   }
 
   std::shared_ptr<Function<dim>>
-  set_mesh_movement_function() override
+  set_mesh_movement_function() final
   {
     std::shared_ptr<Function<dim>> mesh_motion;
 
@@ -675,7 +675,7 @@ public:
   }
 
   void
-  set_input_parameters_poisson(Poisson::InputParameters & param) override
+  set_input_parameters_poisson(Poisson::InputParameters & param) final
   {
     using namespace Poisson;
 
@@ -707,7 +707,7 @@ public:
   }
 
   void set_boundary_conditions_poisson(
-    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) override
+    std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -717,8 +717,7 @@ public:
   }
 
   void
-  set_field_functions_poisson(
-    std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) override
+  set_field_functions_poisson(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -212,7 +212,7 @@ public:
   bool global_coarsening = false;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.right_hand_side = true;
@@ -247,7 +247,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -298,7 +298,8 @@ public:
     mapping.reset(new MappingQGeneric<dim>(mapping_degree));
   }
 
-  void set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor)
+  void
+    set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -308,14 +309,14 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new RightHandSide<dim>());
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -147,7 +147,7 @@ public:
   MeshType    mesh_type        = MeshType::Cartesian;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.right_hand_side = true;
@@ -182,7 +182,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -250,7 +250,8 @@ public:
   }
 
 
-  void set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor)
+  void
+    set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -259,14 +260,14 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new RightHandSide<dim>());
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -46,7 +46,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.right_hand_side = false;
@@ -81,7 +81,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -95,7 +95,8 @@ public:
     mapping.reset(new MappingQGeneric<dim>(mapping_degree));
   }
 
-  void set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor)
+  void
+    set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -104,14 +105,14 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/poisson/template/application.h
+++ b/applications/poisson/template/application.h
@@ -62,7 +62,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     (void)param;
 
@@ -76,7 +76,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     // to avoid warnings (unused variable) use ...
     (void)triangulation;
@@ -87,7 +87,8 @@ public:
   }
 
 
-  void set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor)
+  void
+    set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
 
@@ -98,7 +99,7 @@ public:
 
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     // these lines show exemplarily how the field functions are filled
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
@@ -106,7 +107,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -79,7 +79,7 @@ public:
   MeshType    mesh_type        = MeshType::Cartesian;
 
   void
-  set_input_parameters(InputParameters & param)
+  set_input_parameters(InputParameters & param) final
   {
     // MATHEMATICAL MODEL
     param.right_hand_side = false;
@@ -100,7 +100,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;
@@ -131,20 +131,21 @@ public:
     mapping.reset(new MappingQGeneric<dim>(mapping_degree));
   }
 
-  void set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor)
+  void
+    set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor) final
   {
     (void)boundary_descriptor;
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -339,7 +339,7 @@ public:
   }
 
   void
-  set_material(MaterialDescriptor & material_descriptor)
+  set_material(MaterialDescriptor & material_descriptor) final
   {
     typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
 

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -211,7 +211,7 @@ public:
   double const density = 0.001;
 
   void
-  set_input_parameters(InputParameters & parameters)
+  set_input_parameters(InputParameters & parameters) final
   {
     parameters.problem_type         = ProblemType::Steady;
     parameters.body_force           = use_volume_force;

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -256,7 +256,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -303,7 +303,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -351,7 +351,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     if(use_volume_force)
       field_functions->right_hand_side.reset(new VolumeForce<dim>(this->volume_force));
@@ -363,7 +363,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -293,7 +293,7 @@ public:
   }
 
   void
-  set_material(MaterialDescriptor & material_descriptor)
+  set_material(MaterialDescriptor & material_descriptor) final
   {
     typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
 

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -165,7 +165,7 @@ public:
   unsigned int const repetitions0 = 20, repetitions1 = 4, repetitions2 = 1;
 
   void
-  set_input_parameters(InputParameters & parameters)
+  set_input_parameters(InputParameters & parameters) final
   {
     parameters.problem_type      = ProblemType::QuasiStatic;
     parameters.body_force        = false;

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -198,7 +198,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -260,7 +260,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -306,7 +306,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
 
@@ -315,7 +315,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -189,7 +189,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     AssertThrow(dim == 3, ExcMessage("This application only makes sense for dim=3."));
 
@@ -231,7 +231,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -280,7 +280,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     if(use_volume_force)
       field_functions->right_hand_side.reset(new VolumeForce<dim>(volume_force));
@@ -292,7 +292,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -154,7 +154,7 @@ public:
   double area_force   = 1.0; // "Neumann"
 
   void
-  set_input_parameters(InputParameters & parameters)
+  set_input_parameters(InputParameters & parameters) final
   {
     parameters.problem_type         = ProblemType::QuasiStatic; // Steady;
     parameters.body_force           = use_volume_force;

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -268,7 +268,7 @@ public:
   }
 
   void
-  set_material(MaterialDescriptor & material_descriptor)
+  set_material(MaterialDescriptor & material_descriptor) final
   {
     typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
 

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -403,7 +403,7 @@ public:
   }
 
   void
-  set_material(MaterialDescriptor & material_descriptor)
+  set_material(MaterialDescriptor & material_descriptor) final
   {
     typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
 

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -325,7 +325,7 @@ public:
   double const frequency        = 3.0 / 2.0 * numbers::PI / end_time;
 
   void
-  set_input_parameters(InputParameters & parameters)
+  set_input_parameters(InputParameters & parameters) final
   {
     parameters.problem_type         = unsteady ? ProblemType::Unsteady : ProblemType::Steady;
     parameters.body_force           = true;

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -363,7 +363,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)periodic_faces;
 
@@ -392,7 +392,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
@@ -414,7 +414,7 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     field_functions->right_hand_side.reset(
       new VolumeForce<dim>(max_displacement, length, density, unsteady, frequency, f0));
@@ -424,7 +424,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -65,7 +65,7 @@ public:
               PeriodicFaces &                     periodic_faces,
               unsigned int const                  n_refine_space,
               std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree)
+              unsigned int const                  mapping_degree) final
   {
     (void)triangulation;
     (void)periodic_faces;
@@ -75,7 +75,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     (void)boundary_descriptor;
   }
@@ -87,13 +87,13 @@ public:
   }
 
   void
-  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions)
+  set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) final
   {
     (void)field_functions;
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -55,7 +55,7 @@ public:
   }
 
   void
-  set_input_parameters(InputParameters & parameters)
+  set_input_parameters(InputParameters & parameters) final
   {
     (void)parameters;
   }

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -81,7 +81,7 @@ public:
   }
 
   void
-  set_material(MaterialDescriptor & material_descriptor)
+  set_material(MaterialDescriptor & material_descriptor) final
   {
     (void)material_descriptor;
   }

--- a/include/exadg/grid/deformed_cube_manifold.h
+++ b/include/exadg/grid/deformed_cube_manifold.h
@@ -41,7 +41,7 @@ public:
   }
 
   Point<dim>
-  push_forward(Point<dim> const & chart_point) const
+  push_forward(Point<dim> const & chart_point) const override
   {
     double sinval = deformation;
     for(unsigned int d = 0; d < dim; ++d)
@@ -53,7 +53,7 @@ public:
   }
 
   Point<dim>
-  pull_back(Point<dim> const & space_point) const
+  pull_back(Point<dim> const & space_point) const override
   {
     Point<dim> x = space_point;
     Point<dim> one;

--- a/include/exadg/grid/one_sided_cylindrical_manifold.h
+++ b/include/exadg/grid/one_sided_cylindrical_manifold.h
@@ -104,7 +104,7 @@ public:
    *  point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const
+  push_forward(Point<dim> const & xi) const override
   {
     Point<dim> x;
 
@@ -262,7 +262,7 @@ public:
    *  push_forward operation and Newton's method
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const
+  pull_back(Point<dim> const & x) const override
   {
     Point<dim>     xi;
     Tensor<1, dim> residual = push_forward(xi) - x;
@@ -412,7 +412,7 @@ public:
    *  point x in physical coordinates
    */
   Point<dim>
-  push_forward(Point<dim> const & xi) const
+  push_forward(Point<dim> const & xi) const override
   {
     Point<dim> x;
 
@@ -573,7 +573,7 @@ public:
    *  push_forward operation and Newton's method
    */
   Point<dim>
-  pull_back(Point<dim> const & x) const
+  pull_back(Point<dim> const & x) const override
   {
     Point<dim>     xi;
     Tensor<1, dim> residual = push_forward(xi) - x;
@@ -683,7 +683,7 @@ public:
   }
 
   Point<spacedim>
-  push_forward(Point<spacedim> const & ref_point) const
+  push_forward(Point<spacedim> const & ref_point) const override
   {
     double const radius = ref_point[0];
     double const theta  = ref_point[1];
@@ -707,7 +707,7 @@ public:
   }
 
   Point<spacedim>
-  pull_back(Point<spacedim> const & space_point) const
+  pull_back(Point<spacedim> const & space_point) const override
   {
     Tensor<1, spacedim> vector;
     vector[0] = space_point[0] - center[0];

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -106,7 +106,7 @@ public:
    * This function applies the multigrid preconditioner dst = P^{-1} src.
    */
   void
-  vmult(VectorType & dst, VectorType const & src) const;
+  vmult(VectorType & dst, VectorType const & src) const override;
 
   /*
    * Use multigrid as a solver.
@@ -125,8 +125,8 @@ public:
    * Update of multigrid preconditioner including operators, smoothers, etc. (e.g. for problems
    * with time-dependent coefficients).
    */
-  virtual void
-  update();
+  void
+  update() override;
 
   std::shared_ptr<TimerTree>
   get_timings() const override;

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -117,7 +117,7 @@ public:
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const
+  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
     Timer timer;
 
@@ -225,7 +225,7 @@ public:
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const
+  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
     Timer timer;
 
@@ -326,7 +326,7 @@ public:
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const
+  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
     Timer timer;
 


### PR DESCRIPTION
With a fresh build, I found a few more of these occurrences that I overlooked in #45. (I see a bunch of additional warnings regarding float-integer conversions due to `std::pow` that I want to tackle in the future, which is why I did not detect them when rebasing #45 and only got now on a closer look).