### PR TITLE
Do not store FEEvaluation objects in OperatorBase

### DIFF
--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -303,13 +303,15 @@ protected:
    * operator-specific and define how the operator looks like.
    */
   virtual void
-  reinit_cell(unsigned int const cell) const;
+  reinit_cell(unsigned int const cell, IntegratorCell & integrator) const;
 
   virtual void
-  reinit_face(unsigned int const face) const;
+  reinit_face(unsigned int const face,
+              IntegratorFace &   integrator_m,
+              IntegratorFace &   integrator_p) const;
 
   virtual void
-  reinit_boundary_face(unsigned int const face) const;
+  reinit_boundary_face(unsigned int const face, IntegratorFace & integrator_m) const;
 
   // standard integration procedure with separate loops for cell and face integrals
   virtual void
@@ -339,7 +341,9 @@ protected:
   virtual void
   reinit_face_cell_based(unsigned int const       cell,
                          unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+                         types::boundary_id const boundary_id,
+                         IntegratorFace &         integrator_m,
+                         IntegratorFace &         integrator_p) const;
 
   // This function is currently only needed due to limitations of deal.II which do
   // currently not allow to access neighboring data in case of cell-based face loops.
@@ -383,10 +387,6 @@ protected:
    * Is the discretization based on discontinuous Galerkin method?
    */
   bool is_dg;
-
-  std::shared_ptr<IntegratorCell> integrator;
-  std::shared_ptr<IntegratorFace> integrator_m;
-  std::shared_ptr<IntegratorFace> integrator_p;
 
   /*
    * Block Jacobi preconditioner/smoother: matrix-free version with elementwise iterative solver

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -257,15 +257,19 @@ public:
 
 private:
   void
-  reinit_face(unsigned int const face) const final;
+  reinit_face(unsigned int const face,
+              IntegratorFace &   integrator_m,
+              IntegratorFace &   integrator_p) const final;
 
   void
-  reinit_boundary_face(unsigned int const face) const final;
+  reinit_boundary_face(unsigned int const face, IntegratorFace & integrator_m) const final;
 
   void
   reinit_face_cell_based(unsigned int const       cell,
                          unsigned int const       face,
-                         types::boundary_id const boundary_id) const final;
+                         types::boundary_id const boundary_id,
+                         IntegratorFace &         integrator_m,
+                         IntegratorFace &         integrator_p) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;


### PR DESCRIPTION
Related to the simplex example of #110, I think we should work towards avoiding storing a copy of `FEEvalation` and `FEFaceEvaluation` as class members. These classes are designed to operator in a "stateless" scenario, i.e., to be created at the place where `MatrixFree` allows us to enter during `loop/cell_loop`, and released at the end of this loop. For mixed meshes in the future, we would need to add the `cell_range` or `face_range` to the constructor to be able to select the right quadrature formula.

I think we should discuss in which direction we would want to go here. I make a first suggestion with minimal changes to the `OperatorBase` class, where I only move the construction into the various functions. I also adapted the `LaplaceOperator` application to show how the realization for derived classes would like like, but I did not touch the other classes yet. So ExaDG does not compile at this point.

Things get more messy in some of the non-linear operators or for the convective operator, which need a second `FEEvaluation`/`CellIntegrator` for evaluating the linearization point/velocity. The current proposed solution does not offer a good solution for those, so we would need to set up a class member for those, to be able to isolate the `reinit_cell` function from the inner workings (`do_cell_integral`). The longer-term solution for those might be to put all data structures needed for evaluation of the individual classes into `do_****_integral` into a separate data structure that we set up via `virtual OperatorBase::InternalDataBase OperatorBase::create_evaluation_instance() const`. It creates one additional indirection, so I do not want to test it before we reach consensus here.

Another goal we should discuss at this stage of refactoring is that we might want to switch to a point-wise evaluation setup at some point, i.e., to only implement the operation at a point, https://github.com/exadg/exadg/blob/22330b644cab6a2686ddaee5b212873240c85402/include/exadg/poisson/spatial_discretization/laplace_operator.cpp#L124 , and not spell out the the loop over quadrature points any more (so have deal.II run that internally). `FEEvaluation` does not yet support it, and I actually believe that the right class would be something like an `Iterator` class on top of `FEEvaluation`, so there is no clear path yet. Still, this is something we would need for GPU support in the future and might also be beneficial for more performance-optimized versions of the evaluation e.g. in cell-based iterative solvers.