### PR TITLE
Introduce utility functions create_operator() and create_time_integrator()

### DIFF
--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -171,7 +171,7 @@ private:
   std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
   std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
 
-  std::shared_ptr<Operator<dim, Number>> conv_diff_operator;
+  std::shared_ptr<Operator<dim, Number>> pde_operator;
 
   std::shared_ptr<PostProcessorBase<dim, Number>> postprocessor;
 

--- a/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
+++ b/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
@@ -1,0 +1,83 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_CONVECTION_DIFFUSION_TIME_INTEGRATION_CREATE_TIME_INTEGRATOR_H_
+#define INCLUDE_EXADG_CONVECTION_DIFFUSION_TIME_INTEGRATION_CREATE_TIME_INTEGRATOR_H_
+
+#include <exadg/convection_diffusion/time_integration/time_int_bdf.h>
+#include <exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h>
+#include <exadg/convection_diffusion/user_interface/input_parameters.h>
+
+namespace ExaDG
+{
+namespace ConvDiff
+{
+/**
+ * Creates time integrator depending on type of time integration strategy.
+ */
+template<int dim, typename Number>
+std::shared_ptr<TimeIntBase>
+create_time_integrator(std::shared_ptr<Operator<dim, Number>>          pde_operator,
+                       InputParameters const &                         parameters,
+                       unsigned int const                              refine_steps_time,
+                       MPI_Comm const &                                mpi_comm,
+                       bool const                                      is_test,
+                       std::shared_ptr<PostProcessorInterface<Number>> postprocessor,
+                       std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh,
+                       std::shared_ptr<MatrixFree<dim, Number>>        matrix_free)
+{
+  std::shared_ptr<TimeIntBase> time_integrator;
+
+  if(parameters.temporal_discretization == TemporalDiscretization::ExplRK)
+  {
+    AssertThrow(moving_mesh == nullptr,
+                ExcMessage("ALE functionality is not implemented for ExplRK time integration."));
+
+    time_integrator = std::make_shared<TimeIntExplRK<Number>>(
+      pde_operator, parameters, refine_steps_time, mpi_comm, is_test, postprocessor);
+  }
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDF)
+  {
+    time_integrator = std::make_shared<TimeIntBDF<dim, Number>>(pde_operator,
+                                                                parameters,
+                                                                refine_steps_time,
+                                                                mpi_comm,
+                                                                is_test,
+                                                                postprocessor,
+                                                                moving_mesh,
+                                                                matrix_free);
+  }
+  else
+  {
+    AssertThrow(parameters.temporal_discretization == TemporalDiscretization::ExplRK ||
+                  parameters.temporal_discretization == TemporalDiscretization::BDF,
+                ExcMessage("Specified time integration scheme is not implemented!"));
+  }
+
+  return time_integrator;
+}
+
+} // namespace ConvDiff
+} // namespace ExaDG
+
+
+
+#endif /* INCLUDE_EXADG_CONVECTION_DIFFUSION_TIME_INTEGRATION_CREATE_TIME_INTEGRATOR_H_ */

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -40,7 +40,7 @@ TimeIntBDF<dim, Number>::TimeIntBDF(
   InputParameters const &                         param_in,
   unsigned int const                              refine_steps_time_in,
   MPI_Comm const &                                mpi_comm_in,
-  bool const                                      print_wall_times_in,
+  bool const                                      is_test_in,
   std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
   std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
   std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
@@ -52,7 +52,7 @@ TimeIntBDF<dim, Number>::TimeIntBDF(
                            param_in.adaptive_time_stepping,
                            param_in.restart_data,
                            mpi_comm_in,
-                           print_wall_times_in),
+                           is_test_in),
     pde_operator(operator_in),
     param(param_in),
     refine_steps_time(refine_steps_time_in),

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
@@ -65,7 +65,7 @@ public:
              InputParameters const &                         param_in,
              unsigned int const                              refine_steps_time_in,
              MPI_Comm const &                                mpi_comm_in,
-             bool const                                      print_wall_times_in,
+             bool const                                      is_in,
              std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
              std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
              std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -380,11 +380,7 @@ private:
   std::shared_ptr<MatrixFree<dim, Number>>     fluid_matrix_free;
 
   // spatial discretization
-  std::shared_ptr<IncNS::SpatialOperatorBase<dim, Number>>   fluid_operator;
-  std::shared_ptr<IncNS::OperatorCoupled<dim, Number>>       fluid_operator_coupled;
-  std::shared_ptr<IncNS::OperatorDualSplitting<dim, Number>> fluid_operator_dual_splitting;
-  std::shared_ptr<IncNS::OperatorPressureCorrection<dim, Number>>
-    fluid_operator_pressure_correction;
+  std::shared_ptr<IncNS::SpatialOperatorBase<dim, Number>> fluid_operator;
 
   // temporal discretization
   std::shared_ptr<IncNS::TimeIntBDF<dim, Number>> fluid_time_integrator;

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -19,6 +19,7 @@
  *  ______________________________________________________________________
  */
 
+#include <exadg/convection_diffusion/time_integration/create_time_integrator.h>
 #include <exadg/incompressible_flow_with_transport/driver.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h>
 #include <exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h>
@@ -342,34 +343,15 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   for(unsigned int i = 0; i < n_scalars; ++i)
   {
     // initialize time integrator
-    if(scalar_param[i].temporal_discretization == ConvDiff::TemporalDiscretization::ExplRK)
-    {
-      scalar_time_integrator[i].reset(new ConvDiff::TimeIntExplRK<Number>(conv_diff_operator[i],
-                                                                          scalar_param[i],
-                                                                          0 /* refine_time */,
-                                                                          mpi_comm,
-                                                                          is_test,
-                                                                          scalar_postprocessor[i]));
-    }
-    else if(scalar_param[i].temporal_discretization == ConvDiff::TemporalDiscretization::BDF)
-    {
-      scalar_time_integrator[i].reset(new ConvDiff::TimeIntBDF<dim, Number>(conv_diff_operator[i],
-                                                                            scalar_param[i],
-                                                                            0 /* refine_time */,
-                                                                            mpi_comm,
-                                                                            is_test,
-                                                                            scalar_postprocessor[i],
-                                                                            moving_mapping,
-                                                                            matrix_free));
-    }
-    else
-    {
-      AssertThrow(scalar_param[i].temporal_discretization ==
-                      ConvDiff::TemporalDiscretization::ExplRK ||
-                    scalar_param[i].temporal_discretization ==
-                      ConvDiff::TemporalDiscretization::BDF,
-                  ExcMessage("Specified time integration scheme is not implemented!"));
-    }
+    scalar_time_integrator[i] =
+      ConvDiff::create_time_integrator<dim, Number>(conv_diff_operator[i],
+                                                    scalar_param[i],
+                                                    0 /* refine_time */,
+                                                    mpi_comm,
+                                                    is_test,
+                                                    scalar_postprocessor[i],
+                                                    moving_mapping,
+                                                    matrix_free);
 
     if(scalar_param[i].restarted_simulation == false)
     {

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -132,11 +132,7 @@ private:
   std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
   std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
 
-  std::shared_ptr<IncNS::SpatialOperatorBase<dim, Number>>   fluid_operator_base;
-  std::shared_ptr<IncNS::OperatorCoupled<dim, Number>>       fluid_operator_coupled;
-  std::shared_ptr<IncNS::OperatorDualSplitting<dim, Number>> fluid_operator_dual_splitting;
-  std::shared_ptr<IncNS::OperatorPressureCorrection<dim, Number>>
-    fluid_operator_pressure_correction;
+  std::shared_ptr<IncNS::SpatialOperatorBase<dim, Number>> fluid_operator;
 
   typedef IncNS::PostProcessorBase<dim, Number> Postprocessor;
 

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -263,10 +263,7 @@ private:
   /*
    * Spatial discretization
    */
-  std::shared_ptr<SpatialOperatorBase<dim, Number>>        operator_base;
-  std::shared_ptr<OperatorCoupled<dim, Number>>            operator_coupled;
-  std::shared_ptr<OperatorDualSplitting<dim, Number>>      operator_dual_splitting;
-  std::shared_ptr<OperatorPressureCorrection<dim, Number>> operator_pressure_correction;
+  std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_operator;
 
   /*
    * Postprocessor
@@ -283,9 +280,7 @@ private:
   std::shared_ptr<TimeIntBDF<dim, Number>> time_integrator;
 
   // steady solver
-  typedef DriverSteadyProblems<dim, Number> DriverSteady;
-
-  std::shared_ptr<DriverSteady> driver_steady;
+  std::shared_ptr<DriverSteadyProblems<dim, Number>> driver_steady;
 
   /*
    * Computation time (wall clock time).

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
@@ -352,26 +352,25 @@ template<int dim, typename Number>
 void
 DriverPrecursor<dim, Number>::print_performance_results(double const total_time) const
 {
-  this->pcout << std::endl
-              << "_________________________________________________________________________________"
-              << std::endl
-              << std::endl;
+  pcout << std::endl
+        << "_________________________________________________________________________________"
+        << std::endl
+        << std::endl;
 
   // Iterations
-  this->pcout << std::endl
-              << "Average number of iterations for incompressible Navier-Stokes solver:"
-              << std::endl;
+  pcout << std::endl
+        << "Average number of iterations for incompressible Navier-Stokes solver:" << std::endl;
 
-  this->pcout << std::endl << "Precursor:" << std::endl;
+  pcout << std::endl << "Precursor:" << std::endl;
 
   time_integrator_pre->print_iterations();
 
-  this->pcout << std::endl << "Main:" << std::endl;
+  pcout << std::endl << "Main:" << std::endl;
 
   time_integrator->print_iterations();
 
   // Wall times
-  this->pcout << std::endl << "Wall times for incompressible Navier-Stokes solver:" << std::endl;
+  pcout << std::endl << "Wall times for incompressible Navier-Stokes solver:" << std::endl;
 
   timer_tree.insert({"Incompressible flow"}, total_time);
 
@@ -395,9 +394,9 @@ DriverPrecursor<dim, Number>::print_performance_results(double const total_time)
 
   print_costs(pcout, total_time_avg, N_mpi_processes);
 
-  this->pcout << "_________________________________________________________________________________"
-              << std::endl
-              << std::endl;
+  pcout << "_________________________________________________________________________________"
+        << std::endl
+        << std::endl;
 }
 
 template class DriverPrecursor<2, float>;

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.h
@@ -111,15 +111,8 @@ private:
   /*
    * Spatial discretization
    */
-  std::shared_ptr<SpatialOperatorBase<dim, Number>>        operator_base_pre;
-  std::shared_ptr<OperatorCoupled<dim, Number>>            operator_coupled_pre;
-  std::shared_ptr<OperatorDualSplitting<dim, Number>>      operator_dual_splitting_pre;
-  std::shared_ptr<OperatorPressureCorrection<dim, Number>> operator_pressure_correction_pre;
-
-  std::shared_ptr<SpatialOperatorBase<dim, Number>>        operator_base;
-  std::shared_ptr<OperatorCoupled<dim, Number>>            operator_coupled;
-  std::shared_ptr<OperatorDualSplitting<dim, Number>>      operator_dual_splitting;
-  std::shared_ptr<OperatorPressureCorrection<dim, Number>> operator_pressure_correction;
+  std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_operator_pre;
+  std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_operator;
 
   /*
    * Postprocessor

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
@@ -1,0 +1,110 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_SPATIAL_DISCRETIZATION_CREATE_OPERATOR_H_
+#define INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_SPATIAL_DISCRETIZATION_CREATE_OPERATOR_H_
+
+// ExaDG
+#include <exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h>
+#include <exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h>
+#include <exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h>
+#include <exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h>
+
+namespace ExaDG
+{
+namespace IncNS
+{
+/**
+ * Creates spatial discretization operator depending on type of solution strategy.
+ */
+template<int dim, typename Number>
+std::shared_ptr<SpatialOperatorBase<dim, Number>>
+create_operator(
+  Triangulation<dim> const &          triangulation,
+  std::shared_ptr<Mapping<dim> const> mapping,
+  unsigned int const                  degree_velocity,
+  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
+                                                  periodic_faces,
+  std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
+  std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
+  std::shared_ptr<FieldFunctions<dim>> const      field_functions,
+  InputParameters const &                         parameters,
+  std::string const &                             field,
+  MPI_Comm const &                                mpi_comm)
+{
+  std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_operator;
+
+  // initialize pde_operator
+  if(parameters.temporal_discretization == TemporalDiscretization::BDFCoupledSolution)
+  {
+    pde_operator = std::make_shared<OperatorCoupled<dim, Number>>(triangulation,
+                                                                  mapping,
+                                                                  degree_velocity,
+                                                                  periodic_faces,
+                                                                  boundary_descriptor_velocity,
+                                                                  boundary_descriptor_pressure,
+                                                                  field_functions,
+                                                                  parameters,
+                                                                  field,
+                                                                  mpi_comm);
+  }
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  {
+    pde_operator =
+      std::make_shared<OperatorDualSplitting<dim, Number>>(triangulation,
+                                                           mapping,
+                                                           degree_velocity,
+                                                           periodic_faces,
+                                                           boundary_descriptor_velocity,
+                                                           boundary_descriptor_pressure,
+                                                           field_functions,
+                                                           parameters,
+                                                           field,
+                                                           mpi_comm);
+  }
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
+  {
+    pde_operator =
+      std::make_shared<OperatorPressureCorrection<dim, Number>>(triangulation,
+                                                                mapping,
+                                                                degree_velocity,
+                                                                periodic_faces,
+                                                                boundary_descriptor_velocity,
+                                                                boundary_descriptor_pressure,
+                                                                field_functions,
+                                                                parameters,
+                                                                field,
+                                                                mpi_comm);
+  }
+  else
+  {
+    AssertThrow(false, ExcMessage("Not implemented."));
+  }
+
+  return pde_operator;
+}
+
+} // namespace IncNS
+} // namespace ExaDG
+
+
+
+#endif /* INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_SPATIAL_DISCRETIZATION_CREATE_OPERATOR_H_ */

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -172,19 +172,6 @@ OperatorCoupled<dim, Number>::update_continuity_penalty_operator(VectorType cons
 
 template<int dim, typename Number>
 void
-OperatorCoupled<dim, Number>::initialize_block_vector_velocity_pressure(BlockVectorType & src) const
-{
-  // velocity(1st block) + pressure(2nd block)
-  src.reinit(2);
-
-  this->get_matrix_free().initialize_dof_vector(src.block(0), this->get_dof_index_velocity());
-  this->get_matrix_free().initialize_dof_vector(src.block(1), this->get_dof_index_pressure());
-
-  src.collect_sizes();
-}
-
-template<int dim, typename Number>
-void
 OperatorCoupled<dim, Number>::set_scaling_factor_continuity(double const scaling_factor)
 {
   scaling_factor_continuity = scaling_factor;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -191,7 +191,7 @@ private:
 
   typedef typename Base::VectorType VectorType;
 
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef typename Base::BlockVectorType BlockVectorType;
 
 public:
   /*
@@ -236,13 +236,6 @@ public:
    */
   void
   update_continuity_penalty_operator(VectorType const & velocity);
-
-
-  /*
-   * Initialization of vectors.
-   */
-  void
-  initialize_block_vector_velocity_pressure(BlockVectorType & src) const;
 
   /*
    * Setters and getters.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -787,6 +787,20 @@ SpatialOperatorBase<dim, Number>::initialize_vector_pressure(VectorType & src) c
 
 template<int dim, typename Number>
 void
+SpatialOperatorBase<dim, Number>::initialize_block_vector_velocity_pressure(
+  BlockVectorType & src) const
+{
+  // velocity (1st block) + pressure (2nd block)
+  src.reinit(2);
+
+  matrix_free->initialize_dof_vector(src.block(0), get_dof_index_velocity());
+  matrix_free->initialize_dof_vector(src.block(1), get_dof_index_pressure());
+
+  src.collect_sizes();
+}
+
+template<int dim, typename Number>
+void
 SpatialOperatorBase<dim, Number>::prescribe_initial_conditions(VectorType & velocity,
                                                                VectorType & pressure,
                                                                double const time) const

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -26,6 +26,9 @@
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
 
 // ExaDG
 #include <exadg/incompressible_navier_stokes/spatial_discretization/calculators/divergence_calculator.h>
@@ -60,6 +63,7 @@ using namespace dealii;
 
 template<int dim, typename Number>
 class SpatialOperatorBase;
+
 /*
  * Operator-integration-factor (OIF) sub-stepping.
  */
@@ -124,7 +128,8 @@ template<int dim, typename Number>
 class SpatialOperatorBase : public dealii::Subscriptor
 {
 protected:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef LinearAlgebra::distributed::Vector<Number>      VectorType;
+  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef SpatialOperatorBase<dim, Number> This;
 
@@ -269,6 +274,9 @@ public:
 
   void
   initialize_vector_pressure(VectorType & src) const;
+
+  void
+  initialize_block_vector_velocity_pressure(BlockVectorType & src) const;
 
   /*
    * Prescribe initial conditions using a specified analytical/initial solution function.

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -1,0 +1,105 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_TIME_INTEGRATION_CREATE_TIME_INTEGRATOR_H_
+#define INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_TIME_INTEGRATION_CREATE_TIME_INTEGRATOR_H_
+
+#include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h>
+#include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h>
+#include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h>
+#include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h>
+
+namespace ExaDG
+{
+namespace IncNS
+{
+/**
+ * Creates time integrator depending on type of solution strategy.
+ */
+template<int dim, typename Number>
+std::shared_ptr<TimeIntBDF<dim, Number>>
+create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_operator,
+                       InputParameters const &                           parameters,
+                       unsigned int const                                refine_time,
+                       MPI_Comm const &                                  mpi_comm,
+                       bool const                                        is_test,
+                       std::shared_ptr<PostProcessorInterface<Number>>   postprocessor,
+                       std::shared_ptr<MovingMeshBase<dim, Number>>      moving_mesh,
+                       std::shared_ptr<MatrixFree<dim, Number>>          matrix_free)
+{
+  std::shared_ptr<TimeIntBDF<dim, Number>> time_integrator;
+
+  // initialize pde_operator
+  if(parameters.temporal_discretization == TemporalDiscretization::BDFCoupledSolution)
+  {
+    std::shared_ptr<OperatorCoupled<dim, Number>> operator_coupled =
+      std::dynamic_pointer_cast<OperatorCoupled<dim, Number>>(pde_operator);
+
+    time_integrator.reset(new IncNS::TimeIntBDFCoupled<dim, Number>(operator_coupled,
+                                                                    parameters,
+                                                                    refine_time,
+                                                                    mpi_comm,
+                                                                    is_test,
+                                                                    postprocessor,
+                                                                    moving_mesh,
+                                                                    matrix_free));
+  }
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  {
+    std::shared_ptr<OperatorDualSplitting<dim, Number>> operator_dual_splitting =
+      std::dynamic_pointer_cast<OperatorDualSplitting<dim, Number>>(pde_operator);
+
+    time_integrator.reset(new IncNS::TimeIntBDFDualSplitting<dim, Number>(operator_dual_splitting,
+                                                                          parameters,
+                                                                          refine_time,
+                                                                          mpi_comm,
+                                                                          is_test,
+                                                                          postprocessor,
+                                                                          moving_mesh,
+                                                                          matrix_free));
+  }
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
+  {
+    std::shared_ptr<OperatorPressureCorrection<dim, Number>> operator_pressure_correction =
+      std::dynamic_pointer_cast<OperatorPressureCorrection<dim, Number>>(pde_operator);
+
+    time_integrator.reset(
+      new IncNS::TimeIntBDFPressureCorrection<dim, Number>(operator_pressure_correction,
+                                                           parameters,
+                                                           refine_time,
+                                                           mpi_comm,
+                                                           is_test,
+                                                           postprocessor,
+                                                           moving_mesh,
+                                                           matrix_free));
+  }
+  else
+  {
+    AssertThrow(false, ExcMessage("Not implemented."));
+  }
+
+  return time_integrator;
+}
+
+} // namespace IncNS
+} // namespace ExaDG
+
+#endif /* INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_TIME_INTEGRATION_CREATE_TIME_INTEGRATOR_H_ */

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -42,8 +42,8 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
                        MPI_Comm const &                                  mpi_comm,
                        bool const                                        is_test,
                        std::shared_ptr<PostProcessorInterface<Number>>   postprocessor,
-                       std::shared_ptr<MovingMeshBase<dim, Number>>      moving_mesh,
-                       std::shared_ptr<MatrixFree<dim, Number>>          matrix_free)
+                       std::shared_ptr<MovingMeshBase<dim, Number>>      moving_mesh = nullptr,
+                       std::shared_ptr<MatrixFree<dim, Number>>          matrix_free = nullptr)
 {
   std::shared_ptr<TimeIntBDF<dim, Number>> time_integrator;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -47,7 +47,6 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
 {
   std::shared_ptr<TimeIntBDF<dim, Number>> time_integrator;
 
-  // initialize pde_operator
   if(parameters.temporal_discretization == TemporalDiscretization::BDFCoupledSolution)
   {
     std::shared_ptr<OperatorCoupled<dim, Number>> operator_coupled =

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -52,43 +52,44 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
     std::shared_ptr<OperatorCoupled<dim, Number>> operator_coupled =
       std::dynamic_pointer_cast<OperatorCoupled<dim, Number>>(pde_operator);
 
-    time_integrator.reset(new IncNS::TimeIntBDFCoupled<dim, Number>(operator_coupled,
-                                                                    parameters,
-                                                                    refine_time,
-                                                                    mpi_comm,
-                                                                    is_test,
-                                                                    postprocessor,
-                                                                    moving_mesh,
-                                                                    matrix_free));
+    time_integrator = std::make_shared<IncNS::TimeIntBDFCoupled<dim, Number>>(operator_coupled,
+                                                                              parameters,
+                                                                              refine_time,
+                                                                              mpi_comm,
+                                                                              is_test,
+                                                                              postprocessor,
+                                                                              moving_mesh,
+                                                                              matrix_free);
   }
   else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
   {
     std::shared_ptr<OperatorDualSplitting<dim, Number>> operator_dual_splitting =
       std::dynamic_pointer_cast<OperatorDualSplitting<dim, Number>>(pde_operator);
 
-    time_integrator.reset(new IncNS::TimeIntBDFDualSplitting<dim, Number>(operator_dual_splitting,
-                                                                          parameters,
-                                                                          refine_time,
-                                                                          mpi_comm,
-                                                                          is_test,
-                                                                          postprocessor,
-                                                                          moving_mesh,
-                                                                          matrix_free));
+    time_integrator =
+      std::make_shared<IncNS::TimeIntBDFDualSplitting<dim, Number>>(operator_dual_splitting,
+                                                                    parameters,
+                                                                    refine_time,
+                                                                    mpi_comm,
+                                                                    is_test,
+                                                                    postprocessor,
+                                                                    moving_mesh,
+                                                                    matrix_free);
   }
   else if(parameters.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
   {
     std::shared_ptr<OperatorPressureCorrection<dim, Number>> operator_pressure_correction =
       std::dynamic_pointer_cast<OperatorPressureCorrection<dim, Number>>(pde_operator);
 
-    time_integrator.reset(
-      new IncNS::TimeIntBDFPressureCorrection<dim, Number>(operator_pressure_correction,
-                                                           parameters,
-                                                           refine_time,
-                                                           mpi_comm,
-                                                           is_test,
-                                                           postprocessor,
-                                                           moving_mesh,
-                                                           matrix_free));
+    time_integrator = std::make_shared<IncNS::TimeIntBDFPressureCorrection<dim, Number>>(
+      operator_pressure_correction,
+      parameters,
+      refine_time,
+      mpi_comm,
+      is_test,
+      postprocessor,
+      moving_mesh,
+      matrix_free);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -39,7 +39,7 @@ TimeIntBDF<dim, Number>::TimeIntBDF(
   InputParameters const &                         param_in,
   unsigned int const                              refine_steps_time_in,
   MPI_Comm const &                                mpi_comm_in,
-  bool const                                      print_wall_times_in,
+  bool const                                      is_test_in,
   std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
   std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
   std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
@@ -51,7 +51,7 @@ TimeIntBDF<dim, Number>::TimeIntBDF(
                            param_in.adaptive_time_stepping,
                            param_in.restart_data,
                            mpi_comm_in,
-                           print_wall_times_in),
+                           is_test_in),
     param(param_in),
     refine_steps_time(refine_steps_time_in),
     cfl(param.cfl / std::pow(2.0, refine_steps_time_in)),

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -65,7 +65,7 @@ public:
              InputParameters const &                         param_in,
              unsigned int const                              refine_steps_time_in,
              MPI_Comm const &                                mpi_comm_in,
-             bool const                                      print_wall_times_in,
+             bool const                                      is_test_in,
              std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
              std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
              std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -38,7 +38,7 @@ TimeIntBDFCoupled<dim, Number>::TimeIntBDFCoupled(
   InputParameters const &                         param_in,
   unsigned int const                              refine_steps_time_in,
   MPI_Comm const &                                mpi_comm_in,
-  bool const                                      print_wall_times_in,
+  bool const                                      is_test_in,
   std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
   std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
   std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
@@ -46,7 +46,7 @@ TimeIntBDFCoupled<dim, Number>::TimeIntBDFCoupled(
          param_in,
          refine_steps_time_in,
          mpi_comm_in,
-         print_wall_times_in,
+         is_test_in,
          postprocessor_in,
          moving_mesh_in,
          matrix_free_in),

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -55,7 +55,7 @@ public:
                     InputParameters const &                         param_in,
                     unsigned int const                              refine_steps_time_in,
                     MPI_Comm const &                                mpi_comm_in,
-                    bool const                                      print_wall_times_in,
+                    bool const                                      is_test_in,
                     std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
                     std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
                     std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -38,7 +38,7 @@ TimeIntBDFDualSplitting<dim, Number>::TimeIntBDFDualSplitting(
   InputParameters const &                         param_in,
   unsigned int const                              refine_steps_time_in,
   MPI_Comm const &                                mpi_comm_in,
-  bool const                                      print_wall_times_in,
+  bool const                                      is_test_in,
   std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
   std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
   std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
@@ -46,7 +46,7 @@ TimeIntBDFDualSplitting<dim, Number>::TimeIntBDFDualSplitting(
          param_in,
          refine_steps_time_in,
          mpi_comm_in,
-         print_wall_times_in,
+         is_test_in,
          postprocessor_in,
          moving_mesh_in,
          matrix_free_in),

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -49,7 +49,7 @@ public:
                           InputParameters const &                         param_in,
                           unsigned int const                              refine_steps_time_in,
                           MPI_Comm const &                                mpi_comm_in,
-                          bool const                                      print_wall_times_in,
+                          bool const                                      is_test_in,
                           std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
                           std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
                           std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -50,7 +50,7 @@ public:
     InputParameters const &                         param_in,
     unsigned int const                              refine_steps_time_in,
     MPI_Comm const &                                mpi_comm_in,
-    bool const                                      print_wall_times_in,
+    bool const                                      is_test_in,
     std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
     std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
     std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);


### PR DESCRIPTION
The setup routines for incompressible Navier-Stokes applications distinguish between Coupled/DualSplitting/PressureCorrection schemes, which is quite lengthy for all the different drivers and can easily be simplified by introducing utility functions `create_operator()` and `create_time_integrator()`.

This is still work-in-progress and needs to be rolled out to all drivers in ExaDG that involve the IncNS module.