### PR TITLE
Actually use subcommunicator for PETSc matrix

### DIFF
--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -138,9 +138,10 @@ public:
 
 #ifdef DEAL_II_WITH_TRILINOS
   virtual void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const
+  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                 mpi_comm) const
   {
-    pde_operator->init_system_matrix(system_matrix);
+    pde_operator->init_system_matrix(system_matrix, mpi_comm);
   }
 
   virtual void
@@ -152,9 +153,10 @@ public:
 
 #ifdef DEAL_II_WITH_PETSC
   virtual void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                   mpi_comm) const
   {
-    pde_operator->init_system_matrix(system_matrix);
+    pde_operator->init_system_matrix(system_matrix, mpi_comm);
   }
 
   virtual void

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -89,7 +89,8 @@ public:
 
 #ifdef DEAL_II_WITH_TRILINOS
   virtual void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const = 0;
+  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                 mpi_comm) const = 0;
 
   virtual void
   calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const = 0;
@@ -97,7 +98,8 @@ public:
 
 #ifdef DEAL_II_WITH_PETSC
   virtual void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const = 0;
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                   mpi_comm) const = 0;
 
   virtual void
   calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const = 0;

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -795,6 +795,12 @@ OperatorBase<dim, Number, n_components>::internal_init_system_matrix(
     for(const auto & cell : dof_handler.active_cell_iterators())
       if(cell->is_locally_owned())
         ++n_locally_owned_cells;
+
+    // In case some of the MPI ranks do not have cells, we create a
+    // sub-communicator to exclude all those processes from the PETSc
+    // communication and hence speed up those operations. Note that we have to
+    // free the communicator again, which happens in the preconditioner_amg.h
+    // file which owns the matrix passed to the present function.
     MPI_Comm petsc_communicator;
     if(Utilities::MPI::min(n_locally_owned_cells, dof_handler.get_communicator()) == 0)
       MPI_Comm_split(dof_handler.get_communicator(),

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -193,7 +193,8 @@ public:
    */
 #ifdef DEAL_II_WITH_TRILINOS
   void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
+  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                 mpi_comm) const;
 
   void
   calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
@@ -204,7 +205,8 @@ public:
    */
 #ifdef DEAL_II_WITH_PETSC
   void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                   mpi_comm) const;
 
   void
   calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
@@ -571,7 +573,7 @@ private:
    */
   template<typename SparseMatrix>
   void
-  internal_init_system_matrix(SparseMatrix & system_matrix) const;
+  internal_init_system_matrix(SparseMatrix & system_matrix, MPI_Comm const & mpi_comm) const;
 
   template<typename SparseMatrix>
   void

--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -283,7 +283,7 @@ Driver<dim, Number>::apply_operator(unsigned int const  degree,
   if(operator_type == OperatorType::MatrixBased)
   {
 #ifdef DEAL_II_WITH_TRILINOS
-    pde_operator->init_system_matrix(system_matrix);
+    pde_operator->init_system_matrix(system_matrix, mpi_comm);
     pde_operator->calculate_system_matrix(system_matrix);
 #else
     AssertThrow(false, ExcMessage("Activate DEAL_II_WITH_TRILINOS for matrix-based computations."));

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -433,9 +433,10 @@ Operator<dim, Number, n_components>::get_degree() const
 template<int dim, typename Number, int n_components>
 void
 Operator<dim, Number, n_components>::init_system_matrix(
-  TrilinosWrappers::SparseMatrix & system_matrix) const
+  TrilinosWrappers::SparseMatrix & system_matrix,
+  MPI_Comm const &                 mpi_comm) const
 {
-  laplace_operator.init_system_matrix(system_matrix);
+  laplace_operator.init_system_matrix(system_matrix, mpi_comm);
 }
 
 template<int dim, typename Number, int n_components>
@@ -461,9 +462,10 @@ Operator<dim, Number, n_components>::vmult_matrix_based(
 template<int dim, typename Number, int n_components>
 void
 Operator<dim, Number, n_components>::init_system_matrix(
-  PETScWrappers::MPI::SparseMatrix & system_matrix) const
+  PETScWrappers::MPI::SparseMatrix & system_matrix,
+  MPI_Comm const &                   mpi_comm) const
 {
-  laplace_operator.init_system_matrix(system_matrix);
+  laplace_operator.init_system_matrix(system_matrix, mpi_comm);
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -132,7 +132,8 @@ public:
 
 #ifdef DEAL_II_WITH_TRILINOS
   void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
+  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                 mpi_comm) const;
 
   void
   calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
@@ -145,7 +146,8 @@ public:
 
 #ifdef DEAL_II_WITH_PETSC
   void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
+  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                   mpi_comm) const;
 
   void
   calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -37,32 +37,35 @@ namespace ExaDG
 {
 using namespace dealii;
 
-template<typename Operator>
+template<int dim, int spacedim>
 std::unique_ptr<MPI_Comm, void (*)(MPI_Comm *)>
-create_subcommunicator(Operator const & op)
+create_subcommunicator(DoFHandler<dim, spacedim> const & dof_handler)
 {
   unsigned int n_locally_owned_cells = 0;
-  auto const & dof_handler           = op.get_matrix_free().get_dof_handler();
   for(const auto & cell : dof_handler.active_cell_iterators())
     if(cell->is_locally_owned())
       ++n_locally_owned_cells;
 
+  MPI_Comm const mpi_comm = dof_handler.get_communicator();
+
   // In case some of the MPI ranks do not have cells, we create a
-  // sub-communicator to exclude all those processes from the PETSc
-  // communication and hence speed up those operations. Note that we have to
-  // free the communicator again, which happens in the preconditioner_amg.h
-  // file which owns the matrix passed to the present function.
-  if(Utilities::MPI::min(n_locally_owned_cells, dof_handler.get_communicator()) == 0)
+  // sub-communicator to exclude all those processes from the MPI
+  // communication in the matrix-based operation sand hence speed up those
+  // operations. Note that we have to free the communicator again, which is
+  // done by a custom deleter of the unique pointer that is run when it goes
+  // out of scope.
+  if(Utilities::MPI::min(n_locally_owned_cells, mpi_comm) == 0)
   {
     std::unique_ptr<MPI_Comm, void (*)(MPI_Comm *)> subcommunicator(new MPI_Comm,
                                                                     [](MPI_Comm * comm) {
                                                                       MPI_Comm_free(comm);
                                                                       delete comm;
                                                                     });
-    MPI_Comm_split(dof_handler.get_communicator(),
+    MPI_Comm_split(mpi_comm,
                    n_locally_owned_cells > 0,
-                   Utilities::MPI::this_mpi_process(dof_handler.get_communicator()),
+                   Utilities::MPI::this_mpi_process(mpi_comm),
                    subcommunicator.get());
+
     return subcommunicator;
   }
   else
@@ -70,7 +73,8 @@ create_subcommunicator(Operator const & op)
     std::unique_ptr<MPI_Comm, void (*)(MPI_Comm *)> communicator(new MPI_Comm, [](MPI_Comm * comm) {
       delete comm;
     });
-    *communicator = dof_handler.get_communicator();
+    *communicator = mpi_comm;
+
     return communicator;
   }
 }
@@ -179,7 +183,10 @@ public:
 #endif
 
   PreconditionerBoomerAMG(Operator const & op, BoomerData boomer_data = BoomerData())
-    : subcommunicator(create_subcommunicator(op)), pde_operator(op), boomer_data(boomer_data)
+    : subcommunicator(
+        create_subcommunicator(op.get_matrix_free().get_dof_handler(op.get_dof_index()))),
+      pde_operator(op),
+      boomer_data(boomer_data)
   {
 #ifdef DEAL_II_WITH_PETSC
     // initialize system matrix


### PR DESCRIPTION
In #68, I did prepare for the PETSc matrix to use sub-communicators but not actually apply it. This is done here. The code is a bit awkward because I need to go into the function that creates the matrix and the function that deletes the matrix again, in order to be able to free the MPI subcommunicator. I tested with valgrind that there are no memory leaks. However, I left a TODO for the case that someone has a better idea than me to handle this case.
