### PR TITLE
Avoid deprecated functionality of deal.II

### DIFF
--- a/include/exadg/grid/find_all_active_cells_around_point.h
+++ b/include/exadg/grid/find_all_active_cells_around_point.h
@@ -40,19 +40,16 @@ find_all_active_cells_around_point(Mapping<dim> const &                         
 
   std::vector<Pair> adjacent_cells;
 
-  try
-  {
-    Pair first_cell =
-      GridTools::find_active_cell_around_point(cache, point, cell_hint, marked_vertices, tolerance);
+  Pair first_cell =
+    GridTools::find_active_cell_around_point(cache, point, cell_hint, marked_vertices, tolerance);
 
+  if(first_cell.first != tria.end())
+  {
     // update cell_hint to have a good hint when the function is called next time
     cell_hint = first_cell.first;
 
     adjacent_cells =
       GridTools::find_all_active_cells_around_point(mapping, tria, point, tolerance, first_cell);
-  }
-  catch(...)
-  {
   }
 
   return adjacent_cells;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -975,7 +975,7 @@ SpatialOperatorBase<dim, Number>::adjust_pressure_level_if_undefined(VectorType 
       current = Utilities::MPI::sum(current, mpi_comm);
 
       VectorType vec_temp(pressure);
-      for(unsigned int i = 0; i < vec_temp.local_size(); ++i)
+      for(unsigned int i = 0; i < vec_temp.locally_owned_size(); ++i)
         vec_temp.local_element(i) = 1.;
 
       pressure.add(exact - current, vec_temp);
@@ -1007,7 +1007,7 @@ SpatialOperatorBase<dim, Number>::adjust_pressure_level_if_undefined(VectorType 
       double const current = pressure.mean_value();
 
       VectorType vec_temp(pressure);
-      for(unsigned int i = 0; i < vec_temp.local_size(); ++i)
+      for(unsigned int i = 0; i < vec_temp.locally_owned_size(); ++i)
         vec_temp.local_element(i) = 1.;
 
       pressure.add(exact - current, vec_temp);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -467,7 +467,7 @@ TimeIntBDFCoupled<dim, Number>::postprocessing_stability_analysis()
 
   std::cout << std::endl << "Analysis of eigenvalue spectrum:" << std::endl;
 
-  unsigned int const size = solution[0].block(0).local_size();
+  unsigned int const size = solution[0].block(0).locally_owned_size();
 
   LAPACKFullMatrix<Number> propagation_matrix(size, size);
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -276,7 +276,7 @@ TimeIntBDFDualSplitting<dim, Number>::postprocessing_stability_analysis()
 
   std::cout << std::endl << "Analysis of eigenvalue spectrum:" << std::endl;
 
-  unsigned int const size = velocity[0].local_size();
+  unsigned int const size = velocity[0].locally_owned_size();
 
   LAPACKFullMatrix<Number> propagation_matrix(size, size);
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -282,7 +282,7 @@ TimeIntBDFPressureCorrection<dim, Number>::postprocessing_stability_analysis()
 
   std::cout << std::endl << "Analysis of eigenvalue spectrum:" << std::endl;
 
-  unsigned int const size = velocity[0].local_size();
+  unsigned int const size = velocity[0].locally_owned_size();
 
   LAPACKFullMatrix<Number> propagation_matrix(size, size);
 

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -67,7 +67,7 @@ public:
   void
   apply(VectorType & dst, VectorType const & src) const
   {
-    dst.zero_out_ghosts();
+    dst.zero_out_ghost_values();
 
     matrix_free->cell_loop(&This::cell_loop, this, dst, src);
   }

--- a/include/exadg/postprocessor/write_output.h
+++ b/include/exadg/postprocessor/write_output.h
@@ -45,7 +45,7 @@ write_surface_mesh(Triangulation<dim> const & triangulation,
                    MPI_Comm const &           mpi_comm)
 {
   // write surface mesh only
-  DataOutFaces<dim, DoFHandler<dim>> data_out_surface(true /*surface only*/);
+  DataOutFaces<dim> data_out_surface(true /*surface only*/);
   data_out_surface.attach_triangulation(triangulation);
   data_out_surface.build_patches(mapping, n_subdivisions);
   data_out_surface.write_vtu_with_pvtu_record(folder, file + "_surface", counter, mpi_comm, 4);

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.cpp
@@ -113,7 +113,7 @@ MGTransferH<dim, Number>::interpolate(unsigned int const level_in,
         dst(dof_indices[i]) = dof_values_coarse[i];
     }
 
-  dst.zero_out_ghosts();
+  dst.zero_out_ghost_values();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -215,11 +215,11 @@ private:
       LinearAlgebra::distributed::Vector<typename Operator::value_type> vector;
       pde_operator.initialize_dof_vector(vector);
       VecCreateMPI(system_matrix.get_mpi_communicator(),
-                   vector.get_partitioner()->local_size(),
+                   vector.get_partitioner()->locally_owned_size(),
                    PETSC_DETERMINE,
                    &petsc_vector_dst);
       VecCreateMPI(system_matrix.get_mpi_communicator(),
-                   vector.get_partitioner()->local_size(),
+                   vector.get_partitioner()->locally_owned_size(),
                    PETSC_DETERMINE,
                    &petsc_vector_src);
     }

--- a/include/exadg/solvers_and_preconditioners/utilities/check_multigrid.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/check_multigrid.h
@@ -77,7 +77,7 @@ public:
     underlying_operator.initialize_dof_vector(initial_solution);
     VectorType solution_after_mg_cylce(initial_solution), tmp(initial_solution);
 
-    for(unsigned int i = 0; i < initial_solution.local_size(); ++i)
+    for(unsigned int i = 0; i < initial_solution.locally_owned_size(); ++i)
       initial_solution.local_element(i) = (double)rand() / RAND_MAX;
 
     underlying_operator.vmult(tmp, initial_solution);

--- a/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
@@ -40,7 +40,7 @@ compute_eigenvalues(Operator const &   op,
   rhs.reinit(inverse_diagonal, true);
   // NB: initialize rand in order to obtain "reproducible" results !!!
   srand(1);
-  for(unsigned int i = 0; i < rhs.local_size(); ++i)
+  for(unsigned int i = 0; i < rhs.locally_owned_size(); ++i)
     rhs.local_element(i) = (double)rand() / RAND_MAX;
   if(operator_is_singular)
     set_zero_mean_value(rhs);

--- a/include/exadg/solvers_and_preconditioners/utilities/invert_diagonal.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/invert_diagonal.h
@@ -37,7 +37,7 @@ template<typename Number>
 void
 invert_diagonal(LinearAlgebra::distributed::Vector<Number> & diagonal)
 {
-  for(unsigned int i = 0; i < diagonal.local_size(); ++i)
+  for(unsigned int i = 0; i < diagonal.locally_owned_size(); ++i)
   {
     if(std::abs(diagonal.local_element(i)) > 1.0e-10)
       diagonal.local_element(i) = 1.0 / diagonal.local_element(i);

--- a/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
@@ -61,7 +61,7 @@ apply_petsc_operation(VectorType &                                           dst
     ierr = VecGetArray(petsc_vector_src, &ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    const PetscInt local_size = src.get_partitioner()->local_size();
+    const PetscInt local_size = src.get_partitioner()->locally_owned_size();
     AssertDimension(local_size, static_cast<unsigned int>(end - begin));
     for(PetscInt i = 0; i < local_size; ++i)
     {
@@ -87,7 +87,7 @@ apply_petsc_operation(VectorType &                                           dst
     ierr = VecGetArray(petsc_vector_dst, &ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    const PetscInt local_size = dst.get_partitioner()->local_size();
+    const PetscInt local_size = dst.get_partitioner()->locally_owned_size();
     AssertDimension(local_size, static_cast<unsigned int>(end - begin));
 
     for(PetscInt i = 0; i < local_size; ++i)
@@ -115,11 +115,11 @@ apply_petsc_operation(VectorType &                                           dst
 {
   VectorTypePETSc petsc_vector_dst, petsc_vector_src;
   VecCreateMPI(petsc_mpi_communicator,
-               dst.get_partitioner()->local_size(),
+               dst.get_partitioner()->locally_owned_size(),
                PETSC_DETERMINE,
                &petsc_vector_dst);
   VecCreateMPI(petsc_mpi_communicator,
-               src.get_partitioner()->local_size(),
+               src.get_partitioner()->locally_owned_size(),
                PETSC_DETERMINE,
                &petsc_vector_src);
 

--- a/include/exadg/solvers_and_preconditioners/utilities/verify_calculation_of_diagonal.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/verify_calculation_of_diagonal.h
@@ -62,7 +62,7 @@ verify_calculation_of_diagonal(Operator &                                       
    *  Set dof-value i to 1.0, calculate matrix-vector
    *  product and store row i of the result in diagonal_check.
    */
-  for(unsigned int i = 0; i < diagonal.local_size(); ++i)
+  for(unsigned int i = 0; i < diagonal.locally_owned_size(); ++i)
   {
     src.local_element(i) = 1.0;
 


### PR DESCRIPTION
With the 9.3 release of deal.II and switch to version 10.0-pre, some old functionality has been marked deprecated (it was on the early deprecation state before). This PR makes the necessary updates. All interfaces I use now should also have been available in 9.3 for a few months at least, so the code should be stable. There is one additional change that is a slightly different category, namely the `find_active_cell_around_point` function that has changed behavior in case points are not found, as specified in https://github.com/dealii/dealii/pull/11276.