### PR TITLE
Add some forgotten vec.zero_out_ghost_values()

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.cpp
@@ -143,6 +143,7 @@ MGTransferC<dim, Number, VectorType, components>::do_prolongate(VectorType &    
     fe_eval_dg.distribute_local_to_global(vec_dg);
   }
   dst.copy_locally_owned_data_from(vec_dg);
+  src.zero_out_ghost_values();
 }
 
 template<int dim, typename Number, typename VectorType, int components>

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.cpp
@@ -565,7 +565,10 @@ MGTransferP<dim, Number, VectorType, components>::restrict_and_add(unsigned int 
   // clang-format on
 
   if(!this->is_dg) // only if CG
+  {
     dst.compress(VectorOperation::add);
+    src.zero_out_ghost_values();
+  }
 }
 
 template<int dim, typename Number, typename VectorType, int components>
@@ -643,7 +646,10 @@ MGTransferP<dim, Number, VectorType, components>::prolongate(unsigned int const 
   // clang-format on
 
   if(!this->is_dg) // only if CG
+  {
     dst.compress(VectorOperation::add);
+    src.zero_out_ghost_values();
+  }
 }
 
 


### PR DESCRIPTION
This is something I noticed with the fda benchmark case (using ExaDG's cph multigrid infrastructure without global coarsening), it could be related to the changes I made for #61. The proposed changes add a `zero_out_ghost_values` to those places where we call `update_ghost_values()` a few lines above. Now I don't see any ghosted vector throughout `MultigridAlgorithm`.