### PR TITLE
Make polynomial degree an input parameter

### DIFF
--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -27,6 +27,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         1
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -117,6 +118,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         2
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -207,6 +209,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         3
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -297,6 +300,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         4
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -387,6 +391,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         5
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -477,6 +482,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         6
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -567,6 +573,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         7
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -657,6 +664,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         8
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -747,6 +755,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         9
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -837,6 +846,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         10
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -927,6 +937,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         11
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -1017,6 +1028,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         12
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -1107,6 +1119,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         13
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -1197,6 +1210,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         14
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -1287,6 +1301,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Isoparametric
   Element type:                              DG
+  Polynomial degree:                         15
   IP factor:                                 1.0000e+00
 
 Solver:

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -27,6 +27,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         1
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -117,6 +118,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         2
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -207,6 +209,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         3
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -297,6 +300,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         4
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -387,6 +391,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         5
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -477,6 +482,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         6
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -567,6 +573,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         7
   IP factor:                                 1.0000e+00
 
 Solver:

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -27,6 +27,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         1
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -117,6 +118,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         2
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -207,6 +209,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         3
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -297,6 +300,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         4
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -387,6 +391,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         5
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -477,6 +482,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         6
   IP factor:                                 1.0000e+00
 
 Solver:
@@ -567,6 +573,7 @@ Spatial Discretization:
   Triangulation type:                        Distributed
   Mapping:                                   Cubic
   Element type:                              DG
+  Polynomial degree:                         7
   IP factor:                                 1.0000e+00
 
 Solver:

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -224,6 +224,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     // ALE
     if(fluid_param.mesh_movement_type == IncNS::MeshMovementType::Poisson)
     {
+      ale_poisson_param.degree = fluid_grid_data.mapping_degree;
       application->set_input_parameters_ale(ale_poisson_param);
       ale_poisson_param.check_input_parameters();
       AssertThrow(ale_poisson_param.right_hand_side == false,
@@ -242,7 +243,6 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
       // initialize Poisson operator
       ale_poisson_operator =
         std::make_shared<Poisson::Operator<dim, Number, dim>>(fluid_grid,
-                                                              fluid_grid_data.mapping_degree,
                                                               ale_poisson_boundary_descriptor,
                                                               ale_poisson_field_functions,
                                                               ale_poisson_param,

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -93,6 +93,7 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
     }
     else if(param.mesh_movement_type == MeshMovementType::Poisson)
     {
+      poisson_param.degree = grid_data.mapping_degree;
       application->set_input_parameters_poisson(poisson_param);
       poisson_param.check_input_parameters();
       poisson_param.print(pcout, "List of input parameters for Poisson solver (moving mesh):");
@@ -115,7 +116,6 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
       // initialize Poisson operator
       poisson_operator =
         std::make_shared<Poisson::Operator<dim, Number, dim>>(grid,
-                                                              grid_data.mapping_degree,
                                                               poisson_boundary_descriptor,
                                                               poisson_field_functions,
                                                               poisson_param,

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -127,8 +127,7 @@ public:
   print_performance_results(double const total_time) const;
 
   std::tuple<unsigned int, types::global_dof_index, double>
-  apply_operator(unsigned int const  degree,
-                 std::string const & operator_type_string,
+  apply_operator(std::string const & operator_type_string,
                  unsigned int const  n_repetitions_inner,
                  unsigned int const  n_repetitions_outer) const;
 

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -55,7 +55,6 @@ private:
 
 public:
   Operator(std::shared_ptr<Grid<dim, Number> const>             grid,
-           unsigned int const                                   degree,
            std::shared_ptr<BoundaryDescriptor<rank, dim> const> boundary_descriptor,
            std::shared_ptr<FieldFunctions<dim> const>           field_functions,
            InputParameters const &                              param,
@@ -101,9 +100,6 @@ public:
 
   double
   get_average_convergence_rate() const;
-
-  unsigned int
-  get_degree() const;
 
   unsigned int
   get_dof_index() const;
@@ -165,11 +161,6 @@ private:
    * Grid
    */
   std::shared_ptr<Grid<dim, Number> const> grid;
-
-  /*
-   * Polynomial degree
-   */
-  unsigned int const degree;
 
   /*
    * User interface: Boundary conditions and field functions.

--- a/include/exadg/poisson/throughput.h
+++ b/include/exadg/poisson/throughput.h
@@ -100,8 +100,7 @@ run(ThroughputParameters const & throughput,
   driver->setup(application, degree, refine_space, true);
 
   std::tuple<unsigned int, types::global_dof_index, double> wall_time =
-    driver->apply_operator(degree,
-                           throughput.operator_type,
+    driver->apply_operator(throughput.operator_type,
                            throughput.n_repetitions_inner,
                            throughput.n_repetitions_outer);
 

--- a/include/exadg/poisson/user_interface/input_parameters.cpp
+++ b/include/exadg/poisson/user_interface/input_parameters.cpp
@@ -39,6 +39,7 @@ InputParameters::InputParameters()
     triangulation_type(TriangulationType::Undefined),
     mapping(MappingType::Affine),
     spatial_discretization(SpatialDiscretization::Undefined),
+    degree(1),
     IP_factor(1.0),
 
     // SOLVER
@@ -62,6 +63,8 @@ InputParameters::check_input_parameters()
 
   AssertThrow(spatial_discretization != SpatialDiscretization::Undefined,
               ExcMessage("parameter must be defined."));
+
+  AssertThrow(degree > 0, ExcMessage("Polynomial degree must be larger than zero."));
 
   // SOLVER
   AssertThrow(solver != Solver::Undefined, ExcMessage("parameter must be defined."));
@@ -105,6 +108,8 @@ InputParameters::print_parameters_spatial_discretization(ConditionalOStream & pc
   print_parameter(pcout, "Mapping", enum_to_string(mapping));
 
   print_parameter(pcout, "Element type", enum_to_string(spatial_discretization));
+
+  print_parameter(pcout, "Polynomial degree", degree);
 
   if(spatial_discretization == SpatialDiscretization::DG)
     print_parameter(pcout, "IP factor", IP_factor);

--- a/include/exadg/poisson/user_interface/input_parameters.h
+++ b/include/exadg/poisson/user_interface/input_parameters.h
@@ -84,6 +84,9 @@ public:
   // type of spatial discretization approach
   SpatialDiscretization spatial_discretization;
 
+  // polynomial degree of shape functions
+  unsigned int degree;
+
   // Symmetric interior penalty Galerkin (SIPG) discretization
   // interior penalty parameter scaling factor: default value is 1.0
   double IP_factor;


### PR DESCRIPTION
I think the polynomial degree of the shape functions should become an input parameter rather than being treated as an additional, separate parameter.

 As a motivation, think of more complex elements or codes supporting different types of elements that can not be described by a single int parameter (FE_Q vs. FE_DGQ, etc.). Moreover, the interface for the spatial discretization operator simplifies. Finally, when using solvers from ExaDG in a multiphysics environment with coupling to other problems, there should be one data structure that collects all `ExaDG::Poisson` (or `ExaDG::IncNS`) parameters (the fact that we allow loops over h and k as a simple way of conducting mesh convergence studies is something specific to `ExaDG`).

This PR is work in progress. Currently, the intended design is applied to the `Poisson` module. If we agree on that, I would apply it to the rest of `ExaDG`.