### PR TITLE
introduce pure virtual MovingMeshInterface class

### DIFF
--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -106,10 +106,10 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   if(param.ale_formulation) // moving mesh
   {
     std::shared_ptr<Function<dim>> mesh_motion = application->set_mesh_movement_function();
-    moving_mapping.reset(new MovingMeshFunction<dim, Number>(
+    moving_mesh.reset(new MovingMeshFunction<dim, Number>(
       static_mapping, degree, *triangulation, mesh_motion, param.start_time));
 
-    mapping = moving_mapping;
+    mapping = moving_mesh->get_mapping();
   }
   else // static mapping
   {
@@ -164,7 +164,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                             mpi_comm,
                                                             is_test,
                                                             postprocessor,
-                                                            moving_mapping,
+                                                            moving_mesh,
                                                             matrix_free);
 
       time_integrator->setup(param.restarted_simulation);
@@ -234,7 +234,7 @@ void
 Driver<dim, Number>::ale_update() const
 {
   // move the mesh and update dependent data structures
-  moving_mapping->update(time_integrator->get_next_time(), false);
+  moving_mesh->update(time_integrator->get_next_time(), false);
   matrix_free->update_mapping(*mapping);
   pde_operator->update_after_mesh_movement();
   std::shared_ptr<TimeIntBDF<dim, Number>> time_int_bdf =

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -154,7 +154,7 @@ private:
   std::shared_ptr<Mapping<dim>> static_mapping;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshFunction<dim, Number>> moving_mapping;
+  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
 
   // mapping (static or moving)
   std::shared_ptr<Mapping<dim>> mapping;

--- a/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
+++ b/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
@@ -35,14 +35,14 @@ namespace ConvDiff
  */
 template<int dim, typename Number>
 std::shared_ptr<TimeIntBase>
-create_time_integrator(std::shared_ptr<Operator<dim, Number>>          pde_operator,
-                       InputParameters const &                         parameters,
-                       unsigned int const                              refine_steps_time,
-                       MPI_Comm const &                                mpi_comm,
-                       bool const                                      is_test,
-                       std::shared_ptr<PostProcessorInterface<Number>> postprocessor,
-                       std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh,
-                       std::shared_ptr<MatrixFree<dim, Number>>        matrix_free)
+create_time_integrator(std::shared_ptr<Operator<dim, Number>>            pde_operator,
+                       InputParameters const &                           parameters,
+                       unsigned int const                                refine_steps_time,
+                       MPI_Comm const &                                  mpi_comm,
+                       bool const                                        is_test,
+                       std::shared_ptr<PostProcessorInterface<Number>>   postprocessor,
+                       std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh,
+                       std::shared_ptr<MatrixFree<dim, Number>>          matrix_free)
 {
   std::shared_ptr<TimeIntBase> time_integrator;
 

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -23,7 +23,7 @@
 #include <exadg/convection_diffusion/spatial_discretization/operator.h>
 #include <exadg/convection_diffusion/time_integration/time_int_bdf.h>
 #include <exadg/convection_diffusion/user_interface/input_parameters.h>
-#include <exadg/grid/moving_mesh_base.h>
+#include <exadg/grid/moving_mesh_interface.h>
 #include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/time_step_calculation.h>
 #include <exadg/utilities/print_solver_results.h>
@@ -36,14 +36,14 @@ using namespace dealii;
 
 template<int dim, typename Number>
 TimeIntBDF<dim, Number>::TimeIntBDF(
-  std::shared_ptr<Operator<dim, Number>>          operator_in,
-  InputParameters const &                         param_in,
-  unsigned int const                              refine_steps_time_in,
-  MPI_Comm const &                                mpi_comm_in,
-  bool const                                      is_test_in,
-  std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-  std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
-  std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
+  std::shared_ptr<Operator<dim, Number>>            operator_in,
+  InputParameters const &                           param_in,
+  unsigned int const                                refine_steps_time_in,
+  MPI_Comm const &                                  mpi_comm_in,
+  bool const                                        is_test_in,
+  std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in,
+  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in)
   : TimeIntBDFBase<Number>(param_in.start_time,
                            param_in.end_time,
                            param_in.max_number_of_time_steps,
@@ -484,7 +484,7 @@ void
 TimeIntBDF<dim, Number>::move_mesh_and_update_dependent_data_structures(double const time) const
 {
   moving_mesh->update(time, false);
-  matrix_free->update_mapping(*moving_mesh);
+  matrix_free->update_mapping(*moving_mesh->get_mapping());
   pde_operator->update_after_mesh_movement();
 }
 

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
@@ -36,7 +36,7 @@ using namespace dealii;
 
 // forward declarations
 template<int dim, typename Number>
-class MovingMeshBase;
+class MovingMeshInterface;
 
 namespace ConvDiff
 {
@@ -61,14 +61,14 @@ class TimeIntBDF : public TimeIntBDFBase<Number>
 public:
   typedef typename TimeIntBDFBase<Number>::VectorType VectorType;
 
-  TimeIntBDF(std::shared_ptr<Operator<dim, Number>>          operator_in,
-             InputParameters const &                         param_in,
-             unsigned int const                              refine_steps_time_in,
-             MPI_Comm const &                                mpi_comm_in,
-             bool const                                      is_in,
-             std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-             std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
-             std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);
+  TimeIntBDF(std::shared_ptr<Operator<dim, Number>>            operator_in,
+             InputParameters const &                           param_in,
+             unsigned int const                                refine_steps_time_in,
+             MPI_Comm const &                                  mpi_comm_in,
+             bool const                                        is_in,
+             std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+             std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
+             std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
 
   void
   set_velocities_and_times(std::vector<VectorType const *> const & velocities_in,
@@ -190,8 +190,8 @@ private:
   std::vector<VectorType> vec_grid_coordinates;
   VectorType              grid_coordinates_np;
 
-  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh;
+  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free;
 };
 
 } // namespace ConvDiff

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -391,21 +391,21 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     // mapping for fluid problem (moving mesh)
     if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Poisson)
     {
-      fluid_moving_mapping.reset(
+      fluid_moving_mesh.reset(
         new MovingMeshPoisson<dim, Number>(fluid_static_mapping, ale_poisson_operator));
     }
     else if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Elasticity)
     {
-      fluid_moving_mapping.reset(new MovingMeshElasticity<dim, Number>(fluid_static_mapping,
-                                                                       ale_elasticity_operator,
-                                                                       ale_elasticity_param));
+      fluid_moving_mesh.reset(new MovingMeshElasticity<dim, Number>(fluid_static_mapping,
+                                                                    ale_elasticity_operator,
+                                                                    ale_elasticity_param));
     }
     else
     {
       AssertThrow(false, ExcMessage("not implemented."));
     }
 
-    fluid_mapping = fluid_moving_mapping;
+    fluid_mapping = fluid_moving_mesh->get_mapping();
 
     // initialize fluid_operator
     fluid_operator = IncNS::create_operator<dim, Number>(*fluid_triangulation,
@@ -591,7 +591,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                                        mpi_comm,
                                                                        is_test,
                                                                        fluid_postprocessor,
-                                                                       fluid_moving_mapping,
+                                                                       fluid_moving_mesh,
                                                                        fluid_matrix_free);
 
     fluid_time_integrator->setup(fluid_param.restarted_simulation);
@@ -657,8 +657,8 @@ Driver<dim, Number>::solve_ale() const
 
   sub_timer.restart();
   bool const print_solver_info = fluid_time_integrator->print_solver_info();
-  fluid_moving_mapping->update(fluid_time_integrator->get_next_time(),
-                               print_solver_info and not(is_test));
+  fluid_moving_mesh->update(fluid_time_integrator->get_next_time(),
+                            print_solver_info and not(is_test));
   timer_tree.insert({"FSI", "ALE", "Solve and reinit mapping"}, sub_timer.wall_time());
 
   sub_timer.restart();
@@ -1176,7 +1176,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
   fluid_time_integrator->print_iterations();
 
   pcout << std::endl << "ALE:" << std::endl;
-  fluid_moving_mapping->print_iterations();
+  fluid_moving_mesh->print_iterations();
 
   pcout << std::endl << "Structure:" << std::endl;
   structure_time_integrator->print_iterations();

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -363,7 +363,7 @@ private:
   std::shared_ptr<Mapping<dim>> fluid_static_mapping;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> fluid_moving_mapping;
+  std::shared_ptr<MovingMeshBase<dim, Number>> fluid_moving_mesh;
 
   // mapping (static or moving)
   std::shared_ptr<Mapping<dim>> fluid_mapping;

--- a/include/exadg/grid/moving_mesh_elasticity.h
+++ b/include/exadg/grid/moving_mesh_elasticity.h
@@ -108,9 +108,9 @@ public:
       }
     }
 
-    this->initialize_mapping_q_cache(this->mapping_undeformed,
-                                     displacement,
-                                     pde_operator->get_dof_handler());
+    this->moving_mapping->initialize_mapping_q_cache(this->mapping_undeformed,
+                                                     displacement,
+                                                     pde_operator->get_dof_handler());
   }
 
   /**

--- a/include/exadg/grid/moving_mesh_function.h
+++ b/include/exadg/grid/moving_mesh_function.h
@@ -81,10 +81,10 @@ public:
     FE_Nothing<dim> dummy_fe;
     FEValues<dim>   fe_values(*this->mapping_undeformed,
                             dummy_fe,
-                            QGaussLobatto<dim>(this->get_degree() + 1),
+                            QGaussLobatto<dim>(this->moving_mapping->get_degree() + 1),
                             update_quadrature_points);
 
-    MappingQCache<dim>::initialize(
+    this->moving_mapping->initialize(
       triangulation,
       [&](typename Triangulation<dim>::cell_iterator const & cell) -> std::vector<Point<dim>> {
         fe_values.reinit(cell);
@@ -94,8 +94,8 @@ public:
         for(unsigned int i = 0; i < fe_values.n_quadrature_points; ++i)
         {
           // need to adjust for hierarchic numbering of MappingQCache
-          Point<dim> const point =
-            fe_values.quadrature_point(this->hierarchic_to_lexicographic_numbering[i]);
+          Point<dim> const point = fe_values.quadrature_point(
+            this->moving_mapping->hierarchic_to_lexicographic_numbering[i]);
           Point<dim> displacement;
           for(unsigned int d = 0; d < dim; ++d)
             displacement[d] = displacement_function->value(point, d);

--- a/include/exadg/grid/moving_mesh_function.h
+++ b/include/exadg/grid/moving_mesh_function.h
@@ -66,6 +66,7 @@ public:
     this->initialize(triangulation, mesh_movement_function);
   }
 
+private:
   /**
    * Initializes the MappingQCache object by providing a Function<dim> that describes the
    * displacement of the mesh compared to an undeformed reference configuration described by the
@@ -107,7 +108,6 @@ public:
       });
   }
 
-private:
   std::shared_ptr<Function<dim>> mesh_movement_function;
 
   Triangulation<dim> const & triangulation;

--- a/include/exadg/grid/moving_mesh_interface.h
+++ b/include/exadg/grid/moving_mesh_interface.h
@@ -1,0 +1,83 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// deal.II
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/mapping.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#ifndef INCLUDE_EXADG_GRID_MOVING_MESH_INTERFACE_H_
+#  define INCLUDE_EXADG_GRID_MOVING_MESH_INTERFACE_H_
+
+namespace ExaDG
+{
+using namespace dealii;
+
+/**
+ * Pure-virtual interface class for moving mesh functionality.
+ */
+template<int dim, typename Number>
+class MovingMeshInterface
+{
+public:
+  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+
+  /**
+   * Destructor.
+   */
+  virtual ~MovingMeshInterface()
+  {
+  }
+
+  /**
+   * Updates the mapping, i.e., moves the mesh.
+   */
+  virtual void
+  update(double const time, bool const print_solver_info) = 0;
+
+  /**
+   * Print the number of iterations for PDE type mesh motion problems.
+   */
+  virtual void
+  print_iterations() const
+  {
+    AssertThrow(false, ExcMessage("Has to be overwritten by derived classes."));
+  }
+
+  /**
+   * Extract the grid coordinates of the current mesh configuration and fill a dof-vector given a
+   * corresponding DoFHandler object.
+   */
+  virtual void
+  fill_grid_coordinates_vector(VectorType &            grid_coordinates,
+                               DoFHandler<dim> const & dof_handler) const = 0;
+
+  /**
+   * Return a shared pointer to dealii::Mapping<dim>.
+   */
+  virtual std::shared_ptr<Mapping<dim>>
+  get_mapping() = 0;
+};
+
+} // namespace ExaDG
+
+
+#endif /* INCLUDE_EXADG_GRID_MOVING_MESH_INTERFACE_H_ */

--- a/include/exadg/grid/moving_mesh_poisson.h
+++ b/include/exadg/grid/moving_mesh_poisson.h
@@ -86,9 +86,9 @@ public:
       print_solver_info_linear(pcout, n_iter, timer.wall_time());
     }
 
-    this->initialize_mapping_q_cache(this->mapping_undeformed,
-                                     displacement,
-                                     poisson->get_dof_handler());
+    this->moving_mapping->initialize_mapping_q_cache(this->mapping_undeformed,
+                                                     displacement,
+                                                     poisson->get_dof_handler());
   }
 
   /**

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -142,10 +142,10 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
     std::shared_ptr<Function<dim>> mesh_motion;
     mesh_motion = application->set_mesh_movement_function();
-    moving_mapping.reset(new MovingMeshFunction<dim, Number>(
+    moving_mesh.reset(new MovingMeshFunction<dim, Number>(
       static_mapping, degree, *triangulation, mesh_motion, fluid_param.start_time));
 
-    mapping = moving_mapping;
+    mapping = moving_mesh->get_mapping();
   }
   else // static mesh
   {
@@ -304,7 +304,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                                        mpi_comm,
                                                                        is_test,
                                                                        fluid_postprocessor,
-                                                                       moving_mapping,
+                                                                       moving_mesh,
                                                                        matrix_free);
   }
   else if(fluid_param.solver_type == IncNS::SolverType::Steady)
@@ -350,7 +350,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                     mpi_comm,
                                                     is_test,
                                                     scalar_postprocessor[i],
-                                                    moving_mapping,
+                                                    moving_mesh,
                                                     matrix_free);
 
     if(scalar_param[i].restarted_simulation == false)
@@ -607,7 +607,7 @@ Driver<dim, Number>::ale_update() const
   Timer sub_timer;
 
   sub_timer.restart();
-  moving_mapping->update(fluid_time_integrator->get_next_time(), false);
+  moving_mesh->update(fluid_time_integrator->get_next_time(), false);
   timer_tree.insert({"Flow + transport", "ALE", "Reinit mapping"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -110,7 +110,7 @@ private:
   std::shared_ptr<Mapping<dim>> static_mapping;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshFunction<dim, Number>> moving_mapping;
+  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
 
   // mapping (static or moving)
   std::shared_ptr<Mapping<dim>> mapping;

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -99,7 +99,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     {
       std::shared_ptr<Function<dim>> mesh_motion = application->set_mesh_movement_function();
 
-      moving_mapping.reset(new MovingMeshFunction<dim, Number>(
+      moving_mesh.reset(new MovingMeshFunction<dim, Number>(
         static_mapping, mapping_degree, *triangulation, mesh_motion, param.start_time));
     }
     else if(param.mesh_movement_type == MeshMovementType::Poisson)
@@ -156,14 +156,14 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
       poisson_operator->setup(poisson_matrix_free, poisson_matrix_free_data);
       poisson_operator->setup_solver();
 
-      moving_mapping.reset(new MovingMeshPoisson<dim, Number>(static_mapping, poisson_operator));
+      moving_mesh.reset(new MovingMeshPoisson<dim, Number>(static_mapping, poisson_operator));
     }
     else
     {
       AssertThrow(false, ExcMessage("Not implemented."));
     }
 
-    mapping = moving_mapping;
+    mapping = moving_mesh->get_mapping();
   }
   else // static mesh
   {
@@ -253,7 +253,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                             mpi_comm,
                                                             is_test,
                                                             postprocessor,
-                                                            moving_mapping,
+                                                            moving_mesh,
                                                             matrix_free);
     }
     else if(param.solver_type == SolverType::Steady)
@@ -303,7 +303,7 @@ Driver<dim, Number>::ale_update() const
   Timer sub_timer;
 
   sub_timer.restart();
-  moving_mapping->update(time_integrator->get_next_time(), false);
+  moving_mesh->update(time_integrator->get_next_time(), false);
   timer_tree.insert({"Incompressible flow", "ALE", "Reinit mapping"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -220,7 +220,7 @@ private:
   std::shared_ptr<Mapping<dim>> static_mapping;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mapping;
+  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
 
   // mapping (static or moving)
   std::shared_ptr<Mapping<dim>> mapping;

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -42,7 +42,7 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
                        MPI_Comm const &                                  mpi_comm,
                        bool const                                        is_test,
                        std::shared_ptr<PostProcessorInterface<Number>>   postprocessor,
-                       std::shared_ptr<MovingMeshBase<dim, Number>>      moving_mesh = nullptr,
+                       std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh = nullptr,
                        std::shared_ptr<MatrixFree<dim, Number>>          matrix_free = nullptr)
 {
   std::shared_ptr<TimeIntBDF<dim, Number>> time_integrator;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -19,7 +19,7 @@
  *  ______________________________________________________________________
  */
 
-#include <exadg/grid/moving_mesh_base.h>
+#include <exadg/grid/moving_mesh_interface.h>
 #include <exadg/incompressible_navier_stokes/postprocessor/postprocessor_interface.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h>
@@ -35,14 +35,14 @@ using namespace dealii;
 
 template<int dim, typename Number>
 TimeIntBDF<dim, Number>::TimeIntBDF(
-  std::shared_ptr<OperatorBase>                   operator_in,
-  InputParameters const &                         param_in,
-  unsigned int const                              refine_steps_time_in,
-  MPI_Comm const &                                mpi_comm_in,
-  bool const                                      is_test_in,
-  std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-  std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
-  std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
+  std::shared_ptr<OperatorBase>                     operator_in,
+  InputParameters const &                           param_in,
+  unsigned int const                                refine_steps_time_in,
+  MPI_Comm const &                                  mpi_comm_in,
+  bool const                                        is_test_in,
+  std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in,
+  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in)
   : TimeIntBDFBase<Number>(param_in.start_time,
                            param_in.end_time,
                            param_in.max_number_of_time_steps,
@@ -607,7 +607,7 @@ void
 TimeIntBDF<dim, Number>::move_mesh_and_update_dependent_data_structures(double const time) const
 {
   moving_mesh->update(time, false);
-  matrix_free->update_mapping(*moving_mesh);
+  matrix_free->update_mapping(*moving_mesh->get_mapping());
   operator_base->update_after_mesh_movement();
 }
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -34,7 +34,7 @@ namespace ExaDG
 {
 // forward declarations
 template<int dim, typename Number>
-class MovingMeshBase;
+class MovingMeshInterface;
 
 namespace IncNS
 {
@@ -61,14 +61,14 @@ public:
 
   typedef SpatialOperatorBase<dim, Number> OperatorBase;
 
-  TimeIntBDF(std::shared_ptr<OperatorBase>                   operator_in,
-             InputParameters const &                         param_in,
-             unsigned int const                              refine_steps_time_in,
-             MPI_Comm const &                                mpi_comm_in,
-             bool const                                      is_test_in,
-             std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-             std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
-             std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);
+  TimeIntBDF(std::shared_ptr<OperatorBase>                     operator_in,
+             InputParameters const &                           param_in,
+             unsigned int const                                refine_steps_time_in,
+             MPI_Comm const &                                  mpi_comm_in,
+             bool const                                        is_test_in,
+             std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+             std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
+             std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
 
   virtual ~TimeIntBDF()
   {
@@ -213,8 +213,8 @@ private:
   std::vector<VectorType> vec_grid_coordinates;
   VectorType              grid_coordinates_np;
 
-  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh;
+  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free;
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -34,14 +34,14 @@ using namespace dealii;
 
 template<int dim, typename Number>
 TimeIntBDFCoupled<dim, Number>::TimeIntBDFCoupled(
-  std::shared_ptr<Operator>                       operator_in,
-  InputParameters const &                         param_in,
-  unsigned int const                              refine_steps_time_in,
-  MPI_Comm const &                                mpi_comm_in,
-  bool const                                      is_test_in,
-  std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-  std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
-  std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
+  std::shared_ptr<Operator>                         operator_in,
+  InputParameters const &                           param_in,
+  unsigned int const                                refine_steps_time_in,
+  MPI_Comm const &                                  mpi_comm_in,
+  bool const                                        is_test_in,
+  std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in,
+  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in)
   : Base(operator_in,
          param_in,
          refine_steps_time_in,

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -51,14 +51,14 @@ private:
   typedef OperatorCoupled<dim, Number> Operator;
 
 public:
-  TimeIntBDFCoupled(std::shared_ptr<Operator>                       operator_in,
-                    InputParameters const &                         param_in,
-                    unsigned int const                              refine_steps_time_in,
-                    MPI_Comm const &                                mpi_comm_in,
-                    bool const                                      is_test_in,
-                    std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-                    std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
-                    std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);
+  TimeIntBDFCoupled(std::shared_ptr<Operator>                         operator_in,
+                    InputParameters const &                           param_in,
+                    unsigned int const                                refine_steps_time_in,
+                    MPI_Comm const &                                  mpi_comm_in,
+                    bool const                                        is_test_in,
+                    std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+                    std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
+                    std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
 
   void
   postprocessing_stability_analysis();

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -34,14 +34,14 @@ using namespace dealii;
 
 template<int dim, typename Number>
 TimeIntBDFDualSplitting<dim, Number>::TimeIntBDFDualSplitting(
-  std::shared_ptr<Operator>                       operator_in,
-  InputParameters const &                         param_in,
-  unsigned int const                              refine_steps_time_in,
-  MPI_Comm const &                                mpi_comm_in,
-  bool const                                      is_test_in,
-  std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-  std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
-  std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
+  std::shared_ptr<Operator>                         operator_in,
+  InputParameters const &                           param_in,
+  unsigned int const                                refine_steps_time_in,
+  MPI_Comm const &                                  mpi_comm_in,
+  bool const                                        is_test_in,
+  std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in,
+  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in)
   : Base(operator_in,
          param_in,
          refine_steps_time_in,

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -45,14 +45,15 @@ private:
   typedef OperatorDualSplitting<dim, Number> Operator;
 
 public:
-  TimeIntBDFDualSplitting(std::shared_ptr<Operator>                       pde_operator_in,
-                          InputParameters const &                         param_in,
-                          unsigned int const                              refine_steps_time_in,
-                          MPI_Comm const &                                mpi_comm_in,
-                          bool const                                      is_test_in,
-                          std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-                          std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
-                          std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);
+  TimeIntBDFDualSplitting(
+    std::shared_ptr<Operator>                         pde_operator_in,
+    InputParameters const &                           param_in,
+    unsigned int const                                refine_steps_time_in,
+    MPI_Comm const &                                  mpi_comm_in,
+    bool const                                        is_test_in,
+    std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+    std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
+    std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
 
   virtual ~TimeIntBDFDualSplitting()
   {

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -34,14 +34,14 @@ using namespace dealii;
 
 template<int dim, typename Number>
 TimeIntBDFPressureCorrection<dim, Number>::TimeIntBDFPressureCorrection(
-  std::shared_ptr<Operator>                       operator_in,
-  InputParameters const &                         param_in,
-  unsigned int const                              refine_steps_time_in,
-  MPI_Comm const &                                mpi_comm_in,
-  bool const                                      is_test_in,
-  std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-  std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in,
-  std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in)
+  std::shared_ptr<Operator>                         operator_in,
+  InputParameters const &                           param_in,
+  unsigned int const                                refine_steps_time_in,
+  MPI_Comm const &                                  mpi_comm_in,
+  bool const                                        is_test_in,
+  std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in,
+  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in)
   : Base(operator_in,
          param_in,
          refine_steps_time_in,

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -46,14 +46,14 @@ private:
 
 public:
   TimeIntBDFPressureCorrection(
-    std::shared_ptr<Operator>                       operator_in,
-    InputParameters const &                         param_in,
-    unsigned int const                              refine_steps_time_in,
-    MPI_Comm const &                                mpi_comm_in,
-    bool const                                      is_test_in,
-    std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in,
-    std::shared_ptr<MovingMeshBase<dim, Number>>    moving_mesh_in = nullptr,
-    std::shared_ptr<MatrixFree<dim, Number>>        matrix_free_in = nullptr);
+    std::shared_ptr<Operator>                         operator_in,
+    InputParameters const &                           param_in,
+    unsigned int const                                refine_steps_time_in,
+    MPI_Comm const &                                  mpi_comm_in,
+    bool const                                        is_test_in,
+    std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
+    std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
+    std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
 
   virtual ~TimeIntBDFPressureCorrection()
   {


### PR DESCRIPTION
A preparation for realizing #78 

This PR breaks the inheritance sequence of `MovingMeshBase` (`Mapping` -> ... -> `MappingQCache` -> `MappingDoFVector` -> `MovingMeshBase`) by using composition instead. This way, the time integrators in ExaDG only depend on the pure virtual interface of `MovingMeshInterface` and no longer on the implementation of `MappingDoFVector`. From a different point of view, this PR aims to separate moving mesh functionality from moving mesh data structures. The reason behind is that for an upcoming `ExaDG::Grid` class, the inheritance style is no longer expedient in my opinion as this conflicts with modularity and flexibility. The idea I currently have in mind is that a grid with time dependent mapping will not be derived from `ExaDG::Grid` (say `ExaDG::MovingGrid`), but instead `ExaDG::Grid` has a member function `attach_time_dependent_mapping()` and can internally decide via a getter function `ExaDG::Grid::get_mapping()` which mapping is the correct one to be passed to all other data structures and functionality in ExaDG and deal.II that need a mapping. The moving mesh classes, `MovingMeshBase` and derived ones, would care about the moving mesh functionality, but `ExaDG::Grid` does not need to know about that and how this is realized as long as it has a pointer to a `Mapping` to serve the interfaces of ExaDG and deal.II.