### PR TITLE
inject ExaDG::Grid into spatial discretization classes

### DIFF
--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -179,10 +179,10 @@ public:
     param.use_combined_operator = false;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions({2, 1});
     Point<dim>                point1(0.0, 0.0), point2(L, H);

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -258,10 +258,10 @@ public:
     param.use_combined_operator = false;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions({1, 1});
     Point<dim> point1(X_0 - L / 2.0, Y_0 - H / 2.0), point2(X_0 + L / 2.0, Y_0 + H / 2.0);

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -420,10 +420,10 @@ public:
     param.use_combined_operator = false;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // hypercube volume is [left,right]^dim
     double const left = -1.0, right = 0.5;

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -173,10 +173,10 @@ public:
     param.use_combined_operator = false;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions({2, 1});
     Point<dim>                point1(0.0, -H / 2.), point2(L, H / 2.);

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -183,10 +183,10 @@ public:
     param.use_combined_operator = false;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions({1, 1});
     Point<dim>                point1(0.0, 0.0), point2(L, H);

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -218,10 +218,10 @@ public:
     param.use_combined_operator = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const pi   = numbers::PI;
     double const left = -pi * L, right = pi * L;

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -69,10 +69,10 @@ public:
     // InputParameters::InputParameters()
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -312,10 +312,10 @@ public:
     param.use_combined_operator = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Tensor<1, dim> dimensions;
     dimensions[0] = DIMENSIONS_X1;

--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -139,10 +139,10 @@ public:
     param.use_combined_operator = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // hypercube volume is [left,right]^dim
     GridGenerator::hyper_cube(*grid->triangulation, left, right);

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -186,10 +186,10 @@ public:
     param.store_analytical_velocity_in_dof_vector = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     GridGenerator::hyper_cube(*grid->triangulation, left, right);
 

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -200,10 +200,10 @@ public:
     param.use_combined_operator = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // hypercube volume is [left,right]^dim
     GridGenerator::hyper_cube(*grid->triangulation, left, right);

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -157,10 +157,10 @@ public:
   /*                                                                                    */
   /**************************************************************************************/
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     GridGenerator::hyper_cube(*grid->triangulation, left, right);
 

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -179,10 +179,10 @@ public:
     param.store_analytical_velocity_in_dof_vector = false;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     GridGenerator::hyper_cube(*grid->triangulation, left, right);
 

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -132,10 +132,10 @@ public:
     param.store_analytical_velocity_in_dof_vector = false;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     GridGenerator::hyper_cube(*grid->triangulation, left, right);
 

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -69,10 +69,10 @@ public:
     // TODO fill parameters
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -137,10 +137,10 @@ public:
     param.store_analytical_velocity_in_dof_vector = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -411,10 +411,10 @@ public:
     GridGenerator::merge_triangulations(tria_vec_ptr, tria, 1.e-10);
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     create_triangulation(*grid->triangulation);
 
@@ -742,10 +742,10 @@ public:
     parameters.update_preconditioner_every_newton_iterations = 10;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_structure(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Point<dim> p1, p2;
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -404,10 +404,10 @@ public:
     AssertThrow(false, ExcMessage("not implemented."));
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     create_triangulation_fluid(*grid->triangulation);
 
@@ -882,10 +882,10 @@ public:
     AssertThrow(false, ExcMessage("not implemented."));
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_structure(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     create_triangulation_structure(*grid->triangulation);
 

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -270,10 +270,10 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Triangulation<2> tria_2d;
     GridGenerator::hyper_ball(tria_2d, Point<2>(), R_INNER);
@@ -613,10 +613,10 @@ public:
     parameters.update_preconditioner_every_newton_iterations = 10;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_structure(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Triangulation<2> tria_2d;
     GridGenerator::hyper_shell(tria_2d, Point<2>(), R_INNER, R_OUTER, N_CELLS_AXIAL, true);

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -78,10 +78,10 @@ public:
     // Poisson::InputParameters::InputParameters()
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 
@@ -184,10 +184,10 @@ public:
     (void)parameters;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_structure(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -311,10 +311,10 @@ public:
     param.use_overintegration   = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     GridGenerator::hyper_cube(*grid->triangulation, left, right);
 

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -333,10 +333,10 @@ public:
     param.use_overintegration   = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     GridGenerator::hyper_shell(*grid->triangulation, Point<dim>(), R0, R1, (dim == 3) ? 48 : 12);
 

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -309,10 +309,10 @@ public:
     param.use_overintegration   = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     if(dim == 2)
     {

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -321,10 +321,10 @@ public:
     param.use_overintegration   = true;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     if(dim == 2)
     {

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -84,10 +84,10 @@ public:
     // ConvDiff::InputParameters::InputParameters()
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -380,20 +380,20 @@ public:
     do_set_input_parameters(param, true);
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Geometry::create_grid(grid->triangulation, data.n_refine_global, grid->periodic_faces);
 
     return grid;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_precursor(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Geometry::create_grid_precursor(grid->triangulation,
                                     data.n_refine_global + additional_refinements_precursor,

--- a/applications/incompressible_navier_stokes/backward_facing_step/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/include/postprocessor.h
@@ -73,7 +73,7 @@ public:
     if(pp_data_bfs.turb_ch_data.calculate)
     {
       statistics_turb_ch.reset(new StatisticsManager<dim, Number>(pde_operator.get_dof_handler_u(),
-                                                                  pde_operator.get_mapping()));
+                                                                  *pde_operator.get_mapping()));
 
       statistics_turb_ch->setup(&Geometry::grid_transform_turb_channel, pp_data_bfs.turb_ch_data);
     }
@@ -83,7 +83,7 @@ public:
     {
       inflow_data_calculator.reset(
         new InflowDataCalculator<dim, Number>(pp_data_bfs.inflow_data, this->mpi_comm));
-      inflow_data_calculator->setup(pde_operator.get_dof_handler_u(), pde_operator.get_mapping());
+      inflow_data_calculator->setup(pde_operator.get_dof_handler_u(), *pde_operator.get_mapping());
     }
 
     // evaluation of characteristic quantities along lines
@@ -92,7 +92,7 @@ public:
       line_plot_calculator_statistics.reset(
         new LinePlotCalculatorStatisticsHomogeneous<dim, Number>(pde_operator.get_dof_handler_u(),
                                                                  pde_operator.get_dof_handler_p(),
-                                                                 pde_operator.get_mapping(),
+                                                                 *pde_operator.get_mapping(),
                                                                  this->mpi_comm));
 
       line_plot_calculator_statistics->setup(pp_data_bfs.line_plot_data);

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -247,10 +247,10 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion; // CahouetChabard;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
     GridGenerator::hyper_cube(*grid->triangulation, left, right);

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -213,10 +213,10 @@ public:
     param.solver_data_pressure_block          = SolverData(1e4, 1.e-12, 1.e-6, 100);
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = 0.0, right = L;
     GridGenerator::hyper_cube(*grid->triangulation, left, right);

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -184,10 +184,10 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions(dim, 1);
     repetitions[0] = 2;

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -437,10 +437,10 @@ public:
     do_set_input_parameters(param, true);
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     FDANozzle::create_grid_and_set_boundary_ids_nozzle(grid->triangulation,
                                                        data.n_refine_global,
@@ -449,10 +449,10 @@ public:
     return grid;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_precursor(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Triangulation<2> tria_2d;
     GridGenerator::hyper_ball(tria_2d, Point<2>(), FDANozzle::R_OUTER);

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -72,10 +72,10 @@ public:
     param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-3;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     FDANozzle::create_grid_and_set_boundary_ids_nozzle(grid->triangulation,
                                                        data.n_refine_global,

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
@@ -83,7 +83,7 @@ public:
       // inflow data
       inflow_data_calculator.reset(
         new InflowDataCalculator<dim, Number>(pp_data_fda.inflow_data, mpi_comm));
-      inflow_data_calculator->setup(pde_operator.get_dof_handler_u(), pde_operator.get_mapping());
+      inflow_data_calculator->setup(pde_operator.get_dof_handler_u(), *pde_operator.get_mapping());
 
       // calculation of mean velocity
       mean_velocity_calculator.reset(
@@ -100,7 +100,7 @@ public:
       line_plot_calculator_statistics.reset(
         new LinePlotCalculatorStatistics<dim, Number>(pde_operator.get_dof_handler_u(),
                                                       pde_operator.get_dof_handler_p(),
-                                                      pde_operator.get_mapping(),
+                                                      *pde_operator.get_mapping(),
                                                       this->mpi_comm));
 
       line_plot_calculator_statistics->setup(pp_data_fda.line_plot_data);

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -462,10 +462,10 @@ public:
   }
 
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     this->refine_level = data.n_refine_global;
 

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -251,10 +251,10 @@ public:
   }
 
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     GridGenerator::hyper_cube(*grid->triangulation, left, right);
 

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -206,10 +206,10 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     AssertThrow(dim == 2, ExcMessage("This application is only implemented for dim=2."));
 

--- a/applications/incompressible_navier_stokes/kovasznay/application.h
+++ b/applications/incompressible_navier_stokes/kovasznay/application.h
@@ -263,10 +263,10 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
     GridGenerator::hyper_cube(*grid->triangulation, left, right);

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -323,10 +323,10 @@ public:
     param.multigrid_data_pressure_block.type = MultigridType::cphMG;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     std::vector<unsigned int> repetitions({1, 1});
     Point<dim>                point1(0.0, -H), point2(L, H);

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -261,10 +261,10 @@ public:
     param.preconditioner_viscous = PreconditionerViscous::InverseMassMatrix;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Point<dim> p_1;
     p_1[0] = 0.;

--- a/applications/incompressible_navier_stokes/periodic_hill/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/postprocessor.h
@@ -81,7 +81,7 @@ public:
     line_plot_calculator_statistics.reset(
       new LinePlotCalculatorStatisticsHomogeneous<dim, Number>(pde_operator.get_dof_handler_u(),
                                                                pde_operator.get_dof_handler_p(),
-                                                               pde_operator.get_mapping(),
+                                                               *pde_operator.get_mapping(),
                                                                this->mpi_comm));
 
     line_plot_calculator_statistics->setup(my_pp_data.line_plot_data);

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -349,10 +349,10 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const              y_upper = apply_symmetry_bc ? 0.0 : H / 2.;
     Point<dim>                point1(0.0, -H / 2.), point2(L, y_upper);

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -173,10 +173,10 @@ public:
     param.preconditioner_viscous = PreconditionerViscous::InverseMassMatrix;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = 0.0, right = 1.0;
     GridGenerator::hyper_cube(*grid->triangulation, left, right);

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -285,10 +285,10 @@ public:
     param.preconditioner_pressure_block = SchurComplementPreconditioner::CahouetChabard;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
     GridGenerator::hyper_cube(*grid->triangulation, left, right);

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -345,10 +345,10 @@ public:
     param.preconditioner_pressure_block = SchurComplementPreconditioner::CahouetChabard;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     this->refine_level = data.n_refine_global;
 

--- a/applications/incompressible_navier_stokes/template/application.h
+++ b/applications/incompressible_navier_stokes/template/application.h
@@ -69,10 +69,10 @@ public:
     // IncNS::InputParameters::InputParameters()
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/applications/incompressible_navier_stokes/template_precursor/application.h
+++ b/applications/incompressible_navier_stokes/template_precursor/application.h
@@ -52,10 +52,10 @@ public:
     (void)param;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 
@@ -65,10 +65,10 @@ public:
   }
 
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid_precursor(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -169,10 +169,10 @@ public:
     param.preconditioner_pressure_block = SchurComplementPreconditioner::None;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -213,7 +213,7 @@ public:
 
     // perform setup of turbulent channel related things
     statistics_turb_ch.reset(new StatisticsManager<dim, Number>(pde_operator.get_dof_handler_u(),
-                                                                pde_operator.get_mapping()));
+                                                                *pde_operator.get_mapping()));
 
     statistics_turb_ch->setup(&grid_transform_y, turb_ch_data);
   }
@@ -390,10 +390,10 @@ public:
     param.multigrid_data_pressure_block.type = MultigridType::cphMG;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Tensor<1, dim> dimensions;
     dimensions[0] = DIMENSIONS_X1;

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -474,10 +474,10 @@ public:
     param.preconditioner_pressure_block = SchurComplementPreconditioner::CahouetChabard;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     if(ALE)
     {

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -240,10 +240,10 @@ public:
     param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-6;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const length = 1.0;
     double const left = -length, right = length;

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -175,10 +175,10 @@ public:
     param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-3;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const length = 1.0;
     double const left = -length, right = length;

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -73,10 +73,10 @@ public:
     param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-6;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const length = 1.0;
     double const left = -length, right = length;

--- a/applications/poisson/template/application.h
+++ b/applications/poisson/template/application.h
@@ -69,10 +69,10 @@ public:
   }
 
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -93,10 +93,10 @@ public:
     param.preconditioner = Preconditioner::None;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     double const left = -1.0, right = 1.0;
     double const deformation = 0.1;

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -249,10 +249,10 @@ public:
     this->param = parameters;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // left-bottom-front and right-top-back point
     Point<dim> p1, p2;

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -191,10 +191,10 @@ public:
     this->param = parameters;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     Point<dim> p1, p2;
     p1[0] = 0;

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -182,10 +182,10 @@ public:
     this->param = parameters;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     AssertThrow(dim == 3, ExcMessage("This application only makes sense for dim=3."));
 

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -356,10 +356,10 @@ public:
     this->param = parameters;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // left-bottom-front and right-top-back point
     Point<dim> p1, p2;

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -58,10 +58,10 @@ public:
     (void)parameters;
   }
 
-  std::shared_ptr<Grid<dim>>
+  std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) final
   {
-    std::shared_ptr<Grid<dim>> grid = std::make_shared<Grid<dim>>(data, mpi_comm);
+    std::shared_ptr<Grid<dim, Number>> grid = std::make_shared<Grid<dim, Number>>(data, mpi_comm);
 
     // create triangulation
 

--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -98,8 +98,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   application->set_field_functions(field_functions);
 
   // initialize compressible Navier-Stokes operator
-  pde_operator.reset(new Operator<dim, Number>(*grid->triangulation,
-                                               grid->mapping,
+  pde_operator.reset(new Operator<dim, Number>(grid,
                                                degree,
                                                boundary_descriptor_density,
                                                boundary_descriptor_velocity,

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -145,7 +145,7 @@ private:
 
   InputParameters param;
 
-  std::shared_ptr<Grid<dim>> grid;
+  std::shared_ptr<Grid<dim, Number>> grid;
 
   std::shared_ptr<FieldFunctions<dim>>           field_functions;
   std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -35,7 +35,7 @@ using namespace dealii;
 
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
-  std::shared_ptr<Grid<dim> const>               grid_in,
+  std::shared_ptr<Grid<dim, Number> const>       grid_in,
   unsigned int const                             degree_in,
   std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,
   std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity_in,

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -35,8 +35,7 @@ using namespace dealii;
 
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
-  Triangulation<dim> const &                     triangulation_in,
-  std::shared_ptr<Mapping<dim> const>            mapping_in,
+  std::shared_ptr<Grid<dim> const>               grid_in,
   unsigned int const                             degree_in,
   std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,
   std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity_in,
@@ -47,7 +46,7 @@ Operator<dim, Number>::Operator(
   std::string const &                            field_in,
   MPI_Comm const &                               mpi_comm_in)
   : dealii::Subscriptor(),
-    mapping(mapping_in),
+    grid(grid_in),
     degree(degree_in),
     boundary_descriptor_density(boundary_descriptor_density_in),
     boundary_descriptor_velocity(boundary_descriptor_velocity_in),
@@ -61,9 +60,9 @@ Operator<dim, Number>::Operator(
     fe_scalar(degree_in),
     n_q_points_conv(degree_in + 1),
     n_q_points_visc(degree_in + 1),
-    dof_handler(triangulation_in),
-    dof_handler_vector(triangulation_in),
-    dof_handler_scalar(triangulation_in),
+    dof_handler(*grid_in->triangulation),
+    dof_handler_vector(*grid_in->triangulation),
+    dof_handler_scalar(*grid_in->triangulation),
     mpi_comm(mpi_comm_in),
     pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_in) == 0),
     wall_time_operator_evaluation(0.0)
@@ -184,7 +183,7 @@ Operator<dim, Number>::prescribe_initial_conditions(VectorType & src, double con
   VectorTypeDouble src_double;
   src_double = src;
 
-  VectorTools::interpolate(*mapping,
+  VectorTools::interpolate(*grid->mapping,
                            dof_handler,
                            *(this->field_functions->initial_solution),
                            src_double);
@@ -291,7 +290,7 @@ template<int dim, typename Number>
 Mapping<dim> const &
 Operator<dim, Number>::get_mapping() const
 {
-  return *mapping;
+  return *grid->mapping;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -25,7 +25,6 @@
 // deal.II
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_system.h>
-#include <deal.II/fe/mapping_q.h>
 #include <deal.II/lac/la_parallel_vector.h>
 
 // ExaDG
@@ -35,6 +34,7 @@
 #include <exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h>
 #include <exadg/compressible_navier_stokes/user_interface/field_functions.h>
 #include <exadg/compressible_navier_stokes/user_interface/input_parameters.h>
+#include <exadg/grid/grid.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
 
@@ -51,8 +51,7 @@ private:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
-  Operator(Triangulation<dim> const &                     triangulation_in,
-           std::shared_ptr<Mapping<dim> const>            mapping_in,
+  Operator(std::shared_ptr<Grid<dim> const>               grid_in,
            unsigned int const                             degree_in,
            std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,
            std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity_in,
@@ -188,9 +187,9 @@ private:
   get_quad_index_l2_projections() const;
 
   /*
-   * Mapping
+   * Grid
    */
-  std::shared_ptr<Mapping<dim> const> mapping;
+  std::shared_ptr<Grid<dim> const> grid;
 
   /*
    * polynomial degree

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -51,7 +51,7 @@ private:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
-  Operator(std::shared_ptr<Grid<dim> const>               grid_in,
+  Operator(std::shared_ptr<Grid<dim, Number> const>       grid_in,
            unsigned int const                             degree_in,
            std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,
            std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity_in,
@@ -189,7 +189,7 @@ private:
   /*
    * Grid
    */
-  std::shared_ptr<Grid<dim> const> grid;
+  std::shared_ptr<Grid<dim, Number> const> grid;
 
   /*
    * polynomial degree

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -72,7 +72,7 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -92,7 +92,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   if(param.ale_formulation) // moving mesh
   {
     std::shared_ptr<Function<dim>> mesh_motion = application->set_mesh_movement_function();
-    grid_motion.reset(new MovingMeshFunction<dim, Number>(
+    grid_motion.reset(new GridMotionAnalytical<dim, Number>(
       grid->mapping, degree, *grid->triangulation, mesh_motion, param.start_time));
 
     grid->attach_grid_motion(grid_motion);

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -127,14 +127,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     // initialize time integrator or driver for steady problems
     if(param.problem_type == ProblemType::Unsteady)
     {
-      time_integrator = create_time_integrator<dim, Number>(pde_operator,
-                                                            param,
-                                                            refine_time,
-                                                            mpi_comm,
-                                                            is_test,
-                                                            postprocessor,
-                                                            grid_motion,
-                                                            matrix_free);
+      time_integrator = create_time_integrator<dim, Number>(
+        pde_operator, param, refine_time, mpi_comm, is_test, postprocessor);
 
       time_integrator->setup(param.restarted_simulation);
     }
@@ -205,7 +199,7 @@ Driver<dim, Number>::ale_update() const
   // move the mesh and update dependent data structures
   grid_motion->update(time_integrator->get_next_time(), false);
   matrix_free->update_mapping(*grid->get_dynamic_mapping());
-  pde_operator->update_after_mesh_movement();
+  pde_operator->update_after_grid_motion();
   std::shared_ptr<TimeIntBDF<dim, Number>> time_int_bdf =
     std::dynamic_pointer_cast<TimeIntBDF<dim, Number>>(time_integrator);
   time_int_bdf->ale_update();

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -43,8 +43,8 @@
 #include <exadg/convection_diffusion/user_interface/field_functions.h>
 #include <exadg/convection_diffusion/user_interface/input_parameters.h>
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
+#include <exadg/grid/grid_motion_analytical.h>
 #include <exadg/grid/mapping_degree.h>
-#include <exadg/grid/moving_mesh_function.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_functions.h>
 #include <exadg/utilities/print_general_infos.h>
@@ -151,7 +151,7 @@ private:
   std::shared_ptr<Grid<dim, Number>> grid;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> grid_motion;
+  std::shared_ptr<GridMotionBase<dim, Number>> grid_motion;
 
   InputParameters param;
 

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -148,13 +148,10 @@ private:
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
   // grid
-  std::shared_ptr<Grid<dim>> grid;
+  std::shared_ptr<Grid<dim, Number>> grid;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
-
-  // mapping (static or moving)
-  std::shared_ptr<Mapping<dim>> mapping;
+  std::shared_ptr<MovingMeshBase<dim, Number>> grid_motion;
 
   InputParameters param;
 

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -300,7 +300,7 @@ MultigridPreconditioner<dim, Number>::update_operators_after_mesh_movement()
 {
   for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
   {
-    this->get_operator(level)->update_after_mesh_movement();
+    this->get_operator(level)->update_after_grid_motion();
   }
 }
 

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -52,7 +52,7 @@ MultigridPreconditioner<dim, Number>::initialize(MultigridData const &          
                                                  MultigridOperatorType const & mg_operator_type,
                                                  bool const                    mesh_is_moving,
                                                  Map const *                   dirichlet_bc,
-                                                 PeriodicFacePairs *           periodic_face_pairs)
+                                                 PeriodicFacePairs const *     periodic_face_pairs)
 {
   this->pde_operator     = &pde_operator;
   this->mg_operator_type = mg_operator_type;

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -200,7 +200,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize_dof_handler_and_constraints(
   bool const                 operator_is_singular,
-  PeriodicFacePairs *        periodic_face_pairs,
+  PeriodicFacePairs const *  periodic_face_pairs,
   FiniteElement<dim> const & fe,
   Triangulation<dim> const * tria,
   Map const *                dirichlet_bc)

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -73,7 +73,7 @@ public:
              MultigridOperatorType const &       mg_operator_type,
              bool const                          mesh_is_moving,
              Map const *                         dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                 periodic_face_pairs = nullptr);
+             PeriodicFacePairs const *           periodic_face_pairs = nullptr);
 
   /*
    *  This function updates the multigrid preconditioner.

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -92,7 +92,7 @@ private:
 
   void
   initialize_dof_handler_and_constraints(bool const                 operator_is_singular,
-                                         PeriodicFacePairs *        periodic_face_pairs,
+                                         PeriodicFacePairs const *  periodic_face_pairs,
                                          FiniteElement<dim> const & fe,
                                          Triangulation<dim> const * tria,
                                          Map const *                dirichlet_bc) override;

--- a/include/exadg/convection_diffusion/spatial_discretization/interface.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/interface.h
@@ -117,6 +117,18 @@ public:
   // needed for time step calculation
   virtual unsigned int
   get_polynomial_degree() const = 0;
+
+  // needed for ALE-type problems
+  virtual void
+  move_grid(double const & time) const = 0;
+
+  // needed for ALE-type problems
+  virtual void
+  move_grid_and_update_dependent_data_structures(double const & time) = 0;
+
+  // needed for ALE-type problems
+  virtual void
+  fill_grid_coordinates_vector(VectorType & vector) const = 0;
 };
 } // namespace Interface
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -823,6 +823,37 @@ Operator<dim, Number>::update_conv_diff_operator(double const       time,
   }
 }
 
+/*
+ * Moves the grid for ALE-type problems.
+ */
+template<int dim, typename Number>
+void
+Operator<dim, Number>::move_grid(double const & time) const
+{
+  grid->grid_motion->update(time, false);
+}
+
+/*
+ * Moves the grid and updates dependent data structures for ALE-type problems.
+ */
+template<int dim, typename Number>
+void
+Operator<dim, Number>::move_grid_and_update_dependent_data_structures(double const & time)
+{
+  grid->grid_motion->update(time, false);
+  matrix_free->update_mapping(*grid->get_dynamic_mapping());
+  update_after_grid_motion();
+}
+
+/*
+ * Fills a dof-vector with grid coordinates for ALE-type problems.
+ */
+template<int dim, typename Number>
+void
+Operator<dim, Number>::fill_grid_coordinates_vector(VectorType & vector) const
+{
+  grid->grid_motion->fill_grid_coordinates_vector(vector, this->get_dof_handler_velocity());
+}
 
 template<int dim, typename Number>
 unsigned int
@@ -925,7 +956,7 @@ Operator<dim, Number>::get_number_of_dofs() const
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::update_after_mesh_movement()
+Operator<dim, Number>::update_after_grid_motion()
 {
   // update SIPG penalty parameter of diffusive operator which depends on the deformation
   // of elements

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -823,9 +823,6 @@ Operator<dim, Number>::update_conv_diff_operator(double const       time,
   }
 }
 
-/*
- * Moves the grid for ALE-type problems.
- */
 template<int dim, typename Number>
 void
 Operator<dim, Number>::move_grid(double const & time) const
@@ -833,9 +830,6 @@ Operator<dim, Number>::move_grid(double const & time) const
   grid->grid_motion->update(time, false);
 }
 
-/*
- * Moves the grid and updates dependent data structures for ALE-type problems.
- */
 template<int dim, typename Number>
 void
 Operator<dim, Number>::move_grid_and_update_dependent_data_structures(double const & time)
@@ -845,14 +839,23 @@ Operator<dim, Number>::move_grid_and_update_dependent_data_structures(double con
   update_after_grid_motion();
 }
 
-/*
- * Fills a dof-vector with grid coordinates for ALE-type problems.
- */
 template<int dim, typename Number>
 void
 Operator<dim, Number>::fill_grid_coordinates_vector(VectorType & vector) const
 {
   grid->grid_motion->fill_grid_coordinates_vector(vector, this->get_dof_handler_velocity());
+}
+
+template<int dim, typename Number>
+void
+Operator<dim, Number>::update_after_grid_motion()
+{
+  // update SIPG penalty parameter of diffusive operator which depends on the deformation
+  // of elements
+  if(param.diffusive_problem())
+  {
+    diffusive_kernel->calculate_penalty_parameter(*matrix_free, get_dof_index());
+  }
 }
 
 template<int dim, typename Number>
@@ -952,18 +955,6 @@ types::global_dof_index
 Operator<dim, Number>::get_number_of_dofs() const
 {
   return dof_handler.n_dofs();
-}
-
-template<int dim, typename Number>
-void
-Operator<dim, Number>::update_after_grid_motion()
-{
-  // update SIPG penalty parameter of diffusive operator which depends on the deformation
-  // of elements
-  if(param.diffusive_problem())
-  {
-    diffusive_kernel->calculate_penalty_parameter(*matrix_free, get_dof_index());
-  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -41,25 +41,22 @@ using namespace dealii;
 
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
-  Triangulation<dim> const &                     triangulation_in,
-  std::shared_ptr<Mapping<dim> const>            mapping_in,
+  std::shared_ptr<Grid<dim, Number> const>       grid_in,
   unsigned int const                             degree_in,
-  PeriodicFaces const                            periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptor<dim>> const boundary_descriptor_in,
   std::shared_ptr<FieldFunctions<dim>> const     field_functions_in,
   InputParameters const &                        param_in,
   std::string const &                            field_in,
   MPI_Comm const &                               mpi_comm_in)
   : dealii::Subscriptor(),
-    mapping(mapping_in),
+    grid(grid_in),
     degree(degree_in),
-    periodic_face_pairs(periodic_face_pairs_in),
     boundary_descriptor(boundary_descriptor_in),
     field_functions(field_functions_in),
     param(param_in),
     field(field_in),
     fe(degree_in),
-    dof_handler(triangulation_in),
+    dof_handler(*grid_in->triangulation),
     mpi_comm(mpi_comm_in),
     pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_in) == 0)
 {
@@ -68,7 +65,7 @@ Operator<dim, Number>::Operator(
   if(needs_own_dof_handler_velocity())
   {
     fe_velocity.reset(new FESystem<dim>(FE_DGQ<dim>(degree), dim));
-    dof_handler_velocity.reset(new DoFHandler<dim>(triangulation_in));
+    dof_handler_velocity.reset(new DoFHandler<dim>(*grid->triangulation));
   }
 
   distribute_dofs();
@@ -476,12 +473,12 @@ Operator<dim, Number>::initialize_preconditioner()
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),
                                   dof_handler.get_fe(),
-                                  mapping,
+                                  grid->get_dynamic_mapping(),
                                   combined_operator,
                                   param.mg_operator_type,
                                   param.ale_formulation,
                                   &data.bc->dirichlet_bc,
-                                  &this->periodic_face_pairs);
+                                  &grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -207,6 +207,30 @@ public:
                             VectorType const * velocity = nullptr);
 
   /*
+   * Moves the grid for ALE-type problems.
+   */
+  void
+  move_grid(double const & time) const;
+
+  /*
+   * Moves the grid and updates dependent data structures for ALE-type problems.
+   */
+  void
+  move_grid_and_update_dependent_data_structures(double const & time);
+
+  /*
+   * Fills a dof-vector with grid coordinates for ALE-type problems.
+   */
+  void
+  fill_grid_coordinates_vector(VectorType & vector) const;
+
+  /*
+   * Updates operators after grid has been moved.
+   */
+  void
+  update_after_grid_motion();
+
+  /*
    * This function solves the linear system of equations in case of implicit time integration or
    * steady-state problems (potentially involving the mass, convective, and diffusive
    * operators).
@@ -264,9 +288,6 @@ public:
 
   std::string
   get_dof_name() const;
-
-  void
-  update_after_mesh_movement();
 
   unsigned int
   get_dof_index() const;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -25,7 +25,6 @@
 // deal.II
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_system.h>
-#include <deal.II/fe/mapping_q.h>
 
 // ExaDG
 #include <exadg/convection_diffusion/spatial_discretization/interface.h>
@@ -33,6 +32,7 @@
 #include <exadg/convection_diffusion/user_interface/boundary_descriptor.h>
 #include <exadg/convection_diffusion/user_interface/field_functions.h>
 #include <exadg/convection_diffusion/user_interface/input_parameters.h>
+#include <exadg/grid/grid.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
 #include <exadg/operators/mass_operator.h>
@@ -51,17 +51,12 @@ class Operator : public dealii::Subscriptor, public Interface::Operator<Number>
 private:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    PeriodicFaces;
-
 public:
   /*
    * Constructor.
    */
-  Operator(Triangulation<dim> const &                     triangulation,
-           std::shared_ptr<Mapping<dim> const>            mapping,
+  Operator(std::shared_ptr<Grid<dim, Number> const>       grid,
            unsigned int const                             degree,
-           PeriodicFaces const                            periodic_face_pairs,
            std::shared_ptr<BoundaryDescriptor<dim>> const boundary_descriptor,
            std::shared_ptr<FieldFunctions<dim>> const     field_functions,
            InputParameters const &                        param,
@@ -320,20 +315,14 @@ private:
   initialize_solver();
 
   /*
-   * Mapping
+   * Grid
    */
-  std::shared_ptr<Mapping<dim> const> mapping;
+  std::shared_ptr<Grid<dim, Number> const> grid;
 
   /*
    * Polynomial degree of shape function
    */
   unsigned int const degree;
-
-  /*
-   * Periodic face pairs: This variable is only needed when using a multigrid preconditioner
-   */
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_face_pairs;
 
   /*
    * User interface: Boundary conditions and field functions.

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
@@ -116,7 +116,7 @@ CombinedOperator<dim, Number>::get_data() const
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::update_after_mesh_movement()
+CombinedOperator<dim, Number>::update_after_grid_motion()
 {
   if(operator_data.diffusive_problem)
     diffusive_kernel->calculate_penalty_parameter(*this->matrix_free, operator_data.dof_index);

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
@@ -89,7 +89,7 @@ public:
   get_data() const;
 
   void
-  update_after_mesh_movement();
+  update_after_grid_motion();
 
   LinearAlgebra::distributed::Vector<Number> const &
   get_velocity() const;

--- a/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
+++ b/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
@@ -35,35 +35,24 @@ namespace ConvDiff
  */
 template<int dim, typename Number>
 std::shared_ptr<TimeIntBase>
-create_time_integrator(std::shared_ptr<Operator<dim, Number>>            pde_operator,
-                       InputParameters const &                           parameters,
-                       unsigned int const                                refine_steps_time,
-                       MPI_Comm const &                                  mpi_comm,
-                       bool const                                        is_test,
-                       std::shared_ptr<PostProcessorInterface<Number>>   postprocessor,
-                       std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh,
-                       std::shared_ptr<MatrixFree<dim, Number>>          matrix_free)
+create_time_integrator(std::shared_ptr<Operator<dim, Number>>          pde_operator,
+                       InputParameters const &                         parameters,
+                       unsigned int const                              refine_steps_time,
+                       MPI_Comm const &                                mpi_comm,
+                       bool const                                      is_test,
+                       std::shared_ptr<PostProcessorInterface<Number>> postprocessor)
 {
   std::shared_ptr<TimeIntBase> time_integrator;
 
   if(parameters.temporal_discretization == TemporalDiscretization::ExplRK)
   {
-    AssertThrow(moving_mesh == nullptr,
-                ExcMessage("ALE functionality is not implemented for ExplRK time integration."));
-
     time_integrator = std::make_shared<TimeIntExplRK<Number>>(
       pde_operator, parameters, refine_steps_time, mpi_comm, is_test, postprocessor);
   }
   else if(parameters.temporal_discretization == TemporalDiscretization::BDF)
   {
-    time_integrator = std::make_shared<TimeIntBDF<dim, Number>>(pde_operator,
-                                                                parameters,
-                                                                refine_steps_time,
-                                                                mpi_comm,
-                                                                is_test,
-                                                                postprocessor,
-                                                                moving_mesh,
-                                                                matrix_free);
+    time_integrator = std::make_shared<TimeIntBDF<dim, Number>>(
+      pde_operator, parameters, refine_steps_time, mpi_comm, is_test, postprocessor);
   }
   else
   {

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
@@ -24,7 +24,6 @@
 
 // deal.II
 #include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/matrix_free/matrix_free.h>
 
 // ExaDG
 #include <exadg/time_integration/explicit_runge_kutta.h>
@@ -33,10 +32,6 @@
 namespace ExaDG
 {
 using namespace dealii;
-
-// forward declarations
-template<int dim, typename Number>
-class MovingMeshInterface;
 
 namespace ConvDiff
 {
@@ -61,14 +56,12 @@ class TimeIntBDF : public TimeIntBDFBase<Number>
 public:
   typedef typename TimeIntBDFBase<Number>::VectorType VectorType;
 
-  TimeIntBDF(std::shared_ptr<Operator<dim, Number>>            operator_in,
-             InputParameters const &                           param_in,
-             unsigned int const                                refine_steps_time_in,
-             MPI_Comm const &                                  mpi_comm_in,
-             bool const                                        is_in,
-             std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
-             std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
-             std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
+  TimeIntBDF(std::shared_ptr<Operator<dim, Number>>          operator_in,
+             InputParameters const &                         param_in,
+             unsigned int const                              refine_steps_time_in,
+             MPI_Comm const &                                mpi_comm_in,
+             bool const                                      is_test_in,
+             std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in);
 
   void
   set_velocities_and_times(std::vector<VectorType const *> const & velocities_in,
@@ -104,12 +97,6 @@ private:
 
   void
   prepare_vectors_for_next_timestep();
-
-  void
-  move_mesh(double const time) const;
-
-  void
-  move_mesh_and_update_dependent_data_structures(double const time) const;
 
   void
   solve_timestep();
@@ -189,9 +176,6 @@ private:
   VectorType              grid_velocity;
   std::vector<VectorType> vec_grid_coordinates;
   VectorType              grid_coordinates_np;
-
-  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh;
-  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free;
 };
 
 } // namespace ConvDiff

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -67,7 +67,7 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual std::shared_ptr<Function<dim>>

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -151,10 +151,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     application->set_field_functions_structure(structure_field_functions);
 
     // setup spatial operator
-    structure_operator.reset(new Structure::Operator<dim, Number>(*structure_grid->triangulation,
-                                                                  structure_grid->mapping,
+    structure_operator.reset(new Structure::Operator<dim, Number>(structure_grid,
                                                                   degree_structure,
-                                                                  structure_grid->periodic_faces,
                                                                   structure_boundary_descriptor,
                                                                   structure_field_functions,
                                                                   structure_material_descriptor,
@@ -278,10 +276,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
       // setup spatial operator
       ale_elasticity_operator.reset(
-        new Structure::Operator<dim, Number>(*fluid_grid->triangulation,
-                                             fluid_grid->mapping,
+        new Structure::Operator<dim, Number>(fluid_grid,
                                              fluid_grid_data.mapping_degree,
-                                             fluid_grid->periodic_faces,
                                              ale_elasticity_boundary_descriptor,
                                              ale_elasticity_field_functions,
                                              ale_elasticity_material_descriptor,

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -335,27 +335,24 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     // mapping for fluid problem (moving mesh)
     if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Poisson)
     {
-      fluid_moving_mesh.reset(
-        new MovingMeshPoisson<dim, Number>(fluid_grid->mapping, ale_poisson_operator));
+      fluid_grid_motion.reset(
+        new MovingMeshPoisson<dim, Number>(fluid_grid->get_static_mapping(), ale_poisson_operator));
     }
     else if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Elasticity)
     {
-      fluid_moving_mesh.reset(new MovingMeshElasticity<dim, Number>(fluid_grid->mapping,
-                                                                    ale_elasticity_operator,
-                                                                    ale_elasticity_param));
+      fluid_grid_motion.reset(new MovingMeshElasticity<dim, Number>(
+        fluid_grid->get_static_mapping(), ale_elasticity_operator, ale_elasticity_param));
     }
     else
     {
       AssertThrow(false, ExcMessage("not implemented."));
     }
 
-    fluid_mapping = fluid_moving_mesh->get_mapping();
+    fluid_grid->attach_grid_motion(fluid_grid_motion);
 
     // initialize fluid_operator
-    fluid_operator = IncNS::create_operator<dim, Number>(*fluid_grid->triangulation,
-                                                         fluid_mapping,
+    fluid_operator = IncNS::create_operator<dim, Number>(fluid_grid,
                                                          degree_fluid,
-                                                         fluid_grid->periodic_faces,
                                                          fluid_boundary_descriptor_velocity,
                                                          fluid_boundary_descriptor_pressure,
                                                          fluid_field_functions,
@@ -370,7 +367,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     fluid_matrix_free.reset(new MatrixFree<dim, Number>());
     if(fluid_param.use_cell_based_face_loops)
       Categorization::do_cell_based_loops(*fluid_grid->triangulation, fluid_matrix_free_data->data);
-    fluid_matrix_free->reinit(*fluid_mapping,
+    fluid_matrix_free->reinit(*fluid_grid->get_dynamic_mapping(),
                               fluid_matrix_free_data->get_dof_handler_vector(),
                               fluid_matrix_free_data->get_constraint_vector(),
                               fluid_matrix_free_data->get_quadrature_vector(),
@@ -498,7 +495,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                               structure_boundary_descriptor->neumann_mortar_bc,
                               fluid_grid->triangulation,
                               fluid_operator->get_dof_handler_u(),
-                              *fluid_mapping,
+                              *fluid_grid->get_dynamic_mapping(),
                               stress_fluid,
                               fsi_data.geometric_tolerance);
 
@@ -529,7 +526,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                                        mpi_comm,
                                                                        is_test,
                                                                        fluid_postprocessor,
-                                                                       fluid_moving_mesh,
+                                                                       fluid_grid_motion,
                                                                        fluid_matrix_free);
 
     fluid_time_integrator->setup(fluid_param.restarted_simulation);
@@ -595,12 +592,12 @@ Driver<dim, Number>::solve_ale() const
 
   sub_timer.restart();
   bool const print_solver_info = fluid_time_integrator->print_solver_info();
-  fluid_moving_mesh->update(fluid_time_integrator->get_next_time(),
+  fluid_grid_motion->update(fluid_time_integrator->get_next_time(),
                             print_solver_info and not(is_test));
   timer_tree.insert({"FSI", "ALE", "Solve and reinit mapping"}, sub_timer.wall_time());
 
   sub_timer.restart();
-  fluid_matrix_free->update_mapping(*fluid_mapping);
+  fluid_matrix_free->update_mapping(*fluid_grid->get_dynamic_mapping());
   timer_tree.insert({"FSI", "ALE", "Update matrix-free"}, sub_timer.wall_time());
 
   sub_timer.restart();
@@ -1114,7 +1111,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
   fluid_time_integrator->print_iterations();
 
   pcout << std::endl << "ALE:" << std::endl;
-  fluid_moving_mesh->print_iterations();
+  fluid_grid_motion->print_iterations();
 
   pcout << std::endl << "Structure:" << std::endl;
   structure_time_integrator->print_iterations();

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -336,11 +336,11 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Poisson)
     {
       fluid_grid_motion.reset(
-        new MovingMeshPoisson<dim, Number>(fluid_grid->get_static_mapping(), ale_poisson_operator));
+        new GridMotionPoisson<dim, Number>(fluid_grid->get_static_mapping(), ale_poisson_operator));
     }
     else if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Elasticity)
     {
-      fluid_grid_motion.reset(new MovingMeshElasticity<dim, Number>(
+      fluid_grid_motion.reset(new GridMotionElasticity<dim, Number>(
         fluid_grid->get_static_mapping(), ale_elasticity_operator, ale_elasticity_param));
     }
     else

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -520,14 +520,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                 ExcMessage("Invalid parameter in context of fluid-structure interaction."));
 
     // initialize fluid_time_integrator
-    fluid_time_integrator = IncNS::create_time_integrator<dim, Number>(fluid_operator,
-                                                                       fluid_param,
-                                                                       0 /* refine_time */,
-                                                                       mpi_comm,
-                                                                       is_test,
-                                                                       fluid_postprocessor,
-                                                                       fluid_grid_motion,
-                                                                       fluid_matrix_free);
+    fluid_time_integrator = IncNS::create_time_integrator<dim, Number>(
+      fluid_operator, fluid_param, 0 /* refine_time */, mpi_comm, is_test, fluid_postprocessor);
 
     fluid_time_integrator->setup(fluid_param.restarted_simulation);
 
@@ -601,7 +595,7 @@ Driver<dim, Number>::solve_ale() const
   timer_tree.insert({"FSI", "ALE", "Update matrix-free"}, sub_timer.wall_time());
 
   sub_timer.restart();
-  fluid_operator->update_after_mesh_movement();
+  fluid_operator->update_after_grid_motion();
   timer_tree.insert({"FSI", "ALE", "Update operator"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -245,10 +245,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
       // initialize Poisson operator
       ale_poisson_operator.reset(
-        new Poisson::Operator<dim, Number, dim>(*fluid_grid->triangulation,
-                                                fluid_grid->mapping,
+        new Poisson::Operator<dim, Number, dim>(fluid_grid,
                                                 fluid_grid_data.mapping_degree,
-                                                fluid_grid->periodic_faces,
                                                 ale_poisson_boundary_descriptor,
                                                 ale_poisson_field_functions,
                                                 ale_poisson_param,

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -318,7 +318,7 @@ private:
   Structure::InputParameters structure_param;
 
   // grid
-  std::shared_ptr<Grid<dim>> structure_grid;
+  std::shared_ptr<Grid<dim, Number>> structure_grid;
 
   // material descriptor
   std::shared_ptr<Structure::MaterialDescriptor> structure_material_descriptor;
@@ -348,13 +348,10 @@ private:
   /****************************************** FLUID *******************************************/
 
   // grid
-  std::shared_ptr<Grid<dim>> fluid_grid;
+  std::shared_ptr<Grid<dim, Number>> fluid_grid;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> fluid_moving_mesh;
-
-  // mapping (static or moving)
-  std::shared_ptr<Mapping<dim>> fluid_mapping;
+  std::shared_ptr<MovingMeshBase<dim, Number>> fluid_grid_motion;
 
   // parameters
   IncNS::InputParameters fluid_param;

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -33,9 +33,9 @@
 #include <exadg/utilities/timer_tree.h>
 
 // grid
+#include <exadg/grid/grid_motion_elasticity.h>
+#include <exadg/grid/grid_motion_poisson.h>
 #include <exadg/grid/mapping_degree.h>
-#include <exadg/grid/moving_mesh_elasticity.h>
-#include <exadg/grid/moving_mesh_poisson.h>
 #include <exadg/poisson/spatial_discretization/operator.h>
 
 // IncNS
@@ -351,7 +351,7 @@ private:
   std::shared_ptr<Grid<dim, Number>> fluid_grid;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> fluid_grid_motion;
+  std::shared_ptr<GridMotionBase<dim, Number>> fluid_grid_motion;
 
   // parameters
   IncNS::InputParameters fluid_param;

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -90,7 +90,7 @@ public:
   virtual void
   set_input_parameters_fluid(IncNS::InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid_fluid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
@@ -134,7 +134,7 @@ public:
   virtual void
   set_input_parameters_structure(Structure::InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid_structure(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void

--- a/include/exadg/functions_and_boundary_conditions/verify_boundary_conditions.h
+++ b/include/exadg/functions_and_boundary_conditions/verify_boundary_conditions.h
@@ -29,9 +29,10 @@ namespace ExaDG
 {
 using namespace dealii;
 
-template<int dim, typename BoundaryDescriptor>
+template<int dim, typename Number, typename BoundaryDescriptor>
 void
-verify_boundary_conditions(BoundaryDescriptor const & boundary_descriptor, Grid<dim> const & grid)
+verify_boundary_conditions(BoundaryDescriptor const & boundary_descriptor,
+                           Grid<dim, Number> const &  grid)
 {
   // fill set with periodic boundary ids
   std::set<types::boundary_id> periodic_boundary_ids;

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -29,7 +29,7 @@
 
 // ExaDG
 #include <exadg/grid/enum_types.h>
-#include <exadg/grid/moving_mesh_interface.h>
+#include <exadg/grid/grid_motion_interface.h>
 
 namespace ExaDG
 {
@@ -90,7 +90,7 @@ public:
    * Attach a pointer for moving grid functionality.
    */
   void
-  attach_grid_motion(std::shared_ptr<MovingMeshInterface<dim, Number>> grid_motion_in)
+  attach_grid_motion(std::shared_ptr<GridMotionInterface<dim, Number>> grid_motion_in)
   {
     grid_motion = grid_motion_in;
   }
@@ -137,7 +137,7 @@ public:
   /**
    * Computes and describes dynamic grid motion.
    */
-  std::shared_ptr<MovingMeshInterface<dim, Number>> grid_motion;
+  std::shared_ptr<GridMotionInterface<dim, Number>> grid_motion;
 };
 
 } // namespace ExaDG

--- a/include/exadg/grid/grid_motion_analytical.h
+++ b/include/exadg/grid/grid_motion_analytical.h
@@ -19,10 +19,10 @@
  *  ______________________________________________________________________
  */
 
-#ifndef INCLUDE_MOVING_MESH_H_
-#define INCLUDE_MOVING_MESH_H_
+#ifndef INCLUDE_GRID_GRID_MOTION_ANALYTICAL_H_
+#define INCLUDE_GRID_GRID_MOTION_ANALYTICAL_H_
 
-#include <exadg/grid/moving_mesh_base.h>
+#include <exadg/grid/grid_motion_base.h>
 
 namespace ExaDG
 {
@@ -33,7 +33,7 @@ using namespace dealii;
  * Function<dim> object.
  */
 template<int dim, typename Number>
-class MovingMeshFunction : public MovingMeshBase<dim, Number>
+class GridMotionAnalytical : public GridMotionBase<dim, Number>
 {
 public:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
@@ -41,12 +41,12 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshFunction(std::shared_ptr<Mapping<dim> const>  mapping_undeformed,
-                     unsigned int const                   mapping_degree_q_cache,
-                     Triangulation<dim> const &           triangulation,
-                     std::shared_ptr<Function<dim>> const mesh_movement_function,
-                     double const                         start_time)
-    : MovingMeshBase<dim, Number>(mapping_undeformed, mapping_degree_q_cache, triangulation),
+  GridMotionAnalytical(std::shared_ptr<Mapping<dim> const>  mapping_undeformed,
+                       unsigned int const                   mapping_degree_q_cache,
+                       Triangulation<dim> const &           triangulation,
+                       std::shared_ptr<Function<dim>> const mesh_movement_function,
+                       double const                         start_time)
+    : GridMotionBase<dim, Number>(mapping_undeformed, mapping_degree_q_cache, triangulation),
       mesh_movement_function(mesh_movement_function),
       triangulation(triangulation)
   {
@@ -54,7 +54,7 @@ public:
   }
 
   /**
-   * Updates the mesh coordinates using a Function<dim> object evaluated at a given time.
+   * Updates the grid coordinates using a Function<dim> object evaluated at a given time.
    */
   void
   update(double const time, bool const print_solver_info) override
@@ -69,7 +69,7 @@ public:
 private:
   /**
    * Initializes the MappingQCache object by providing a Function<dim> that describes the
-   * displacement of the mesh compared to an undeformed reference configuration described by the
+   * displacement of the grid compared to an undeformed reference configuration described by the
    * static mapping of this class.
    */
   void
@@ -115,4 +115,4 @@ private:
 
 } // namespace ExaDG
 
-#endif /*INCLUDE_MOVING_MESH_H_*/
+#endif /*INCLUDE_GRID_GRID_MOTION_ANALYTICAL_H_*/

--- a/include/exadg/grid/grid_motion_base.h
+++ b/include/exadg/grid/grid_motion_base.h
@@ -19,22 +19,22 @@
  *  ______________________________________________________________________
  */
 
-#ifndef INCLUDE_EXADG_GRID_MOVING_MESH_BASE_H_
-#define INCLUDE_EXADG_GRID_MOVING_MESH_BASE_H_
+#ifndef INCLUDE_EXADG_GRID_GRID_MOTION_BASE_H_
+#define INCLUDE_EXADG_GRID_GRID_MOTION_BASE_H_
 
 // ExaDG
+#include <exadg/grid/grid_motion_interface.h>
 #include <exadg/grid/mapping_dof_vector.h>
-#include <exadg/grid/moving_mesh_interface.h>
 
 namespace ExaDG
 {
 using namespace dealii;
 
 /**
- * Base class for moving mesh problems based on MappingFiniteElement.
+ * Base class for moving grid problems.
  */
 template<int dim, typename Number>
-class MovingMeshBase : public MovingMeshInterface<dim, Number>
+class GridMotionBase : public GridMotionInterface<dim, Number>
 {
 public:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
@@ -42,7 +42,7 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshBase(std::shared_ptr<Mapping<dim> const> mapping_undeformed,
+  GridMotionBase(std::shared_ptr<Mapping<dim> const> mapping_undeformed,
                  unsigned int const                  mapping_degree_q_cache,
                  Triangulation<dim> const &          triangulation)
     : mapping_undeformed(mapping_undeformed)
@@ -81,4 +81,4 @@ protected:
 
 } // namespace ExaDG
 
-#endif /* INCLUDE_EXADG_GRID_MOVING_MESH_BASE_H_ */
+#endif /* INCLUDE_EXADG_GRID_GRID_MOTION_BASE_H_ */

--- a/include/exadg/grid/grid_motion_elasticity.h
+++ b/include/exadg/grid/grid_motion_elasticity.h
@@ -19,14 +19,14 @@
  *  ______________________________________________________________________
  */
 
-#ifndef INCLUDE_EXADG_GRID_MOVING_MESH_ELASTICITY_H_
-#define INCLUDE_EXADG_GRID_MOVING_MESH_ELASTICITY_H_
+#ifndef INCLUDE_EXADG_GRID_GRID_MOTION_ELASTICITY_H_
+#define INCLUDE_EXADG_GRID_GRID_MOTION_ELASTICITY_H_
 
 // deal.II
 #include <deal.II/base/timer.h>
 
 // ExaDG
-#include <exadg/grid/moving_mesh_base.h>
+#include <exadg/grid/grid_motion_base.h>
 #include <exadg/structure/spatial_discretization/operator.h>
 #include <exadg/utilities/print_solver_results.h>
 
@@ -35,10 +35,10 @@ namespace ExaDG
 using namespace dealii;
 
 /**
- * Class for moving mesh problems based on a pseudo-solid mesh motion technique.
+ * Class for moving grid problems based on a pseudo-solid grid motion technique.
  */
 template<int dim, typename Number>
-class MovingMeshElasticity : public MovingMeshBase<dim, Number>
+class GridMotionElasticity : public GridMotionBase<dim, Number>
 {
 public:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
@@ -46,10 +46,10 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshElasticity(std::shared_ptr<Mapping<dim> const>               mapping_undeformed,
+  GridMotionElasticity(std::shared_ptr<Mapping<dim> const>               mapping_undeformed,
                        std::shared_ptr<Structure::Operator<dim, Number>> structure_operator,
                        Structure::InputParameters const &                structure_parameters)
-    : MovingMeshBase<dim, Number>(mapping_undeformed,
+    : GridMotionBase<dim, Number>(mapping_undeformed,
                                   // extract mapping_degree_moving from elasticity operator
                                   structure_operator->get_dof_handler().get_fe().degree,
                                   structure_operator->get_dof_handler().get_triangulation()),
@@ -64,7 +64,7 @@ public:
   }
 
   /**
-   * Updates the mapping, i.e., moves the mesh by solving a pseudo-solid problem.
+   * Updates the mapping, i.e., moves the grid by solving a pseudo-solid problem.
    */
   void
   update(double const time, bool const print_solver_info) override
@@ -169,4 +169,4 @@ private:
 
 } // namespace ExaDG
 
-#endif /* INCLUDE_EXADG_GRID_MOVING_MESH_ELASTICITY_H_ */
+#endif /* INCLUDE_EXADG_GRID_GRID_MOTION_ELASTICITY_H_ */

--- a/include/exadg/grid/grid_motion_interface.h
+++ b/include/exadg/grid/grid_motion_interface.h
@@ -24,18 +24,18 @@
 #include <deal.II/fe/mapping.h>
 #include <deal.II/lac/la_parallel_vector.h>
 
-#ifndef INCLUDE_EXADG_GRID_MOVING_MESH_INTERFACE_H_
-#  define INCLUDE_EXADG_GRID_MOVING_MESH_INTERFACE_H_
+#ifndef INCLUDE_EXADG_GRID_GRID_MOTION_INTERFACE_H_
+#  define INCLUDE_EXADG_GRID_GRID_MOTION_INTERFACE_H_
 
 namespace ExaDG
 {
 using namespace dealii;
 
 /**
- * Pure-virtual interface class for moving mesh functionality.
+ * Pure-virtual interface class for moving grid functionality.
  */
 template<int dim, typename Number>
-class MovingMeshInterface
+class GridMotionInterface
 {
 public:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
@@ -43,18 +43,18 @@ public:
   /**
    * Destructor.
    */
-  virtual ~MovingMeshInterface()
+  virtual ~GridMotionInterface()
   {
   }
 
   /**
-   * Updates the mapping, i.e., moves the mesh.
+   * Updates the mapping, i.e., moves the grid.
    */
   virtual void
   update(double const time, bool const print_solver_info) = 0;
 
   /**
-   * Print the number of iterations for PDE type mesh motion problems.
+   * Print the number of iterations for PDE type grid motion problems.
    */
   virtual void
   print_iterations() const
@@ -80,4 +80,4 @@ public:
 } // namespace ExaDG
 
 
-#endif /* INCLUDE_EXADG_GRID_MOVING_MESH_INTERFACE_H_ */
+#endif /* INCLUDE_EXADG_GRID_GRID_MOTION_INTERFACE_H_ */

--- a/include/exadg/grid/grid_motion_poisson.h
+++ b/include/exadg/grid/grid_motion_poisson.h
@@ -19,14 +19,14 @@
  *  ______________________________________________________________________
  */
 
-#ifndef INCLUDE_EXADG_GRID_MOVING_MESH_POISSON_H_
-#define INCLUDE_EXADG_GRID_MOVING_MESH_POISSON_H_
+#ifndef INCLUDE_EXADG_GRID_GRID_MOTION_POISSON_H_
+#define INCLUDE_EXADG_GRID_GRID_MOTION_POISSON_H_
 
 // deal.II
 #include <deal.II/base/timer.h>
 
 // ExaDG
-#include <exadg/grid/moving_mesh_base.h>
+#include <exadg/grid/grid_motion_base.h>
 #include <exadg/poisson/spatial_discretization/operator.h>
 #include <exadg/utilities/print_solver_results.h>
 
@@ -35,10 +35,10 @@ namespace ExaDG
 using namespace dealii;
 
 /**
- * Class for moving mesh problems based on a Poisson-type mesh motion technique.
+ * Class for moving grid problems based on a Poisson-type grid motion technique.
  */
 template<int dim, typename Number>
-class MovingMeshPoisson : public MovingMeshBase<dim, Number>
+class GridMotionPoisson : public GridMotionBase<dim, Number>
 {
 public:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
@@ -46,9 +46,9 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshPoisson(std::shared_ptr<Mapping<dim> const>                  mapping_undeformed,
+  GridMotionPoisson(std::shared_ptr<Mapping<dim> const>                  mapping_undeformed,
                     std::shared_ptr<Poisson::Operator<dim, Number, dim>> poisson_operator)
-    : MovingMeshBase<dim, Number>(mapping_undeformed,
+    : GridMotionBase<dim, Number>(mapping_undeformed,
                                   // extract mapping_degree_moving from Poisson operator
                                   poisson_operator->get_dof_handler().get_fe().degree,
                                   poisson_operator->get_dof_handler().get_triangulation()),
@@ -122,4 +122,4 @@ private:
 
 } // namespace ExaDG
 
-#endif /* INCLUDE_EXADG_GRID_MOVING_MESH_POISSON_H_ */
+#endif /* INCLUDE_EXADG_GRID_GRID_MOTION_POISSON_H_ */

--- a/include/exadg/grid/moving_mesh_base.h
+++ b/include/exadg/grid/moving_mesh_base.h
@@ -65,8 +65,8 @@ public:
     moving_mapping->fill_grid_coordinates_vector(grid_coordinates, dof_handler);
   }
 
-  std::shared_ptr<Mapping<dim>>
-  get_mapping() final
+  std::shared_ptr<Mapping<dim> const>
+  get_mapping() const final
   {
     return moving_mapping;
   }

--- a/include/exadg/grid/moving_mesh_elasticity.h
+++ b/include/exadg/grid/moving_mesh_elasticity.h
@@ -46,7 +46,7 @@ public:
   /**
    * Constructor.
    */
-  MovingMeshElasticity(std::shared_ptr<Mapping<dim>>                     mapping_undeformed,
+  MovingMeshElasticity(std::shared_ptr<Mapping<dim> const>               mapping_undeformed,
                        std::shared_ptr<Structure::Operator<dim, Number>> structure_operator,
                        Structure::InputParameters const &                structure_parameters)
     : MovingMeshBase<dim, Number>(mapping_undeformed,

--- a/include/exadg/grid/moving_mesh_interface.h
+++ b/include/exadg/grid/moving_mesh_interface.h
@@ -73,8 +73,8 @@ public:
   /**
    * Return a shared pointer to dealii::Mapping<dim>.
    */
-  virtual std::shared_ptr<Mapping<dim>>
-  get_mapping() = 0;
+  virtual std::shared_ptr<Mapping<dim> const>
+  get_mapping() const = 0;
 };
 
 } // namespace ExaDG

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -280,14 +280,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   // depends on quantities such as the time_step_size or gamma0!!!)
   if(fluid_param.solver_type == IncNS::SolverType::Unsteady)
   {
-    fluid_time_integrator = IncNS::create_time_integrator<dim, Number>(fluid_operator,
-                                                                       fluid_param,
-                                                                       0 /* refine_time */,
-                                                                       mpi_comm,
-                                                                       is_test,
-                                                                       fluid_postprocessor,
-                                                                       grid_motion,
-                                                                       matrix_free);
+    fluid_time_integrator = IncNS::create_time_integrator<dim, Number>(
+      fluid_operator, fluid_param, 0 /* refine_time */, mpi_comm, is_test, fluid_postprocessor);
   }
   else if(fluid_param.solver_type == IncNS::SolverType::Steady)
   {
@@ -595,7 +589,7 @@ Driver<dim, Number>::ale_update() const
   timer_tree.insert({"Flow + transport", "ALE", "Update matrix-free"}, sub_timer.wall_time());
 
   sub_timer.restart();
-  fluid_operator->update_after_mesh_movement();
+  fluid_operator->update_after_grid_motion();
   for(unsigned int i = 0; i < n_scalars; ++i)
     conv_diff_operator[i]->update_after_grid_motion();
   timer_tree.insert({"Flow + transport", "ALE", "Update all operators"}, sub_timer.wall_time());

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -138,7 +138,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
     std::shared_ptr<Function<dim>> mesh_motion;
     mesh_motion = application->set_mesh_movement_function();
-    grid_motion.reset(new MovingMeshFunction<dim, Number>(
+    grid_motion.reset(new GridMotionAnalytical<dim, Number>(
       grid->mapping, degree, *grid->triangulation, mesh_motion, fluid_param.start_time));
 
     grid->attach_grid_motion(grid_motion);

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -331,9 +331,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                                                     0 /* refine_time */,
                                                     mpi_comm,
                                                     is_test,
-                                                    scalar_postprocessor[i],
-                                                    grid_motion,
-                                                    matrix_free);
+                                                    scalar_postprocessor[i]);
 
     if(scalar_param[i].restarted_simulation == false)
     {
@@ -599,7 +597,7 @@ Driver<dim, Number>::ale_update() const
   sub_timer.restart();
   fluid_operator->update_after_mesh_movement();
   for(unsigned int i = 0; i < n_scalars; ++i)
-    conv_diff_operator[i]->update_after_mesh_movement();
+    conv_diff_operator[i]->update_after_grid_motion();
   timer_tree.insert({"Flow + transport", "ALE", "Update all operators"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -100,17 +100,12 @@ private:
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
   /*
-   * Mesh
+   * Grid
    */
-
-  // grid
-  std::shared_ptr<Grid<dim>> grid;
+  std::shared_ptr<Grid<dim, Number>> grid;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
-
-  // mapping (static or moving)
-  std::shared_ptr<Mapping<dim>> mapping;
+  std::shared_ptr<MovingMeshBase<dim, Number>> grid_motion;
 
   bool use_adaptive_time_stepping;
 

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -27,8 +27,8 @@
 
 // utilities
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
+#include <exadg/grid/grid_motion_analytical.h>
 #include <exadg/grid/mapping_degree.h>
-#include <exadg/grid/moving_mesh_function.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/utilities/print_functions.h>
 #include <exadg/utilities/print_general_infos.h>
@@ -105,7 +105,7 @@ private:
   std::shared_ptr<Grid<dim, Number>> grid;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> grid_motion;
+  std::shared_ptr<GridMotionBase<dim, Number>> grid_motion;
 
   bool use_adaptive_time_stepping;
 

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -214,14 +214,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     // depends on quantities such as the time_step_size or gamma0!!!)
     if(param.solver_type == SolverType::Unsteady)
     {
-      time_integrator = create_time_integrator<dim, Number>(pde_operator,
-                                                            param,
-                                                            refine_time,
-                                                            mpi_comm,
-                                                            is_test,
-                                                            postprocessor,
-                                                            moving_mesh,
-                                                            matrix_free);
+      time_integrator = create_time_integrator<dim, Number>(
+        pde_operator, param, refine_time, mpi_comm, is_test, postprocessor);
     }
     else if(param.solver_type == SolverType::Steady)
     {
@@ -278,7 +272,7 @@ Driver<dim, Number>::ale_update() const
   timer_tree.insert({"Incompressible flow", "ALE", "Update matrix-free"}, sub_timer.wall_time());
 
   sub_timer.restart();
-  pde_operator->update_after_mesh_movement();
+  pde_operator->update_after_grid_motion();
   timer_tree.insert({"Incompressible flow", "ALE", "Update operator"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -85,11 +85,11 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     {
       std::shared_ptr<Function<dim>> mesh_motion = application->set_mesh_movement_function();
 
-      moving_mesh.reset(new MovingMeshFunction<dim, Number>(grid->mapping,
-                                                            grid_data.mapping_degree,
-                                                            *grid->triangulation,
-                                                            mesh_motion,
-                                                            param.start_time));
+      grid_motion.reset(new GridMotionAnalytical<dim, Number>(grid->mapping,
+                                                              grid_data.mapping_degree,
+                                                              *grid->triangulation,
+                                                              mesh_motion,
+                                                              param.start_time));
     }
     else if(param.mesh_movement_type == MeshMovementType::Poisson)
     {
@@ -137,14 +137,14 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
       poisson_operator->setup(poisson_matrix_free, poisson_matrix_free_data);
       poisson_operator->setup_solver();
 
-      moving_mesh.reset(new MovingMeshPoisson<dim, Number>(grid->mapping, poisson_operator));
+      grid_motion.reset(new GridMotionPoisson<dim, Number>(grid->mapping, poisson_operator));
     }
     else
     {
       AssertThrow(false, ExcMessage("Not implemented."));
     }
 
-    grid->attach_grid_motion(moving_mesh);
+    grid->attach_grid_motion(grid_motion);
   }
 
   // boundary conditions
@@ -264,7 +264,7 @@ Driver<dim, Number>::ale_update() const
   Timer sub_timer;
 
   sub_timer.restart();
-  moving_mesh->update(time_integrator->get_next_time(), false);
+  grid_motion->update(time_integrator->get_next_time(), false);
   timer_tree.insert({"Incompressible flow", "ALE", "Reinit mapping"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -113,10 +113,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                              "as for actual application problem."));
 
       // initialize Poisson operator
-      poisson_operator.reset(new Poisson::Operator<dim, Number, dim>(*grid->triangulation,
-                                                                     grid->mapping,
+      poisson_operator.reset(new Poisson::Operator<dim, Number, dim>(grid,
                                                                      grid_data.mapping_degree,
-                                                                     grid->periodic_faces,
                                                                      poisson_boundary_descriptor,
                                                                      poisson_field_functions,
                                                                      poisson_param,

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -210,17 +210,12 @@ private:
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
   /*
-   * Mesh
+   * Grid
    */
-
-  // grid
-  std::shared_ptr<Grid<dim>> grid;
+  std::shared_ptr<Grid<dim, Number>> grid;
 
   // moving mapping (ALE)
   std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
-
-  // mapping (static or moving)
-  std::shared_ptr<Mapping<dim>> mapping;
 
   // solve mesh deformation by a Poisson problem
   Poisson::InputParameters poisson_param;

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -23,9 +23,9 @@
 #define INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_DRIVER_H_
 
 #include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
+#include <exadg/grid/grid_motion_analytical.h>
+#include <exadg/grid/grid_motion_poisson.h>
 #include <exadg/grid/mapping_degree.h>
-#include <exadg/grid/moving_mesh_function.h>
-#include <exadg/grid/moving_mesh_poisson.h>
 #include <exadg/incompressible_navier_stokes/postprocessor/postprocessor_base.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h>
@@ -215,7 +215,7 @@ private:
   std::shared_ptr<Grid<dim, Number>> grid;
 
   // moving mapping (ALE)
-  std::shared_ptr<MovingMeshBase<dim, Number>> moving_mesh;
+  std::shared_ptr<GridMotionBase<dim, Number>> grid_motion;
 
   // solve mesh deformation by a Poisson problem
   Poisson::InputParameters poisson_param;

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
@@ -180,10 +180,8 @@ DriverPrecursor<dim, Number>::setup(std::shared_ptr<ApplicationBasePrecursor<dim
               ExcMessage("This is an unsteady solver. Check input parameters."));
 
   // initialize pde_operator_pre (precursor domain)
-  pde_operator = create_operator<dim, Number>(*grid_pre->triangulation,
-                                              grid_pre->mapping,
+  pde_operator = create_operator<dim, Number>(grid_pre,
                                               degree,
-                                              grid_pre->periodic_faces,
                                               boundary_descriptor_velocity_pre,
                                               boundary_descriptor_pressure_pre,
                                               field_functions_pre,
@@ -192,10 +190,8 @@ DriverPrecursor<dim, Number>::setup(std::shared_ptr<ApplicationBasePrecursor<dim
                                               mpi_comm);
 
   // initialize operator_base (actual domain)
-  pde_operator = create_operator<dim, Number>(*grid->triangulation,
-                                              grid->mapping,
+  pde_operator = create_operator<dim, Number>(grid,
                                               degree,
-                                              grid->periodic_faces,
                                               boundary_descriptor_velocity,
                                               boundary_descriptor_pressure,
                                               field_functions,

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.h
@@ -80,7 +80,7 @@ private:
   /*
    * Grid
    */
-  std::shared_ptr<Grid<dim>> grid_pre, grid;
+  std::shared_ptr<Grid<dim, Number>> grid_pre, grid;
 
   /*
    * Field functions and boundary descriptor

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -58,15 +58,15 @@ PostProcessor<dim, Number>::setup(Operator const & pde_operator)
   output_generator.setup(pde_operator,
                          pde_operator.get_dof_handler_u(),
                          pde_operator.get_dof_handler_p(),
-                         pde_operator.get_mapping(),
+                         *pde_operator.get_mapping(),
                          pp_data.output_data);
 
   error_calculator_u.setup(pde_operator.get_dof_handler_u(),
-                           pde_operator.get_mapping(),
+                           *pde_operator.get_mapping(),
                            pp_data.error_data_u);
 
   error_calculator_p.setup(pde_operator.get_dof_handler_p(),
-                           pde_operator.get_mapping(),
+                           *pde_operator.get_mapping(),
                            pp_data.error_data_p);
 
   lift_and_drag_calculator.setup(pde_operator.get_dof_handler_u(),
@@ -77,7 +77,7 @@ PostProcessor<dim, Number>::setup(Operator const & pde_operator)
                                  pp_data.lift_and_drag_data);
 
   pressure_difference_calculator.setup(pde_operator.get_dof_handler_p(),
-                                       pde_operator.get_mapping(),
+                                       *pde_operator.get_mapping(),
                                        pp_data.pressure_difference_data);
 
   div_and_mass_error_calculator.setup(pde_operator.get_matrix_free(),
@@ -97,7 +97,7 @@ PostProcessor<dim, Number>::setup(Operator const & pde_operator)
 
   line_plot_calculator.setup(pde_operator.get_dof_handler_u(),
                              pde_operator.get_dof_handler_p(),
-                             pde_operator.get_mapping(),
+                             *pde_operator.get_mapping(),
                              pp_data.line_plot_data);
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -46,7 +46,7 @@ MultigridPreconditioner<dim, Number>::initialize(MultigridData const &          
                                                  MultigridOperatorType const & mg_operator_type,
                                                  bool const                    mesh_is_moving,
                                                  Map const *                   dirichlet_bc,
-                                                 PeriodicFacePairs *           periodic_face_pairs)
+                                                 PeriodicFacePairs const *     periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -231,7 +231,7 @@ MultigridPreconditioner<dim, Number>::update_operators_after_mesh_movement()
 {
   for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
   {
-    get_operator(level)->update_after_mesh_movement();
+    get_operator(level)->update_after_grid_motion();
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -67,7 +67,7 @@ public:
              MultigridOperatorType const &       mg_operator_type,
              bool const                          mesh_is_moving,
              Map const *                         dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                 periodic_face_pairs = nullptr);
+             PeriodicFacePairs const *           periodic_face_pairs = nullptr);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -45,7 +45,7 @@ MultigridPreconditionerProjection<dim, Number>::initialize(
   PDEOperator const &                 pde_operator,
   bool const                          mesh_is_moving,
   Map const *                         dirichlet_bc,
-  PeriodicFacePairs *                 periodic_face_pairs)
+  PeriodicFacePairs const *           periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
@@ -66,7 +66,7 @@ public:
              PDEOperator const &                 pde_operator,
              bool const                          mesh_is_moving,
              Map const *                         dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                 periodic_face_pairs = nullptr);
+             PeriodicFacePairs const *           periodic_face_pairs = nullptr);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
@@ -37,28 +37,22 @@ namespace IncNS
  */
 template<int dim, typename Number>
 std::shared_ptr<SpatialOperatorBase<dim, Number>>
-create_operator(
-  Triangulation<dim> const &          triangulation,
-  std::shared_ptr<Mapping<dim> const> mapping,
-  unsigned int const                  degree_velocity,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                  periodic_faces,
-  std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
-  std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
-  std::shared_ptr<FieldFunctions<dim>> const      field_functions,
-  InputParameters const &                         parameters,
-  std::string const &                             field,
-  MPI_Comm const &                                mpi_comm)
+create_operator(std::shared_ptr<Grid<dim, Number> const>        grid,
+                unsigned int const                              degree_velocity,
+                std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
+                std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
+                std::shared_ptr<FieldFunctions<dim>> const      field_functions,
+                InputParameters const &                         parameters,
+                std::string const &                             field,
+                MPI_Comm const &                                mpi_comm)
 {
   std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_operator;
 
   // initialize pde_operator
   if(parameters.temporal_discretization == TemporalDiscretization::BDFCoupledSolution)
   {
-    pde_operator = std::make_shared<OperatorCoupled<dim, Number>>(triangulation,
-                                                                  mapping,
+    pde_operator = std::make_shared<OperatorCoupled<dim, Number>>(grid,
                                                                   degree_velocity,
-                                                                  periodic_faces,
                                                                   boundary_descriptor_velocity,
                                                                   boundary_descriptor_pressure,
                                                                   field_functions,
@@ -69,10 +63,8 @@ create_operator(
   else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
   {
     pde_operator =
-      std::make_shared<OperatorDualSplitting<dim, Number>>(triangulation,
-                                                           mapping,
+      std::make_shared<OperatorDualSplitting<dim, Number>>(grid,
                                                            degree_velocity,
-                                                           periodic_faces,
                                                            boundary_descriptor_velocity,
                                                            boundary_descriptor_pressure,
                                                            field_functions,
@@ -83,10 +75,8 @@ create_operator(
   else if(parameters.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
   {
     pde_operator =
-      std::make_shared<OperatorPressureCorrection<dim, Number>>(triangulation,
-                                                                mapping,
+      std::make_shared<OperatorPressureCorrection<dim, Number>>(grid,
                                                                 degree_velocity,
-                                                                periodic_faces,
                                                                 boundary_descriptor_velocity,
                                                                 boundary_descriptor_pressure,
                                                                 field_functions,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -830,7 +830,7 @@ OperatorCoupled<dim, Number>::update_block_preconditioner()
     {
       if(this->param.exact_inversion_of_laplace_operator == true)
       {
-        laplace_operator->update_after_mesh_movement();
+        laplace_operator->update_penalty_parameter();
       }
 
       multigrid_preconditioner_schur_complement->update();

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -197,18 +197,14 @@ public:
   /*
    * Constructor.
    */
-  OperatorCoupled(
-    Triangulation<dim> const &          triangulation_in,
-    std::shared_ptr<Mapping<dim> const> mapping_in,
-    unsigned int const                  degree_u_in,
-    std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                    periodic_face_pairs_in,
-    std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
-    std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure_in,
-    std::shared_ptr<FieldFunctions<dim>> const      field_functions_in,
-    InputParameters const &                         parameters_in,
-    std::string const &                             field_in,
-    MPI_Comm const &                                mpi_comm_in);
+  OperatorCoupled(std::shared_ptr<Grid<dim, Number> const>        grid,
+                  unsigned int const                              degree_u,
+                  std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
+                  std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
+                  std::shared_ptr<FieldFunctions<dim>> const      field_functions,
+                  InputParameters const &                         parameters,
+                  std::string const &                             field,
+                  MPI_Comm const &                                mpi_comm);
 
   /*
    * Destructor.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -33,21 +33,16 @@ using namespace dealii;
 
 template<int dim, typename Number>
 OperatorDualSplitting<dim, Number>::OperatorDualSplitting(
-  Triangulation<dim> const &          triangulation_in,
-  std::shared_ptr<Mapping<dim> const> mapping_in,
-  unsigned int const                  degree_u_in,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                  periodic_face_pairs_in,
+  std::shared_ptr<Grid<dim, Number> const>        grid_in,
+  unsigned int const                              degree_u_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
   std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure_in,
   std::shared_ptr<FieldFunctions<dim>> const      field_functions_in,
   InputParameters const &                         parameters_in,
   std::string const &                             field_in,
   MPI_Comm const &                                mpi_comm_in)
-  : ProjectionBase(triangulation_in,
-                   mapping_in,
+  : ProjectionBase(grid_in,
                    degree_u_in,
-                   periodic_face_pairs_in,
                    boundary_descriptor_velocity_in,
                    boundary_descriptor_pressure_in,
                    field_functions_in,
@@ -116,23 +111,23 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
   }
   else if(this->param.preconditioner_viscous == PreconditionerViscous::Multigrid)
   {
-    typedef MultigridPreconditioner<dim, Number> MULTIGRID;
+    typedef MultigridPreconditioner<dim, Number> Multigrid;
 
-    helmholtz_preconditioner.reset(new MULTIGRID(this->mpi_comm));
+    helmholtz_preconditioner.reset(new Multigrid(this->mpi_comm));
 
-    std::shared_ptr<MULTIGRID> mg_preconditioner =
-      std::dynamic_pointer_cast<MULTIGRID>(helmholtz_preconditioner);
+    std::shared_ptr<Multigrid> mg_preconditioner =
+      std::dynamic_pointer_cast<Multigrid>(helmholtz_preconditioner);
 
     auto & dof_handler = this->get_dof_handler_u();
     mg_preconditioner->initialize(this->param.multigrid_data_viscous,
                                   &dof_handler.get_triangulation(),
                                   dof_handler.get_fe(),
-                                  this->mapping,
+                                  this->get_mapping(),
                                   this->momentum_operator,
                                   MultigridOperatorType::ReactionDiffusion,
                                   this->param.ale_formulation,
                                   &this->momentum_operator.get_data().bc->dirichlet_bc,
-                                  &this->periodic_face_pairs);
+                                  &this->grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
@@ -56,11 +56,8 @@ public:
    * Constructor.
    */
   OperatorDualSplitting(
-    Triangulation<dim> const &          triangulation,
-    std::shared_ptr<Mapping<dim> const> mapping,
-    unsigned int const                  degree_u,
-    std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                    periodic_face_pairs,
+    std::shared_ptr<Grid<dim, Number> const>        grid,
+    unsigned int const                              degree_u,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
     std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
     std::shared_ptr<FieldFunctions<dim>> const      field_functions,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -33,21 +33,16 @@ using namespace dealii;
 
 template<int dim, typename Number>
 OperatorPressureCorrection<dim, Number>::OperatorPressureCorrection(
-  Triangulation<dim> const &          triangulation_in,
-  std::shared_ptr<Mapping<dim> const> mapping_in,
-  unsigned int const                  degree_u_in,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                  periodic_face_pairs_in,
+  std::shared_ptr<Grid<dim, Number> const>        grid_in,
+  unsigned int const                              degree_u_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
   std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure_in,
   std::shared_ptr<FieldFunctions<dim>> const      field_functions_in,
   InputParameters const &                         parameters_in,
   std::string const &                             field_in,
   MPI_Comm const &                                mpi_comm_in)
-  : ProjectionBase(triangulation_in,
-                   mapping_in,
+  : ProjectionBase(grid_in,
                    degree_u_in,
-                   periodic_face_pairs_in,
                    boundary_descriptor_velocity_in,
                    boundary_descriptor_pressure_in,
                    field_functions_in,
@@ -135,12 +130,12 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
     mg_preconditioner->initialize(this->param.multigrid_data_momentum,
                                   &dof_handler.get_triangulation(),
                                   dof_handler.get_fe(),
-                                  this->mapping,
+                                  this->get_mapping(),
                                   this->momentum_operator,
                                   this->param.multigrid_operator_type_momentum,
                                   this->param.ale_formulation,
                                   &this->momentum_operator.get_data().bc->dirichlet_bc,
-                                  &this->periodic_face_pairs);
+                                  &this->grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
@@ -105,11 +105,8 @@ public:
    * Constructor.
    */
   OperatorPressureCorrection(
-    Triangulation<dim> const &          triangulation,
-    std::shared_ptr<Mapping<dim> const> mapping,
-    unsigned int const                  degree_u,
-    std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                    periodic_face_pairs,
+    std::shared_ptr<Grid<dim, Number> const>        grid,
+    unsigned int const                              degree_u,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
     std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
     std::shared_ptr<FieldFunctions<dim>> const      field_functions,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -73,13 +73,13 @@ OperatorProjectionMethods<dim, Number>::setup(
 
 template<int dim, typename Number>
 void
-OperatorProjectionMethods<dim, Number>::update_after_mesh_movement()
+OperatorProjectionMethods<dim, Number>::update_after_grid_motion()
 {
-  Base::update_after_mesh_movement();
+  Base::update_after_grid_motion();
 
   // update SIPG penalty parameter of Laplace operator which depends on the deformation
   // of elements
-  laplace_operator.update_after_mesh_movement();
+  laplace_operator.update_penalty_parameter();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -32,21 +32,16 @@ using namespace dealii;
 
 template<int dim, typename Number>
 OperatorProjectionMethods<dim, Number>::OperatorProjectionMethods(
-  Triangulation<dim> const &          triangulation_in,
-  std::shared_ptr<Mapping<dim> const> mapping_in,
-  unsigned int const                  degree_u_in,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                  periodic_face_pairs_in,
+  std::shared_ptr<Grid<dim, Number> const>        grid_in,
+  unsigned int const                              degree_u_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
   std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure_in,
   std::shared_ptr<FieldFunctions<dim>> const      field_functions_in,
   InputParameters const &                         parameters_in,
   std::string const &                             field_in,
   MPI_Comm const &                                mpi_comm_in)
-  : Base(triangulation_in,
-         mapping_in,
+  : Base(grid_in,
          degree_u_in,
-         periodic_face_pairs_in,
          boundary_descriptor_velocity_in,
          boundary_descriptor_pressure_in,
          field_functions_in,
@@ -187,11 +182,11 @@ OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poiss
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),
                                   dof_handler.get_fe(),
-                                  this->mapping,
+                                  this->get_mapping(),
                                   laplace_operator.get_data(),
                                   this->param.ale_formulation,
                                   &laplace_operator.get_data().bc->dirichlet_bc,
-                                  &this->periodic_face_pairs);
+                                  &this->grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -48,11 +48,8 @@ public:
    * Constructor.
    */
   OperatorProjectionMethods(
-    Triangulation<dim> const &          triangulation,
-    std::shared_ptr<Mapping<dim> const> mapping,
-    unsigned int const                  degree_u,
-    std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                    periodic_face_pairs,
+    std::shared_ptr<Grid<dim, Number> const>        grid,
+    unsigned int const                              degree_u,
     std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
     std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
     std::shared_ptr<FieldFunctions<dim>> const      field_functions,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -72,7 +72,7 @@ public:
         std::string const &                          dof_index_temperature = "") override;
 
   void
-  update_after_mesh_movement() override;
+  update_after_grid_motion() override;
 
   /*
    * This function evaluates the rhs-contribution of the viscous term and adds the result to the

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -129,7 +129,7 @@ MomentumOperator<dim, Number>::set_solution_linearization(VectorType const & vel
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::update_after_mesh_movement()
+MomentumOperator<dim, Number>::update_after_grid_motion()
 {
   if(operator_data.viscous_problem)
     viscous_kernel->calculate_penalty_parameter(this->get_matrix_free(),

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
@@ -91,7 +91,7 @@ public:
    * Update of operator (required, e.g., for multigrid).
    */
   void
-  update_after_mesh_movement();
+  update_after_grid_motion();
 
   void
   set_velocity_copy(VectorType const & velocity) const;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1320,7 +1320,31 @@ SpatialOperatorBase<dim, Number>::calculate_dissipation_continuity_term(
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::update_after_mesh_movement()
+SpatialOperatorBase<dim, Number>::move_grid(double const & time) const
+{
+  grid->grid_motion->update(time, false);
+}
+
+template<int dim, typename Number>
+void
+SpatialOperatorBase<dim, Number>::move_grid_and_update_dependent_data_structures(
+  double const & time)
+{
+  grid->grid_motion->update(time, false);
+  matrix_free->update_mapping(*get_mapping());
+  update_after_grid_motion();
+}
+
+template<int dim, typename Number>
+void
+SpatialOperatorBase<dim, Number>::fill_grid_coordinates_vector(VectorType & vector) const
+{
+  grid->grid_motion->fill_grid_coordinates_vector(vector, get_dof_handler_u());
+}
+
+template<int dim, typename Number>
+void
+SpatialOperatorBase<dim, Number>::update_after_grid_motion()
 {
   if(this->param.use_turbulence_model)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -38,11 +38,8 @@ using namespace dealii;
 
 template<int dim, typename Number>
 SpatialOperatorBase<dim, Number>::SpatialOperatorBase(
-  Triangulation<dim> const &          triangulation_in,
-  std::shared_ptr<Mapping<dim> const> mapping_in,
-  unsigned int const                  degree_u_in,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                  periodic_face_pairs_in,
+  std::shared_ptr<Grid<dim, Number> const>        grid_in,
+  unsigned int const                              degree_u_in,
   std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity_in,
   std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure_in,
   std::shared_ptr<FieldFunctions<dim>> const      field_functions_in,
@@ -50,10 +47,8 @@ SpatialOperatorBase<dim, Number>::SpatialOperatorBase(
   std::string const &                             field_in,
   MPI_Comm const &                                mpi_comm_in)
   : dealii::Subscriptor(),
-    triangulation(triangulation_in),
-    mapping(mapping_in),
+    grid(grid_in),
     degree_u(degree_u_in),
-    periodic_face_pairs(periodic_face_pairs_in),
     boundary_descriptor_velocity(boundary_descriptor_velocity_in),
     boundary_descriptor_pressure(boundary_descriptor_pressure_in),
     field_functions(field_functions_in),
@@ -64,9 +59,9 @@ SpatialOperatorBase<dim, Number>::SpatialOperatorBase(
     fe_u(new FESystem<dim>(FE_DGQ<dim>(degree_u_in), dim)),
     fe_p(parameters_in.get_degree_p(degree_u_in)),
     fe_u_scalar(degree_u_in),
-    dof_handler_u(triangulation_in),
-    dof_handler_p(triangulation_in),
-    dof_handler_u_scalar(triangulation_in),
+    dof_handler_u(*grid_in->triangulation),
+    dof_handler_p(*grid_in->triangulation),
+    dof_handler_u_scalar(*grid_in->triangulation),
     pressure_level_is_undefined(false),
     mpi_comm(mpi_comm_in),
     pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
@@ -88,7 +83,7 @@ SpatialOperatorBase<dim, Number>::SpatialOperatorBase(
   // Erroneously, the boundary descriptor might contain too many boundary IDs which
   // do not even exist in the triangulation. Here, we make sure that each entry of
   // the boundary descriptor has indeed a counterpart in the triangulation.
-  std::vector<types::boundary_id> boundary_ids = triangulation.get_boundary_ids();
+  std::vector<types::boundary_id> boundary_ids = grid->triangulation->get_boundary_ids();
   for(auto it = boundary_descriptor_pressure->dirichlet_bc.begin();
       it != boundary_descriptor_pressure->dirichlet_bc.end();
       ++it)
@@ -516,7 +511,7 @@ SpatialOperatorBase<dim, Number>::initialize_turbulence_model()
   model_data.dof_index           = get_dof_index_velocity();
   model_data.quad_index          = get_quad_index_velocity_linear();
   model_data.degree              = degree_u;
-  turbulence_model.initialize(*matrix_free, *mapping, viscous_kernel, model_data);
+  turbulence_model.initialize(*matrix_free, *get_mapping(), viscous_kernel, model_data);
 }
 
 template<int dim, typename Number>
@@ -680,10 +675,10 @@ SpatialOperatorBase<dim, Number>::get_quad_index_velocity_linearized() const
 }
 
 template<int dim, typename Number>
-Mapping<dim> const &
+std::shared_ptr<Mapping<dim> const>
 SpatialOperatorBase<dim, Number>::get_mapping() const
 {
-  return *mapping;
+  return grid->get_dynamic_mapping();
 }
 
 template<int dim, typename Number>
@@ -816,12 +811,12 @@ SpatialOperatorBase<dim, Number>::prescribe_initial_conditions(VectorType & velo
   velocity_double = velocity;
   pressure_double = pressure;
 
-  VectorTools::interpolate(*mapping,
+  VectorTools::interpolate(*get_mapping(),
                            dof_handler_u,
                            *(field_functions->initial_solution_velocity),
                            velocity_double);
 
-  VectorTools::interpolate(*mapping,
+  VectorTools::interpolate(*get_mapping(),
                            dof_handler_p,
                            *(field_functions->initial_solution_pressure),
                            pressure_double);
@@ -920,7 +915,7 @@ SpatialOperatorBase<dim, Number>::calculate_cfl_from_time_step(VectorType &     
                                                                double const time_step_size) const
 {
   calculate_cfl<dim, Number>(cfl,
-                             triangulation,
+                             *grid->triangulation,
                              *matrix_free,
                              get_dof_index_velocity(),
                              get_quad_index_velocity_linear(),
@@ -998,7 +993,7 @@ SpatialOperatorBase<dim, Number>::adjust_pressure_level_if_undefined(VectorType 
       vec_double = pressure; // initialize
 
       field_functions->analytical_solution_pressure->set_time(time);
-      VectorTools::interpolate(*mapping,
+      VectorTools::interpolate(*get_mapping(),
                                dof_handler_p,
                                *(field_functions->analytical_solution_pressure),
                                vec_double);
@@ -1136,17 +1131,14 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
   std::shared_ptr<MultigridPoisson> mg_preconditioner =
     std::dynamic_pointer_cast<MultigridPoisson>(preconditioner);
 
-  // explicit copy needed since function is called on const
-  auto periodic_face_pairs = this->periodic_face_pairs;
-
   mg_preconditioner->initialize(mg_data,
                                 &dof_handler_u_scalar.get_triangulation(),
                                 dof_handler_u_scalar.get_fe(),
-                                mapping,
+                                grid->get_dynamic_mapping(),
                                 laplace_operator.get_data(),
                                 this->param.ale_formulation,
                                 &laplace_operator.get_data().bc->dirichlet_bc,
-                                &periodic_face_pairs);
+                                &grid->periodic_faces);
 
   // setup solver
   Krylov::SolverDataCG solver_data;
@@ -1333,7 +1325,7 @@ SpatialOperatorBase<dim, Number>::update_after_mesh_movement()
   if(this->param.use_turbulence_model)
   {
     // the mesh (and hence the filter width) changes in case of ALE formulation
-    turbulence_model.calculate_filter_width(*mapping);
+    turbulence_model.calculate_filter_width(*get_mapping());
   }
 
   if(this->param.viscous_problem())
@@ -1444,22 +1436,22 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
     }
     else if(param.preconditioner_projection == PreconditionerProjection::Multigrid)
     {
-      typedef MultigridPreconditionerProjection<dim, Number> MULTIGRID;
+      typedef MultigridPreconditionerProjection<dim, Number> Multigrid;
 
-      preconditioner_projection.reset(new MULTIGRID(this->mpi_comm));
+      preconditioner_projection.reset(new Multigrid(this->mpi_comm));
 
-      std::shared_ptr<MULTIGRID> mg_preconditioner =
-        std::dynamic_pointer_cast<MULTIGRID>(preconditioner_projection);
+      std::shared_ptr<Multigrid> mg_preconditioner =
+        std::dynamic_pointer_cast<Multigrid>(preconditioner_projection);
 
       auto const & dof_handler = this->get_dof_handler_u();
       mg_preconditioner->initialize(this->param.multigrid_data_projection,
                                     &dof_handler.get_triangulation(),
                                     dof_handler.get_fe(),
-                                    this->mapping,
+                                    this->get_mapping(),
                                     *this->projection_operator,
                                     this->param.ale_formulation,
                                     &this->projection_operator->get_data().bc->dirichlet_bc,
-                                    &this->periodic_face_pairs);
+                                    &grid->periodic_faces);
     }
     else
     {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -25,12 +25,12 @@
 // deal.II
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_system.h>
-#include <deal.II/fe/mapping_q.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
 
 
 // ExaDG
+#include <exadg/grid/grid.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/calculators/divergence_calculator.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/calculators/q_criterion_calculator.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/calculators/streamfunction_calculator_rhs_operator.h>
@@ -148,18 +148,14 @@ public:
   /*
    * Constructor.
    */
-  SpatialOperatorBase(
-    Triangulation<dim> const &          triangulation,
-    std::shared_ptr<Mapping<dim> const> mapping,
-    unsigned int const                  degree_u,
-    std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const
-                                                    periodic_face_pairs,
-    std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
-    std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
-    std::shared_ptr<FieldFunctions<dim>> const      field_functions,
-    InputParameters const &                         parameters,
-    std::string const &                             field,
-    MPI_Comm const &                                mpi_comm);
+  SpatialOperatorBase(std::shared_ptr<Grid<dim, Number> const>        grid,
+                      unsigned int const                              degree_u,
+                      std::shared_ptr<BoundaryDescriptorU<dim>> const boundary_descriptor_velocity,
+                      std::shared_ptr<BoundaryDescriptorP<dim>> const boundary_descriptor_pressure,
+                      std::shared_ptr<FieldFunctions<dim>> const      field_functions,
+                      InputParameters const &                         parameters,
+                      std::string const &                             field,
+                      MPI_Comm const &                                mpi_comm);
 
   /*
    * Destructor.
@@ -226,7 +222,7 @@ public:
   unsigned int
   get_degree_p() const;
 
-  Mapping<dim> const &
+  std::shared_ptr<Mapping<dim> const>
   get_mapping() const;
 
   FESystem<dim> const &
@@ -480,22 +476,14 @@ protected:
   unsteady_problem_has_to_be_solved() const;
 
   /*
-   * Triangulation
+   * Grid
    */
-  Triangulation<dim> const & triangulation;
-
-  /*
-   * Mapping
-   */
-  std::shared_ptr<Mapping<dim> const> mapping;
+  std::shared_ptr<Grid<dim, Number> const> grid;
 
   /*
    * Polynomial degree of velocity shape functions.
    */
   unsigned int const degree_u;
-
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_face_pairs;
 
   /*
    * User interface: Boundary conditions and field functions.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -458,10 +458,33 @@ public:
   double
   calculate_dissipation_continuity_term(VectorType const & velocity) const;
 
-  // Arbitrary Lagrangian-Eulerian (ALE) formulation
-  virtual void
-  update_after_mesh_movement();
+  /*
+   * Moves the grid for ALE-type problems.
+   */
+  void
+  move_grid(double const & time) const;
 
+  /*
+   * Moves the grid and updates dependent data structures for ALE-type problems.
+   */
+  void
+  move_grid_and_update_dependent_data_structures(double const & time);
+
+  /*
+   * Fills a dof-vector with grid coordinates for ALE-type problems.
+   */
+  void
+  fill_grid_coordinates_vector(VectorType & vector) const;
+
+  /*
+   * Updates operators after grid has been moved.
+   */
+  virtual void
+  update_after_grid_motion();
+
+  /*
+   * Sets the grid velocity.
+   */
   void
   set_grid_velocity(VectorType velocity);
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -41,9 +41,7 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
                        unsigned int const                                refine_time,
                        MPI_Comm const &                                  mpi_comm,
                        bool const                                        is_test,
-                       std::shared_ptr<PostProcessorInterface<Number>>   postprocessor,
-                       std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh = nullptr,
-                       std::shared_ptr<MatrixFree<dim, Number>>          matrix_free = nullptr)
+                       std::shared_ptr<PostProcessorInterface<Number>>   postprocessor)
 {
   std::shared_ptr<TimeIntBDF<dim, Number>> time_integrator;
 
@@ -52,29 +50,16 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
     std::shared_ptr<OperatorCoupled<dim, Number>> operator_coupled =
       std::dynamic_pointer_cast<OperatorCoupled<dim, Number>>(pde_operator);
 
-    time_integrator = std::make_shared<IncNS::TimeIntBDFCoupled<dim, Number>>(operator_coupled,
-                                                                              parameters,
-                                                                              refine_time,
-                                                                              mpi_comm,
-                                                                              is_test,
-                                                                              postprocessor,
-                                                                              moving_mesh,
-                                                                              matrix_free);
+    time_integrator = std::make_shared<IncNS::TimeIntBDFCoupled<dim, Number>>(
+      operator_coupled, parameters, refine_time, mpi_comm, is_test, postprocessor);
   }
   else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
   {
     std::shared_ptr<OperatorDualSplitting<dim, Number>> operator_dual_splitting =
       std::dynamic_pointer_cast<OperatorDualSplitting<dim, Number>>(pde_operator);
 
-    time_integrator =
-      std::make_shared<IncNS::TimeIntBDFDualSplitting<dim, Number>>(operator_dual_splitting,
-                                                                    parameters,
-                                                                    refine_time,
-                                                                    mpi_comm,
-                                                                    is_test,
-                                                                    postprocessor,
-                                                                    moving_mesh,
-                                                                    matrix_free);
+    time_integrator = std::make_shared<IncNS::TimeIntBDFDualSplitting<dim, Number>>(
+      operator_dual_splitting, parameters, refine_time, mpi_comm, is_test, postprocessor);
   }
   else if(parameters.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
   {
@@ -82,14 +67,7 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
       std::dynamic_pointer_cast<OperatorPressureCorrection<dim, Number>>(pde_operator);
 
     time_integrator = std::make_shared<IncNS::TimeIntBDFPressureCorrection<dim, Number>>(
-      operator_pressure_correction,
-      parameters,
-      refine_time,
-      mpi_comm,
-      is_test,
-      postprocessor,
-      moving_mesh,
-      matrix_free);
+      operator_pressure_correction, parameters, refine_time, mpi_comm, is_test, postprocessor);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -24,7 +24,6 @@
 
 // deal.II
 #include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/matrix_free/matrix_free.h>
 
 // ExaDG
 #include <exadg/time_integration/explicit_runge_kutta.h>
@@ -32,10 +31,6 @@
 
 namespace ExaDG
 {
-// forward declarations
-template<int dim, typename Number>
-class MovingMeshInterface;
-
 namespace IncNS
 {
 using namespace dealii;
@@ -61,14 +56,12 @@ public:
 
   typedef SpatialOperatorBase<dim, Number> OperatorBase;
 
-  TimeIntBDF(std::shared_ptr<OperatorBase>                     operator_in,
-             InputParameters const &                           param_in,
-             unsigned int const                                refine_steps_time_in,
-             MPI_Comm const &                                  mpi_comm_in,
-             bool const                                        is_test_in,
-             std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
-             std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
-             std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
+  TimeIntBDF(std::shared_ptr<OperatorBase>                   operator_in,
+             InputParameters const &                         param_in,
+             unsigned int const                              refine_steps_time_in,
+             MPI_Comm const &                                mpi_comm_in,
+             bool const                                      is_test_in,
+             std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in);
 
   virtual ~TimeIntBDF()
   {
@@ -127,12 +120,6 @@ protected:
   calculate_sum_alphai_ui_oif_substepping(VectorType & sum_alphai_ui,
                                           double const cfl,
                                           double const cfl_oif) final;
-
-  void
-  move_mesh(double const time) const;
-
-  void
-  move_mesh_and_update_dependent_data_structures(double const time) const;
 
   InputParameters const & param;
 
@@ -212,9 +199,6 @@ private:
   VectorType              grid_velocity;
   std::vector<VectorType> vec_grid_coordinates;
   VectorType              grid_coordinates_np;
-
-  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh;
-  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free;
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -34,22 +34,13 @@ using namespace dealii;
 
 template<int dim, typename Number>
 TimeIntBDFCoupled<dim, Number>::TimeIntBDFCoupled(
-  std::shared_ptr<Operator>                         operator_in,
-  InputParameters const &                           param_in,
-  unsigned int const                                refine_steps_time_in,
-  MPI_Comm const &                                  mpi_comm_in,
-  bool const                                        is_test_in,
-  std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
-  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in,
-  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in)
-  : Base(operator_in,
-         param_in,
-         refine_steps_time_in,
-         mpi_comm_in,
-         is_test_in,
-         postprocessor_in,
-         moving_mesh_in,
-         matrix_free_in),
+  std::shared_ptr<Operator>                       operator_in,
+  InputParameters const &                         param_in,
+  unsigned int const                              refine_steps_time_in,
+  MPI_Comm const &                                mpi_comm_in,
+  bool const                                      is_test_in,
+  std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in)
+  : Base(operator_in, param_in, refine_steps_time_in, mpi_comm_in, is_test_in, postprocessor_in),
     pde_operator(operator_in),
     solution(this->order),
     iterations({0, {0, 0}}),
@@ -76,7 +67,7 @@ void
 TimeIntBDFCoupled<dim, Number>::initialize_current_solution()
 {
   if(this->param.ale_formulation)
-    this->move_mesh(this->get_time());
+    pde_operator->move_grid(this->get_time());
 
   pde_operator->prescribe_initial_conditions(solution[0].block(0),
                                              solution[0].block(1),
@@ -91,7 +82,7 @@ TimeIntBDFCoupled<dim, Number>::initialize_former_solutions()
   for(unsigned int i = 1; i < solution.size(); ++i)
   {
     if(this->param.ale_formulation)
-      this->move_mesh(this->get_previous_time(i));
+      pde_operator->move_grid(this->get_previous_time(i));
 
     pde_operator->prescribe_initial_conditions(solution[i].block(0),
                                                solution[i].block(1),

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -51,14 +51,12 @@ private:
   typedef OperatorCoupled<dim, Number> Operator;
 
 public:
-  TimeIntBDFCoupled(std::shared_ptr<Operator>                         operator_in,
-                    InputParameters const &                           param_in,
-                    unsigned int const                                refine_steps_time_in,
-                    MPI_Comm const &                                  mpi_comm_in,
-                    bool const                                        is_test_in,
-                    std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
-                    std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
-                    std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
+  TimeIntBDFCoupled(std::shared_ptr<Operator>                       operator_in,
+                    InputParameters const &                         param_in,
+                    unsigned int const                              refine_steps_time_in,
+                    MPI_Comm const &                                mpi_comm_in,
+                    bool const                                      is_test_in,
+                    std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in);
 
   void
   postprocessing_stability_analysis();

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -34,22 +34,13 @@ using namespace dealii;
 
 template<int dim, typename Number>
 TimeIntBDFDualSplitting<dim, Number>::TimeIntBDFDualSplitting(
-  std::shared_ptr<Operator>                         operator_in,
-  InputParameters const &                           param_in,
-  unsigned int const                                refine_steps_time_in,
-  MPI_Comm const &                                  mpi_comm_in,
-  bool const                                        is_test_in,
-  std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
-  std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in,
-  std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in)
-  : Base(operator_in,
-         param_in,
-         refine_steps_time_in,
-         mpi_comm_in,
-         is_test_in,
-         postprocessor_in,
-         moving_mesh_in,
-         matrix_free_in),
+  std::shared_ptr<Operator>                       operator_in,
+  InputParameters const &                         param_in,
+  unsigned int const                              refine_steps_time_in,
+  MPI_Comm const &                                mpi_comm_in,
+  bool const                                      is_test_in,
+  std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in)
+  : Base(operator_in, param_in, refine_steps_time_in, mpi_comm_in, is_test_in, postprocessor_in),
     pde_operator(operator_in),
     velocity(this->order),
     pressure(this->order),
@@ -164,7 +155,7 @@ void
 TimeIntBDFDualSplitting<dim, Number>::initialize_current_solution()
 {
   if(this->param.ale_formulation)
-    this->move_mesh(this->get_time());
+    pde_operator->move_grid(this->get_time());
 
   pde_operator->prescribe_initial_conditions(velocity[0], pressure[0], this->get_time());
 }
@@ -177,7 +168,7 @@ TimeIntBDFDualSplitting<dim, Number>::initialize_former_solutions()
   for(unsigned int i = 1; i < velocity.size(); ++i)
   {
     if(this->param.ale_formulation)
-      this->move_mesh(this->get_previous_time(i));
+      pde_operator->move_grid(this->get_previous_time(i));
 
     pde_operator->prescribe_initial_conditions(velocity[i],
                                                pressure[i],
@@ -191,7 +182,7 @@ TimeIntBDFDualSplitting<dim, Number>::initialize_acceleration_and_velocity_on_bo
 {
   // fill vector velocity_dbc: The first entry [0] is already needed if start_with_low_order == true
   if(this->param.ale_formulation)
-    this->move_mesh_and_update_dependent_data_structures(this->get_time());
+    pde_operator->move_grid_and_update_dependent_data_structures(this->get_time());
   pde_operator->interpolate_velocity_dirichlet_bc(velocity_dbc[0], this->get_time());
   // ... and previous times if start_with_low_order == false
   if(this->start_with_low_order == false)
@@ -200,7 +191,7 @@ TimeIntBDFDualSplitting<dim, Number>::initialize_acceleration_and_velocity_on_bo
     {
       double const time = this->get_time() - double(i) * this->get_time_step_size();
       if(this->param.ale_formulation)
-        this->move_mesh_and_update_dependent_data_structures(time);
+        pde_operator->move_grid_and_update_dependent_data_structures(time);
       pde_operator->interpolate_velocity_dirichlet_bc(velocity_dbc[i], time);
     }
   }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -45,15 +45,12 @@ private:
   typedef OperatorDualSplitting<dim, Number> Operator;
 
 public:
-  TimeIntBDFDualSplitting(
-    std::shared_ptr<Operator>                         pde_operator_in,
-    InputParameters const &                           param_in,
-    unsigned int const                                refine_steps_time_in,
-    MPI_Comm const &                                  mpi_comm_in,
-    bool const                                        is_test_in,
-    std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
-    std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
-    std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
+  TimeIntBDFDualSplitting(std::shared_ptr<Operator>                       pde_operator_in,
+                          InputParameters const &                         param_in,
+                          unsigned int const                              refine_steps_time_in,
+                          MPI_Comm const &                                mpi_comm_in,
+                          bool const                                      is_test_in,
+                          std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in);
 
   virtual ~TimeIntBDFDualSplitting()
   {

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -45,15 +45,12 @@ private:
   typedef OperatorPressureCorrection<dim, Number> Operator;
 
 public:
-  TimeIntBDFPressureCorrection(
-    std::shared_ptr<Operator>                         operator_in,
-    InputParameters const &                           param_in,
-    unsigned int const                                refine_steps_time_in,
-    MPI_Comm const &                                  mpi_comm_in,
-    bool const                                        is_test_in,
-    std::shared_ptr<PostProcessorInterface<Number>>   postprocessor_in,
-    std::shared_ptr<MovingMeshInterface<dim, Number>> moving_mesh_in = nullptr,
-    std::shared_ptr<MatrixFree<dim, Number>>          matrix_free_in = nullptr);
+  TimeIntBDFPressureCorrection(std::shared_ptr<Operator>                       operator_in,
+                               InputParameters const &                         param_in,
+                               unsigned int const                              refine_steps_time_in,
+                               MPI_Comm const &                                mpi_comm_in,
+                               bool const                                      is_test_in,
+                               std::shared_ptr<PostProcessorInterface<Number>> postprocessor_in);
 
   virtual ~TimeIntBDFPressureCorrection()
   {

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -77,7 +77,7 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
@@ -164,7 +164,7 @@ public:
   virtual void
   set_input_parameters_precursor(InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid_precursor(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void

--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -102,15 +102,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   }
 
   // initialize Poisson operator
-  pde_operator.reset(new Operator<dim, Number>(*grid->triangulation,
-                                               grid->mapping,
-                                               degree,
-                                               grid->periodic_faces,
-                                               boundary_descriptor,
-                                               field_functions,
-                                               param,
-                                               "Poisson",
-                                               mpi_comm));
+  pde_operator.reset(new Operator<dim, Number>(
+    grid, degree, boundary_descriptor, field_functions, param, "Poisson", mpi_comm));
 
   // initialize matrix_free
   matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -146,7 +146,7 @@ private:
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
   // grid
-  std::shared_ptr<Grid<dim>> grid;
+  std::shared_ptr<Grid<dim, Number>> grid;
 
   InputParameters param;
 

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -167,7 +167,7 @@ MultigridPreconditioner<dim, Number, n_components>::update_operators_after_mesh_
 {
   for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
   {
-    get_operator(level)->update_after_mesh_movement();
+    get_operator(level)->update_penalty_parameter();
   }
 }
 

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -38,8 +38,8 @@ template<int dim, typename Number, int n_components>
 void
 MultigridPreconditioner<dim, Number, n_components>::initialize(
   MultigridData const &                  mg_data,
-  const Triangulation<dim> *             tria,
-  const FiniteElement<dim> &             fe,
+  Triangulation<dim> const *             tria,
+  FiniteElement<dim> const &             fe,
   std::shared_ptr<Mapping<dim> const>    mapping,
   LaplaceOperatorData<rank, dim> const & data_in,
   bool const                             mesh_is_moving,

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -44,7 +44,7 @@ MultigridPreconditioner<dim, Number, n_components>::initialize(
   LaplaceOperatorData<rank, dim> const & data_in,
   bool const                             mesh_is_moving,
   Map const *                            dirichlet_bc,
-  PeriodicFacePairs *                    periodic_face_pairs)
+  PeriodicFacePairs const *              periodic_face_pairs)
 {
   data = data_in;
 

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -61,8 +61,8 @@ public:
 
   void
   initialize(MultigridData const &                  mg_data,
-             const Triangulation<dim> *             tria,
-             const FiniteElement<dim> &             fe,
+             Triangulation<dim> const *             tria,
+             FiniteElement<dim> const &             fe,
              std::shared_ptr<Mapping<dim> const>    mapping,
              LaplaceOperatorData<rank, dim> const & data_in,
              bool const                             mesh_is_moving,

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -67,7 +67,7 @@ public:
              LaplaceOperatorData<rank, dim> const & data_in,
              bool const                             mesh_is_moving,
              Map const *                            dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                    periodic_face_pairs = nullptr);
+             PeriodicFacePairs const *              periodic_face_pairs = nullptr);
 
   void
   update() override;

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -59,7 +59,7 @@ LaplaceOperator<dim, Number, n_components>::calculate_penalty_parameter(
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::update_after_mesh_movement()
+LaplaceOperator<dim, Number, n_components>::update_penalty_parameter()
 {
   calculate_penalty_parameter(this->get_matrix_free(), this->get_data().dof_index);
 }

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -243,7 +243,7 @@ public:
                               unsigned int const              dof_index);
 
   void
-  update_after_mesh_movement();
+  update_penalty_parameter();
 
   // Some more functionality on top of what is provided by the base class.
   // This function evaluates the inhomogeneous boundary face integrals in DG where the

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -46,7 +46,7 @@ using namespace dealii;
 
 template<int dim, typename Number, int n_components>
 Operator<dim, Number, n_components>::Operator(
-  std::shared_ptr<Grid<dim> const>                     grid_in,
+  std::shared_ptr<Grid<dim, Number> const>             grid_in,
   unsigned int const                                   degree_in,
   std::shared_ptr<BoundaryDescriptor<rank, dim>> const boundary_descriptor_in,
   std::shared_ptr<FieldFunctions<dim>> const           field_functions_in,

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -46,24 +46,21 @@ using namespace dealii;
 
 template<int dim, typename Number, int n_components>
 Operator<dim, Number, n_components>::Operator(
-  Triangulation<dim> const &                           triangulation_in,
-  std::shared_ptr<Mapping<dim> const>                  mapping_in,
+  std::shared_ptr<Grid<dim> const>                     grid_in,
   unsigned int const                                   degree_in,
-  PeriodicFaces const                                  periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptor<rank, dim>> const boundary_descriptor_in,
   std::shared_ptr<FieldFunctions<dim>> const           field_functions_in,
   InputParameters const &                              param_in,
   std::string const &                                  field_in,
   MPI_Comm const &                                     mpi_comm_in)
   : dealii::Subscriptor(),
-    mapping(mapping_in),
+    grid(grid_in),
     degree(degree_in),
-    periodic_face_pairs(periodic_face_pairs_in),
     boundary_descriptor(boundary_descriptor_in),
     field_functions(field_functions_in),
     param(param_in),
     field(field_in),
-    dof_handler(triangulation_in),
+    dof_handler(*grid_in->triangulation),
     mpi_comm(mpi_comm_in),
     pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_in) == 0)
 {
@@ -260,11 +257,11 @@ Operator<dim, Number, n_components>::setup_solver()
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),
                                   dof_handler.get_fe(),
-                                  mapping,
+                                  grid->mapping,
                                   laplace_operator.get_data(),
                                   false /* moving_mesh */,
                                   &laplace_operator.get_data().bc->dirichlet_bc,
-                                  &periodic_face_pairs);
+                                  &grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -54,7 +54,7 @@ private:
 #endif
 
 public:
-  Operator(std::shared_ptr<Grid<dim> const>                     grid,
+  Operator(std::shared_ptr<Grid<dim, Number> const>             grid,
            unsigned int const                                   degree,
            std::shared_ptr<BoundaryDescriptor<rank, dim>> const boundary_descriptor,
            std::shared_ptr<FieldFunctions<dim>> const           field_functions,
@@ -164,7 +164,7 @@ private:
   /*
    * Grid
    */
-  std::shared_ptr<Grid<dim> const> grid;
+  std::shared_ptr<Grid<dim, Number> const> grid;
 
   /*
    * Polynomial degree

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -22,24 +22,16 @@
 #ifndef INCLUDE_LAPLACE_DG_LAPLACE_OPERATION_H_
 #define INCLUDE_LAPLACE_DG_LAPLACE_OPERATION_H_
 
-// deal.II
-#include <deal.II/fe/mapping_q.h>
-
 // ExaDG
-
-// matrix-free
+#include <exadg/grid/grid.h>
 #include <exadg/matrix_free/matrix_free_data.h>
-
-// operators
 #include <exadg/operators/rhs_operator.h>
 #include <exadg/poisson/spatial_discretization/laplace_operator.h>
-#include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
-
-// user interface
 #include <exadg/poisson/user_interface/analytical_solution.h>
 #include <exadg/poisson/user_interface/boundary_descriptor.h>
 #include <exadg/poisson/user_interface/field_functions.h>
 #include <exadg/poisson/user_interface/input_parameters.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
 
 namespace ExaDG
 {
@@ -61,14 +53,9 @@ private:
   typedef LinearAlgebra::distributed::Vector<double> VectorTypeDouble;
 #endif
 
-  typedef std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    PeriodicFaces;
-
 public:
-  Operator(Triangulation<dim> const &                           triangulation,
-           std::shared_ptr<Mapping<dim> const>                  mapping,
+  Operator(std::shared_ptr<Grid<dim> const>                     grid,
            unsigned int const                                   degree,
-           PeriodicFaces const                                  periodic_face_pairs,
            std::shared_ptr<BoundaryDescriptor<rank, dim>> const boundary_descriptor,
            std::shared_ptr<FieldFunctions<dim>> const           field_functions,
            InputParameters const &                              param,
@@ -175,20 +162,14 @@ private:
   setup_operators();
 
   /*
-   * Mapping
+   * Grid
    */
-  std::shared_ptr<Mapping<dim> const> mapping;
+  std::shared_ptr<Grid<dim> const> grid;
 
   /*
    * Polynomial degree
    */
   unsigned int const degree;
-
-  /*
-   * Periodic face pairs: This variable is only needed when using a multigrid preconditioner
-   */
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    periodic_face_pairs;
 
   /*
    * User interface: Boundary conditions and field functions.

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -75,7 +75,7 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void

--- a/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
@@ -80,7 +80,8 @@ void
 add_periodicity_constraints(
   DoFHandler<dim> const & dof_handler,
   unsigned int const      level,
-  std::vector<typename GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
+  std::vector<
+    typename GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const &
                               periodic_face_pairs_level0,
   AffineConstraints<Number> & affine_constraints_own)
 {
@@ -115,7 +116,7 @@ add_constraints(
   DoFHandler<dim> const &     dof_handler,
   AffineConstraints<Number> & affine_constraints_own,
   MGConstrainedDoFs const &   mg_constrained_dofs,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
+  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const &
                      periodic_face_pairs,
   unsigned int const level)
 {

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -58,9 +58,9 @@ MultigridPreconditionerBase<dim, Number>::initialize(MultigridData const &      
                                                      Triangulation<dim> const *          tria,
                                                      FiniteElement<dim> const &          fe,
                                                      std::shared_ptr<Mapping<dim> const> mapping,
-                                                     bool const          operator_is_singular,
-                                                     Map const *         dirichlet_bc,
-                                                     PeriodicFacePairs * periodic_face_pairs)
+                                                     bool const                operator_is_singular,
+                                                     Map const *               dirichlet_bc,
+                                                     PeriodicFacePairs const * periodic_face_pairs)
 {
   this->data = data;
 
@@ -631,7 +631,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::initialize_dof_handler_and_constraints(
   bool const                 operator_is_singular,
-  PeriodicFacePairs *        periodic_face_pairs_in,
+  PeriodicFacePairs const *  periodic_face_pairs_in,
   FiniteElement<dim> const & fe,
   Triangulation<dim> const * tria,
   Map const *                dirichlet_bc_in)
@@ -673,7 +673,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constraints(
   bool                                                                 is_singular,
-  PeriodicFacePairs &                                                  periodic_face_pairs,
+  PeriodicFacePairs const &                                            periodic_face_pairs,
   FiniteElement<dim> const &                                           fe,
   Triangulation<dim> const *                                           tria,
   Map const &                                                          dirichlet_bc,

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -100,7 +100,7 @@ public:
              std::shared_ptr<Mapping<dim> const> mapping,
              bool const                          operator_is_singular = false,
              Map const *                         dirichlet_bc         = nullptr,
-             PeriodicFacePairs *                 periodic_face_pairs  = nullptr);
+             PeriodicFacePairs const *           periodic_face_pairs  = nullptr);
 
   /*
    * This function applies the multigrid preconditioner dst = P^{-1} src.
@@ -173,7 +173,7 @@ protected:
    */
   virtual void
   initialize_dof_handler_and_constraints(bool                       is_singular,
-                                         PeriodicFacePairs *        periodic_face_pairs,
+                                         PeriodicFacePairs const *  periodic_face_pairs,
                                          FiniteElement<dim> const & fe,
                                          Triangulation<dim> const * tria,
                                          Map const *                dirichlet_bc);
@@ -181,7 +181,7 @@ protected:
   void
   do_initialize_dof_handler_and_constraints(
     bool                                                                 is_singular,
-    PeriodicFacePairs &                                                  periodic_face_pairs,
+    PeriodicFacePairs const &                                            periodic_face_pairs,
     FiniteElement<dim> const &                                           fe,
     Triangulation<dim> const *                                           tria,
     Map const &                                                          dirichlet_bc,

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -93,10 +93,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   application->set_field_functions(field_functions);
 
   // setup spatial operator
-  pde_operator.reset(new Operator<dim, Number>(*grid->triangulation,
-                                               grid->mapping,
+  pde_operator.reset(new Operator<dim, Number>(grid,
                                                degree,
-                                               grid->periodic_faces,
                                                boundary_descriptor,
                                                field_functions,
                                                material_descriptor,

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -131,7 +131,7 @@ private:
   InputParameters param;
 
   // grid
-  std::shared_ptr<Grid<dim>> grid;
+  std::shared_ptr<Grid<dim, Number>> grid;
 
   // material descriptor
   std::shared_ptr<MaterialDescriptor> material_descriptor;

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -43,7 +43,7 @@ MultigridPreconditioner<dim, Number>::initialize(
   ElasticityOperatorBase<dim, Number> const & pde_operator,
   bool const                                  nonlinear_operator,
   Map const *                                 dirichlet_bc,
-  PeriodicFacePairs *                         periodic_face_pairs)
+  PeriodicFacePairs const *                   periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -68,7 +68,7 @@ public:
              ElasticityOperatorBase<dim, Number> const & pde_operator,
              bool const                                  nonlinear_operator,
              Map const *                                 dirichlet_bc        = nullptr,
-             PeriodicFacePairs *                         periodic_face_pairs = nullptr);
+             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -39,10 +39,8 @@ using namespace dealii;
 
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
-  Triangulation<dim> &                           triangulation_in,
-  std::shared_ptr<Mapping<dim> const>            mapping_in,
+  std::shared_ptr<Grid<dim> const>               grid_in,
   unsigned int const &                           degree_in,
-  PeriodicFaces const &                          periodic_face_pairs_in,
   std::shared_ptr<BoundaryDescriptor<dim>> const boundary_descriptor_in,
   std::shared_ptr<FieldFunctions<dim>> const     field_functions_in,
   std::shared_ptr<MaterialDescriptor> const      material_descriptor_in,
@@ -50,8 +48,7 @@ Operator<dim, Number>::Operator(
   std::string const &                            field_in,
   MPI_Comm const &                               mpi_comm_in)
   : dealii::Subscriptor(),
-    mapping(mapping_in),
-    periodic_face_pairs(periodic_face_pairs_in),
+    grid(grid_in),
     boundary_descriptor(boundary_descriptor_in),
     field_functions(field_functions_in),
     material_descriptor(material_descriptor_in),
@@ -59,7 +56,7 @@ Operator<dim, Number>::Operator(
     field(field_in),
     degree(degree_in),
     fe(FE_Q<dim>(degree_in), dim),
-    dof_handler(triangulation_in),
+    dof_handler(*grid_in->triangulation),
     mpi_comm(mpi_comm_in),
     pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_in) == 0)
 {
@@ -350,11 +347,11 @@ Operator<dim, Number>::initialize_preconditioner()
       mg_preconditioner->initialize(param.multigrid_data,
                                     &dof_handler.get_triangulation(),
                                     dof_handler.get_fe(),
-                                    mapping,
+                                    grid->mapping,
                                     elasticity_operator_nonlinear,
                                     true,
                                     &elasticity_operator_nonlinear.get_data().bc->dirichlet_bc,
-                                    &this->periodic_face_pairs);
+                                    &grid->periodic_faces);
     }
     else
     {
@@ -367,11 +364,11 @@ Operator<dim, Number>::initialize_preconditioner()
       mg_preconditioner->initialize(param.multigrid_data,
                                     &dof_handler.get_triangulation(),
                                     dof_handler.get_fe(),
-                                    mapping,
+                                    grid->mapping,
                                     elasticity_operator_linear,
                                     false,
                                     &elasticity_operator_linear.get_data().bc->dirichlet_bc,
-                                    &this->periodic_face_pairs);
+                                    &grid->periodic_faces);
     }
   }
   else if(param.preconditioner == Preconditioner::AMG)
@@ -733,7 +730,7 @@ template<int dim, typename Number>
 Mapping<dim> const &
 Operator<dim, Number>::get_mapping() const
 {
-  return *mapping;
+  return *grid->mapping;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -39,7 +39,7 @@ using namespace dealii;
 
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
-  std::shared_ptr<Grid<dim> const>               grid_in,
+  std::shared_ptr<Grid<dim, Number> const>       grid_in,
   unsigned int const &                           degree_in,
   std::shared_ptr<BoundaryDescriptor<dim>> const boundary_descriptor_in,
   std::shared_ptr<FieldFunctions<dim>> const     field_functions_in,

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -173,7 +173,7 @@ public:
   /*
    * Constructor.
    */
-  Operator(std::shared_ptr<Grid<dim> const>               grid_in,
+  Operator(std::shared_ptr<Grid<dim, Number> const>       grid_in,
            unsigned int const &                           degree_in,
            std::shared_ptr<BoundaryDescriptor<dim>> const boundary_descriptor_in,
            std::shared_ptr<FieldFunctions<dim>> const     field_functions_in,
@@ -351,7 +351,7 @@ private:
   /*
    * Grid
    */
-  std::shared_ptr<Grid<dim> const> grid;
+  std::shared_ptr<Grid<dim, Number> const> grid;
 
   /*
    * User interface.

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -24,9 +24,9 @@
 
 // deal.II
 #include <deal.II/fe/fe_system.h>
-#include <deal.II/fe/mapping_q.h>
 
 // ExaDG
+#include <exadg/grid/grid.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
 #include <exadg/operators/mass_operator.h>
@@ -169,17 +169,12 @@ private:
 
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-    PeriodicFaces;
-
 public:
   /*
    * Constructor.
    */
-  Operator(Triangulation<dim> &                           triangulation_in,
-           std::shared_ptr<Mapping<dim> const>            mapping_in,
+  Operator(std::shared_ptr<Grid<dim> const>               grid_in,
            unsigned int const &                           degree_in,
-           PeriodicFaces const &                          periodic_face_pairs_in,
            std::shared_ptr<BoundaryDescriptor<dim>> const boundary_descriptor_in,
            std::shared_ptr<FieldFunctions<dim>> const     field_functions_in,
            std::shared_ptr<MaterialDescriptor> const      material_descriptor_in,
@@ -354,14 +349,9 @@ private:
   initialize_solver();
 
   /*
-   * Mapping
+   * Grid
    */
-  std::shared_ptr<Mapping<dim> const> mapping;
-
-  /*
-   * Periodic boundaries.
-   */
-  PeriodicFaces periodic_face_pairs;
+  std::shared_ptr<Grid<dim> const> grid;
 
   /*
    * User interface.

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -69,7 +69,7 @@ public:
   virtual void
   set_input_parameters(InputParameters & parameters) = 0;
 
-  virtual std::shared_ptr<Grid<dim>>
+  virtual std::shared_ptr<Grid<dim, Number>>
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void

--- a/include/exadg/utilities/print_general_infos.h
+++ b/include/exadg/utilities/print_general_infos.h
@@ -116,9 +116,9 @@ print_matrixfree_info(ConditionalOStream const & pcout)
   // clang-format on
 }
 
-template<int dim>
+template<int dim, typename Number>
 inline void
-print_grid_info(ConditionalOStream const & pcout, Grid<dim> const & grid)
+print_grid_info(ConditionalOStream const & pcout, Grid<dim, Number> const & grid)
 {
   pcout << std::endl
         << "Generating grid for " << dim << "-dimensional problem:" << std::endl


### PR DESCRIPTION
This is the next PR related to the introduction of the new `ExaDG::Grid` class, see PR #80.

In the present PR, the `ExaDG::Grid` class is injected into the spatial discretization operators. It could make sense to inject `ExaDG::Grid` into `MultigridPreconditioner` in a next step (?).

The time integrators no longer depend on `MovingMeshInterface` and `MatrixFree`, since these aspects are more closely related to the spatial discretization scheme and should therefore be handled by the `pde_operator` in the time integrator class, i.e., matrix-free evaluation is a detail of the spatial discretization that should not be visible by the time integrator.

Some renaming has been performed due to a change in terminology from "Mesh" to "Grid", related to PR #80.