### PR TITLE
Remove most instance of GeometryInfo within include/

### DIFF
--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.h
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.h
@@ -458,13 +458,13 @@ public:
     {
       if(!cell->is_artificial() && cell->at_boundary())
       {
-        for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for(const unsigned int f : cell->face_indices())
         {
           if(cell->face(f)->at_boundary())
           {
             if(map_bc.find(cell->face(f)->boundary_id()) != map_bc.end())
             {
-              for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+              for(const unsigned int v : cell->face(f)->vertex_indices())
               {
                 marked_vertices[cell->face(f)->vertex_index(v)] = true;
               }

--- a/include/exadg/functions_and_boundary_conditions/verify_boundary_conditions.h
+++ b/include/exadg/functions_and_boundary_conditions/verify_boundary_conditions.h
@@ -50,7 +50,7 @@ verify_boundary_conditions(BoundaryDescriptor const & boundary_descriptor,
   // Make sure that each boundary face has exactly one boundary type
   for(auto cell : *grid.triangulation)
   {
-    for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for(const unsigned int f : cell.face_indices())
     {
       if(cell.at_boundary(f))
       {

--- a/include/exadg/grid/calculate_maximum_aspect_ratio.h
+++ b/include/exadg/grid/calculate_maximum_aspect_ratio.h
@@ -38,11 +38,11 @@ calculate_maximum_vertex_distance(typename Triangulation<dim>::active_cell_itera
 {
   double maximum_vertex_distance = 0.0;
 
-  for(unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for(const unsigned int i : cell->vertex_indices())
   {
     Point<dim> & ref_vertex = cell->vertex(i);
     // start the loop with the second vertex!
-    for(unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+    for(const unsigned int j : cell->vertex_indices())
     {
       if(j != i)
       {

--- a/include/exadg/grid/one_sided_cylindrical_manifold.h
+++ b/include/exadg/grid/one_sided_cylindrical_manifold.h
@@ -109,9 +109,9 @@ public:
     Point<dim> x;
 
     // standard mapping from reference space to physical space using d-linear shape functions
-    for(unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for(const unsigned int v : cell->vertex_indices())
     {
-      double shape_function_value = GeometryInfo<dim>::d_linear_shape_function(xi, v);
+      double shape_function_value = cell->reference_cell().d_linear_shape_function(xi, v);
       x += shape_function_value * cell->vertex(v);
     }
 
@@ -139,9 +139,10 @@ public:
     // calculate displacement as compared to straight sided quadrilateral element
     // on the face that is subject to the manifold
     Tensor<1, 2> displ, x_lin;
-    for(unsigned int v = 0; v < GeometryInfo<1>::vertices_per_cell; ++v)
+    for(unsigned int v : ReferenceCells::template get_hypercube<1>().vertex_indices())
     {
-      double shape_function_value = GeometryInfo<1>::d_linear_shape_function(Point<1>(xi_face), v);
+      double shape_function_value =
+        ReferenceCells::template get_hypercube<1>().d_linear_shape_function(Point<1>(xi_face), v);
 
       unsigned int vertex_id = get_vertex_id(v);
       Point<dim>   vertex    = cell->vertex(vertex_id);
@@ -153,9 +154,10 @@ public:
     displ = x_S - x_lin;
 
     // deformation decreases linearly in the second (other) direction
-    Point<1>     xi_other_1d  = Point<1>(xi_other);
-    unsigned int index_1d     = get_index_1d();
-    double       fading_value = GeometryInfo<1>::d_linear_shape_function(xi_other_1d, index_1d);
+    Point<1>     xi_other_1d = Point<1>(xi_other);
+    unsigned int index_1d    = get_index_1d();
+    double       fading_value =
+      ReferenceCells::template get_hypercube<1>().d_linear_shape_function(xi_other_1d, index_1d);
     x[0] += fading_value * displ[0];
     x[1] += fading_value * displ[1];
 
@@ -246,10 +248,10 @@ public:
     Tensor<2, dim> jacobian;
 
     // standard mapping from reference space to physical space using d-linear shape functions
-    for(unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for(const unsigned int v : cell->vertex_indices())
     {
       Tensor<1, dim> shape_function_gradient =
-        GeometryInfo<dim>::d_linear_shape_function_gradient(xi, v);
+        cell->reference_cell().d_linear_shape_function_gradient(xi, v);
       jacobian += outer_product(cell->vertex(v), shape_function_gradient);
     }
 
@@ -417,9 +419,9 @@ public:
     Point<dim> x;
 
     // standard mapping from reference space to physical space using d-linear shape functions
-    for(unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for(const unsigned int v : cell->vertex_indices())
     {
-      double shape_function_value = GeometryInfo<dim>::d_linear_shape_function(xi, v);
+      double shape_function_value = cell->reference_cell().d_linear_shape_function(xi, v);
       x += shape_function_value * cell->vertex(v);
     }
 
@@ -447,9 +449,10 @@ public:
     // calculate displacement as compared to straight sided quadrilateral element
     // on the face that is subject to the manifold
     Tensor<1, 2> displ, x_lin;
-    for(unsigned int v = 0; v < GeometryInfo<1>::vertices_per_cell; ++v)
+    for(const unsigned int v : ReferenceCells::template get_hypercube<1>().vertex_indices())
     {
-      double shape_function_value = GeometryInfo<1>::d_linear_shape_function(Point<1>(xi_face), v);
+      double shape_function_value =
+        ReferenceCells::template get_hypercube<1>().d_linear_shape_function(Point<1>(xi_face), v);
 
       unsigned int vertex_id = get_vertex_id(v);
       Point<dim>   vertex    = cell->vertex(vertex_id);
@@ -464,9 +467,10 @@ public:
     displ *= (1 - xi[2] * (r_0 - r_1) / r_0);
 
     // deformation decreases linearly in the second (other) direction
-    Point<1>     xi_other_1d  = Point<1>(xi_other);
-    unsigned int index_1d     = get_index_1d();
-    double       fading_value = GeometryInfo<1>::d_linear_shape_function(xi_other_1d, index_1d);
+    Point<1>     xi_other_1d = Point<1>(xi_other);
+    unsigned int index_1d    = get_index_1d();
+    double       fading_value =
+      ReferenceCells::template get_hypercube<1>().d_linear_shape_function(xi_other_1d, index_1d);
     x[0] += fading_value * displ[0];
     x[1] += fading_value * displ[1];
 
@@ -557,10 +561,10 @@ public:
     Tensor<2, dim> jacobian;
 
     // standard mapping from reference space to physical space using d-linear shape functions
-    for(unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for(const unsigned int v : cell->vertex_indices())
     {
       Tensor<1, dim> shape_function_gradient =
-        GeometryInfo<dim>::d_linear_shape_function_gradient(xi, v);
+        cell->reference_cell().d_linear_shape_function_gradient(xi, v);
       jacobian += outer_product(cell->vertex(v), shape_function_gradient);
     }
 

--- a/include/exadg/grid/periodic_box.h
+++ b/include/exadg/grid/periodic_box.h
@@ -62,7 +62,7 @@ create_periodic_box(
         cell != triangulation->end();
         ++cell)
     {
-      for(unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for(const unsigned int v : cell->vertex_indices())
       {
         if(vertex_touched[cell->vertex_index(v)] == false)
         {
@@ -79,8 +79,7 @@ create_periodic_box(
                                              endc = triangulation->end();
   for(; cell != endc; ++cell)
   {
-    for(unsigned int face_number = 0; face_number < GeometryInfo<dim>::faces_per_cell;
-        ++face_number)
+    for(const unsigned int face_number : cell->face_indices())
     {
       // x-direction
       if((std::fabs(cell->face(face_number)->center()(0) - left) < 1e-12))

--- a/include/exadg/operators/interior_penalty_parameter.h
+++ b/include/exadg/operators/interior_penalty_parameter.h
@@ -73,7 +73,7 @@ calculate_penalty_parameter(AlignedVector<VectorizedArray<Number>> & array_penal
 
       // calculate surface area
       Number surface_area = 0;
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(const unsigned int f : cell->face_indices())
       {
         fe_face_values.reinit(cell, f);
         Number const factor = (cell->at_boundary(f) && !cell->has_periodic_neighbor(f)) ? 1. : 0.5;

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -618,7 +618,7 @@ OperatorBase<dim, Number, n_components>::apply_add_block_diagonal_elementwise(
   if(is_dg && evaluate_face_integrals())
   {
     // face integrals
-    unsigned int const n_faces = GeometryInfo<dim>::faces_per_cell;
+    unsigned int const n_faces = ReferenceCells::template get_hypercube<dim>().n_faces();
     for(unsigned int face = 0; face < n_faces; ++face)
     {
       auto bids = (*matrix_free).get_faces_by_cells_boundary_id(cell, face);
@@ -1409,7 +1409,7 @@ OperatorBase<dim, Number, n_components>::cell_based_loop_diagonal(
     }
 
     // loop over all faces and gather results into local diagonal local_diag
-    unsigned int const n_faces = GeometryInfo<dim>::faces_per_cell;
+    unsigned int const n_faces = ReferenceCells::template get_hypercube<dim>().n_faces();
     for(unsigned int face = 0; face < n_faces; ++face)
     {
       auto bids = matrix_free.get_faces_by_cells_boundary_id(cell, face);
@@ -1699,7 +1699,7 @@ OperatorBase<dim, Number, n_components>::cell_based_loop_block_diagonal(
     }
 
     // loop over all faces
-    unsigned int const n_faces = GeometryInfo<dim>::faces_per_cell;
+    unsigned int const n_faces = ReferenceCells::template get_hypercube<dim>().n_faces();
     for(unsigned int face = 0; face < n_faces; ++face)
     {
       auto bids = matrix_free.get_faces_by_cells_boundary_id(cell, face);


### PR DESCRIPTION
references #104

Remaining instances are:

https://github.com/exadg/exadg/blob/35a791d68c7e05e127302e9c82edc9890506887b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp#L170

https://github.com/exadg/exadg/blob/35a791d68c7e05e127302e9c82edc9890506887b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp#L238

https://github.com/exadg/exadg/blob/35a791d68c7e05e127302e9c82edc9890506887b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp#L290

https://github.com/exadg/exadg/blob/35a791d68c7e05e127302e9c82edc9890506887b/include/exadg/vector_tools/interpolate_solution.h#L67

https://github.com/exadg/exadg/blob/35a791d68c7e05e127302e9c82edc9890506887b/include/exadg/vector_tools/point_value.h#L47

since these two functions are not supported by `ReferenceCell`.