### PR TITLE
rename construct_postprocessor() -> create_postprocessor()

### DIFF
--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -277,7 +277,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output      = this->write_output;

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -297,7 +297,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output      = this->write_output;

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -479,7 +479,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output      = this->write_output;

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -243,7 +243,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -223,7 +223,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -273,7 +273,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -110,7 +110,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -393,7 +393,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -187,7 +187,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -215,7 +215,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -243,7 +243,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -187,7 +187,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -210,7 +210,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -195,7 +195,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output  = this->write_output;

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -97,7 +97,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -195,7 +195,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -518,7 +518,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -835,7 +835,7 @@ public:
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -542,7 +542,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -1014,7 +1014,7 @@ public:
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -403,7 +403,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -728,7 +728,7 @@ public:
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     using namespace Structure;
 

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -166,7 +166,7 @@ public:
 
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 
@@ -219,7 +219,7 @@ public:
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -397,7 +397,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -444,9 +444,9 @@ public:
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
-  construct_postprocessor_scalar(unsigned int const degree,
-                                 MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index) final
+  create_postprocessor_scalar(unsigned int const degree,
+                              MPI_Comm const &   mpi_comm,
+                              unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -392,7 +392,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -438,9 +438,9 @@ public:
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
-  construct_postprocessor_scalar(unsigned int const degree,
-                                 MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index) final
+  create_postprocessor_scalar(unsigned int const degree,
+                              MPI_Comm const &   mpi_comm,
+                              unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -399,7 +399,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -446,9 +446,9 @@ public:
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
-  construct_postprocessor_scalar(unsigned int const degree,
-                                 MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index) final
+  create_postprocessor_scalar(unsigned int const degree,
+                              MPI_Comm const &   mpi_comm,
+                              unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -374,7 +374,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     IncNS::PostProcessorData<dim> pp_data;
 
@@ -417,9 +417,9 @@ public:
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
-  construct_postprocessor_scalar(unsigned int const degree,
-                                 MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index) final
+  create_postprocessor_scalar(unsigned int const degree,
+                              MPI_Comm const &   mpi_comm,
+                              unsigned int const scalar_index) final
   {
     ConvDiff::PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output = this->write_output;

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -124,7 +124,7 @@ public:
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 
@@ -162,9 +162,9 @@ public:
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
-  construct_postprocessor_scalar(unsigned int const degree,
-                                 MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index) final
+  create_postprocessor_scalar(unsigned int const degree,
+                              MPI_Comm const &   mpi_comm,
+                              unsigned int const scalar_index) final
   {
     (void)degree;
     (void)scalar_index;

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -482,7 +482,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 
@@ -730,7 +730,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -285,7 +285,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -268,7 +268,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -247,7 +247,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -623,7 +623,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 
@@ -825,7 +825,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
 

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -106,7 +106,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm)
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -544,7 +544,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -307,7 +307,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -262,7 +262,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/kovasznay/application.h
+++ b/applications/incompressible_navier_stokes/kovasznay/application.h
@@ -329,7 +329,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -376,7 +376,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -356,7 +356,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -484,7 +484,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -216,7 +216,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -327,7 +327,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -474,7 +474,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/template/application.h
+++ b/applications/incompressible_navier_stokes/template/application.h
@@ -112,7 +112,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_navier_stokes/template_precursor/application.h
+++ b/applications/incompressible_navier_stokes/template_precursor/application.h
@@ -114,7 +114,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 
@@ -127,7 +127,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -221,7 +221,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -462,7 +462,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -732,7 +732,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
 

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -308,7 +308,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -256,7 +256,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -105,7 +105,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/poisson/template/application.h
+++ b/applications/poisson/template/application.h
@@ -102,7 +102,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -141,7 +141,7 @@ public:
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -357,7 +357,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -309,7 +309,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -286,7 +286,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -418,7 +418,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     PostProcessorData<dim> pp_data;
     pp_data.output_data.write_output       = this->write_output;

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -89,7 +89,7 @@ public:
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) final
   {
     (void)degree;
 

--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -107,7 +107,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   // initialize postprocessor
   if(!is_throughput_study)
   {
-    postprocessor = application->construct_postprocessor(degree, mpi_comm);
+    postprocessor = application->create_postprocessor(degree, mpi_comm);
     postprocessor->setup(*pde_operator);
 
     // initialize time integrator

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -82,7 +82,7 @@ public:
   set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
   void
   set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -121,7 +121,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   if(!is_throughput_study)
   {
     // initialize postprocessor
-    postprocessor = application->construct_postprocessor(degree, mpi_comm);
+    postprocessor = application->create_postprocessor(degree, mpi_comm);
     postprocessor->setup(*pde_operator, *grid->get_dynamic_mapping());
 
     // initialize time integrator or driver for steady problems

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -86,7 +86,7 @@ public:
   set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
   void
   set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -175,7 +175,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
     // initialize postprocessor
     structure_postprocessor =
-      application->construct_postprocessor_structure(degree_structure, mpi_comm);
+      application->create_postprocessor_structure(degree_structure, mpi_comm);
     structure_postprocessor->setup(structure_operator->get_dof_handler(), *structure_grid->mapping);
 
     timer_tree.insert({"FSI", "Setup", "Structure"}, timer_local.wall_time());
@@ -373,7 +373,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     fluid_operator->setup(fluid_matrix_free, fluid_matrix_free_data);
 
     // setup postprocessor
-    fluid_postprocessor = application->construct_postprocessor_fluid(degree_fluid, mpi_comm);
+    fluid_postprocessor = application->create_postprocessor_fluid(degree_fluid, mpi_comm);
     fluid_postprocessor->setup(*fluid_operator);
 
     timer_tree.insert({"FSI", "Setup", "Fluid"}, timer_local.wall_time());

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -97,7 +97,7 @@ public:
   set_field_functions_fluid(std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
-  construct_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor_fluid(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
   // ALE
 
@@ -144,7 +144,7 @@ public:
     std::shared_ptr<Structure::FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<Structure::PostProcessor<dim, Number>>
-  construct_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor_structure(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
 protected:
   std::string parameter_file;

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -260,12 +260,12 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   }
 
   // setup postprocessor
-  fluid_postprocessor = application->construct_postprocessor(degree, mpi_comm);
+  fluid_postprocessor = application->create_postprocessor(degree, mpi_comm);
   fluid_postprocessor->setup(*fluid_operator);
 
   for(unsigned int i = 0; i < n_scalars; ++i)
   {
-    scalar_postprocessor[i] = application->construct_postprocessor_scalar(degree, mpi_comm, i);
+    scalar_postprocessor[i] = application->create_postprocessor_scalar(degree, mpi_comm, i);
     scalar_postprocessor[i]->setup(*conv_diff_operator[i], *grid->get_dynamic_mapping());
   }
 

--- a/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
+++ b/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
@@ -83,9 +83,9 @@ public:
                              unsigned int const                             scalar_index = 0) = 0;
 
   virtual std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>
-  construct_postprocessor_scalar(unsigned int const degree,
-                                 MPI_Comm const &   mpi_comm,
-                                 unsigned int const scalar_index = 0) = 0;
+  create_postprocessor_scalar(unsigned int const degree,
+                              MPI_Comm const &   mpi_comm,
+                              unsigned int const scalar_index = 0) = 0;
 
 protected:
   std::string  output_directory = "output/", output_name = "output";

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -190,7 +190,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   if(!is_throughput_study)
   {
     // setup postprocessor
-    postprocessor = application->construct_postprocessor(degree, mpi_comm);
+    postprocessor = application->create_postprocessor(degree, mpi_comm);
     postprocessor->setup(*pde_operator);
 
     // setup time integrator before calling setup_solvers

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
@@ -213,10 +213,10 @@ DriverPrecursor<dim, Number>::setup(std::shared_ptr<ApplicationBasePrecursor<dim
   pde_operator->setup(matrix_free, matrix_free_data);
 
   // setup postprocessor
-  postprocessor_pre = application->construct_postprocessor_precursor(degree, mpi_comm);
+  postprocessor_pre = application->create_postprocessor_precursor(degree, mpi_comm);
   postprocessor_pre->setup(*pde_operator_pre);
 
-  postprocessor = application->construct_postprocessor(degree, mpi_comm);
+  postprocessor = application->create_postprocessor(degree, mpi_comm);
   postprocessor->setup(*pde_operator);
 
 

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -87,7 +87,7 @@ public:
   set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
   // Moving mesh (analytical function)
   virtual std::shared_ptr<Function<dim>>
@@ -173,7 +173,7 @@ public:
   set_field_functions_precursor(std::shared_ptr<FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<PostProcessorBase<dim, Number>>
-  construct_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor_precursor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 };
 
 

--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -129,7 +129,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   // initialize postprocessor
   if(not(is_throughput_study))
   {
-    postprocessor = application->construct_postprocessor(degree, mpi_comm);
+    postprocessor = application->create_postprocessor(degree, mpi_comm);
     postprocessor->setup(pde_operator->get_dof_handler(), *grid->mapping);
   }
 

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -85,7 +85,7 @@ public:
   set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<Poisson::PostProcessorBase<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
   void
   set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -118,7 +118,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
   if(!is_throughput_study)
   {
     // initialize postprocessor
-    postprocessor = application->construct_postprocessor(degree, mpi_comm);
+    postprocessor = application->create_postprocessor(degree, mpi_comm);
     postprocessor->setup(pde_operator->get_dof_handler(), pde_operator->get_mapping());
 
     // initialize time integrator/driver

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -82,7 +82,7 @@ public:
   set_field_functions(std::shared_ptr<FieldFunctions<dim>> field_functions) = 0;
 
   virtual std::shared_ptr<PostProcessor<dim, Number>>
-  construct_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
+  create_postprocessor(unsigned int const degree, MPI_Comm const & mpi_comm) = 0;
 
   void
   set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)


### PR DESCRIPTION
For consistency with the function `Application::create_grid()`, I renamed `Application::construct_postprocessor()` into  `Application::create_postprocessor()`.

Now, we have two types of functions in `Application`: 
- (i) `create_...()`, which creates/allocates objects, and 
- (ii) `set_...()` with sets/initializes objects that have already been constructed.