### PR TITLE
introduce class ExaDG::Grid.

### DIFF
--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -202,28 +202,25 @@ public:
      *   |__________________________________|
      *             indicator = 0
      */
-    typename Triangulation<dim>::cell_iterator cell = grid->triangulation->begin(),
-                                               endc = grid->triangulation->end();
-    for(; cell != endc; ++cell)
+    for(auto cell : *grid->triangulation)
     {
-      for(unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;
-          ++face_number)
+      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
       {
-        if(std::fabs(cell->face(face_number)->center()(1) - point2[1]) < 1e-12)
+        if(std::fabs(cell.face(face)->center()(1) - point2[1]) < 1e-12)
         {
-          cell->face(face_number)->set_boundary_id(1);
+          cell.face(face)->set_boundary_id(1);
         }
-        else if(std::fabs(cell->face(face_number)->center()(1) - 0.0) < 1e-12)
+        else if(std::fabs(cell.face(face)->center()(1) - 0.0) < 1e-12)
         {
-          cell->face(face_number)->set_boundary_id(0);
+          cell.face(face)->set_boundary_id(0);
         }
-        else if(std::fabs(cell->face(face_number)->center()(0) - 0.0) < 1e-12)
+        else if(std::fabs(cell.face(face)->center()(0) - 0.0) < 1e-12)
         {
-          cell->face(face_number)->set_boundary_id(0 + 10);
+          cell.face(face)->set_boundary_id(0 + 10);
         }
-        else if(std::fabs(cell->face(face_number)->center()(0) - point2[0]) < 1e-12)
+        else if(std::fabs(cell.face(face)->center()(0) - point2[0]) < 1e-12)
         {
-          cell->face(face_number)->set_boundary_id(1 + 10);
+          cell.face(face)->set_boundary_id(1 + 10);
         }
       }
     }

--- a/applications/compressible_navier_stokes/couette/tests/couette.output
+++ b/applications/compressible_navier_stokes/couette/tests/couette.output
@@ -59,8 +59,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     0
+  Max. number of refinements:                0
   Number of cells:                           2
+  Mapping degree:                            3
 
 Construct compressible Navier-Stokes DG operator ...
 

--- a/applications/compressible_navier_stokes/euler_vortex/tests/euler_vortex.output
+++ b/applications/compressible_navier_stokes/euler_vortex/tests/euler_vortex.output
@@ -58,8 +58,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     4
+  Max. number of refinements:                4
   Number of cells:                           256
+  Mapping degree:                            7
 
 Construct compressible Navier-Stokes DG operator ...
 

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -429,20 +429,17 @@ public:
     double const left = -1.0, right = 0.5;
     GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    typename Triangulation<dim>::cell_iterator cell = grid->triangulation->begin(),
-                                               endc = grid->triangulation->end();
-    for(; cell != endc; ++cell)
+    for(auto cell : *grid->triangulation)
     {
-      for(unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;
-          ++face_number)
+      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
       {
-        if(std::fabs(cell->face(face_number)->center()(1) - left) < 1e-12)
+        if(std::fabs(cell.face(face)->center()(1) - left) < 1e-12)
         {
-          cell->face(face_number)->set_boundary_id(0 + 10);
+          cell.face(face)->set_boundary_id(0 + 10);
         }
-        else if(std::fabs(cell->face(face_number)->center()(1) - right) < 1e-12)
+        else if(std::fabs(cell.face(face)->center()(1) - right) < 1e-12)
         {
-          cell->face(face_number)->set_boundary_id(1 + 10);
+          cell.face(face)->set_boundary_id(1 + 10);
         }
       }
     }

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -357,8 +357,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -422,19 +420,17 @@ public:
     param.use_combined_operator = false;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
     // hypercube volume is [left,right]^dim
     double const left = -1.0, right = 0.5;
-    GridGenerator::hyper_cube(*triangulation, left, right);
+    GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    typename Triangulation<dim>::cell_iterator cell = triangulation->begin(),
-                                               endc = triangulation->end();
+    typename Triangulation<dim>::cell_iterator cell = grid->triangulation->begin(),
+                                               endc = grid->triangulation->end();
     for(; cell != endc; ++cell)
     {
       for(unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;
@@ -451,13 +447,13 @@ public:
       }
     }
 
-    auto tria = dynamic_cast<Triangulation<dim> *>(&*triangulation);
-    GridTools::collect_periodic_faces(*tria, 0 + 10, 1 + 10, 1, periodic_faces);
-    triangulation->add_periodicity(periodic_faces);
+    auto tria = dynamic_cast<Triangulation<dim> *>(&*grid->triangulation);
+    GridTools::collect_periodic_faces(*tria, 0 + 10, 1 + 10, 1, grid->periodic_faces);
+    grid->triangulation->add_periodicity(grid->periodic_faces);
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/compressible_navier_stokes/manufactured_solution/tests/manufactured.output
+++ b/applications/compressible_navier_stokes/manufactured_solution/tests/manufactured.output
@@ -58,8 +58,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            6
 
 Construct compressible Navier-Stokes DG operator ...
 
@@ -104,10 +105,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 3.7533e-02:
-  Relative error (L2-norm): 5.86825e-14
+  Relative error (L2-norm): 5.86793e-14
 
 Calculate error for all fields at time t = 7.5031e-02:
-  Relative error (L2-norm): 1.18045e-13
+  Relative error (L2-norm): 1.18015e-13
 
 ________________________________________________________________________________
 
@@ -115,10 +116,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 1.1253e-01:
-  Relative error (L2-norm): 1.93757e-13
+  Relative error (L2-norm): 1.93746e-13
 
 Calculate error for all fields at time t = 1.5003e-01:
-  Relative error (L2-norm): 3.00392e-13
+  Relative error (L2-norm): 3.00426e-13
 
 ________________________________________________________________________________
 
@@ -126,10 +127,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 1.8753e-01:
-  Relative error (L2-norm): 4.48812e-13
+  Relative error (L2-norm): 4.48824e-13
 
 Calculate error for all fields at time t = 2.2502e-01:
-  Relative error (L2-norm): 6.40675e-13
+  Relative error (L2-norm): 6.40637e-13
 
 ________________________________________________________________________________
 
@@ -137,10 +138,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 2.6252e-01:
-  Relative error (L2-norm): 8.68319e-13
+  Relative error (L2-norm): 8.68344e-13
 
 Calculate error for all fields at time t = 3.0002e-01:
-  Relative error (L2-norm): 1.11776e-12
+  Relative error (L2-norm): 1.11768e-12
 
 ________________________________________________________________________________
 
@@ -148,7 +149,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 3.3752e-01:
-  Relative error (L2-norm): 1.36958e-12
+  Relative error (L2-norm): 1.36961e-12
 
 Calculate error for all fields at time t = 3.7502e-01:
   Relative error (L2-norm): 1.60226e-12
@@ -159,10 +160,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 4.1252e-01:
-  Relative error (L2-norm): 1.79534e-12
+  Relative error (L2-norm): 1.79537e-12
 
 Calculate error for all fields at time t = 4.5001e-01:
-  Relative error (L2-norm): 1.93049e-12
+  Relative error (L2-norm): 1.93053e-12
 
 ________________________________________________________________________________
 
@@ -170,10 +171,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 4.8751e-01:
-  Relative error (L2-norm): 1.99501e-12
+  Relative error (L2-norm): 1.99498e-12
 
 Calculate error for all fields at time t = 5.2501e-01:
-  Relative error (L2-norm): 1.98270e-12
+  Relative error (L2-norm): 1.98267e-12
 
 ________________________________________________________________________________
 
@@ -181,10 +182,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 5.6251e-01:
-  Relative error (L2-norm): 1.89480e-12
+  Relative error (L2-norm): 1.89481e-12
 
 Calculate error for all fields at time t = 6.0001e-01:
-  Relative error (L2-norm): 1.73987e-12
+  Relative error (L2-norm): 1.73986e-12
 
 ________________________________________________________________________________
 
@@ -192,10 +193,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 6.3751e-01:
-  Relative error (L2-norm): 1.53238e-12
+  Relative error (L2-norm): 1.53244e-12
 
 Calculate error for all fields at time t = 6.7500e-01:
-  Relative error (L2-norm): 1.29161e-12
+  Relative error (L2-norm): 1.29162e-12
 
 ________________________________________________________________________________
 
@@ -203,7 +204,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 7.1250e-01:
-  Relative error (L2-norm): 1.03888e-12
+  Relative error (L2-norm): 1.03882e-12
 
 Calculate error for all fields at time t = 7.5000e-01:
-  Relative error (L2-norm): 7.94707e-13
+  Relative error (L2-norm): 7.94726e-13

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -183,15 +183,12 @@ public:
     GridGenerator::subdivided_hyper_rectangle(*grid->triangulation, repetitions, point1, point2);
 
     // set boundary indicator
-    typename Triangulation<dim>::cell_iterator cell = grid->triangulation->begin(),
-                                               endc = grid->triangulation->end();
-    for(; cell != endc; ++cell)
+    for(auto cell : *grid->triangulation)
     {
-      for(unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;
-          ++face_number)
+      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
       {
-        if((std::fabs(cell->face(face_number)->center()(0) - L) < 1e-12))
-          cell->face(face_number)->set_boundary_id(1);
+        if((std::fabs(cell.face(face)->center()(0) - L) < 1e-12))
+          cell.face(face)->set_boundary_id(1);
       }
     }
 

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -128,8 +128,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -185,22 +183,18 @@ public:
     param.use_combined_operator = false;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions({1, 1});
     Point<dim>                point1(0.0, 0.0), point2(L, H);
-    GridGenerator::subdivided_hyper_rectangle(*triangulation, repetitions, point1, point2);
+    GridGenerator::subdivided_hyper_rectangle(*grid->triangulation, repetitions, point1, point2);
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/compressible_navier_stokes/shear_flow/tests/shear_flow.output
+++ b/applications/compressible_navier_stokes/shear_flow/tests/shear_flow.output
@@ -59,8 +59,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            6
 
 Construct compressible Navier-Stokes DG operator ...
 

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -115,8 +115,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -220,13 +218,11 @@ public:
     param.use_combined_operator = true;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
     double const pi   = numbers::PI;
     double const left = -pi * L, right = pi * L;
     double const deformation = 0.1;
@@ -245,16 +241,18 @@ public:
       AssertThrow(false, ExcMessage("Not implemented."));
     }
 
-    create_periodic_box(triangulation,
-                        n_refine_space,
-                        periodic_faces,
+    create_periodic_box(grid->triangulation,
+                        data.n_refine_global,
+                        grid->periodic_faces,
                         this->n_subdivisions_1d_hypercube,
                         left,
                         right,
                         curvilinear_mesh,
                         deformation);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void set_boundary_conditions(

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -52,8 +52,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -71,18 +69,16 @@ public:
     // InputParameters::InputParameters()
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
 

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -329,11 +329,9 @@ public:
 
     // manifold
     unsigned int manifold_id = 1;
-    for(typename Triangulation<dim>::cell_iterator cell = grid->triangulation->begin();
-        cell != grid->triangulation->end();
-        ++cell)
+    for(auto cell : *grid->triangulation)
     {
-      cell->set_all_manifold_ids(manifold_id);
+      cell.set_all_manifold_ids(manifold_id);
     }
 
     // apply mesh stretching towards no-slip boundaries in y-direction

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -259,8 +259,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -314,27 +312,25 @@ public:
     param.use_combined_operator = true;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
     Tensor<1, dim> dimensions;
     dimensions[0] = DIMENSIONS_X1;
     dimensions[1] = DIMENSIONS_X2;
     if(dim == 3)
       dimensions[2] = DIMENSIONS_X3;
 
-    GridGenerator::hyper_rectangle(*triangulation,
+    GridGenerator::hyper_rectangle(*grid->triangulation,
                                    Point<dim>(-dimensions / 2.0),
                                    Point<dim>(dimensions / 2.0));
 
     // manifold
     unsigned int manifold_id = 1;
-    for(typename Triangulation<dim>::cell_iterator cell = triangulation->begin();
-        cell != triangulation->end();
+    for(typename Triangulation<dim>::cell_iterator cell = grid->triangulation->begin();
+        cell != grid->triangulation->end();
         ++cell)
     {
       cell->set_all_manifold_ids(manifold_id);
@@ -342,30 +338,29 @@ public:
 
     // apply mesh stretching towards no-slip boundaries in y-direction
     static const ManifoldTurbulentChannel<dim> manifold(dimensions);
-    triangulation->set_manifold(manifold_id, manifold);
+    grid->triangulation->set_manifold(manifold_id, manifold);
 
     // periodicity in x- and z-direction
     // add 10 to avoid conflicts with dirichlet boundary, which is 0
-    triangulation->begin()->face(0)->set_all_boundary_ids(0 + 10);
-    triangulation->begin()->face(1)->set_all_boundary_ids(1 + 10);
+    grid->triangulation->begin()->face(0)->set_all_boundary_ids(0 + 10);
+    grid->triangulation->begin()->face(1)->set_all_boundary_ids(1 + 10);
     // periodicity in z-direction
     if(dim == 3)
     {
-      triangulation->begin()->face(4)->set_all_boundary_ids(2 + 10);
-      triangulation->begin()->face(5)->set_all_boundary_ids(3 + 10);
+      grid->triangulation->begin()->face(4)->set_all_boundary_ids(2 + 10);
+      grid->triangulation->begin()->face(5)->set_all_boundary_ids(3 + 10);
     }
 
-    auto tria = dynamic_cast<Triangulation<dim> *>(&*triangulation);
-    GridTools::collect_periodic_faces(*tria, 0 + 10, 1 + 10, 0, periodic_faces);
+    auto tria = dynamic_cast<Triangulation<dim> *>(&*grid->triangulation);
+    GridTools::collect_periodic_faces(*tria, 0 + 10, 1 + 10, 0, grid->periodic_faces);
     if(dim == 3)
-      GridTools::collect_periodic_faces(*tria, 2 + 10, 3 + 10, 2, periodic_faces);
+      GridTools::collect_periodic_faces(*tria, 2 + 10, 3 + 10, 2, grid->periodic_faces);
 
-    triangulation->add_periodicity(periodic_faces);
+    grid->triangulation->add_periodicity(grid->periodic_faces);
 
-    // perform global refinements
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
+++ b/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
@@ -84,8 +84,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     4
+  Max. number of refinements:                4
   Number of cells:                           256
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 
@@ -200,8 +201,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     4
+  Max. number of refinements:                4
   Number of cells:                           256
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 
@@ -316,8 +318,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     4
+  Max. number of refinements:                4
   Number of cells:                           256
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 
@@ -345,7 +348,7 @@ Solving steady state problem ...
 ... done!
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 1.11728e-04
+  Relative error (L2-norm): 1.11729e-04
 
 
 
@@ -432,8 +435,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     4
+  Max. number of refinements:                4
   Number of cells:                           256
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 
@@ -461,7 +465,7 @@ Solving steady state problem ...
 ... done!
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 6.62444e-06
+  Relative error (L2-norm): 6.62560e-06
 
 
 
@@ -548,8 +552,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     4
+  Max. number of refinements:                4
   Number of cells:                           256
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 
@@ -577,4 +582,4 @@ Solving steady state problem ...
 ... done!
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.41737e-07
+  Relative error (L2-norm): 4.61241e-07

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -95,8 +95,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -188,20 +186,16 @@ public:
     param.store_analytical_velocity_in_dof_vector = true;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
-    GridGenerator::hyper_cube(*triangulation, left, right);
+    GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -126,8 +126,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -202,22 +200,19 @@ public:
     param.use_combined_operator = true;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
     // hypercube volume is [left,right]^dim
-    GridGenerator::hyper_cube(*triangulation, left, right);
+    GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
+
 
   void
   set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final

--- a/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
+++ b/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
@@ -74,8 +74,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     4
+  Max. number of refinements:                4
   Number of cells:                           256
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -85,8 +85,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -159,19 +157,16 @@ public:
   /*                                                                                    */
   /**************************************************************************************/
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
-    GridGenerator::hyper_cube(*triangulation, left, right);
-    triangulation->refine_global(n_refine_space);
+    GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/applications/convection_diffusion/deforming_hill/tests/convective_explicit_time_int.output
+++ b/applications/convection_diffusion/deforming_hill/tests/convective_explicit_time_int.output
@@ -54,8 +54,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           16
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
@@ -84,8 +84,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 

--- a/applications/convection_diffusion/sine_wave/tests/explicit_time_int.output
+++ b/applications/convection_diffusion/sine_wave/tests/explicit_time_int.output
@@ -57,8 +57,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           16
+  Mapping degree:                            1
 
 Construct convection-diffusion operator ...
 

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -54,8 +54,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -71,18 +69,16 @@ public:
     // TODO fill parameters
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -52,8 +52,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -80,19 +78,16 @@ public:
     // Poisson::InputParameters::InputParameters()
   }
 
-  void
-  create_grid_fluid(std::shared_ptr<Triangulation<dim>> triangulation,
-                    PeriodicFaces &                     periodic_faces,
-                    unsigned int const                  n_refine_space,
-                    std::shared_ptr<Mapping<dim>> &     mapping,
-                    unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    // to avoid warnings (unused variable) use ...
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void
@@ -189,18 +184,16 @@ public:
     (void)parameters;
   }
 
-  void
-  create_grid_structure(std::shared_ptr<Triangulation<dim>> triangulation,
-                        PeriodicFaces &                     periodic_faces,
-                        unsigned int const                  n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid_structure(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -52,8 +52,6 @@ template<int dim, typename Number>
 class Application : public FTI::ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : FTI::ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -86,19 +84,16 @@ public:
     // ConvDiff::InputParameters::InputParameters()
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    // to avoid warnings (unused variable) use ...
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -149,8 +149,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBasePrecursor<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBasePrecursor<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -382,30 +380,26 @@ public:
     do_set_input_parameters(param, true);
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    Geometry::create_grid(triangulation, n_refine_space, periodic_faces);
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    Geometry::create_grid(grid->triangulation, data.n_refine_global, grid->periodic_faces);
+
+    return grid;
   }
 
-  void
-  create_grid_precursor(std::shared_ptr<Triangulation<dim>> triangulation,
-                        PeriodicFaces &                     periodic_faces,
-                        unsigned int const                  n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid_precursor(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    Geometry::create_grid_precursor(triangulation,
-                                    n_refine_space + additional_refinements_precursor,
-                                    periodic_faces);
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    Geometry::create_grid_precursor(grid->triangulation,
+                                    data.n_refine_global + additional_refinements_precursor,
+                                    grid->periodic_faces);
+
+    return grid;
   }
 
   void

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -126,8 +126,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -249,20 +247,17 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion; // CahouetChabard;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
-    GridGenerator::hyper_cube(*triangulation, left, right);
-    triangulation->refine_global(n_refine_space);
+    GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -56,8 +56,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -186,14 +184,10 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions(dim, 1);
     repetitions[0] = 2;
@@ -208,22 +202,21 @@ public:
     if(dim == 3)
       point2[2] = H;
 
-    GridGenerator::subdivided_hyper_rectangle(*triangulation, repetitions, point1, point2);
+    GridGenerator::subdivided_hyper_rectangle(*grid->triangulation, repetitions, point1, point2);
 
     // set boundary indicator
-    for(auto cell : triangulation->active_cell_iterators())
+    for(auto cell : grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;
-          ++face_number)
+      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
       {
-        if((std::fabs(cell->face(face_number)->center()(0) - L) < 1e-12))
-          cell->face(face_number)->set_boundary_id(1);
+        if((std::fabs(cell->face(face)->center()(0) - L) < 1e-12))
+          cell->face(face)->set_boundary_id(1);
       }
     }
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
+++ b/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
@@ -122,8 +122,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            2
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -160,10 +161,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 7.74871e-13
+  Absolute error (L2-norm): 7.81266e-13
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 2.09042e-11
+  Absolute error (L2-norm): 2.11294e-11
 
 
 
@@ -288,8 +289,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            3
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -326,10 +328,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 8.93060e-13
+  Absolute error (L2-norm): 5.46529e-13
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 1.71147e-11
+  Absolute error (L2-norm): 1.03890e-11
 
 
 
@@ -454,8 +456,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            4
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -492,10 +495,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 3.42529e-14
+  Absolute error (L2-norm): 2.98389e-14
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 9.59828e-13
+  Absolute error (L2-norm): 8.22650e-13
 
 
 
@@ -620,8 +623,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            5
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -658,7 +662,7 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 9.37557e-12
+  Absolute error (L2-norm): 9.34871e-12
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 2.32389e-10
+  Absolute error (L2-norm): 2.32619e-10

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -53,8 +53,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -253,20 +251,16 @@ public:
   }
 
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
-    GridGenerator::hyper_cube(*triangulation, left, right);
+    GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   std::shared_ptr<Function<dim>>

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
@@ -140,8 +140,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           16
+  Mapping degree:                            3
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -196,61 +197,61 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0004e+00:
-  Relative error (L2-norm): 9.03070e-16
+  Relative error (L2-norm): 3.65222e-15
 
 Calculate error for pressure at time t = 1.0004e+00:
-  Relative error (L2-norm): 1.24490e-13
+  Relative error (L2-norm): 5.38441e-13
 
 Calculate error for velocity at time t = 2.0019e+00:
-  Relative error (L2-norm): 1.77036e-15
+  Relative error (L2-norm): 2.38912e-15
 
 Calculate error for pressure at time t = 2.0019e+00:
-  Relative error (L2-norm): 1.10191e-13
+  Relative error (L2-norm): 2.56655e-13
 
 Calculate error for velocity at time t = 3.0033e+00:
-  Relative error (L2-norm): 8.92961e-16
+  Relative error (L2-norm): 1.95513e-15
 
 Calculate error for pressure at time t = 3.0033e+00:
-  Relative error (L2-norm): 7.50280e-14
+  Relative error (L2-norm): 9.29507e-14
 
 Calculate error for velocity at time t = 4.0048e+00:
-  Relative error (L2-norm): 2.69872e-15
+  Relative error (L2-norm): 2.47510e-15
 
 Calculate error for pressure at time t = 4.0048e+00:
-  Relative error (L2-norm): 3.43763e-13
+  Relative error (L2-norm): 4.58763e-13
 
 Calculate error for velocity at time t = 5.0007e+00:
-  Relative error (L2-norm): 9.54290e-16
+  Relative error (L2-norm): 9.78441e-16
 
 Calculate error for pressure at time t = 5.0007e+00:
-  Relative error (L2-norm): 3.85309e-13
+  Relative error (L2-norm): 1.73388e-13
 
 Calculate error for velocity at time t = 6.0021e+00:
-  Relative error (L2-norm): 1.67219e-15
+  Relative error (L2-norm): 3.72967e-15
 
 Calculate error for pressure at time t = 6.0021e+00:
-  Relative error (L2-norm): 3.43982e-13
+  Relative error (L2-norm): 6.67161e-13
 
 Calculate error for velocity at time t = 7.0036e+00:
-  Relative error (L2-norm): 1.08278e-15
+  Relative error (L2-norm): 1.20146e-15
 
 Calculate error for pressure at time t = 7.0036e+00:
-  Relative error (L2-norm): 7.61722e-13
+  Relative error (L2-norm): 4.74842e-14
 
 Calculate error for velocity at time t = 8.0051e+00:
-  Relative error (L2-norm): 9.68446e-16
+  Relative error (L2-norm): 2.01180e-15
 
 Calculate error for pressure at time t = 8.0051e+00:
-  Relative error (L2-norm): 1.08110e-12
+  Relative error (L2-norm): 4.69524e-13
 
 Calculate error for velocity at time t = 9.0009e+00:
-  Relative error (L2-norm): 1.36696e-15
+  Relative error (L2-norm): 2.45807e-15
 
 Calculate error for pressure at time t = 9.0009e+00:
-  Relative error (L2-norm): 4.87471e-14
+  Relative error (L2-norm): 2.55316e-13
 
 Calculate error for velocity at time t = 1.0002e+01:
-  Relative error (L2-norm): 2.98430e-15
+  Relative error (L2-norm): 1.93105e-15
 
 Calculate error for pressure at time t = 1.0002e+01:
-  Relative error (L2-norm): 3.11829e-13
+  Relative error (L2-norm): 2.20083e-13

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
@@ -138,8 +138,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           16
+  Mapping degree:                            3
 
 Construct incompressible Navier-Stokes operator ...
 

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -178,8 +178,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -351,45 +349,42 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
     double const              y_upper = apply_symmetry_bc ? 0.0 : H / 2.;
     Point<dim>                point1(0.0, -H / 2.), point2(L, y_upper);
     std::vector<unsigned int> repetitions({2, 1});
-    GridGenerator::subdivided_hyper_rectangle(*triangulation, repetitions, point1, point2);
+    GridGenerator::subdivided_hyper_rectangle(*grid->triangulation, repetitions, point1, point2);
 
     // set boundary indicator
-    for(auto cell : triangulation->active_cell_iterators())
+    for(auto cell : grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;
-          ++face_number)
+      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
       {
-        if((std::fabs(cell->face(face_number)->center()(0) - 0.0) < 1e-12))
-          cell->face(face_number)->set_boundary_id(1);
-        if((std::fabs(cell->face(face_number)->center()(0) - L) < 1e-12))
-          cell->face(face_number)->set_boundary_id(2);
+        if((std::fabs(cell->face(face)->center()(0) - 0.0) < 1e-12))
+          cell->face(face)->set_boundary_id(1);
+        if((std::fabs(cell->face(face)->center()(0) - L) < 1e-12))
+          cell->face(face)->set_boundary_id(2);
 
         if(apply_symmetry_bc) // upper wall
-          if((std::fabs(cell->face(face_number)->center()(1) - y_upper) < 1e-12))
-            cell->face(face_number)->set_boundary_id(3);
+          if((std::fabs(cell->face(face)->center()(1) - y_upper) < 1e-12))
+            cell->face(face)->set_boundary_id(3);
       }
     }
 
     if(boundary_condition == BoundaryCondition::Periodic)
     {
-      auto tria = dynamic_cast<Triangulation<dim> *>(&*triangulation);
-      GridTools::collect_periodic_faces(*tria, 1, 2, 0, periodic_faces);
-      triangulation->add_periodicity(periodic_faces);
+      auto tria = dynamic_cast<Triangulation<dim> *>(&*grid->triangulation);
+      GridTools::collect_periodic_faces(*tria, 1, 2, 0, grid->periodic_faces);
+      grid->triangulation->add_periodicity(grid->periodic_faces);
     }
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -136,8 +136,9 @@ High-order dual splitting scheme:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     0
+  Max. number of refinements:                0
   Number of cells:                           2
+  Mapping degree:                            2
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -192,10 +193,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0002e+01:
-  Absolute error (L2-norm): 8.65222e-16
+  Absolute error (L2-norm): 7.89288e-16
 
 Calculate error for pressure at time t = 1.0002e+01:
-  Absolute error (L2-norm): 8.01050e-15
+  Absolute error (L2-norm): 1.81750e-14
 
 ________________________________________________________________________________
 
@@ -203,10 +204,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 2.0001e+01:
-  Absolute error (L2-norm): 5.69336e-16
+  Absolute error (L2-norm): 5.39655e-16
 
 Calculate error for pressure at time t = 2.0001e+01:
-  Absolute error (L2-norm): 1.10996e-14
+  Absolute error (L2-norm): 3.06722e-14
 
 ________________________________________________________________________________
 
@@ -214,10 +215,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 3.0100e+01:
-  Absolute error (L2-norm): 7.53680e-16
+  Absolute error (L2-norm): 9.95003e-16
 
 Calculate error for pressure at time t = 3.0100e+01:
-  Absolute error (L2-norm): 3.53110e-14
+  Absolute error (L2-norm): 8.20301e-15
 
 ________________________________________________________________________________
 
@@ -225,10 +226,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 4.0099e+01:
-  Absolute error (L2-norm): 7.93010e-16
+  Absolute error (L2-norm): 6.80210e-16
 
 Calculate error for pressure at time t = 4.0099e+01:
-  Absolute error (L2-norm): 1.94530e-14
+  Absolute error (L2-norm): 8.84113e-15
 
 ________________________________________________________________________________
 
@@ -236,10 +237,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 5.0098e+01:
-  Absolute error (L2-norm): 7.33410e-16
+  Absolute error (L2-norm): 8.45119e-16
 
 Calculate error for pressure at time t = 5.0098e+01:
-  Absolute error (L2-norm): 9.85441e-15
+  Absolute error (L2-norm): 1.63242e-14
 
 ________________________________________________________________________________
 
@@ -247,10 +248,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 6.0097e+01:
-  Absolute error (L2-norm): 7.73283e-16
+  Absolute error (L2-norm): 1.08758e-15
 
 Calculate error for pressure at time t = 6.0097e+01:
-  Absolute error (L2-norm): 1.97067e-14
+  Absolute error (L2-norm): 3.54423e-14
 
 ________________________________________________________________________________
 
@@ -258,10 +259,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 7.0096e+01:
-  Absolute error (L2-norm): 6.94789e-16
+  Absolute error (L2-norm): 8.10883e-16
 
 Calculate error for pressure at time t = 7.0096e+01:
-  Absolute error (L2-norm): 1.97862e-14
+  Absolute error (L2-norm): 1.51651e-14
 
 ________________________________________________________________________________
 
@@ -269,10 +270,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 8.0095e+01:
-  Absolute error (L2-norm): 9.67315e-16
+  Absolute error (L2-norm): 9.15130e-16
 
 Calculate error for pressure at time t = 8.0095e+01:
-  Absolute error (L2-norm): 3.45989e-14
+  Absolute error (L2-norm): 2.05420e-14
 
 ________________________________________________________________________________
 
@@ -280,10 +281,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0094e+01:
-  Absolute error (L2-norm): 8.28232e-16
+  Absolute error (L2-norm): 8.53509e-16
 
 Calculate error for pressure at time t = 9.0094e+01:
-  Absolute error (L2-norm): 1.66863e-14
+  Absolute error (L2-norm): 1.06107e-14
 
 ________________________________________________________________________________
 
@@ -291,7 +292,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0009e+02:
-  Absolute error (L2-norm): 1.10440e-15
+  Absolute error (L2-norm): 1.05029e-15
 
 Calculate error for pressure at time t = 1.0009e+02:
-  Absolute error (L2-norm): 2.05075e-14
+  Absolute error (L2-norm): 2.56668e-14

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -136,8 +136,9 @@ High-order dual splitting scheme:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     0
+  Max. number of refinements:                0
   Number of cells:                           2
+  Mapping degree:                            2
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -192,10 +193,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0093e+01:
-  Absolute error (L2-norm): 6.29380e-16
+  Absolute error (L2-norm): 1.05388e-15
 
 Calculate error for pressure at time t = 1.0093e+01:
-  Absolute error (L2-norm): 9.12260e-15
+  Absolute error (L2-norm): 2.54455e-14
 
 ________________________________________________________________________________
 
@@ -203,10 +204,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 2.0011e+01:
-  Absolute error (L2-norm): 7.87829e-16
+  Absolute error (L2-norm): 7.77234e-16
 
 Calculate error for pressure at time t = 2.0011e+01:
-  Absolute error (L2-norm): 1.07500e-14
+  Absolute error (L2-norm): 1.49759e-14
 
 ________________________________________________________________________________
 
@@ -214,10 +215,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 3.0030e+01:
-  Absolute error (L2-norm): 6.81519e-16
+  Absolute error (L2-norm): 6.60021e-16
 
 Calculate error for pressure at time t = 3.0030e+01:
-  Absolute error (L2-norm): 1.25141e-15
+  Absolute error (L2-norm): 3.66149e-15
 
 ________________________________________________________________________________
 
@@ -225,10 +226,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 4.0048e+01:
-  Absolute error (L2-norm): 7.90642e-16
+  Absolute error (L2-norm): 6.78476e-16
 
 Calculate error for pressure at time t = 4.0048e+01:
-  Absolute error (L2-norm): 6.09294e-15
+  Absolute error (L2-norm): 1.06551e-14
 
 ________________________________________________________________________________
 
@@ -236,10 +237,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 5.0067e+01:
-  Absolute error (L2-norm): 6.26899e-16
+  Absolute error (L2-norm): 7.31115e-16
 
 Calculate error for pressure at time t = 5.0067e+01:
-  Absolute error (L2-norm): 1.65252e-14
+  Absolute error (L2-norm): 7.35121e-15
 
 ________________________________________________________________________________
 
@@ -247,10 +248,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 6.0086e+01:
-  Absolute error (L2-norm): 4.92360e-16
+  Absolute error (L2-norm): 5.14123e-16
 
 Calculate error for pressure at time t = 6.0086e+01:
-  Absolute error (L2-norm): 5.74424e-15
+  Absolute error (L2-norm): 6.82496e-15
 
 ________________________________________________________________________________
 
@@ -258,10 +259,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 7.0004e+01:
-  Absolute error (L2-norm): 6.78901e-16
+  Absolute error (L2-norm): 4.78612e-16
 
 Calculate error for pressure at time t = 7.0004e+01:
-  Absolute error (L2-norm): 1.04466e-14
+  Absolute error (L2-norm): 7.08202e-15
 
 ________________________________________________________________________________
 
@@ -269,10 +270,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 8.0022e+01:
-  Absolute error (L2-norm): 8.94810e-16
+  Absolute error (L2-norm): 5.31713e-16
 
 Calculate error for pressure at time t = 8.0022e+01:
-  Absolute error (L2-norm): 3.01244e-15
+  Absolute error (L2-norm): 1.85308e-15
 
 ________________________________________________________________________________
 
@@ -280,10 +281,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0041e+01:
-  Absolute error (L2-norm): 4.91882e-16
+  Absolute error (L2-norm): 6.21610e-16
 
 Calculate error for pressure at time t = 9.0041e+01:
-  Absolute error (L2-norm): 1.39139e-14
+  Absolute error (L2-norm): 2.70162e-15
 
 ________________________________________________________________________________
 
@@ -291,7 +292,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0006e+02:
-  Absolute error (L2-norm): 6.13220e-16
+  Absolute error (L2-norm): 8.15936e-16
 
 Calculate error for pressure at time t = 1.0006e+02:
-  Absolute error (L2-norm): 9.23930e-15
+  Absolute error (L2-norm): 9.82875e-15

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -136,8 +136,9 @@ High-order dual splitting scheme:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     0
+  Max. number of refinements:                0
   Number of cells:                           2
+  Mapping degree:                            2
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -206,7 +207,7 @@ Calculate error for velocity at time t = 2.0041e+01:
   Absolute error (L2-norm): 1.39979e-02
 
 Calculate error for pressure at time t = 2.0041e+01:
-  Absolute error (L2-norm): 1.35427e-11
+  Absolute error (L2-norm): 1.34278e-11
 
 ________________________________________________________________________________
 
@@ -217,7 +218,7 @@ Calculate error for velocity at time t = 3.0061e+01:
   Absolute error (L2-norm): 1.15278e-03
 
 Calculate error for pressure at time t = 3.0061e+01:
-  Absolute error (L2-norm): 1.87364e-12
+  Absolute error (L2-norm): 2.12358e-12
 
 ________________________________________________________________________________
 
@@ -228,7 +229,7 @@ Calculate error for velocity at time t = 4.0061e+01:
   Absolute error (L2-norm): 9.54122e-05
 
 Calculate error for pressure at time t = 4.0061e+01:
-  Absolute error (L2-norm): 9.62002e-14
+  Absolute error (L2-norm): 1.15354e-13
 
 ________________________________________________________________________________
 
@@ -239,7 +240,7 @@ Calculate error for velocity at time t = 5.0061e+01:
   Absolute error (L2-norm): 7.89701e-06
 
 Calculate error for pressure at time t = 5.0061e+01:
-  Absolute error (L2-norm): 9.33057e-15
+  Absolute error (L2-norm): 1.64219e-14
 
 ________________________________________________________________________________
 
@@ -250,7 +251,7 @@ Calculate error for velocity at time t = 6.0061e+01:
   Absolute error (L2-norm): 6.53613e-07
 
 Calculate error for pressure at time t = 6.0061e+01:
-  Absolute error (L2-norm): 5.03464e-15
+  Absolute error (L2-norm): 9.05782e-16
 
 ________________________________________________________________________________
 
@@ -261,7 +262,7 @@ Calculate error for velocity at time t = 7.0061e+01:
   Absolute error (L2-norm): 5.40977e-08
 
 Calculate error for pressure at time t = 7.0061e+01:
-  Absolute error (L2-norm): 1.63164e-15
+  Absolute error (L2-norm): 2.95145e-15
 
 ________________________________________________________________________________
 
@@ -272,7 +273,7 @@ Calculate error for velocity at time t = 8.0061e+01:
   Absolute error (L2-norm): 4.47752e-09
 
 Calculate error for pressure at time t = 8.0061e+01:
-  Absolute error (L2-norm): 9.17411e-16
+  Absolute error (L2-norm): 7.60837e-16
 
 ________________________________________________________________________________
 
@@ -283,7 +284,7 @@ Calculate error for velocity at time t = 9.0061e+01:
   Absolute error (L2-norm): 3.70584e-10
 
 Calculate error for pressure at time t = 9.0061e+01:
-  Absolute error (L2-norm): 1.23891e-15
+  Absolute error (L2-norm): 1.78647e-15
 
 ________________________________________________________________________________
 
@@ -291,7 +292,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0006e+02:
-  Absolute error (L2-norm): 3.06681e-11
+  Absolute error (L2-norm): 3.06687e-11
 
 Calculate error for pressure at time t = 1.0006e+02:
-  Absolute error (L2-norm): 2.37986e-15
+  Absolute error (L2-norm): 6.93657e-16

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -136,8 +136,9 @@ High-order dual splitting scheme:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     0
+  Max. number of refinements:                0
   Number of cells:                           2
+  Mapping degree:                            2
 
 Construct incompressible Navier-Stokes operator ...
 
@@ -195,7 +196,7 @@ Calculate error for velocity at time t = 1.0036e+01:
   Absolute error (L2-norm): 1.69108e-01
 
 Calculate error for pressure at time t = 1.0036e+01:
-  Absolute error (L2-norm): 9.57753e-10
+  Absolute error (L2-norm): 1.29621e-09
 
 ________________________________________________________________________________
 
@@ -206,7 +207,7 @@ Calculate error for velocity at time t = 2.0037e+01:
   Absolute error (L2-norm): 1.39719e-02
 
 Calculate error for pressure at time t = 2.0037e+01:
-  Absolute error (L2-norm): 5.92462e-11
+  Absolute error (L2-norm): 1.04334e-10
 
 ________________________________________________________________________________
 
@@ -217,7 +218,7 @@ Calculate error for velocity at time t = 3.0057e+01:
   Absolute error (L2-norm): 1.14904e-03
 
 Calculate error for pressure at time t = 3.0057e+01:
-  Absolute error (L2-norm): 3.50761e-12
+  Absolute error (L2-norm): 5.43842e-12
 
 ________________________________________________________________________________
 
@@ -228,7 +229,7 @@ Calculate error for velocity at time t = 4.0057e+01:
   Absolute error (L2-norm): 9.49692e-05
 
 Calculate error for pressure at time t = 4.0057e+01:
-  Absolute error (L2-norm): 4.45021e-13
+  Absolute error (L2-norm): 7.19261e-13
 
 ________________________________________________________________________________
 
@@ -239,7 +240,7 @@ Calculate error for velocity at time t = 5.0057e+01:
   Absolute error (L2-norm): 7.84928e-06
 
 Calculate error for pressure at time t = 5.0057e+01:
-  Absolute error (L2-norm): 3.80143e-14
+  Absolute error (L2-norm): 8.01440e-14
 
 ________________________________________________________________________________
 
@@ -250,7 +251,7 @@ Calculate error for velocity at time t = 6.0057e+01:
   Absolute error (L2-norm): 6.48750e-07
 
 Calculate error for pressure at time t = 6.0057e+01:
-  Absolute error (L2-norm): 8.95339e-15
+  Absolute error (L2-norm): 2.55261e-15
 
 ________________________________________________________________________________
 
@@ -261,7 +262,7 @@ Calculate error for velocity at time t = 7.0057e+01:
   Absolute error (L2-norm): 5.36197e-08
 
 Calculate error for pressure at time t = 7.0057e+01:
-  Absolute error (L2-norm): 2.97348e-15
+  Absolute error (L2-norm): 3.53150e-15
 
 ________________________________________________________________________________
 
@@ -272,7 +273,7 @@ Calculate error for velocity at time t = 8.0057e+01:
   Absolute error (L2-norm): 4.43171e-09
 
 Calculate error for pressure at time t = 8.0057e+01:
-  Absolute error (L2-norm): 5.35431e-15
+  Absolute error (L2-norm): 1.16664e-15
 
 ________________________________________________________________________________
 
@@ -280,10 +281,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0057e+01:
-  Absolute error (L2-norm): 3.66279e-10
+  Absolute error (L2-norm): 3.66277e-10
 
 Calculate error for pressure at time t = 9.0057e+01:
-  Absolute error (L2-norm): 5.49098e-15
+  Absolute error (L2-norm): 7.35425e-16
 
 ________________________________________________________________________________
 
@@ -291,7 +292,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0006e+02:
-  Absolute error (L2-norm): 3.02670e-11
+  Absolute error (L2-norm): 3.02646e-11
 
 Calculate error for pressure at time t = 1.0006e+02:
-  Absolute error (L2-norm): 1.61940e-15
+  Absolute error (L2-norm): 8.22660e-15

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -150,8 +150,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -287,20 +285,17 @@ public:
     param.preconditioner_pressure_block = SchurComplementPreconditioner::CahouetChabard;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
-    GridGenerator::hyper_cube(*triangulation, left, right);
-    triangulation->refine_global(n_refine_space);
+    GridGenerator::hyper_cube(*grid->triangulation, left, right);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/applications/incompressible_navier_stokes/template/application.h
+++ b/applications/incompressible_navier_stokes/template/application.h
@@ -52,8 +52,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -71,19 +69,16 @@ public:
     // IncNS::InputParameters::InputParameters()
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    // to avoid warnings (unused variable) use ...
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/applications/incompressible_navier_stokes/template_precursor/application.h
+++ b/applications/incompressible_navier_stokes/template_precursor/application.h
@@ -32,8 +32,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBasePrecursor<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBasePrecursor<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -54,33 +52,31 @@ public:
     (void)param;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
-  void
-  create_grid_precursor(std::shared_ptr<Triangulation<dim>> triangulation,
-                        PeriodicFaces &                     periodic_faces,
-                        unsigned int const                  n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree) final
+
+  std::shared_ptr<Grid<dim>>
+  create_grid_precursor(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
+
 
   void
   set_boundary_conditions(

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -49,8 +49,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -171,13 +169,11 @@ public:
     param.preconditioner_pressure_block = SchurComplementPreconditioner::None;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;
 
@@ -195,16 +191,16 @@ public:
       AssertThrow(false, ExcMessage("Not implemented."));
     }
 
-    create_periodic_box(triangulation,
-                        n_refine_space,
-                        periodic_faces,
+    create_periodic_box(grid->triangulation,
+                        data.n_refine_global,
+                        grid->periodic_faces,
                         this->n_subdivisions_1d_hypercube,
                         left,
                         right,
                         curvilinear_mesh,
                         deformation);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void set_boundary_conditions(

--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -60,8 +60,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            1
 
 Construct Poisson operator ...
 
@@ -149,8 +150,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            2
 
 Construct Poisson operator ...
 
@@ -238,8 +240,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -327,8 +330,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            4
 
 Construct Poisson operator ...
 
@@ -416,8 +420,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            5
 
 Construct Poisson operator ...
 
@@ -505,8 +510,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            6
 
 Construct Poisson operator ...
 
@@ -594,8 +600,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            7
 
 Construct Poisson operator ...
 
@@ -683,8 +690,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            8
 
 Construct Poisson operator ...
 
@@ -772,8 +780,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            9
 
 Construct Poisson operator ...
 
@@ -861,8 +870,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            10
 
 Construct Poisson operator ...
 
@@ -950,8 +960,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            11
 
 Construct Poisson operator ...
 
@@ -1039,8 +1050,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            12
 
 Construct Poisson operator ...
 
@@ -1128,8 +1140,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            13
 
 Construct Poisson operator ...
 
@@ -1154,7 +1167,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.24997e-11
+  Relative error (L2-norm): 4.24996e-11
 
 
 
@@ -1217,8 +1230,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            14
 
 Construct Poisson operator ...
 
@@ -1243,7 +1257,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 2.47319e-12
+  Relative error (L2-norm): 2.47323e-12
 
 
 
@@ -1306,8 +1320,9 @@ Numerical parameters:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     3
+  Max. number of refinements:                3
   Number of cells:                           64
+  Mapping degree:                            15
 
 Construct Poisson operator ...
 
@@ -1332,4 +1347,4 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 2.28170e-12
+  Relative error (L2-norm): 2.28171e-12

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -60,8 +60,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -149,8 +150,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -238,8 +240,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -327,8 +330,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -416,8 +420,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -505,8 +510,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -594,8 +600,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -60,8 +60,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -149,8 +150,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -238,8 +240,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -327,8 +330,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -416,8 +420,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -505,8 +510,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 
@@ -594,8 +600,9 @@ Numerical parameters:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     2
+  Max. number of refinements:                2
   Number of cells:                           512
+  Mapping degree:                            3
 
 Construct Poisson operator ...
 

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -35,8 +35,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -75,24 +73,19 @@ public:
     param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-6;
   }
 
-
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
     double const length = 1.0;
     double const left = -length, right = length;
 
-    GridGenerator::hyper_cube_slit(*triangulation, left, right);
+    GridGenerator::hyper_cube_slit(*grid->triangulation, left, right);
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/poisson/template/application.h
+++ b/applications/poisson/template/application.h
@@ -51,8 +51,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -71,19 +69,16 @@ public:
   }
 
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    // to avoid warnings (unused variable) use ...
-    (void)triangulation;
-    (void)n_refine_space;
-    (void)periodic_faces;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
 

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -51,8 +51,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -95,13 +93,11 @@ public:
     param.preconditioner = Preconditioner::None;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;
 
@@ -119,16 +115,16 @@ public:
       AssertThrow(false, ExcMessage("Not implemented."));
     }
 
-    create_periodic_box(triangulation,
-                        n_refine_space,
-                        periodic_faces,
+    create_periodic_box(grid->triangulation,
+                        data.n_refine_global,
+                        grid->periodic_faces,
                         this->n_subdivisions_1d_hypercube,
                         left,
                         right,
                         curvilinear_mesh,
                         deformation);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -125,8 +125,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -193,14 +191,10 @@ public:
     this->param = parameters;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)periodic_faces;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
 
     Point<dim> p1, p2;
     p1[0] = 0;
@@ -219,12 +213,12 @@ public:
     if(dim == 3)
       repetitions[2] = this->repetitions2;
 
-    GridGenerator::subdivided_hyper_rectangle(*triangulation, repetitions, p1, p2);
+    GridGenerator::subdivided_hyper_rectangle(*grid->triangulation, repetitions, p1, p2);
 
-    element_length = this->length / (this->repetitions0 * pow(2, n_refine_space));
+    element_length = this->length / (this->repetitions0 * pow(2, data.n_refine_global));
 
     double const tol = 1.e-8;
-    for(auto cell : *triangulation)
+    for(auto cell : *grid->triangulation)
     {
       for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
       {
@@ -254,9 +248,9 @@ public:
       }
     }
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -113,8 +113,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -184,21 +182,17 @@ public:
     this->param = parameters;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
     AssertThrow(dim == 3, ExcMessage("This application only makes sense for dim=3."));
 
-    (void)periodic_faces;
-
-    GridGenerator::cylinder_shell(*triangulation, height, inner_radius, outer_radius);
+    GridGenerator::cylinder_shell(*grid->triangulation, height, inner_radius, outer_radius);
 
     // 0 = bottom ; 1 = top ; 2 = inner and outer radius
-    for(auto cell : triangulation->active_cell_iterators())
+    for(auto cell : grid->triangulation->active_cell_iterators())
     {
       for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
       {
@@ -225,9 +219,9 @@ public:
       }
     }
 
-    triangulation->refine_global(n_refine_space);
+    grid->triangulation->refine_global(data.n_refine_global);
 
-    mapping.reset(new MappingQGeneric<dim>(mapping_degree));
+    return grid;
   }
 
   void

--- a/applications/structure/manufactured/tests/2d.output
+++ b/applications/structure/manufactured/tests/2d.output
@@ -76,8 +76,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -191,8 +192,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -306,8 +308,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -421,8 +424,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -536,8 +540,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -651,8 +656,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -766,8 +772,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -881,8 +888,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -996,8 +1004,9 @@ Linear solver:
 
 Generating grid for 2-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           4
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 

--- a/applications/structure/manufactured/tests/3d.output
+++ b/applications/structure/manufactured/tests/3d.output
@@ -76,8 +76,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -191,8 +192,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -306,8 +308,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -421,8 +424,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -536,8 +540,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -651,8 +656,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -766,8 +772,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -881,8 +888,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 
@@ -996,8 +1004,9 @@ Linear solver:
 
 Generating grid for 3-dimensional problem:
 
-  Number of refinements:                     1
+  Max. number of refinements:                1
   Number of cells:                           8
+  Mapping degree:                            1
 
 Construct elasticity operator ...
 

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -32,8 +32,6 @@ template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   Application(std::string input_file) : ApplicationBase<dim, Number>(input_file)
   {
     // parse application-specific parameters
@@ -60,18 +58,16 @@ public:
     (void)parameters;
   }
 
-  void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) final
+  std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    (void)triangulation;
-    (void)periodic_faces;
-    (void)n_refine_space;
-    (void)mapping;
-    (void)mapping_degree;
+    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+
+    // create triangulation
+
+    grid->triangulation->refine_global(data.n_refine_global);
+
+    return grid;
   }
 
   void

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -30,6 +30,7 @@
 #include <exadg/compressible_navier_stokes/user_interface/field_functions.h>
 #include <exadg/compressible_navier_stokes/user_interface/input_parameters.h>
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
+#include <exadg/grid/grid.h>
 #include <exadg/grid/mapping_degree.h>
 #include <exadg/grid/mapping_dof_vector.h>
 #include <exadg/matrix_free/matrix_free_data.h>
@@ -145,15 +146,7 @@ private:
 
   InputParameters param;
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> triangulation;
-
-  // mapping
-  std::shared_ptr<Mapping<dim>> mapping;
-
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_faces;
+  std::shared_ptr<Grid<dim>> grid;
 
   std::shared_ptr<FieldFunctions<dim>>           field_functions;
   std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density;

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -30,7 +30,6 @@
 #include <exadg/compressible_navier_stokes/user_interface/field_functions.h>
 #include <exadg/compressible_navier_stokes/user_interface/input_parameters.h>
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
-#include <exadg/grid/grid.h>
 #include <exadg/grid/mapping_degree.h>
 #include <exadg/grid/mapping_dof_vector.h>
 #include <exadg/matrix_free/matrix_free_data.h>

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -35,6 +35,7 @@
 #include <exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h>
 #include <exadg/compressible_navier_stokes/user_interface/field_functions.h>
 #include <exadg/compressible_navier_stokes/user_interface/input_parameters.h>
+#include <exadg/grid/grid.h>
 
 namespace ExaDG
 {
@@ -47,10 +48,6 @@ template<int dim, typename Number>
 class ApplicationBase
 {
 public:
-  typedef
-    typename std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-      PeriodicFaces;
-
   virtual void
   add_parameters(ParameterHandler & prm)
   {
@@ -75,12 +72,8 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) = 0;
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
   set_boundary_conditions(

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -119,7 +119,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   matrix_free.reset(new MatrixFree<dim, Number>());
   if(param.use_cell_based_face_loops)
-    Categorization::do_cell_based_loops(*triangulation, matrix_free_data->data);
+    Categorization::do_cell_based_loops(*grid->triangulation, matrix_free_data->data);
   matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -147,21 +147,14 @@ private:
   // application
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> triangulation;
-
-  // static mapping
-  std::shared_ptr<Mapping<dim>> static_mapping;
+  // grid
+  std::shared_ptr<Grid<dim>> grid;
 
   // moving mapping (ALE)
   std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
 
   // mapping (static or moving)
   std::shared_ptr<Mapping<dim>> mapping;
-
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_faces;
 
   InputParameters param;
 

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -31,6 +31,7 @@
 #include <exadg/convection_diffusion/user_interface/boundary_descriptor.h>
 #include <exadg/convection_diffusion/user_interface/field_functions.h>
 #include <exadg/convection_diffusion/user_interface/input_parameters.h>
+#include <exadg/grid/grid.h>
 
 namespace ExaDG
 {
@@ -42,10 +43,6 @@ template<int dim, typename Number>
 class ApplicationBase
 {
 public:
-  typedef
-    typename std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-      PeriodicFaces;
-
   virtual void
   add_parameters(ParameterHandler & prm)
   {
@@ -70,12 +67,8 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) = 0;
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual std::shared_ptr<Function<dim>>
   set_mesh_movement_function()

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -317,15 +317,8 @@ private:
   // input parameters
   Structure::InputParameters structure_param;
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> structure_triangulation;
-
-  // mapping
-  std::shared_ptr<Mapping<dim>> structure_mapping;
-
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    structure_periodic_faces;
+  // grid
+  std::shared_ptr<Grid<dim>> structure_grid;
 
   // material descriptor
   std::shared_ptr<Structure::MaterialDescriptor> structure_material_descriptor;
@@ -354,13 +347,8 @@ private:
 
   /****************************************** FLUID *******************************************/
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> fluid_triangulation;
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    fluid_periodic_faces;
-
-  // mapping
-  std::shared_ptr<Mapping<dim>> fluid_static_mapping;
+  // grid
+  std::shared_ptr<Grid<dim>> fluid_grid;
 
   // moving mapping (ALE)
   std::shared_ptr<MovingMeshBase<dim, Number>> fluid_moving_mesh;

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -93,16 +93,6 @@ public:
   virtual std::shared_ptr<Grid<dim>>
   create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
-  // currently required for test cases with analytical mesh movement
-  virtual std::shared_ptr<Function<dim>>
-  set_mesh_movement_function_fluid()
-  {
-    std::shared_ptr<Function<dim>> mesh_motion;
-    mesh_motion.reset(new Functions::ZeroFunction<dim>(dim));
-
-    return mesh_motion;
-  }
-
   virtual void
   set_boundary_conditions_fluid(
     std::shared_ptr<IncNS::BoundaryDescriptorU<dim>> boundary_descriptor_velocity,
@@ -114,9 +104,9 @@ public:
   virtual std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
   construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
-  // Moving mesh
+  // ALE
 
-  // Poisson type mesh smoothing
+  // Poisson type mesh motion
   virtual void
   set_input_parameters_ale(Poisson::InputParameters & parameters) = 0;
 
@@ -126,7 +116,7 @@ public:
   virtual void
   set_field_functions_ale(std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions) = 0;
 
-  // elasticity type mesh smoothing
+  // elasticity type mesh motion
   virtual void
   set_input_parameters_ale(Structure::InputParameters & parameters) = 0;
 

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -30,6 +30,7 @@
 #include <deal.II/grid/manifold_lib.h>
 
 // ExaDG
+#include <exadg/grid/grid.h>
 
 // Fluid
 #include <exadg/incompressible_navier_stokes/postprocessor/postprocessor.h>
@@ -89,12 +90,8 @@ public:
   virtual void
   set_input_parameters_fluid(IncNS::InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid_fluid(std::shared_ptr<Triangulation<dim>> triangulation,
-                    PeriodicFaces &                     periodic_faces,
-                    unsigned int const                  n_refine_space,
-                    std::shared_ptr<Mapping<dim>> &     mapping,
-                    unsigned int const                  mapping_degree) = 0;
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   // currently required for test cases with analytical mesh movement
   virtual std::shared_ptr<Function<dim>>
@@ -147,12 +144,8 @@ public:
   virtual void
   set_input_parameters_structure(Structure::InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid_structure(std::shared_ptr<Triangulation<dim>> triangulation,
-                        PeriodicFaces &                     periodic_faces,
-                        unsigned int const                  n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree) = 0;
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid_structure(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
   set_boundary_conditions_structure(

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -22,10 +22,18 @@
 #ifndef INCLUDE_EXADG_GRID_GRID_H_
 #define INCLUDE_EXADG_GRID_GRID_H_
 
+// deal.II
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_tools.h>
+
+// ExaDG
 #include <exadg/grid/enum_types.h>
 
 namespace ExaDG
 {
+using namespace dealii;
+
 struct GridData
 {
   GridData()

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -1,0 +1,100 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_GRID_GRID_H_
+#define INCLUDE_EXADG_GRID_GRID_H_
+
+#include <exadg/grid/enum_types.h>
+
+namespace ExaDG
+{
+struct GridData
+{
+  GridData()
+    : triangulation_type(TriangulationType::Distributed), n_refine_global(0), mapping_degree(1)
+  {
+  }
+
+  TriangulationType triangulation_type;
+
+  unsigned int n_refine_global;
+
+  unsigned int mapping_degree;
+
+  // TODO: path to a grid file
+  // std::string grid_file;
+};
+
+template<int dim>
+class Grid
+{
+public:
+  typedef
+    typename std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
+      PeriodicFaces;
+
+  /**
+   * Constructor.
+   */
+  Grid(GridData const & data, MPI_Comm const & mpi_comm)
+  {
+    // triangulation
+    if(data.triangulation_type == TriangulationType::Distributed)
+    {
+      triangulation = std::make_shared<parallel::distributed::Triangulation<dim>>(
+        mpi_comm,
+        dealii::Triangulation<dim>::none,
+        parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+    }
+    else if(data.triangulation_type == TriangulationType::FullyDistributed)
+    {
+      triangulation = std::make_shared<parallel::fullydistributed::Triangulation<dim>>(mpi_comm);
+    }
+    else
+    {
+      AssertThrow(false, ExcMessage("Invalid parameter triangulation_type."));
+    }
+
+    // mapping
+    mapping.reset(new MappingQGeneric<dim>(data.mapping_degree));
+  }
+
+  /**
+   * dealii::Triangulation.
+   */
+  std::shared_ptr<Triangulation<dim>> triangulation;
+
+  /**
+   * dealii::GridTools::PeriodicFacePair's.
+   */
+  PeriodicFaces periodic_faces;
+
+  /**
+   * dealii::Mapping.
+   */
+  std::shared_ptr<Mapping<dim>> mapping;
+};
+
+} // namespace ExaDG
+
+
+
+#endif /* INCLUDE_EXADG_GRID_GRID_H_ */

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -103,21 +103,14 @@ private:
    * Mesh
    */
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> triangulation;
-
-  // mapping
-  std::shared_ptr<Mapping<dim>> static_mapping;
+  // grid
+  std::shared_ptr<Grid<dim>> grid;
 
   // moving mapping (ALE)
   std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
 
   // mapping (static or moving)
   std::shared_ptr<Mapping<dim>> mapping;
-
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_faces;
 
   bool use_adaptive_time_stepping;
 

--- a/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
+++ b/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
@@ -22,14 +22,13 @@
 #ifndef INCLUDE_EXADG_INCOMPRESSIBLE_FLOW_WITH_TRANSPORT_USER_INTERFACE_APPLICATION_BASE_H_
 #define INCLUDE_EXADG_INCOMPRESSIBLE_FLOW_WITH_TRANSPORT_USER_INTERFACE_APPLICATION_BASE_H_
 
-// IncNS
-#include <exadg/incompressible_navier_stokes/user_interface/application_base.h>
-
-// ConvDiff
+// ExaDG
 #include <exadg/convection_diffusion/postprocessor/postprocessor.h>
 #include <exadg/convection_diffusion/user_interface/boundary_descriptor.h>
 #include <exadg/convection_diffusion/user_interface/field_functions.h>
 #include <exadg/convection_diffusion/user_interface/input_parameters.h>
+#include <exadg/grid/grid.h>
+#include <exadg/incompressible_navier_stokes/user_interface/application_base.h>
 
 namespace ExaDG
 {
@@ -44,8 +43,6 @@ template<int dim, typename Number>
 class ApplicationBase : public IncNS::ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   virtual void
   add_parameters(ParameterHandler & prm)
   {

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -210,7 +210,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   matrix_free.reset(new MatrixFree<dim, Number>());
   if(param.use_cell_based_face_loops)
     Categorization::do_cell_based_loops(*grid->triangulation, matrix_free_data->data);
-  matrix_free->reinit(*grid->mapping,
+  matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),
                       matrix_free_data->get_quadrature_vector(),

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -70,28 +70,14 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   param.check_input_parameters(pcout);
   param.print(pcout, "List of input parameters:");
 
-  // triangulation
-  if(param.triangulation_type == TriangulationType::Distributed)
-  {
-    triangulation.reset(new parallel::distributed::Triangulation<dim>(
-      mpi_comm,
-      dealii::Triangulation<dim>::none,
-      parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy));
-  }
-  else if(param.triangulation_type == TriangulationType::FullyDistributed)
-  {
-    triangulation.reset(new parallel::fullydistributed::Triangulation<dim>(mpi_comm));
-  }
-  else
-  {
-    AssertThrow(false, ExcMessage("Invalid parameter triangulation_type."));
-  }
+  // grid
+  GridData grid_data;
+  grid_data.triangulation_type = param.triangulation_type;
+  grid_data.n_refine_global    = refine_space;
+  grid_data.mapping_degree     = get_mapping_degree(param.mapping, degree);
 
-  // triangulation and mapping
-  unsigned int const mapping_degree = get_mapping_degree(param.mapping, degree);
-  application->create_grid(
-    triangulation, periodic_faces, refine_space, static_mapping, mapping_degree);
-  print_grid_data(pcout, refine_space, *triangulation);
+  grid = application->create_grid(grid_data, mpi_comm);
+  print_grid_info(pcout, *grid);
 
   if(param.ale_formulation) // moving mesh
   {
@@ -99,8 +85,11 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     {
       std::shared_ptr<Function<dim>> mesh_motion = application->set_mesh_movement_function();
 
-      moving_mesh.reset(new MovingMeshFunction<dim, Number>(
-        static_mapping, mapping_degree, *triangulation, mesh_motion, param.start_time));
+      moving_mesh.reset(new MovingMeshFunction<dim, Number>(grid->mapping,
+                                                            grid_data.mapping_degree,
+                                                            *grid->triangulation,
+                                                            mesh_motion,
+                                                            param.start_time));
     }
     else if(param.mesh_movement_type == MeshMovementType::Poisson)
     {
@@ -110,7 +99,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
       poisson_boundary_descriptor.reset(new Poisson::BoundaryDescriptor<1, dim>());
       application->set_boundary_conditions_poisson(poisson_boundary_descriptor);
-      verify_boundary_conditions(*poisson_boundary_descriptor, *triangulation, periodic_faces);
+      verify_boundary_conditions(*poisson_boundary_descriptor,
+                                 *grid->triangulation,
+                                 grid->periodic_faces);
 
       poisson_field_functions.reset(new Poisson::FieldFunctions<dim>());
       application->set_field_functions_poisson(poisson_field_functions);
@@ -124,10 +115,10 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                              "as for actual application problem."));
 
       // initialize Poisson operator
-      poisson_operator.reset(new Poisson::Operator<dim, Number, dim>(*triangulation,
-                                                                     mapping,
-                                                                     mapping_degree,
-                                                                     periodic_faces,
+      poisson_operator.reset(new Poisson::Operator<dim, Number, dim>(*grid->triangulation,
+                                                                     grid->mapping,
+                                                                     grid_data.mapping_degree,
+                                                                     grid->periodic_faces,
                                                                      poisson_boundary_descriptor,
                                                                      poisson_field_functions,
                                                                      poisson_param,
@@ -140,8 +131,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
       poisson_matrix_free.reset(new MatrixFree<dim, Number>());
       if(poisson_param.enable_cell_based_face_loops)
-        Categorization::do_cell_based_loops(*triangulation, poisson_matrix_free_data->data);
-      poisson_matrix_free->reinit(*static_mapping,
+        Categorization::do_cell_based_loops(*grid->triangulation, poisson_matrix_free_data->data);
+      poisson_matrix_free->reinit(*grid->mapping,
                                   poisson_matrix_free_data->get_dof_handler_vector(),
                                   poisson_matrix_free_data->get_constraint_vector(),
                                   poisson_matrix_free_data->get_quadrature_vector(),
@@ -150,7 +141,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
       poisson_operator->setup(poisson_matrix_free, poisson_matrix_free_data);
       poisson_operator->setup_solver();
 
-      moving_mesh.reset(new MovingMeshPoisson<dim, Number>(static_mapping, poisson_operator));
+      moving_mesh.reset(new MovingMeshPoisson<dim, Number>(grid->mapping, poisson_operator));
     }
     else
     {
@@ -161,7 +152,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   }
   else // static mesh
   {
-    mapping = static_mapping;
+    mapping = grid->mapping;
   }
 
   // boundary conditions
@@ -169,8 +160,12 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   boundary_descriptor_pressure.reset(new BoundaryDescriptorP<dim>());
 
   application->set_boundary_conditions(boundary_descriptor_velocity, boundary_descriptor_pressure);
-  verify_boundary_conditions(*boundary_descriptor_velocity, *triangulation, periodic_faces);
-  verify_boundary_conditions(*boundary_descriptor_pressure, *triangulation, periodic_faces);
+  verify_boundary_conditions(*boundary_descriptor_velocity,
+                             *grid->triangulation,
+                             grid->periodic_faces);
+  verify_boundary_conditions(*boundary_descriptor_pressure,
+                             *grid->triangulation,
+                             grid->periodic_faces);
 
   // field functions
   field_functions.reset(new FieldFunctions<dim>());
@@ -178,10 +173,10 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   if(param.solver_type == SolverType::Unsteady)
   {
-    pde_operator = create_operator<dim, Number>(*triangulation,
+    pde_operator = create_operator<dim, Number>(*grid->triangulation,
                                                 mapping,
                                                 degree,
-                                                periodic_faces,
+                                                grid->periodic_faces,
                                                 boundary_descriptor_velocity,
                                                 boundary_descriptor_pressure,
                                                 field_functions,
@@ -192,10 +187,10 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   else if(param.solver_type == SolverType::Steady)
   {
     pde_operator =
-      std::make_shared<IncNS::OperatorCoupled<dim, Number>>(*triangulation,
+      std::make_shared<IncNS::OperatorCoupled<dim, Number>>(*grid->triangulation,
                                                             mapping,
                                                             degree,
-                                                            periodic_faces,
+                                                            grid->periodic_faces,
                                                             boundary_descriptor_velocity,
                                                             boundary_descriptor_pressure,
                                                             field_functions,
@@ -214,8 +209,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   matrix_free.reset(new MatrixFree<dim, Number>());
   if(param.use_cell_based_face_loops)
-    Categorization::do_cell_based_loops(*triangulation, matrix_free_data->data);
-  matrix_free->reinit(*mapping,
+    Categorization::do_cell_based_loops(*grid->triangulation, matrix_free_data->data);
+  matrix_free->reinit(*grid->mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),
                       matrix_free_data->get_quadrature_vector(),

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -213,11 +213,8 @@ private:
    * Mesh
    */
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> triangulation;
-
-  // static mapping
-  std::shared_ptr<Mapping<dim>> static_mapping;
+  // grid
+  std::shared_ptr<Grid<dim>> grid;
 
   // moving mapping (ALE)
   std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
@@ -225,18 +222,11 @@ private:
   // mapping (static or moving)
   std::shared_ptr<Mapping<dim>> mapping;
 
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_faces;
-
   // solve mesh deformation by a Poisson problem
   Poisson::InputParameters poisson_param;
 
   std::shared_ptr<Poisson::FieldFunctions<dim>>        poisson_field_functions;
   std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> poisson_boundary_descriptor;
-
-  // static mesh for Poisson problem
-  std::shared_ptr<Mapping<dim>> poisson_mapping;
 
   std::shared_ptr<MatrixFreeData<dim, Number>>         poisson_matrix_free_data;
   std::shared_ptr<MatrixFree<dim, Number>>             poisson_matrix_free;

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.h
@@ -78,19 +78,13 @@ private:
   std::shared_ptr<ApplicationBasePrecursor<dim, Number>> application;
 
   /*
-   * Mesh
+   * Grid
    */
+  std::shared_ptr<Grid<dim>> grid_pre, grid;
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> triangulation_pre, triangulation;
-
-  // mapping
-  std::shared_ptr<Mapping<dim>> mapping_pre, mapping;
-
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_faces_pre, periodic_faces;
-
+  /*
+   * Field functions and boundary descriptor
+   */
   std::shared_ptr<FieldFunctions<dim>>      field_functions_pre, field_functions;
   std::shared_ptr<BoundaryDescriptorU<dim>> boundary_descriptor_velocity_pre,
     boundary_descriptor_velocity;

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -31,6 +31,7 @@
 
 // ExaDG
 #include <exadg/convection_diffusion/user_interface/boundary_descriptor.h>
+#include <exadg/grid/grid.h>
 #include <exadg/incompressible_navier_stokes/postprocessor/postprocessor.h>
 #include <exadg/incompressible_navier_stokes/user_interface/boundary_descriptor.h>
 #include <exadg/incompressible_navier_stokes/user_interface/field_functions.h>
@@ -52,10 +53,6 @@ template<int dim, typename Number>
 class ApplicationBase
 {
 public:
-  typedef
-    typename std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-      PeriodicFaces;
-
   virtual void
   add_parameters(ParameterHandler & prm)
   {
@@ -80,12 +77,8 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) = 0;
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
   set_boundary_conditions(
@@ -159,8 +152,6 @@ template<int dim, typename Number>
 class ApplicationBasePrecursor : public ApplicationBase<dim, Number>
 {
 public:
-  typedef typename ApplicationBase<dim, Number>::PeriodicFaces PeriodicFaces;
-
   ApplicationBasePrecursor(std::string parameter_file)
     : ApplicationBase<dim, Number>(parameter_file)
   {
@@ -173,12 +164,8 @@ public:
   virtual void
   set_input_parameters_precursor(InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid_precursor(std::shared_ptr<Triangulation<dim>> triangulation,
-                        PeriodicFaces &                     periodic_faces,
-                        unsigned int const                  n_refine_space,
-                        std::shared_ptr<Mapping<dim>> &     mapping,
-                        unsigned int const                  mapping_degree) = 0;
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid_precursor(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
   set_boundary_conditions_precursor(

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -145,15 +145,8 @@ private:
   // application
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> triangulation;
-
-  // mapping
-  std::shared_ptr<Mapping<dim>> mapping;
-
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_faces;
+  // grid
+  std::shared_ptr<Grid<dim>> grid;
 
   InputParameters param;
 

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -31,6 +31,7 @@
 #include <deal.II/grid/tria_description.h>
 
 // ExaDG
+#include <exadg/grid/grid.h>
 #include <exadg/poisson/postprocessor/postprocessor.h>
 #include <exadg/poisson/user_interface/boundary_descriptor.h>
 #include <exadg/poisson/user_interface/field_functions.h>
@@ -74,12 +75,8 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) = 0;
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
     set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<0, dim>> boundary_descriptor) = 0;

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -130,15 +130,8 @@ private:
   // user input parameters
   InputParameters param;
 
-  // triangulation
-  std::shared_ptr<Triangulation<dim>> triangulation;
-
-  // mapping
-  std::shared_ptr<Mapping<dim>> mapping;
-
-  // periodic boundaries
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_faces;
+  // grid
+  std::shared_ptr<Grid<dim>> grid;
 
   // material descriptor
   std::shared_ptr<MaterialDescriptor> material_descriptor;

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -27,6 +27,7 @@
 #include <deal.II/grid/grid_generator.h>
 
 // ExaDG
+#include <exadg/grid/grid.h>
 #include <exadg/structure/material/library/st_venant_kirchhoff.h>
 #include <exadg/structure/postprocessor/postprocessor.h>
 #include <exadg/structure/user_interface/boundary_descriptor.h>
@@ -44,10 +45,6 @@ template<int dim, typename Number>
 class ApplicationBase
 {
 public:
-  typedef
-    typename std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-      PeriodicFaces;
-
   virtual void
   add_parameters(ParameterHandler & prm)
   {
@@ -72,13 +69,8 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual void
-  create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-              PeriodicFaces &                     periodic_faces,
-              unsigned int const                  n_refine_space,
-              std::shared_ptr<Mapping<dim>> &     mapping,
-              unsigned int const                  mapping_degree) = 0;
-
+  virtual std::shared_ptr<Grid<dim>>
+  create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
   set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) = 0;

--- a/include/exadg/utilities/print_general_infos.h
+++ b/include/exadg/utilities/print_general_infos.h
@@ -116,22 +116,6 @@ print_matrixfree_info(ConditionalOStream const & pcout)
   // clang-format on
 }
 
-// TODO remove this function later once ExaDG::Grid is used everywhere
-// print grid info
-template<int dim>
-inline void
-print_grid_data(ConditionalOStream const & pcout,
-                unsigned int const         n_refine_space,
-                Triangulation<dim> const & triangulation)
-{
-  pcout << std::endl
-        << "Generating grid for " << dim << "-dimensional problem:" << std::endl
-        << std::endl;
-
-  print_parameter(pcout, "Number of refinements", n_refine_space);
-  print_parameter(pcout, "Number of cells", triangulation.n_global_active_cells());
-}
-
 template<int dim>
 inline void
 print_grid_info(ConditionalOStream const & pcout, Grid<dim> const & grid)

--- a/include/exadg/utilities/print_general_infos.h
+++ b/include/exadg/utilities/print_general_infos.h
@@ -29,6 +29,7 @@
 #include <deal.II/distributed/tria_base.h>
 
 // ExaDG
+#include <exadg/grid/grid.h>
 #include <exadg/utilities/print_functions.h>
 
 namespace ExaDG
@@ -115,6 +116,7 @@ print_matrixfree_info(ConditionalOStream const & pcout)
   // clang-format on
 }
 
+// TODO remove this function later once ExaDG::Grid is used everywhere
 // print grid info
 template<int dim>
 inline void
@@ -128,6 +130,23 @@ print_grid_data(ConditionalOStream const & pcout,
 
   print_parameter(pcout, "Number of refinements", n_refine_space);
   print_parameter(pcout, "Number of cells", triangulation.n_global_active_cells());
+}
+
+template<int dim>
+inline void
+print_grid_info(ConditionalOStream const & pcout, Grid<dim> const & grid)
+{
+  pcout << std::endl
+        << "Generating grid for " << dim << "-dimensional problem:" << std::endl
+        << std::endl;
+
+  print_parameter(pcout, "Max. number of refinements", grid.triangulation->n_global_levels() - 1);
+  print_parameter(pcout, "Number of cells", grid.triangulation->n_global_active_cells());
+
+  std::shared_ptr<MappingQGeneric<dim>> mapping_q_generic =
+    std::dynamic_pointer_cast<MappingQGeneric<dim>>(grid.mapping);
+  if(mapping_q_generic.get() != 0)
+    print_parameter(pcout, "Mapping degree", mapping_q_generic->get_degree());
 }
 } // namespace ExaDG
 


### PR DESCRIPTION
resolves #78 

The goal of this MR is to simplify interfaces, render them more stable (as we detected that we had to change this part quite often in the past), and being prepared for upcoming features such as, e.g., reading in grid files or simplicial/mixed meshes, which should all be handled by the new `ExaDG::Grid` class in order to not always touch many other places in the code (including all the application files).

@kronbichler @peterrum @bergbauer Since this is quite elementary for the design of `ExaDG`, please share your opinion and what we should have in mind already right now e.g. for upcoming features mentioned above.

Upcoming PRs: Many interfaces in `ExaDG` are so far not adapted to the new `Grid` class, which is certainly a major point of discussion, i.e., how deep to inject this new class into `ExaDG` and at which level of the implementation to work with raw (here: `deal.II`) data types. I would plan to at least "inject" `ExaDG::Grid` into the spatial discretization operators.