### PR TITLE
refactor MatrixFreeData to avoid code duplication

### DIFF
--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -124,7 +124,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                mpi_comm));
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>(triangulation, false));
+  matrix_free_data.reset(new MatrixFreeData<dim, Number>());
   matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());

--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -111,23 +111,21 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   application->set_field_functions(field_functions);
 
   // initialize compressible Navier-Stokes operator
-  comp_navier_stokes_operator.reset(new Operator<dim, Number>(*triangulation,
-                                                              mapping,
-                                                              degree,
-                                                              boundary_descriptor_density,
-                                                              boundary_descriptor_velocity,
-                                                              boundary_descriptor_pressure,
-                                                              boundary_descriptor_energy,
-                                                              field_functions,
-                                                              param,
-                                                              "fluid",
-                                                              mpi_comm));
+  pde_operator.reset(new Operator<dim, Number>(*triangulation,
+                                               mapping,
+                                               degree,
+                                               boundary_descriptor_density,
+                                               boundary_descriptor_velocity,
+                                               boundary_descriptor_pressure,
+                                               boundary_descriptor_energy,
+                                               field_functions,
+                                               param,
+                                               "fluid",
+                                               mpi_comm));
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>());
-  matrix_free_data->data.tasks_parallel_scheme =
-    MatrixFree<dim, Number>::AdditionalData::partition_partition;
-  comp_navier_stokes_operator->fill_matrix_free_data(*matrix_free_data);
+  matrix_free_data.reset(new MatrixFreeData<dim, Number>(triangulation, false));
+  matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
   matrix_free->reinit(*mapping,
@@ -137,17 +135,17 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                       matrix_free_data->data);
 
   // setup compressible Navier-Stokes operator
-  comp_navier_stokes_operator->setup(matrix_free, matrix_free_data);
+  pde_operator->setup(matrix_free, matrix_free_data);
 
   // initialize postprocessor
   if(!is_throughput_study)
   {
     postprocessor = application->construct_postprocessor(degree, mpi_comm);
-    postprocessor->setup(*comp_navier_stokes_operator);
+    postprocessor->setup(*pde_operator);
 
     // initialize time integrator
     time_integrator.reset(new TimeIntExplRK<Number>(
-      comp_navier_stokes_operator, param, refine_time, mpi_comm, is_test, postprocessor));
+      pde_operator, param, refine_time, mpi_comm, is_test, postprocessor));
     time_integrator->setup(param.restarted_simulation);
   }
 
@@ -184,7 +182,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
   timer_tree.print_level(pcout, 2);
 
   // Throughput in DoFs/s per time step per core
-  types::global_dof_index const DoFs            = comp_navier_stokes_operator->get_number_of_dofs();
+  types::global_dof_index const DoFs            = pde_operator->get_number_of_dofs();
   unsigned int const            N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
   unsigned int const            N_time_steps    = time_integrator->get_number_of_time_steps();
 
@@ -219,26 +217,26 @@ Driver<dim, Number>::apply_operator(unsigned int const  degree,
   VectorType dst, src;
 
   // initialize vectors
-  comp_navier_stokes_operator->initialize_dof_vector(src);
-  comp_navier_stokes_operator->initialize_dof_vector(dst);
+  pde_operator->initialize_dof_vector(src);
+  pde_operator->initialize_dof_vector(dst);
   src = 1.0;
   dst = 1.0;
 
   const std::function<void(void)> operator_evaluation = [&](void) {
     if(operator_type == OperatorType::ConvectiveTerm)
-      comp_navier_stokes_operator->evaluate_convective(dst, src, 0.0);
+      pde_operator->evaluate_convective(dst, src, 0.0);
     else if(operator_type == OperatorType::ViscousTerm)
-      comp_navier_stokes_operator->evaluate_viscous(dst, src, 0.0);
+      pde_operator->evaluate_viscous(dst, src, 0.0);
     else if(operator_type == OperatorType::ViscousAndConvectiveTerms)
-      comp_navier_stokes_operator->evaluate_convective_and_viscous(dst, src, 0.0);
+      pde_operator->evaluate_convective_and_viscous(dst, src, 0.0);
     else if(operator_type == OperatorType::InverseMassOperator)
-      comp_navier_stokes_operator->apply_inverse_mass(dst, src);
+      pde_operator->apply_inverse_mass(dst, src);
     else if(operator_type == OperatorType::InverseMassOperatorDstDst)
-      comp_navier_stokes_operator->apply_inverse_mass(dst, dst);
+      pde_operator->apply_inverse_mass(dst, dst);
     else if(operator_type == OperatorType::VectorUpdate)
       dst.sadd(2.0, 1.0, src);
     else if(operator_type == OperatorType::EvaluateOperatorExplicit)
-      comp_navier_stokes_operator->evaluate(dst, src, 0.0);
+      pde_operator->evaluate(dst, src, 0.0);
     else
       AssertThrow(false, ExcMessage("Specified operator type not implemented"));
   };
@@ -248,7 +246,7 @@ Driver<dim, Number>::apply_operator(unsigned int const  degree,
     operator_evaluation, degree, n_repetitions_inner, n_repetitions_outer, mpi_comm);
 
   // calculate throughput
-  types::global_dof_index const dofs = comp_navier_stokes_operator->get_number_of_dofs();
+  types::global_dof_index const dofs = pde_operator->get_number_of_dofs();
 
   double const throughput = (double)dofs / wall_time;
 
@@ -267,7 +265,7 @@ Driver<dim, Number>::apply_operator(unsigned int const  degree,
   pcout << std::endl << " ... done." << std::endl << std::endl;
 
   return std::tuple<unsigned int, types::global_dof_index, double>(
-    comp_navier_stokes_operator->get_polynomial_degree(), dofs, throughput);
+    pde_operator->get_polynomial_degree(), dofs, throughput);
 }
 
 template class Driver<2, float>;

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -32,7 +32,7 @@
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
 #include <exadg/grid/mapping_degree.h>
 #include <exadg/grid/mapping_dof_vector.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_general_infos.h>
 
 namespace ExaDG

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -164,7 +164,7 @@ private:
   std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
   std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
 
-  std::shared_ptr<Operator<dim, Number>> comp_navier_stokes_operator;
+  std::shared_ptr<Operator<dim, Number>> pde_operator;
 
   std::shared_ptr<PostProcessorBase<dim, Number>> postprocessor;
 

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -35,7 +35,7 @@
 #include <exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h>
 #include <exadg/compressible_navier_stokes/user_interface/field_functions.h>
 #include <exadg/compressible_navier_stokes/user_interface/input_parameters.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
 
 namespace ExaDG

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -128,11 +128,12 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                mpi_comm));
 
   // initialize matrix_free
-  matrix_free_data.reset(
-    new MatrixFreeData<dim, Number>(triangulation, param.use_cell_based_face_loops));
+  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
+  if(param.use_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*triangulation, matrix_free_data->data);
   matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -128,16 +128,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                mpi_comm));
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>());
-  matrix_free_data->data.tasks_parallel_scheme =
-    MatrixFree<dim, Number>::AdditionalData::partition_partition;
-  if(param.use_cell_based_face_loops)
-  {
-    auto tria =
-      std::dynamic_pointer_cast<parallel::distributed::Triangulation<dim> const>(triangulation);
-    Categorization::do_cell_based_loops(*tria, matrix_free_data->data);
-  }
-  pde_operator->fill_matrix_free_data(*matrix_free_data);
+  matrix_free_data.reset(
+    new MatrixFreeData<dim, Number>(triangulation, param.use_cell_based_face_loops));
+  matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
   matrix_free->reinit(*mapping,

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -45,7 +45,7 @@
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
 #include <exadg/grid/mapping_degree.h>
 #include <exadg/grid/moving_mesh_function.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_functions.h>
 #include <exadg/utilities/print_general_infos.h>
 

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -121,8 +121,6 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
   unsigned int const                     h_level)
 {
   matrix_free_data.data.mg_level = h_level;
-  matrix_free_data.data.tasks_parallel_scheme =
-    MatrixFree<dim, MultigridNumber>::AdditionalData::none;
 
   MappingFlags flags;
   if(data.unsteady_problem)

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -33,7 +33,7 @@
 #include <exadg/convection_diffusion/user_interface/boundary_descriptor.h>
 #include <exadg/convection_diffusion/user_interface/field_functions.h>
 #include <exadg/convection_diffusion/user_interface/input_parameters.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
 #include <exadg/operators/mass_operator.h>
 #include <exadg/operators/rhs_operator.h>

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -71,7 +71,7 @@ TimeIntBDF<dim, Number>::TimeIntBDF(
     AssertThrow(moving_mesh != nullptr,
                 ExcMessage("Shared pointer moving_mesh is not correctly initialized."));
     AssertThrow(matrix_free != nullptr,
-                ExcMessage("Shared pointer matrix_free_wrapper is not correctly initialized."));
+                ExcMessage("Shared pointer matrix_free_data is not correctly initialized."));
   }
 }
 

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -182,8 +182,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                                   mpi_comm));
 
     // initialize matrix_free
-    structure_matrix_free_data.reset(
-      new MatrixFreeData<dim, Number>(structure_triangulation, false));
+    structure_matrix_free_data.reset(new MatrixFreeData<dim, Number>());
     structure_matrix_free_data->append(structure_operator);
 
     structure_matrix_free.reset(new MatrixFree<dim, Number>());
@@ -351,7 +350,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     }
     else if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Elasticity)
     {
-      ale_matrix_free_data.reset(new MatrixFreeData<dim, Number>(fluid_triangulation, false));
+      ale_matrix_free_data.reset(new MatrixFreeData<dim, Number>());
       ale_matrix_free_data->append(ale_elasticity_operator);
     }
     else

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -341,10 +341,10 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     }
 
     // initialize matrix_free_data
+    ale_matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
+
     if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Poisson)
     {
-      ale_matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-
       if(ale_poisson_param.enable_cell_based_face_loops)
         Categorization::do_cell_based_loops(*fluid_triangulation, ale_matrix_free_data->data);
 
@@ -352,7 +352,6 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     }
     else if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Elasticity)
     {
-      ale_matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
       ale_matrix_free_data->append(ale_elasticity_operator);
     }
     else

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -28,7 +28,7 @@
 // utilities
 #include <exadg/functions_and_boundary_conditions/interface_coupling.h>
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_general_infos.h>
 #include <exadg/utilities/timer_tree.h>
 

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -227,18 +227,11 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   }
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>());
-  matrix_free_data->data.tasks_parallel_scheme =
-    MatrixFree<dim, Number>::AdditionalData::partition_partition;
-  if(fluid_param.use_cell_based_face_loops)
-  {
-    auto tria =
-      std::dynamic_pointer_cast<parallel::distributed::Triangulation<dim> const>(triangulation);
-    Categorization::do_cell_based_loops(*tria, matrix_free_data->data);
-  }
-  fluid_operator->fill_matrix_free_data(*matrix_free_data);
+  matrix_free_data.reset(
+    new MatrixFreeData<dim, Number>(triangulation, fluid_param.use_cell_based_face_loops));
+  matrix_free_data->append(fluid_operator);
   for(unsigned int i = 0; i < n_scalars; ++i)
-    conv_diff_operator[i]->fill_matrix_free_data(*matrix_free_data);
+    matrix_free_data->append(conv_diff_operator[i]);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
   matrix_free->reinit(*mapping,

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -227,13 +227,14 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   }
 
   // initialize matrix_free
-  matrix_free_data.reset(
-    new MatrixFreeData<dim, Number>(triangulation, fluid_param.use_cell_based_face_loops));
+  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(fluid_operator);
   for(unsigned int i = 0; i < n_scalars; ++i)
     matrix_free_data->append(conv_diff_operator[i]);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
+  if(fluid_param.use_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*triangulation, matrix_free_data->data);
   matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -29,7 +29,7 @@
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
 #include <exadg/grid/mapping_degree.h>
 #include <exadg/grid/moving_mesh_function.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_functions.h>
 #include <exadg/utilities/print_general_infos.h>
 #include <exadg/utilities/timer_tree.h>

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -135,16 +135,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                                      mpi_comm));
 
       // initialize matrix_free
-      poisson_matrix_free_data.reset(new MatrixFreeData<dim, Number>());
-      poisson_matrix_free_data->data.tasks_parallel_scheme =
-        MatrixFree<dim, Number>::AdditionalData::partition_partition;
-      if(poisson_param.enable_cell_based_face_loops)
-      {
-        auto tria =
-          std::dynamic_pointer_cast<parallel::distributed::Triangulation<dim> const>(triangulation);
-        Categorization::do_cell_based_loops(*tria, poisson_matrix_free_data->data);
-      }
-      poisson_operator->fill_matrix_free_data(*poisson_matrix_free_data);
+      poisson_matrix_free_data.reset(
+        new MatrixFreeData<dim, Number>(triangulation, poisson_param.enable_cell_based_face_loops));
+      poisson_matrix_free_data->append(poisson_operator);
 
       poisson_matrix_free.reset(new MatrixFree<dim, Number>());
       poisson_matrix_free->reinit(*static_mapping,
@@ -215,16 +208,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   }
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>());
-  matrix_free_data->data.tasks_parallel_scheme =
-    MatrixFree<dim, Number>::AdditionalData::partition_partition;
-  if(param.use_cell_based_face_loops)
-  {
-    auto tria =
-      std::dynamic_pointer_cast<parallel::distributed::Triangulation<dim> const>(triangulation);
-    Categorization::do_cell_based_loops(*tria, matrix_free_data->data);
-  }
-  pde_operator->fill_matrix_free_data(*matrix_free_data);
+  matrix_free_data.reset(
+    new MatrixFreeData<dim, Number>(triangulation, param.use_cell_based_face_loops));
+  matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
   matrix_free->reinit(*mapping,

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -135,11 +135,12 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                                      mpi_comm));
 
       // initialize matrix_free
-      poisson_matrix_free_data.reset(
-        new MatrixFreeData<dim, Number>(triangulation, poisson_param.enable_cell_based_face_loops));
+      poisson_matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
       poisson_matrix_free_data->append(poisson_operator);
 
       poisson_matrix_free.reset(new MatrixFree<dim, Number>());
+      if(poisson_param.enable_cell_based_face_loops)
+        Categorization::do_cell_based_loops(*triangulation, poisson_matrix_free_data->data);
       poisson_matrix_free->reinit(*static_mapping,
                                   poisson_matrix_free_data->get_dof_handler_vector(),
                                   poisson_matrix_free_data->get_constraint_vector(),
@@ -208,11 +209,12 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   }
 
   // initialize matrix_free
-  matrix_free_data.reset(
-    new MatrixFreeData<dim, Number>(triangulation, param.use_cell_based_face_loops));
+  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
+  if(param.use_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*triangulation, matrix_free_data->data);
   matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -35,7 +35,7 @@
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h>
 #include <exadg/incompressible_navier_stokes/user_interface/application_base.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_general_infos.h>
 
 namespace ExaDG

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
@@ -236,16 +236,10 @@ DriverPrecursor<dim, Number>::setup(std::shared_ptr<ApplicationBasePrecursor<dim
 
 
   // initialize matrix_free precursor
-  matrix_free_data_pre.reset(new MatrixFreeData<dim, Number>());
-  matrix_free_data_pre->data.tasks_parallel_scheme =
-    MatrixFree<dim, Number>::AdditionalData::partition_partition;
-  if(param_pre.use_cell_based_face_loops)
-  {
-    auto tria =
-      std::dynamic_pointer_cast<parallel::distributed::Triangulation<dim> const>(triangulation_pre);
-    Categorization::do_cell_based_loops(*tria, matrix_free_data_pre->data);
-  }
-  pde_operator_pre->fill_matrix_free_data(*matrix_free_data_pre);
+  matrix_free_data_pre.reset(
+    new MatrixFreeData<dim, Number>(triangulation_pre, param_pre.use_cell_based_face_loops));
+  matrix_free_data_pre->append(pde_operator_pre);
+
   matrix_free_pre.reset(new MatrixFree<dim, Number>());
   matrix_free_pre->reinit(*mapping_pre,
                           matrix_free_data_pre->get_dof_handler_vector(),
@@ -254,16 +248,10 @@ DriverPrecursor<dim, Number>::setup(std::shared_ptr<ApplicationBasePrecursor<dim
                           matrix_free_data_pre->data);
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>());
-  matrix_free_data->data.tasks_parallel_scheme =
-    MatrixFree<dim, Number>::AdditionalData::partition_partition;
-  if(param.use_cell_based_face_loops)
-  {
-    auto tria =
-      std::dynamic_pointer_cast<parallel::distributed::Triangulation<dim> const>(triangulation);
-    Categorization::do_cell_based_loops(*tria, matrix_free_data->data);
-  }
-  pde_operator->fill_matrix_free_data(*matrix_free_data);
+  matrix_free_data.reset(
+    new MatrixFreeData<dim, Number>(triangulation, param.use_cell_based_face_loops));
+  matrix_free_data->append(pde_operator);
+
   matrix_free.reset(new MatrixFree<dim, Number>());
   matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
@@ -236,11 +236,12 @@ DriverPrecursor<dim, Number>::setup(std::shared_ptr<ApplicationBasePrecursor<dim
 
 
   // initialize matrix_free precursor
-  matrix_free_data_pre.reset(
-    new MatrixFreeData<dim, Number>(triangulation_pre, param_pre.use_cell_based_face_loops));
+  matrix_free_data_pre = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data_pre->append(pde_operator_pre);
 
   matrix_free_pre.reset(new MatrixFree<dim, Number>());
+  if(param_pre.use_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*triangulation_pre, matrix_free_data_pre->data);
   matrix_free_pre->reinit(*mapping_pre,
                           matrix_free_data_pre->get_dof_handler_vector(),
                           matrix_free_data_pre->get_constraint_vector(),
@@ -248,11 +249,12 @@ DriverPrecursor<dim, Number>::setup(std::shared_ptr<ApplicationBasePrecursor<dim
                           matrix_free_data_pre->data);
 
   // initialize matrix_free
-  matrix_free_data.reset(
-    new MatrixFreeData<dim, Number>(triangulation, param.use_cell_based_face_loops));
+  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
+  if(param.use_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*triangulation, matrix_free_data->data);
   matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.h
@@ -32,7 +32,7 @@
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h>
 #include <exadg/incompressible_navier_stokes/user_interface/application_base.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_general_infos.h>
 
 namespace ExaDG

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -111,8 +111,6 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
   unsigned int const                     h_level)
 {
   matrix_free_data.data.mg_level = h_level;
-  matrix_free_data.data.tasks_parallel_scheme =
-    MatrixFree<dim, MultigridNumber>::AdditionalData::none;
 
   if(data.unsteady_problem)
     matrix_free_data.append_mapping_flags(MassKernel<dim, Number>::get_mapping_flags());

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -84,8 +84,6 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
   unsigned int const                     h_level)
 {
   matrix_free_data.data.mg_level = h_level;
-  matrix_free_data.data.tasks_parallel_scheme =
-    MatrixFree<dim, MultigridNumber>::AdditionalData::none;
 
   MappingFlags flags;
   matrix_free_data.append_mapping_flags(MassKernel<dim, Number>::get_mapping_flags());

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -47,7 +47,7 @@
 #include <exadg/incompressible_navier_stokes/user_interface/boundary_descriptor.h>
 #include <exadg/incompressible_navier_stokes/user_interface/field_functions.h>
 #include <exadg/incompressible_navier_stokes/user_interface/input_parameters.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
 #include <exadg/operators/mass_operator.h>
 #include <exadg/poisson/preconditioners/multigrid_preconditioner.h>

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -70,7 +70,7 @@ TimeIntBDF<dim, Number>::TimeIntBDF(
     AssertThrow(moving_mesh != nullptr,
                 ExcMessage("Shared pointer moving_mesh is not correctly initialized."));
     AssertThrow(matrix_free != nullptr,
-                ExcMessage("Shared pointer matrix_free_wrapper is not correctly initialized."));
+                ExcMessage("Shared pointer matrix_free_data is not correctly initialized."));
   }
 }
 

--- a/include/exadg/matrix_free/categorization.h
+++ b/include/exadg/matrix_free/categorization.h
@@ -37,7 +37,7 @@ using namespace dealii;
  */
 template<int dim, typename AdditionalData>
 void
-do_cell_based_loops(const Triangulation<dim> & tria,
+do_cell_based_loops(Triangulation<dim> const & tria,
                     AdditionalData &           data,
                     unsigned int const         level = numbers::invalid_unsigned_int)
 {

--- a/include/exadg/matrix_free/matrix_free_data.h
+++ b/include/exadg/matrix_free/matrix_free_data.h
@@ -19,8 +19,8 @@
  *  ______________________________________________________________________
  */
 
-#ifndef INCLUDE_FUNCTIONALITIES_MATRIX_FREE_WRAPPER_H_
-#define INCLUDE_FUNCTIONALITIES_MATRIX_FREE_WRAPPER_H_
+#ifndef INCLUDE_FUNCTIONALITIES_MATRIX_FREE_DATA_H_
+#define INCLUDE_FUNCTIONALITIES_MATRIX_FREE_DATA_H_
 
 // deal.II
 #include <deal.II/distributed/tria.h>
@@ -208,4 +208,4 @@ private:
 };
 } // namespace ExaDG
 
-#endif /* INCLUDE_FUNCTIONALITIES_MATRIX_FREE_WRAPPER_H_ */
+#endif /* INCLUDE_FUNCTIONALITIES_MATRIX_FREE_DATA_H_ */

--- a/include/exadg/matrix_free/matrix_free_data.h
+++ b/include/exadg/matrix_free/matrix_free_data.h
@@ -39,26 +39,11 @@ struct MatrixFreeData
 {
 public:
   /**
-   * Default constructor. Does not care about categorization of cells in case of cell based face
-   * loops.
+   * Default constructor.
    */
   MatrixFreeData()
   {
     data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;
-  }
-
-  /**
-   * Cnstructor that cares about categorization of cells in case of cell based face loops.
-   */
-  MatrixFreeData(std::shared_ptr<Triangulation<dim> const> const triangulation,
-                 bool const                                      use_cell_based_face_loops)
-  {
-    data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;
-
-    if(use_cell_based_face_loops)
-    {
-      Categorization::do_cell_based_loops(*triangulation, data);
-    }
   }
 
   /**

--- a/include/exadg/matrix_free/matrix_free_wrapper.h
+++ b/include/exadg/matrix_free/matrix_free_wrapper.h
@@ -44,6 +44,7 @@ public:
    */
   MatrixFreeData()
   {
+    data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;
   }
 
   /**
@@ -52,13 +53,11 @@ public:
   MatrixFreeData(std::shared_ptr<Triangulation<dim> const> const triangulation,
                  bool const                                      use_cell_based_face_loops)
   {
-    data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::partition_partition;
+    data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;
 
     if(use_cell_based_face_loops)
     {
-      auto tria =
-        std::dynamic_pointer_cast<parallel::distributed::Triangulation<dim> const>(triangulation);
-      Categorization::do_cell_based_loops(*tria, data);
+      Categorization::do_cell_based_loops(*triangulation, data);
     }
   }
 

--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -126,11 +126,12 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                mpi_comm));
 
   // initialize matrix_free
-  matrix_free_data.reset(
-    new MatrixFreeData<dim, Number>(triangulation, param.enable_cell_based_face_loops));
+  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
+  if(param.enable_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*triangulation, matrix_free_data->data);
   matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -163,7 +163,7 @@ private:
   std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
   std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
 
-  std::shared_ptr<Operator<dim, Number>> poisson_operator;
+  std::shared_ptr<Operator<dim, Number>> pde_operator;
 
   std::shared_ptr<PostProcessorBase<dim, Number>> postprocessor;
 

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -31,7 +31,7 @@
 #include <exadg/grid/calculate_maximum_aspect_ratio.h>
 #include <exadg/grid/mapping_degree.h>
 #include <exadg/grid/mapping_dof_vector.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/poisson/spatial_discretization/operator.h>
 #include <exadg/poisson/user_interface/application_base.h>
 #include <exadg/utilities/print_functions.h>

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -28,7 +28,7 @@
 // ExaDG
 
 // matrix-free
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 
 // operators
 #include <exadg/operators/rhs_operator.h>

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -28,7 +28,7 @@
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 
 // ExaDG
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/multigrid_operator_base.h>
 #include <exadg/solvers_and_preconditioners/multigrid/levels_hybrid_multigrid.h>
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_input_parameters.h>

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -116,7 +116,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                mpi_comm));
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>(triangulation, false));
+  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -116,10 +116,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                mpi_comm));
 
   // initialize matrix_free
-  matrix_free_data.reset(new MatrixFreeData<dim, Number>());
-  matrix_free_data->data.tasks_parallel_scheme =
-    MatrixFree<dim, Number>::AdditionalData::partition_partition;
-  pde_operator->fill_matrix_free_data(*matrix_free_data);
+  matrix_free_data.reset(new MatrixFreeData<dim, Number>(triangulation, false));
+  matrix_free_data->append(pde_operator);
 
   matrix_free.reset(new MatrixFree<dim, Number>());
   matrix_free->reinit(*mapping,

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -29,7 +29,7 @@
 // ExaDG
 #include <exadg/grid/mapping_degree.h>
 #include <exadg/grid/mapping_dof_vector.h>
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/structure/spatial_discretization/operator.h>
 #include <exadg/structure/time_integration/driver_quasi_static_problems.h>
 #include <exadg/structure/time_integration/driver_steady_problems.h>

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -84,8 +84,6 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
   unsigned int const                     h_level)
 {
   matrix_free_data.data.mg_level = h_level;
-  matrix_free_data.data.tasks_parallel_scheme =
-    MatrixFree<dim, MultigridNumber>::AdditionalData::none;
 
   if(nonlinear)
     matrix_free_data.append_mapping_flags(PDEOperatorNonlinear::get_mapping_flags());

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -27,7 +27,7 @@
 #include <deal.II/fe/mapping_q.h>
 
 // ExaDG
-#include <exadg/matrix_free/matrix_free_wrapper.h>
+#include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
 #include <exadg/operators/mass_operator.h>
 #include <exadg/solvers_and_preconditioners/newton/newton_solver.h>


### PR DESCRIPTION
Two questions came up during refactoring:

- Why do we use `data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::partition_partition;` within the drivers, and `data.tasks_parallel_scheme = MatrixFree<dim, MultigridNumber>::AdditionalData::none;` within multigrid? Can we unify this? Is this still up to date with the most recent deal.II version, etc.?
- In the new constructor of `MatrixFreeData` (previously within the `Driver`s): Why do we cast to `parallel::distributed::Triangulation<dim>` if the function `Categorization::do_cell_based_loops()` called afterwards only expects `Triangulation<dim>`?