### PR TITLE
Allow to set up AMG on an arbitrary mesh level for global coarsening

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -70,9 +70,9 @@ MultigridPreconditionerBase<dim, Number>::initialize(MultigridData const &      
 
   bool const is_dg = fe.dofs_per_vertex == 0;
 
-  this->initialize_levels(tria, fe.degree, is_dg);
-
   this->initialize_coarse_grid_triangulations(tria);
+
+  this->initialize_levels(tria, fe.degree, is_dg);
 
   this->initialize_mapping();
 
@@ -144,7 +144,9 @@ MultigridPreconditionerBase<dim, Number>::initialize_levels(Triangulation<dim> c
   }
   else // h-MG is involved working on all mesh levels
   {
-    for(unsigned int h = 0; h < tria->n_global_levels(); h++)
+    unsigned int const n_h_levels =
+      (data.use_global_coarsening ? coarse_grid_triangulations.size() : tria->n_global_levels());
+    for(unsigned int h = 0; h < n_h_levels; h++)
       h_levels.push_back(h);
   }
 


### PR DESCRIPTION
In testing the impact of additional h-levels on scaling, I wanted to test setting up AMG on some intermediate level of the h-coarsening algorithm (for global coarsening multigrid). My idea was that I want to return fewer levels in `create_geometric_coarsening_sequence` by simply removing some of the shared pointers of triangulations at the start of the vector, as this is a clean solution without touching much other part in the algorithm except for this single place I change now. (This selection of triangulation will needr some heuristic that I do not want to commit yet as I have too little experimental results.)

Due to the general infrastructure in deal.II and for the base operator here in ExaDG, this should be already possible with the global coarsening algorithms, if we just set up the h-levels after we know the number of triangulations.

For curiosity, here are some numbers with 16 nodes regarding the multigrid timings:
```
180m DoFs with Q3 on lung with 11 generations
create all levels:
    Multigrid           2.891e+01 s   100.000 %  2.721e+01 [p594]   3.013e+01 [p 72]
      level 7           1.642e+01 s    56.795 %  1.419e+01 [p727]   1.827e+01 [p504]
      level 6           7.040e+00 s    24.350 %  6.226e+00 [p573]   7.684e+00 [p740]
      level 5           2.614e+00 s     9.039 %  2.130e+00 [p553]   3.058e+00 [p  6]
      level 4           8.139e-01 s     2.815 %  6.538e-01 [p166]   1.205e+00 [p 12]
      level 3           3.147e-01 s     1.088 %  2.273e-01 [p164]   6.049e-01 [p755]
      level 2           2.080e-01 s     0.719 %  1.062e-01 [p412]   1.086e+00 [p731]
      level 1           1.394e-01 s     0.482 %  7.480e-03 [p739]   8.283e-01 [p710]
      level 0           6.299e-01 s     2.179 %  5.620e-03 [p713]   6.993e-01 [p 17]
      Other             7.322e-01 s     2.532 %  5.854e-01 [p597]   8.770e-01 [p301]

remove the last two levels:
    Multigrid           2.881e+01 s   100.000 %  2.705e+01 [p753]   3.004e+01 [p 72]
      level 5           1.635e+01 s    56.759 %  1.425e+01 [p727]   1.826e+01 [p504]
      level 4           7.002e+00 s    24.308 %  6.217e+00 [p573]   7.747e+00 [p448]
      level 3           2.594e+00 s     9.004 %  2.156e+00 [p548]   3.142e+00 [p701]
      level 2           7.799e-01 s     2.707 %  6.267e-01 [p156]   1.217e+00 [p 13]
      level 1           3.251e-01 s     1.129 %  2.413e-01 [p 96]   6.072e-01 [p755]
      level 0           1.027e+00 s     3.566 %  9.885e-01 [p247]   1.118e+00 [p 17]
      Other             7.279e-01 s     2.527 %  5.831e-01 [p485]   8.758e-01 [p312]
```
The timings give first the average and share, then the minimum and maximum among the ranks. Overall, there is no significant difference, with the exception that on the computation with all levels I only have 710 out of the 768 MPI processes in the AMG (due to the size of the coarse mesh). One could say that summing the average time for levels 0,1,2 for the original setup should be compared to the time on level 0. Indeed, there is not a huge difference (the variant is slightly slower). The test is most interesting regarding the behavior with more MPI processes than just 768.

Overall, it might not help too much, but on the other hand it also won't hurt to support this case.