### PR TITLE
Avoid implicit float-to-int conversions

### DIFF
--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -193,7 +193,7 @@ public:
       // clang-format on
       prm.parse_input(input_file, "", true, true);
 
-      n_points = 20 * (degree + 1) * std::pow(2.0, refine_space);
+      n_points = 20 * (degree + 1) * Utilities::pow(2, refine_space);
     }
 
     inflow_data_storage.reset(new InflowDataStorage<dim>(n_points,

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/include/orr_sommerfeld_equation.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/include/orr_sommerfeld_equation.h
@@ -272,7 +272,7 @@ compute_eigenvector(std::vector<std::complex<double>> & eigenvector,
          &lwork,
          dwork.data(),
          &info);
-  lwork = work[0].real();
+  lwork = static_cast<int>(work[0].real());
   work.resize(lwork);
 
   pcout << "Size of work array: " << lwork << std::endl;

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -98,7 +98,7 @@ get_dofs_per_element(std::string const & input_file,
 {
   (void)input_file;
 
-  unsigned int const dofs_per_element = (dim + 2) * std::pow(degree + 1, dim);
+  unsigned int const dofs_per_element = (dim + 2) * Utilities::pow(degree + 1, dim);
 
   return dofs_per_element;
 }

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -101,7 +101,7 @@ get_dofs_per_element(std::string const & input_file,
 {
   (void)input_file;
 
-  unsigned int const dofs_per_element = std::pow(degree + 1, dim);
+  unsigned int const dofs_per_element = Utilities::pow(degree + 1, dim);
 
   return dofs_per_element;
 }

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -365,7 +365,7 @@ TimeIntBDF<dim, Number>::calculate_time_step_size()
     this->pcout << std::endl
                 << "Calculation of time step size (max efficiency):" << std::endl
                 << std::endl;
-    print_parameter(this->pcout, "C_eff", param.c_eff / std::pow(2, refine_steps_time));
+    print_parameter(this->pcout, "C_eff", param.c_eff / std::pow(2.0, refine_steps_time));
     print_parameter(this->pcout, "Time step size", time_step);
   }
   else

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
@@ -229,7 +229,7 @@ TimeIntExplRK<Number>::calculate_time_step_size()
     this->pcout << std::endl
                 << "Calculation of time step size (max efficiency):" << std::endl
                 << std::endl;
-    print_parameter(this->pcout, "C_eff", param.c_eff / std::pow(2, refine_steps_time));
+    print_parameter(this->pcout, "C_eff", param.c_eff / std::pow(2.0, refine_steps_time));
     print_parameter(this->pcout, "Time step size", this->time_step);
   }
   else

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -132,12 +132,12 @@ get_dofs_per_element(std::string const & input_file,
   OperatorType operator_type;
   string_to_enum(operator_type, operator_type_string);
 
-  unsigned int const velocity_dofs_per_element = dim * std::pow(degree + 1, dim);
+  unsigned int const velocity_dofs_per_element = dim * Utilities::pow(degree + 1, dim);
   unsigned int       pressure_dofs_per_element = 1;
   if(pressure_degree == "MixedOrder")
-    pressure_dofs_per_element = std::pow(degree, dim);
+    pressure_dofs_per_element = Utilities::pow(degree, dim);
   else if(pressure_degree == "EqualOrder")
-    pressure_dofs_per_element = std::pow(degree + 1, dim);
+    pressure_dofs_per_element = Utilities::pow(degree + 1, dim);
   else
     AssertThrow(false, ExcMessage("Not implemented."));
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -434,7 +434,7 @@ TimeIntBDF<dim, Number>::calculate_time_step_size()
     this->pcout << std::endl
                 << "Calculation of time step size (max efficiency):" << std::endl
                 << std::endl;
-    print_parameter(this->pcout, "C_eff", param.c_eff / std::pow(2, refine_steps_time));
+    print_parameter(this->pcout, "C_eff", param.c_eff / std::pow(2.0, refine_steps_time));
     print_parameter(this->pcout, "Time step size", time_step);
   }
   else

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -99,9 +99,9 @@ get_dofs_per_element(std::string const & input_file,
   unsigned int dofs_per_element = 1;
 
   if(spatial_discretization == "CG")
-    dofs_per_element = std::pow(degree, dim);
+    dofs_per_element = Utilities::pow(degree, dim);
   else if(spatial_discretization == "DG")
-    dofs_per_element = std::pow(degree + 1, dim);
+    dofs_per_element = Utilities::pow(degree + 1, dim);
   else
     AssertThrow(false, ExcMessage("Not implemented."));
 

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
@@ -138,17 +138,17 @@ public:
     std::vector<types::global_dof_index> indices_has, indices_want;
 
     for(auto const & I : local_cells)
-      for(types::global_dof_index i = 0; i < dealii::Utilities::pow(points_dst, dim); i++)
+      for(types::global_dof_index i = 0; i < Utilities::pow(points_dst, dim); i++)
         for(types::global_dof_index d = 0; d < dim; d++)
         {
           types::global_dof_index index =
             (I / (n_cells_1D * n_cells_1D) * points_dst + i / (points_dst * points_dst)) *
-              dealii::Utilities::pow(n_cells_1D * points_dst, 2) +
+              Utilities::pow(n_cells_1D * points_dst, 2) +
             (((I / n_cells_1D) % n_cells_1D) * points_dst + ((i / points_dst) % points_dst)) *
-              dealii::Utilities::pow(n_cells_1D * points_dst, 1) +
+              Utilities::pow(n_cells_1D * points_dst, 1) +
             (I % (n_cells_1D)*points_dst + i % (points_dst));
 
-          indices_has.push_back(d * dealii::Utilities::pow(points_dst * n_cells_1D, dim) + index);
+          indices_has.push_back(d * Utilities::pow(points_dst * n_cells_1D, dim) + index);
         }
 
     types::global_dof_index N  = s.cells * s.points_dst;
@@ -161,10 +161,9 @@ public:
         for(types::global_dof_index j = 0; j < N; j++)
           for(types::global_dof_index i = 0; i < Nx; i++, c++)
             if(i < N)
-              indices_want.push_back(d * dealii::Utilities::pow(points_dst * n_cells_1D, dim) +
-                                     (k + start) *
-                                       dealii::Utilities::pow(points_dst * n_cells_1D, 2) +
-                                     j * dealii::Utilities::pow(points_dst * n_cells_1D, 1) + i);
+              indices_want.push_back(d * Utilities::pow(points_dst * n_cells_1D, dim) +
+                                     (k + start) * Utilities::pow(points_dst * n_cells_1D, 2) +
+                                     j * Utilities::pow(points_dst * n_cells_1D, 1) + i);
             else
               indices_want.push_back(numbers::invalid_dof_index); // x-padding
 
@@ -205,16 +204,10 @@ public:
 
       // ... permute
       timer.start("Permutation");
-      ArrayView<double>       dst(fftw.u_real,
-                            s.dim *
-                              dealii::Utilities::pow(static_cast<types::global_dof_index>(
-                                                       s.cells * s.points_dst),
-                                                     s.dim) *
-                              2);
-      ArrayView<double const> src_(
-        ipol.dst,
-        s.dim * dealii::Utilities::pow(static_cast<types::global_dof_index>(s.cells * s.points_dst),
-                                       s.dim));
+      types::global_dof_index const size =
+        Utilities::pow(static_cast<types::global_dof_index>(s.cells * s.points_dst), s.dim) * s.dim;
+      ArrayView<double>       dst(fftw.u_real, size * 2);
+      ArrayView<double const> src_(ipol.dst, size);
       nonconti->export_to_ghosted_array(src_, dst);
 
       timer.append("Permutation");

--- a/include/exadg/postprocessor/mirror_dof_vector_taylor_green.h
+++ b/include/exadg/postprocessor/mirror_dof_vector_taylor_green.h
@@ -70,13 +70,13 @@ apply_taylor_green_symmetry(DoFHandler<dim> const &                            d
     map_lex_to_cell_full;
 
   {
-    auto norm_point_to_lex = [&](auto const c) {
+    auto norm_point_to_lex = [&](Point<dim> const c) {
       // convert normalized point [0, 1] to lex
       if(dim == 2)
-        return std::floor(c[0]) + n_cells_1d * std::floor(c[1]);
+        return static_cast<std::size_t>(std::floor(c[0]) + n_cells_1d * std::floor(c[1]));
       else
-        return std::floor(c[0]) + n_cells_1d * std::floor(c[1]) +
-               n_cells_1d * n_cells_1d * std::floor(c[2]);
+        return static_cast<std::size_t>(std::floor(c[0]) + n_cells_1d * std::floor(c[1]) +
+                                        n_cells_1d * n_cells_1d * std::floor(c[2]));
     };
 
     // ... has (symm)

--- a/include/exadg/postprocessor/spectral_analysis/bijection.h
+++ b/include/exadg/postprocessor/spectral_analysis/bijection.h
@@ -103,7 +103,7 @@ public:
                                                    1,
                                                    -dealii::numbers::PI,
                                                    dealii::numbers::PI);
-      triangulation.refine_global(round(log(n) / log(2)));
+      triangulation.refine_global(static_cast<unsigned int>(std::round(std::log(n) / std::log(2))));
       init(triangulation);
     }
     else if(s.dim == 3)
@@ -113,7 +113,7 @@ public:
                                                    1,
                                                    -dealii::numbers::PI,
                                                    dealii::numbers::PI);
-      triangulation.refine_global(round(log(n) / log(2)));
+      triangulation.refine_global(static_cast<unsigned int>(std::round(std::log(n) / std::log(2))));
       init(triangulation);
     }
   }
@@ -137,8 +137,9 @@ public:
     int n = s.cells;
 
     {
-      unsigned int const n_active_cells    = triangulation.n_global_active_cells();
-      unsigned int const n_active_cells_1d = std::pow(n_active_cells, 1.0 / s.dim) + 0.49;
+      unsigned int const n_active_cells = triangulation.n_global_active_cells();
+      unsigned int const n_active_cells_1d =
+        static_cast<unsigned int>(std::pow(n_active_cells, 1.0 / s.dim) + 0.49);
 
       std::vector<int> temp_indices;
 
@@ -148,7 +149,7 @@ public:
           continue;
 
         double x = 1000, y = 1000, z = 1000;
-        for(int v = 0; v < int(std::pow(2, s.dim)); v++)
+        for(int v = 0; v < dealii::Utilities::pow(2, s.dim); v++)
         {
           auto vertex = cell->vertex(v);
           x           = std::min(x, vertex[0]);
@@ -206,9 +207,8 @@ public:
         int temp_counter = counter;
         for(int d = 0; d < s.dim; d++)
         {
-          int r = temp_counter % n;
+          Y[d] = temp_counter % n;
           temp_counter /= n;
-          Y[d] = r + 0.5;
         }
 
         // ... save position

--- a/include/exadg/postprocessor/spectral_analysis/interpolation.h
+++ b/include/exadg/postprocessor/spectral_analysis/interpolation.h
@@ -122,9 +122,9 @@ public:
     points_target = s.points_dst;
 
     // number of gauss lobatto points per cell and ...
-    dofs_source = pow(points_source, DIM);
+    dofs_source = dealii::Utilities::pow(points_source, DIM);
     // ...number of equidistant points per cell
-    dofs_target = pow(points_target, DIM);
+    dofs_target = dealii::Utilities::pow(points_target, DIM);
 
     // allocate memory for source (only needed if values are read by IO)...
     src = new double[cells * dofs_source * DIM];

--- a/include/exadg/postprocessor/spectral_analysis/permutation.h
+++ b/include/exadg/postprocessor/spectral_analysis/permutation.h
@@ -124,13 +124,13 @@ public:
     bsize = FFT.bsize;
 
     // data structures for determining the communication partners...
-    int                 has_length = (end - start) * pow(points, dim);
+    int                 has_length = (end - start) * dealii::Utilities::pow(points, dim);
     unsigned long int * has        = new unsigned long int[has_length];
     int *               has_procs  = new int[has_length];
     send_buffer                    = new double[has_length * dim];
     send_index                     = new int[has_length];
 
-    int                 want_length = (end_ - start_) * pow(n * points, dim - 1);
+    int                 want_length = (end_ - start_) * dealii::Utilities::pow(n * points, dim - 1);
     unsigned long int * want        = new unsigned long int[want_length];
     int *               want_procs  = new int[want_length];
     recv_buffer                     = new double[want_length * dim];
@@ -207,7 +207,7 @@ public:
       for(int jj = 0; jj < pow(n * points, dim - 1); jj++, counter++)
       {
         // ... determine dof
-        unsigned long int temp = ii * pow(n * points, dim - 1) + jj;
+        unsigned long int temp = ii * dealii::Utilities::pow(n * points, dim - 1) + jj;
         want[counter]          = temp;
         // ... determine owning process
         int t = dim == 3 ? (temp % pn) / points + ((temp % (pn * pn)) / pn) / points * n +

--- a/include/exadg/postprocessor/spectral_analysis/spectrum.h
+++ b/include/exadg/postprocessor/spectral_analysis/spectrum.h
@@ -127,7 +127,7 @@ public:
         _indices_proc_rows[c] = i;
 
     // ... clean up
-    delete global_elements;
+    delete[] global_elements;
 
     // modify global size for input array
     n[dim - 1] = N;
@@ -307,7 +307,7 @@ public:
           // determine wavenumber...
           double r = sqrt(pow(MIN(i, N - i), 2.0) + pow(MIN(j, N - j), 2.0));
           // ... use for binning
-          int p = round(r);
+          int p = static_cast<int>(std::round(r));
           // ... update energy
           e[p] += u_comp2(MIN(i, N - i), j)[0] * u_comp2(MIN(i, N - i), j)[0] +
                   u_comp2(MIN(i, N - i), j)[1] * u_comp2(MIN(i, N - i), j)[1] +
@@ -332,7 +332,7 @@ public:
             double r =
               sqrt(pow(MIN(i, N - i), 2.0) + pow(MIN(j, N - j), 2.0) + pow(MIN(k_, N - k_), 2.0));
             // ... use for binning
-            int p = round(r);
+            int p = static_cast<int>(std::round(r));
             // ... update energy
             e[p] += u_comp3(MIN(i, N - i), j, k_)[0] * u_comp3(MIN(i, N - i), j, k_)[0] +
                     u_comp3(MIN(i, N - i), j, k_)[1] * u_comp3(MIN(i, N - i), j, k_)[1] +
@@ -394,8 +394,8 @@ public:
   {
     int start     = local_start;
     int end       = local_end;
-    int delta     = 2 * (N / 2 + 1) * pow(N, dim - 2);
-    int delta_all = 2 * (N / 2 + 1) * pow(N, dim - 1) * sizeof(double);
+    int delta     = 2 * (N / 2 + 1) * dealii::Utilities::pow(N, dim - 2);
+    int delta_all = 2 * (N / 2 + 1) * dealii::Utilities::pow(N, dim - 1) * sizeof(double);
 
     //
     int        dofs = (end - start) * delta;
@@ -436,8 +436,8 @@ public:
   {
     int start     = local_start;
     int end       = local_end;
-    int delta     = 2 * (N / 2 + 1) * pow(N, dim - 2);
-    int delta_all = 2 * (N / 2 + 1) * pow(N, dim - 1) * sizeof(double);
+    int delta     = 2 * (N / 2 + 1) * dealii::Utilities::pow(N, dim - 2);
+    int delta_all = 2 * (N / 2 + 1) * dealii::Utilities::pow(N, dim - 1) * sizeof(double);
 
     //
     int        dofs = (end - start) * delta;

--- a/include/exadg/postprocessor/statistics_manager.cpp
+++ b/include/exadg/postprocessor/statistics_manager.cpp
@@ -98,7 +98,7 @@ StatisticsManager<dim, Number>::setup(const std::function<double(double const &)
     AssertThrow(n_points_y_per_cell >= 2,
                 ExcMessage("Number of points in y-direction per cell is invalid."));
 
-    n_cells_y_dir *= std::pow(2, dof_handler.get_triangulation().n_global_levels() - 1);
+    n_cells_y_dir *= Utilities::pow(2, dof_handler.get_triangulation().n_global_levels() - 1);
 
     unsigned int const n_points_y_glob = n_cells_y_dir * (n_points_y_per_cell - 1) + 1;
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -1263,7 +1263,8 @@ MultigridPreconditionerBase<dim, Number>::initialize_chebyshev_smoother_coarse_g
   // solver tolerance
   double const eps = solver_data.rel_tol;
 
-  smoother_data.degree = std::log(1. / eps + std::sqrt(1. / eps / eps - 1.)) / std::log(1. / sigma);
+  smoother_data.degree = static_cast<unsigned int>(
+    std::log(1. / eps + std::sqrt(1. / eps / eps - 1.)) / std::log(1. / sigma));
   smoother_data.eig_cg_n_iterations = 0;
 
   std::shared_ptr<Chebyshev> smoother = std::dynamic_pointer_cast<Chebyshev>(smoothers[0]);

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.cpp
@@ -347,7 +347,7 @@ MGTransferP<dim, Number, VectorType, components>::reinit(
 
   this->quad_index                 = numbers::invalid_unsigned_int;
   unsigned int const n_q_points_1d = degree_1 + 1;
-  unsigned int const n_q_points    = std::pow(n_q_points_1d, dim);
+  unsigned int const n_q_points    = Utilities::pow(n_q_points_1d, dim);
 
   for(unsigned int quad_index = 0; quad_index < matrixfree_1->get_mapping_info().cell_data.size();
       quad_index++)

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -84,7 +84,7 @@ get_dofs_per_element(std::string const & input_file,
 {
   (void)input_file;
 
-  unsigned int const dofs_per_element = std::pow(degree, dim) * dim;
+  unsigned int const dofs_per_element = Utilities::pow(degree, dim) * dim;
 
   return dofs_per_element;
 }

--- a/include/exadg/utilities/hypercube_resolution_parameters.h
+++ b/include/exadg/utilities/hypercube_resolution_parameters.h
@@ -71,13 +71,13 @@ fill_resolutions_vector(
 {
   unsigned int l = 0, n_subdivisions_1d = 1;
 
-  double n_cells_min = (double)n_dofs_min / dofs_per_element;
-  double n_cells_max = (double)n_dofs_max / dofs_per_element;
+  types::global_dof_index n_cells_min = n_dofs_min / dofs_per_element;
+  types::global_dof_index n_cells_max = (n_dofs_max + dofs_per_element - 1) / dofs_per_element;
 
-  int    refine_level = 0;
-  double n_cells      = 1.0;
+  int                     refine_level = 0;
+  types::global_dof_index n_cells      = 1;
 
-  while(n_cells <= std::pow(2.0, dim) * n_cells_max)
+  while(n_cells <= Utilities::pow(2ULL, dim) * n_cells_max)
   {
     // We want to increase the problem size approximately by a factor of two, which is
     // realized by using a coarse grid with {3,4}^dim elements in 2D and {3,4,5}^dim elements
@@ -87,7 +87,8 @@ fill_resolutions_vector(
     if(refine_level >= 2)
     {
       n_subdivisions_1d = 3;
-      n_cells = Utilities::pow(n_subdivisions_1d, dim) * std::pow(2.0, (refine_level - 2) * dim);
+      n_cells =
+        Utilities::pow(n_subdivisions_1d, dim) * Utilities::pow(2ULL, (refine_level - 2) * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -107,7 +108,7 @@ fill_resolutions_vector(
     // coarse grid with only a single cell, and refine_level uniform refinements
     {
       n_subdivisions_1d = 1;
-      n_cells           = std::pow(2.0, refine_level * dim);
+      n_cells           = Utilities::pow(2ULL, refine_level * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -128,7 +129,8 @@ fill_resolutions_vector(
     if(dim == 3 && refine_level >= 2)
     {
       n_subdivisions_1d = 5;
-      n_cells = Utilities::pow(n_subdivisions_1d, dim) * std::pow(2.0, (refine_level - 2) * dim);
+      n_cells =
+        Utilities::pow(n_subdivisions_1d, dim) * Utilities::pow(2ULL, (refine_level - 2) * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -147,7 +149,7 @@ fill_resolutions_vector(
 
     // perform one global refinement
     ++refine_level;
-    n_cells = std::pow(2.0, refine_level * dim);
+    n_cells = Utilities::pow(2ULL, refine_level * dim);
   }
 
   if(run_type == RunType::FixedProblemSize)

--- a/include/exadg/utilities/hypercube_resolution_parameters.h
+++ b/include/exadg/utilities/hypercube_resolution_parameters.h
@@ -71,8 +71,8 @@ fill_resolutions_vector(
 {
   unsigned int l = 0, n_subdivisions_1d = 1;
 
-  types::global_dof_index n_cells_min = n_dofs_min / dofs_per_element;
-  types::global_dof_index n_cells_max = (n_dofs_max + dofs_per_element - 1) / dofs_per_element;
+  types::global_dof_index n_cells_min = (n_dofs_min + dofs_per_element - 1) / dofs_per_element;
+  types::global_dof_index n_cells_max = n_dofs_max / dofs_per_element;
 
   int                     refine_level = 0;
   types::global_dof_index n_cells      = 1;

--- a/include/exadg/utilities/hypercube_resolution_parameters.h
+++ b/include/exadg/utilities/hypercube_resolution_parameters.h
@@ -77,7 +77,7 @@ fill_resolutions_vector(
   int    refine_level = 0;
   double n_cells      = 1.0;
 
-  while(n_cells <= std::pow(2, dim) * n_cells_max)
+  while(n_cells <= std::pow(2.0, dim) * n_cells_max)
   {
     // We want to increase the problem size approximately by a factor of two, which is
     // realized by using a coarse grid with {3,4}^dim elements in 2D and {3,4,5}^dim elements
@@ -87,7 +87,7 @@ fill_resolutions_vector(
     if(refine_level >= 2)
     {
       n_subdivisions_1d = 3;
-      n_cells           = std::pow(n_subdivisions_1d, dim) * std::pow(2., (refine_level - 2) * dim);
+      n_cells = Utilities::pow(n_subdivisions_1d, dim) * std::pow(2.0, (refine_level - 2) * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -107,7 +107,7 @@ fill_resolutions_vector(
     // coarse grid with only a single cell, and refine_level uniform refinements
     {
       n_subdivisions_1d = 1;
-      n_cells           = std::pow(2., refine_level * dim);
+      n_cells           = std::pow(2.0, refine_level * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -128,7 +128,7 @@ fill_resolutions_vector(
     if(dim == 3 && refine_level >= 2)
     {
       n_subdivisions_1d = 5;
-      n_cells           = std::pow(n_subdivisions_1d, dim) * std::pow(2., (refine_level - 2) * dim);
+      n_cells = Utilities::pow(n_subdivisions_1d, dim) * std::pow(2.0, (refine_level - 2) * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -147,7 +147,7 @@ fill_resolutions_vector(
 
     // perform one global refinement
     ++refine_level;
-    n_cells = std::pow(2., refine_level * dim);
+    n_cells = std::pow(2.0, refine_level * dim);
   }
 
   if(run_type == RunType::FixedProblemSize)


### PR DESCRIPTION
This pull request allows me to finally compile ExaDG without warnings. The compiler complained about the following kind of double-to-float conversions (to give one representative example):
```
In file included from /home/kronbichler/Work/dg/exadg/applications/incompressible_navier_stokes/fda_benchmark/solver.cpp:26:
/home/kronbichler/Work/dg/exadg/applications/incompressible_navier_stokes/fda_benchmark/application.h:196:36: warning: implicit conversion turns floating-point number into integer: 'double' to 'unsigned int' [-Wfloat-conversion]
      n_points = 20 * (degree + 1) * std::pow(2.0, refine_space);
               ~ ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
What happens is that (at least for clang) `std::pow` takes a floating point argument and produces a floating point result, which is propagated through the multiplication and finally assigned to the integer `n_points`. That implicit conversion is what the compiler complains about. This PR addresses conversions by two approaches:
- Use deal.II's dedicated integer power mechanism `Utilities::pow` for integer powers, e.g. `(degree+1)^dim`, to avoid creating floating point numbers in the first place
- Where floating point numbers are necessary, e.g. for `round(log(n) / log(2))`, I added explicit casts.