### PR TITLE
Refactor CompNS::BoundaryDescriptor

### DIFF
--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -235,36 +235,35 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_density,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pressure,
-                          std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
     // density
-    boundary_descriptor_density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
-    boundary_descriptor_density->dirichlet_bc.insert(pair(1, new DensityBC<dim>()));
-    //  boundary_descriptor_density->neumann_bc.insert(pair(0,new Functions::ZeroFunction<dim>(1)));
-    //  boundary_descriptor_density->neumann_bc.insert(pair(1,new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
+    boundary_descriptor->density->dirichlet_bc.insert(pair(1, new DensityBC<dim>()));
+    //  boundary_descriptor->density->neumann_bc.insert(pair(0,new
+    //  Functions::ZeroFunction<dim>(1)));
+    //  boundary_descriptor->density->neumann_bc.insert(pair(1,new
+    //  Functions::ZeroFunction<dim>(1)));
 
     // velocity
-    boundary_descriptor_velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor_velocity->dirichlet_bc.insert(pair(1, new VelocityBC<dim>()));
+    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->velocity->dirichlet_bc.insert(pair(1, new VelocityBC<dim>()));
 
     // pressure
-    boundary_descriptor_pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor_pressure->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
 
     // energy: prescribe temperature
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Temperature));
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(1, EnergyBoundaryVariable::Temperature));
 
-    boundary_descriptor_energy->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor_energy->dirichlet_bc.insert(
+    boundary_descriptor->energy->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy->dirichlet_bc.insert(
       pair(1, new Functions::ConstantFunction<dim>(T_0, 1)));
   }
 

--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -235,7 +235,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;

--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -241,29 +241,29 @@ public:
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
     // density
-    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
-    boundary_descriptor->density->dirichlet_bc.insert(pair(1, new DensityBC<dim>()));
-    //  boundary_descriptor->density->neumann_bc.insert(pair(0,new
+    boundary_descriptor->density.dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
+    boundary_descriptor->density.dirichlet_bc.insert(pair(1, new DensityBC<dim>()));
+    //  boundary_descriptor->density.neumann_bc.insert(pair(0,new
     //  Functions::ZeroFunction<dim>(1)));
-    //  boundary_descriptor->density->neumann_bc.insert(pair(1,new
+    //  boundary_descriptor->density.neumann_bc.insert(pair(1,new
     //  Functions::ZeroFunction<dim>(1)));
 
     // velocity
-    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor->velocity->dirichlet_bc.insert(pair(1, new VelocityBC<dim>()));
+    boundary_descriptor->velocity.dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->velocity.dirichlet_bc.insert(pair(1, new VelocityBC<dim>()));
 
     // pressure
-    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->pressure->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
 
     // energy: prescribe temperature
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Temperature));
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(1, EnergyBoundaryVariable::Temperature));
 
-    boundary_descriptor->energy->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->energy->dirichlet_bc.insert(
+    boundary_descriptor->energy.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy.dirichlet_bc.insert(
       pair(1, new Functions::ConstantFunction<dim>(T_0, 1)));
   }
 

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -273,21 +273,18 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_density,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pressure,
-                          std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
-    boundary_descriptor_density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
-    boundary_descriptor_velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor_pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
+    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
     // energy: prescribe energy
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
-    boundary_descriptor_energy->dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
+    boundary_descriptor->energy->dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
   }
 
   void

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -273,7 +273,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -278,13 +278,13 @@ public:
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
-    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
-    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->density.dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
+    boundary_descriptor->velocity.dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
     // energy: prescribe energy
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
-    boundary_descriptor->energy->dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
+    boundary_descriptor->energy.dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
   }
 
   void

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -459,13 +459,13 @@ public:
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
-    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
-    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->energy->dirichlet_bc.insert(
+    boundary_descriptor->density.dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
+    boundary_descriptor->velocity.dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy.dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(E_0, 1)));
     // set energy boundary variable
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
   }
 

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -454,7 +454,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -454,21 +454,18 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_density,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pressure,
-                          std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
-    boundary_descriptor_density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
-    boundary_descriptor_velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor_pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor_energy->dirichlet_bc.insert(
+    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
+    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy->dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(E_0, 1)));
     // set energy boundary variable
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
   }
 

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -210,28 +210,27 @@ public:
     // density
     // For Neumann boundaries, no value is prescribed (only first derivative of density occurs in
     // equations). Hence the specified function is irrelevant (i.e., it is not used).
-    boundary_descriptor->density->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->density->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->density.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->density.neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
 
     // velocity
-    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor->velocity->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+    boundary_descriptor->velocity.dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->velocity.neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(dim)));
 
     // pressure
-    boundary_descriptor->pressure->dirichlet_bc.insert(
+    boundary_descriptor->pressure.dirichlet_bc.insert(
       pair(1, new Functions::ConstantFunction<dim>(RHO_0 * R * T_0, 1)));
-    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
 
     // energy: prescribe temperature
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Temperature));
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(1, EnergyBoundaryVariable::Temperature));
 
-    boundary_descriptor->energy->dirichlet_bc.insert(
+    boundary_descriptor->energy.dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(T_0, 1)));
-    boundary_descriptor->energy->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy.neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
   }
 
   void

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -198,7 +198,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -198,10 +198,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_density,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pressure,
-                          std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
@@ -213,27 +210,28 @@ public:
     // density
     // For Neumann boundaries, no value is prescribed (only first derivative of density occurs in
     // equations). Hence the specified function is irrelevant (i.e., it is not used).
-    boundary_descriptor_density->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor_density->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->density->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->density->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
 
     // velocity
-    boundary_descriptor_velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor_velocity->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(dim)));
+    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->velocity->neumann_bc.insert(
+      pair(1, new Functions::ZeroFunction<dim>(dim)));
 
     // pressure
-    boundary_descriptor_pressure->dirichlet_bc.insert(
+    boundary_descriptor->pressure->dirichlet_bc.insert(
       pair(1, new Functions::ConstantFunction<dim>(RHO_0 * R * T_0, 1)));
-    boundary_descriptor_pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
 
     // energy: prescribe temperature
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Temperature));
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(1, EnergyBoundaryVariable::Temperature));
 
-    boundary_descriptor_energy->dirichlet_bc.insert(
+    boundary_descriptor->energy->dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(T_0, 1)));
-    boundary_descriptor_energy->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
   }
 
   void

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -198,22 +198,19 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_density,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pressure,
-                          std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
-    boundary_descriptor_density->dirichlet_bc.insert(
+    boundary_descriptor->density->dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(RHO_0, 1)));
-    boundary_descriptor_velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor_pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
     // energy: prescribe energy
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
-    boundary_descriptor_energy->dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
+    boundary_descriptor->energy->dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
   }
 
   void

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -203,14 +203,14 @@ public:
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
-    boundary_descriptor->density->dirichlet_bc.insert(
+    boundary_descriptor->density.dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(RHO_0, 1)));
-    boundary_descriptor->velocity->dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
-    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->velocity.dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
     // energy: prescribe energy
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
-    boundary_descriptor->energy->dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
+    boundary_descriptor->energy.dirichlet_bc.insert(pair(0, new EnergyBC<dim>()));
   }
 
   void

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -198,7 +198,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -255,11 +255,7 @@ public:
     return grid;
   }
 
-  void set_boundary_conditions(
-    std::shared_ptr<BoundaryDescriptor<dim>> /*boundary_descriptor_density*/,
-    std::shared_ptr<BoundaryDescriptor<dim>> /*boundary_descriptor_velocity*/,
-    std::shared_ptr<BoundaryDescriptor<dim>> /*boundary_descriptor_pressure*/,
-    std::shared_ptr<BoundaryDescriptorEnergy<dim>> /*boundary_descriptor_energy*/)
+  void set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> /*boundary_descriptor*/)
   {
     // test case with periodic BC -> boundary descriptors remain empty
   }

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -255,8 +255,11 @@ public:
     return grid;
   }
 
-  void set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> /*boundary_descriptor*/)
+  void
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
+    (void)boundary_descriptor;
+
     // test case with periodic BC -> boundary descriptors remain empty
   }
 

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -89,13 +89,13 @@ public:
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
     // these lines show exemplarily how the boundary descriptors are filled
-    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->velocity->dirichlet_bc.insert(
+    boundary_descriptor->density.dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->velocity.dirichlet_bc.insert(
       pair(0, new Functions::ZeroFunction<dim>(dim)));
-    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->energy->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy.dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
     // set energy boundary variable
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
   }
 

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -83,22 +83,19 @@ public:
 
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_density,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pressure,
-                          std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
     // these lines show exemplarily how the boundary descriptors are filled
-    boundary_descriptor_density->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor_velocity->dirichlet_bc.insert(
+    boundary_descriptor->density->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->velocity->dirichlet_bc.insert(
       pair(0, new Functions::ZeroFunction<dim>(dim)));
-    boundary_descriptor_pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor_energy->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->energy->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
     // set energy boundary variable
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
   }
 

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -83,7 +83,7 @@ public:
 
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -369,15 +369,15 @@ public:
 
     // For Neumann boundaries, no value is prescribed (only first derivative of density occurs in
     // equations). Hence the specified function is irrelevant (i.e., it is not used).
-    boundary_descriptor->density->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->velocity->dirichlet_bc.insert(
+    boundary_descriptor->density.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->velocity.dirichlet_bc.insert(
       pair(0, new Functions::ZeroFunction<dim>(dim)));
-    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure.neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
 
     // energy: prescribe temperature
-    boundary_descriptor->energy->boundary_variable.insert(
+    boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Temperature));
-    boundary_descriptor->energy->dirichlet_bc.insert(
+    boundary_descriptor->energy.dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(T_0, 1)));
   }
 

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -362,7 +362,7 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) final
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -362,25 +362,22 @@ public:
   }
 
   void
-  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_density,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_velocity,
-                          std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pressure,
-                          std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy)
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor)
   {
     typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
     typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
 
     // For Neumann boundaries, no value is prescribed (only first derivative of density occurs in
     // equations). Hence the specified function is irrelevant (i.e., it is not used).
-    boundary_descriptor_density->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor_velocity->dirichlet_bc.insert(
+    boundary_descriptor->density->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->velocity->dirichlet_bc.insert(
       pair(0, new Functions::ZeroFunction<dim>(dim)));
-    boundary_descriptor_pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->pressure->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
 
     // energy: prescribe temperature
-    boundary_descriptor_energy->boundary_variable.insert(
+    boundary_descriptor->energy->boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Temperature));
-    boundary_descriptor_energy->dirichlet_bc.insert(
+    boundary_descriptor->energy->dirichlet_bc.insert(
       pair(0, new Functions::ConstantFunction<dim>(T_0, 1)));
   }
 

--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -79,35 +79,16 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   grid = application->create_grid(grid_data, mpi_comm);
   print_grid_info(pcout, *grid);
 
-  boundary_descriptor_density.reset(new BoundaryDescriptor<dim>());
-  boundary_descriptor_velocity.reset(new BoundaryDescriptor<dim>());
-  boundary_descriptor_pressure.reset(new BoundaryDescriptor<dim>());
-  boundary_descriptor_energy.reset(new BoundaryDescriptorEnergy<dim>());
-
-  application->set_boundary_conditions(boundary_descriptor_density,
-                                       boundary_descriptor_velocity,
-                                       boundary_descriptor_pressure,
-                                       boundary_descriptor_energy);
-
-  verify_boundary_conditions(*boundary_descriptor_density, *grid);
-  verify_boundary_conditions(*boundary_descriptor_velocity, *grid);
-  verify_boundary_conditions(*boundary_descriptor_pressure, *grid);
-  verify_boundary_conditions(*boundary_descriptor_energy, *grid);
+  boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
+  application->set_boundary_conditions(boundary_descriptor);
+  CompNS::verify_boundary_conditions<dim>(boundary_descriptor, *grid);
 
   field_functions.reset(new FieldFunctions<dim>());
   application->set_field_functions(field_functions);
 
   // initialize compressible Navier-Stokes operator
-  pde_operator.reset(new Operator<dim, Number>(grid,
-                                               degree,
-                                               boundary_descriptor_density,
-                                               boundary_descriptor_velocity,
-                                               boundary_descriptor_pressure,
-                                               boundary_descriptor_energy,
-                                               field_functions,
-                                               param,
-                                               "fluid",
-                                               mpi_comm));
+  pde_operator.reset(new Operator<dim, Number>(
+    grid, degree, boundary_descriptor, field_functions, param, "fluid", mpi_comm));
 
   // initialize matrix_free
   matrix_free_data.reset(new MatrixFreeData<dim, Number>());

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -147,11 +147,8 @@ private:
 
   std::shared_ptr<Grid<dim, Number>> grid;
 
-  std::shared_ptr<FieldFunctions<dim>>           field_functions;
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density;
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity;
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_pressure;
-  std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy;
+  std::shared_ptr<FieldFunctions<dim>>     field_functions;
+  std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor;
 
   std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
   std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
@@ -154,7 +154,7 @@ inline DEAL_II_ALWAYS_INLINE //
   Tensor<rank, dim, VectorizedArray<Number>>
   calculate_exterior_value(Tensor<rank, dim, VectorizedArray<Number>> const & value_m,
                            BoundaryType const                                 boundary_type,
-                           std::shared_ptr<BoundaryDescriptorStd<dim> const>  boundary_descriptor,
+                           BoundaryDescriptorStd<dim> const &                 boundary_descriptor,
                            types::boundary_id const &                         boundary_id,
                            Point<dim, VectorizedArray<Number>> const &        q_point,
                            Number const &                                     time)
@@ -163,7 +163,7 @@ inline DEAL_II_ALWAYS_INLINE //
 
   if(boundary_type == BoundaryType::Dirichlet)
   {
-    auto bc = boundary_descriptor->dirichlet_bc.find(boundary_id)->second;
+    auto bc = boundary_descriptor.dirichlet_bc.find(boundary_id)->second;
     auto g  = FunctionEvaluator<rank, dim, Number>::value(bc, q_point, time);
 
     value_p = -value_m + Tensor<rank, dim, VectorizedArray<Number>>(2.0 * g);
@@ -187,13 +187,12 @@ inline DEAL_II_ALWAYS_INLINE //
 template<int dim, typename Number, int rank>
 inline DEAL_II_ALWAYS_INLINE //
   Tensor<rank, dim, VectorizedArray<Number>>
-  calculate_exterior_normal_grad(
-    Tensor<rank, dim, VectorizedArray<Number>> const & grad_M_normal,
-    BoundaryType const &                               boundary_type,
-    std::shared_ptr<BoundaryDescriptorStd<dim> const>  boundary_descriptor,
-    types::boundary_id const &                         boundary_id,
-    Point<dim, VectorizedArray<Number>> const &        q_point,
-    Number const &                                     time)
+  calculate_exterior_normal_grad(Tensor<rank, dim, VectorizedArray<Number>> const & grad_M_normal,
+                                 BoundaryType const &                               boundary_type,
+                                 BoundaryDescriptorStd<dim> const &          boundary_descriptor,
+                                 types::boundary_id const &                  boundary_id,
+                                 Point<dim, VectorizedArray<Number>> const & q_point,
+                                 Number const &                              time)
 {
   Tensor<rank, dim, VectorizedArray<Number>> grad_P_normal;
 
@@ -204,7 +203,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(boundary_type == BoundaryType::Neumann)
   {
-    auto bc = boundary_descriptor->neumann_bc.find(boundary_id)->second;
+    auto bc = boundary_descriptor.neumann_bc.find(boundary_id)->second;
     auto h  = FunctionEvaluator<rank, dim, Number>::value(bc, q_point, time);
 
     grad_P_normal = -grad_M_normal + Tensor<rank, dim, VectorizedArray<Number>>(2.0 * h);
@@ -864,13 +863,12 @@ private:
 
       types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
 
-      BoundaryType boundary_type_density  = data.bc->density->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_velocity = data.bc->velocity->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_pressure = data.bc->pressure->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_energy   = data.bc->energy->get_boundary_type(boundary_id);
+      BoundaryType boundary_type_density  = data.bc->density.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_velocity = data.bc->velocity.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_pressure = data.bc->pressure.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_energy   = data.bc->energy.get_boundary_type(boundary_id);
 
-      EnergyBoundaryVariable boundary_variable =
-        data.bc->energy->get_boundary_variable(boundary_id);
+      EnergyBoundaryVariable boundary_variable = data.bc->energy.get_boundary_variable(boundary_id);
 
       for(unsigned int q = 0; q < density.n_q_points; ++q)
       {
@@ -1552,12 +1550,11 @@ private:
 
       types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
 
-      BoundaryType boundary_type_density  = data.bc->density->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_velocity = data.bc->velocity->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_energy   = data.bc->energy->get_boundary_type(boundary_id);
+      BoundaryType boundary_type_density  = data.bc->density.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_velocity = data.bc->velocity.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_energy   = data.bc->energy.get_boundary_type(boundary_id);
 
-      EnergyBoundaryVariable boundary_variable =
-        data.bc->energy->get_boundary_variable(boundary_id);
+      EnergyBoundaryVariable boundary_variable = data.bc->energy.get_boundary_variable(boundary_id);
 
       for(unsigned int q = 0; q < density.n_q_points; ++q)
       {
@@ -1846,13 +1843,12 @@ private:
 
       types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
 
-      BoundaryType boundary_type_density  = data.bc->density->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_velocity = data.bc->velocity->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_pressure = data.bc->pressure->get_boundary_type(boundary_id);
-      BoundaryType boundary_type_energy   = data.bc->energy->get_boundary_type(boundary_id);
+      BoundaryType boundary_type_density  = data.bc->density.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_velocity = data.bc->velocity.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_pressure = data.bc->pressure.get_boundary_type(boundary_id);
+      BoundaryType boundary_type_energy   = data.bc->energy.get_boundary_type(boundary_id);
 
-      EnergyBoundaryVariable boundary_variable =
-        data.bc->energy->get_boundary_variable(boundary_id);
+      EnergyBoundaryVariable boundary_variable = data.bc->energy.get_boundary_variable(boundary_id);
 
       for(unsigned int q = 0; q < density.n_q_points; ++q)
       {

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
@@ -661,7 +661,7 @@ public:
     // calculate rho_P
     scalar rho_P = calculate_exterior_value<dim, Number, 0>(rho_M,
                                                             boundary_type_density,
-                                                            data.bc->energy,
+                                                            data.bc->density,
                                                             boundary_id,
                                                             density.quadrature_point(q),
                                                             this->eval_time);

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -37,10 +37,7 @@ template<int dim, typename Number>
 Operator<dim, Number>::Operator(
   std::shared_ptr<Grid<dim, Number> const>       grid_in,
   unsigned int const                             degree_in,
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity_in,
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_pressure_in,
-  std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy_in,
+  std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor_in,
   std::shared_ptr<FieldFunctions<dim>>           field_functions_in,
   InputParameters const &                        param_in,
   std::string const &                            field_in,
@@ -48,10 +45,7 @@ Operator<dim, Number>::Operator(
   : dealii::Subscriptor(),
     grid(grid_in),
     degree(degree_in),
-    boundary_descriptor_density(boundary_descriptor_density_in),
-    boundary_descriptor_velocity(boundary_descriptor_velocity_in),
-    boundary_descriptor_pressure(boundary_descriptor_pressure_in),
-    boundary_descriptor_energy(boundary_descriptor_energy_in),
+    boundary_descriptor(boundary_descriptor_in),
     field_functions(field_functions_in),
     param(param_in),
     field(field_in),
@@ -482,10 +476,7 @@ Operator<dim, Number>::setup_operators()
   ConvectiveOperatorData<dim> convective_operator_data;
   convective_operator_data.dof_index             = get_dof_index_all();
   convective_operator_data.quad_index            = get_quad_index_overintegration_conv();
-  convective_operator_data.bc_rho                = boundary_descriptor_density;
-  convective_operator_data.bc_u                  = boundary_descriptor_velocity;
-  convective_operator_data.bc_p                  = boundary_descriptor_pressure;
-  convective_operator_data.bc_E                  = boundary_descriptor_energy;
+  convective_operator_data.bc                    = boundary_descriptor;
   convective_operator_data.heat_capacity_ratio   = param.heat_capacity_ratio;
   convective_operator_data.specific_gas_constant = param.specific_gas_constant;
   convective_operator.initialize(*matrix_free, convective_operator_data);
@@ -500,9 +491,7 @@ Operator<dim, Number>::setup_operators()
   viscous_operator_data.thermal_conductivity  = param.thermal_conductivity;
   viscous_operator_data.heat_capacity_ratio   = param.heat_capacity_ratio;
   viscous_operator_data.specific_gas_constant = param.specific_gas_constant;
-  viscous_operator_data.bc_rho                = boundary_descriptor_density;
-  viscous_operator_data.bc_u                  = boundary_descriptor_velocity;
-  viscous_operator_data.bc_E                  = boundary_descriptor_energy;
+  viscous_operator_data.bc                    = boundary_descriptor;
   viscous_operator.initialize(*matrix_free, viscous_operator_data);
 
   if(param.use_combined_operator == true)
@@ -514,10 +503,7 @@ Operator<dim, Number>::setup_operators()
     CombinedOperatorData<dim> combined_operator_data;
     combined_operator_data.dof_index  = get_dof_index_all();
     combined_operator_data.quad_index = get_quad_index_overintegration_vis();
-    combined_operator_data.bc_rho     = boundary_descriptor_density;
-    combined_operator_data.bc_u       = boundary_descriptor_velocity;
-    combined_operator_data.bc_p       = boundary_descriptor_pressure;
-    combined_operator_data.bc_E       = boundary_descriptor_energy;
+    combined_operator_data.bc         = boundary_descriptor;
 
     combined_operator.initialize(*matrix_free,
                                  combined_operator_data,

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -51,16 +51,13 @@ private:
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
-  Operator(std::shared_ptr<Grid<dim, Number> const>       grid_in,
-           unsigned int const                             degree_in,
-           std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density_in,
-           std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity_in,
-           std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_pressure_in,
-           std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy_in,
-           std::shared_ptr<FieldFunctions<dim>>           field_functions_in,
-           InputParameters const &                        param_in,
-           std::string const &                            field_in,
-           MPI_Comm const &                               mpi_comm_in);
+  Operator(std::shared_ptr<Grid<dim, Number> const>       grid,
+           unsigned int const                             degree,
+           std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor,
+           std::shared_ptr<FieldFunctions<dim>>           field_functions,
+           InputParameters const &                        param,
+           std::string const &                            field,
+           MPI_Comm const &                               mpi_comm);
 
   void
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
@@ -199,10 +196,7 @@ private:
   /*
    * User interface: Boundary conditions and field functions.
    */
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_density;
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_velocity;
-  std::shared_ptr<BoundaryDescriptor<dim>>       boundary_descriptor_pressure;
-  std::shared_ptr<BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy;
+  std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor;
   std::shared_ptr<FieldFunctions<dim>>           field_functions;
 
   /*
@@ -229,12 +223,6 @@ private:
   DoFHandler<dim> dof_handler_vector; // e.g. velocity
   DoFHandler<dim> dof_handler_scalar; // scalar quantity, e.g, pressure
 
-  /*
-   * Constraints.
-   */
-  AffineConstraints<Number> constraint;
-
-
   std::string const dof_index_all    = "all_fields";
   std::string const dof_index_vector = "vector";
   std::string const dof_index_scalar = "scalar";
@@ -246,6 +234,11 @@ private:
   std::string const quad_index_l2_projections = quad_index_standard;
   // alternative: use more accurate over-integration strategy
   //  std::string const quad_index_l2_projections = quad_index_overintegration_conv;
+
+  /*
+   * Constraints.
+   */
+  AffineConstraints<Number> constraint;
 
   /*
    * Matrix-free operator evaluation.

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -76,11 +76,7 @@ public:
   create_grid(GridData const & data, MPI_Comm const & mpi_comm) = 0;
 
   virtual void
-  set_boundary_conditions(
-    std::shared_ptr<CompNS::BoundaryDescriptor<dim>>       boundary_descriptor_density,
-    std::shared_ptr<CompNS::BoundaryDescriptor<dim>>       boundary_descriptor_velocity,
-    std::shared_ptr<CompNS::BoundaryDescriptor<dim>>       boundary_descriptor_pressure,
-    std::shared_ptr<CompNS::BoundaryDescriptorEnergy<dim>> boundary_descriptor_energy) = 0;
+  set_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor) = 0;
 
   virtual void
   set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) = 0;

--- a/include/exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h
@@ -108,18 +108,10 @@ struct BoundaryDescriptorEnergy : public BoundaryDescriptorStd<dim>
 template<int dim>
 struct BoundaryDescriptor
 {
-  BoundaryDescriptor()
-  {
-    density  = std::make_shared<BoundaryDescriptorStd<dim>>();
-    velocity = std::make_shared<BoundaryDescriptorStd<dim>>();
-    pressure = std::make_shared<BoundaryDescriptorStd<dim>>();
-    energy   = std::make_shared<BoundaryDescriptorEnergy<dim>>();
-  }
-
-  std::shared_ptr<BoundaryDescriptorStd<dim>>    density;
-  std::shared_ptr<BoundaryDescriptorStd<dim>>    velocity;
-  std::shared_ptr<BoundaryDescriptorStd<dim>>    pressure;
-  std::shared_ptr<BoundaryDescriptorEnergy<dim>> energy;
+  BoundaryDescriptorStd<dim>    density;
+  BoundaryDescriptorStd<dim>    velocity;
+  BoundaryDescriptorStd<dim>    pressure;
+  BoundaryDescriptorEnergy<dim> energy;
 };
 
 template<int dim, typename Number>

--- a/include/exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h
@@ -119,10 +119,10 @@ inline void
 verify_boundary_conditions(std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor,
                            Grid<dim, Number> const &                      grid)
 {
-  ExaDG::verify_boundary_conditions(*(boundary_descriptor->density), grid);
-  ExaDG::verify_boundary_conditions(*(boundary_descriptor->velocity), grid);
-  ExaDG::verify_boundary_conditions(*(boundary_descriptor->pressure), grid);
-  ExaDG::verify_boundary_conditions(*(boundary_descriptor->energy), grid);
+  ExaDG::verify_boundary_conditions(boundary_descriptor->density, grid);
+  ExaDG::verify_boundary_conditions(boundary_descriptor->velocity, grid);
+  ExaDG::verify_boundary_conditions(boundary_descriptor->pressure, grid);
+  ExaDG::verify_boundary_conditions(boundary_descriptor->energy, grid);
 }
 
 } // namespace CompNS


### PR DESCRIPTION
It appears to be much simpler to combine the boundary descriptors for density, velocity, pressure, energy to a single one, and use this one in the interfaces.