### PR TITLE
Make ExaDG compile with PETSc but without Trilinos

### DIFF
--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -49,9 +49,7 @@ private:
   typedef LaplaceOperator<dim, Number, n_components> Laplace;
 
   typedef LinearAlgebra::distributed::Vector<Number> VectorType;
-#ifdef DEAL_II_WITH_TRILINOS
   typedef LinearAlgebra::distributed::Vector<double> VectorTypeDouble;
-#endif
 
 public:
   Operator(std::shared_ptr<Grid<dim, Number> const>             grid,

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -176,6 +176,7 @@ public:
     {
       if(additional_data.amg_data.amg_type == AMGType::ML)
       {
+#ifdef DEAL_II_WITH_TRILINOS
         // create temporal vectors of type NumberAMG (double)
         VectorTypeAMG dst_tri;
         dst_tri.reinit(dst, false);
@@ -211,6 +212,7 @@ public:
 
         // convert NumberAMG (double) -> MultigridNumber (float)
         dst.copy_locally_owned_data_from(dst_tri);
+#endif
       }
       else if(additional_data.amg_data.amg_type == AMGType::BoomerAMG)
       {

--- a/include/exadg/time_integration/time_int_base.cpp
+++ b/include/exadg/time_integration/time_int_base.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <exadg/time_integration/time_int_base.h>
+#include <iostream>
 
 namespace ExaDG
 {

--- a/include/exadg/utilities/print_solver_results.h
+++ b/include/exadg/utilities/print_solver_results.h
@@ -27,6 +27,8 @@
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
+#include <iostream>
+
 namespace ExaDG
 {
 using namespace dealii;


### PR DESCRIPTION
When trying to compile ExaDG without Trilinos I noticed a few errors. This PR addresses all issues I found.