### PR TITLE
MGTransfer: Use prolongate_add rather than prolongate

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h
@@ -230,8 +230,7 @@ private:
 #endif
 
       // prolongation
-      transfer.prolongate(level, t[level], solution[level - 1]);
-      solution[level] += t[level];
+      transfer.prolongate_and_add(level, solution[level], solution[level - 1]);
 
       // post-smoothing
       (*smoother)[level]->step(solution[level], defect[level]);

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer.h
@@ -39,7 +39,7 @@ public:
   restrict_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const = 0;
 
   virtual void
-  prolongate(unsigned int const level, VectorType & dst, VectorType const & src) const = 0;
+  prolongate_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const = 0;
 };
 } // namespace ExaDG
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.cpp
@@ -96,16 +96,12 @@ MGTransferC<dim, Number, VectorType, components>::do_restrict_and_add(VectorType
   FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
   FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
 
-  VectorType vec_dg;
-  data_composite.initialize_dof_vector(vec_dg, 1);
-  vec_dg.copy_locally_owned_data_from(src);
-
   for(unsigned int cell = 0; cell < data_composite.n_cell_batches(); ++cell)
   {
     fe_eval_cg.reinit(cell);
     fe_eval_dg.reinit(cell);
 
-    fe_eval_dg.read_dof_values(vec_dg);
+    fe_eval_dg.read_dof_values(src);
 
     for(unsigned int i = 0; i < fe_eval_cg.static_dofs_per_cell; i++)
       fe_eval_cg.begin_dof_values()[i] = fe_eval_dg.begin_dof_values()[i];
@@ -127,9 +123,6 @@ MGTransferC<dim, Number, VectorType, components>::do_prolongate(VectorType &    
   FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
   FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
 
-  VectorType vec_dg;
-  data_composite.initialize_dof_vector(vec_dg, 1);
-
   for(unsigned int cell = 0; cell < data_composite.n_cell_batches(); ++cell)
   {
     fe_eval_cg.reinit(cell);
@@ -140,9 +133,8 @@ MGTransferC<dim, Number, VectorType, components>::do_prolongate(VectorType &    
     for(unsigned int i = 0; i < fe_eval_cg.static_dofs_per_cell; i++)
       fe_eval_dg.begin_dof_values()[i] = fe_eval_cg.begin_dof_values()[i];
 
-    fe_eval_dg.distribute_local_to_global(vec_dg);
+    fe_eval_dg.distribute_local_to_global(dst);
   }
-  dst.copy_locally_owned_data_from(vec_dg);
   src.zero_out_ghost_values();
 }
 
@@ -210,9 +202,9 @@ MGTransferC<dim, Number, VectorType, components>::restrict_and_add(unsigned int 
 
 template<int dim, typename Number, typename VectorType, int components>
 void
-MGTransferC<dim, Number, VectorType, components>::prolongate(unsigned int const /*level*/,
-                                                             VectorType &       dst,
-                                                             VectorType const & src) const
+MGTransferC<dim, Number, VectorType, components>::prolongate_and_add(unsigned int const /*level*/,
+                                                                     VectorType &       dst,
+                                                                     VectorType const & src) const
 {
   switch(this->fe_degree)
   {

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.h
@@ -57,7 +57,7 @@ public:
   restrict_and_add(unsigned int const /*level*/, VectorType & dst, VectorType const & src) const;
 
   void
-  prolongate(unsigned int const /*level*/, VectorType & dst, VectorType const & src) const;
+  prolongate_and_add(unsigned int const /*level*/, VectorType & dst, VectorType const & src) const;
 
 private:
   template<int degree>

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.cpp
@@ -38,11 +38,12 @@ MGTransferGlobalCoarsening<dim, Number, VectorType>::restrict_and_add(unsigned i
 
 template<int dim, typename Number, typename VectorType>
 void
-MGTransferGlobalCoarsening<dim, Number, VectorType>::prolongate(unsigned int const level,
-                                                                VectorType &       dst,
-                                                                VectorType const & src) const
+MGTransferGlobalCoarsening<dim, Number, VectorType>::prolongate_and_add(
+  unsigned int const level,
+  VectorType &       dst,
+  VectorType const & src) const
 {
-  mg_transfer_global_coarsening->prolongate(level, dst, src);
+  mg_transfer_global_coarsening->prolongate_and_add(level, dst, src);
 }
 
 template<int dim, typename Number, typename VectorType>

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.h
@@ -56,7 +56,7 @@ public:
   restrict_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const;
 
   void
-  prolongate(unsigned int const level, VectorType & dst, VectorType const & src) const;
+  prolongate_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const;
 
 private:
   MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> transfers;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.cpp
@@ -197,11 +197,12 @@ MGTransferGlobalRefinement<dim, Number, VectorType>::restrict_and_add(unsigned i
 
 template<int dim, typename Number, typename VectorType>
 void
-MGTransferGlobalRefinement<dim, Number, VectorType>::prolongate(unsigned int const level,
-                                                                VectorType &       dst,
-                                                                VectorType const & src) const
+MGTransferGlobalRefinement<dim, Number, VectorType>::prolongate_and_add(
+  unsigned int const level,
+  VectorType &       dst,
+  VectorType const & src) const
 {
-  this->mg_level_object[level]->prolongate(level, dst, src);
+  this->mg_level_object[level]->prolongate_and_add(level, dst, src);
 }
 
 typedef dealii::LinearAlgebra::distributed::Vector<float>  VectorTypeFloat;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.h
@@ -57,7 +57,7 @@ public:
   restrict_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const;
 
   virtual void
-  prolongate(unsigned int const level, VectorType & dst, VectorType const & src) const;
+  prolongate_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const;
 
 private:
   MGLevelObject<std::shared_ptr<MGTransfer<VectorType>>> mg_level_object;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.cpp
@@ -46,13 +46,13 @@ MGTransferH<dim, Number>::set_operator(
 
 template<int dim, typename Number>
 void
-MGTransferH<dim, Number>::prolongate(unsigned int const to_level,
-                                     VectorType &       dst,
-                                     VectorType const & src) const
+MGTransferH<dim, Number>::prolongate_and_add(unsigned int const to_level,
+                                             VectorType &       dst,
+                                             VectorType const & src) const
 {
-  MGTransferMatrixFree<dim, Number>::prolongate(level_to_triangulation_level_map[to_level],
-                                                dst,
-                                                src);
+  MGTransferMatrixFree<dim, Number>::prolongate_and_add(level_to_triangulation_level_map[to_level],
+                                                        dst,
+                                                        src);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.h
@@ -56,7 +56,7 @@ public:
     MGLevelObject<std::shared_ptr<MultigridOperatorBase<dim, Number>>> const & operator_in);
 
   virtual void
-  prolongate(unsigned int const to_level, VectorType & dst, VectorType const & src) const;
+  prolongate_and_add(unsigned int const to_level, VectorType & dst, VectorType const & src) const;
 
   virtual void
   restrict_and_add(unsigned int const from_level, VectorType & dst, VectorType const & src) const;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.cpp
@@ -293,15 +293,10 @@ MGTransferP<dim, Number, VectorType, components>::do_prolongate(VectorType &    
                                            fe_eval2.begin_dof_values(),
                                            fe_eval1.begin_dof_values());
 
-    if(is_dg)
-    {
-      fe_eval1.set_dof_values(dst);
-    }
-    else
-    {
+    if(!is_dg)
       weight_residuum<dim, fe_degree_1, Number>(*matrixfree_1, fe_eval1, cell, this->weights);
-      fe_eval1.distribute_local_to_global(dst);
-    }
+
+    fe_eval1.distribute_local_to_global(dst);
   }
 }
 
@@ -573,13 +568,12 @@ MGTransferP<dim, Number, VectorType, components>::restrict_and_add(unsigned int 
 
 template<int dim, typename Number, typename VectorType, int components>
 void
-MGTransferP<dim, Number, VectorType, components>::prolongate(unsigned int const /*level*/,
-                                                             VectorType &       dst,
-                                                             VectorType const & src) const
+MGTransferP<dim, Number, VectorType, components>::prolongate_and_add(unsigned int const /*level*/,
+                                                                     VectorType &       dst,
+                                                                     VectorType const & src) const
 {
   if(!this->is_dg) // only if CG
   {
-    dst = 0.0;
     src.update_ghost_values();
   }
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.h
@@ -62,7 +62,7 @@ public:
   restrict_and_add(unsigned int const /*level*/, VectorType & dst, VectorType const & src) const;
 
   virtual void
-  prolongate(unsigned int const /*level*/, VectorType & dst, VectorType const & src) const;
+  prolongate_and_add(unsigned int const /*level*/, VectorType & dst, VectorType const & src) const;
 
 private:
   template<int fe_degree_1, int fe_degree_2>


### PR DESCRIPTION
This allows for more efficient realization in the multigrid transfer classes, since the natural operation on the cell level is `add_into` (aka `distribute_local_to_global`), avoiding two passes through the vectors.