### PR TITLE
Fix integer type in MG coarsening setup for 64 bit integers

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -340,7 +340,7 @@ public:
     // factor of 8, which limits makes sure that we do not create too many
     // messages for individual MPI processes.
     unsigned int const grain_size_limit =
-      std::min(200U, 8 * n_cells / n_mpi_processes_per_level.back() + 1);
+      std::min<unsigned int>(200, 8 * n_cells / n_mpi_processes_per_level.back() + 1);
 
     RepartitioningPolicyTools::MinimalGranularityPolicy<dim, spacedim> partitioning_policy(
       grain_size_limit);


### PR DESCRIPTION
Observed when working with the new master branch on SuperMUC; I did not see it in my local tests where I use `global_dof_index = unsigned int`.