### PR TITLE
add TriangulationType::Serial

### DIFF
--- a/include/exadg/grid/enum_types.cpp
+++ b/include/exadg/grid/enum_types.cpp
@@ -39,6 +39,9 @@ enum_to_string(TriangulationType const enum_type)
     case TriangulationType::Undefined:
       string_type = "Undefined";
       break;
+    case TriangulationType::Serial:
+      string_type = "Serial";
+      break;
     case TriangulationType::Distributed:
       string_type = "Distributed";
       break;

--- a/include/exadg/grid/enum_types.h
+++ b/include/exadg/grid/enum_types.h
@@ -38,6 +38,7 @@ namespace ExaDG
 enum class TriangulationType
 {
   Undefined,
+  Serial,
   Distributed,
   FullyDistributed
 };

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -66,7 +66,12 @@ public:
   Grid(GridData const & data, MPI_Comm const & mpi_comm)
   {
     // triangulation
-    if(data.triangulation_type == TriangulationType::Distributed)
+    if(data.triangulation_type == TriangulationType::Serial)
+    {
+      AssertDimension(Utilities::MPI::n_mpi_processes(mpi_comm), 1);
+      triangulation = std::make_shared<Triangulation<dim>>();
+    }
+    else if(data.triangulation_type == TriangulationType::Distributed)
     {
       triangulation = std::make_shared<parallel::distributed::Triangulation<dim>>(
         mpi_comm,


### PR DESCRIPTION
realizes a part of #110 as a separate PR.

I assume we do not need to add asserts in ExaDG since we all interfaces should be written with `Triangulation` (some time ago we had `parallel::distributed::Triangulation`)?