### PR TITLE
Adapt to new class names in deal.II for evaluation

### DIFF
--- a/include/exadg/matrix_free/resolve_templates.h
+++ b/include/exadg/matrix_free/resolve_templates.h
@@ -27,6 +27,27 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+
+
+template struct dealii::internal::FEEvaluationFactory<deal_II_dimension, deal_II_scalar_vectorized>;
+
+template struct dealii::internal::FEFaceEvaluationFactory<deal_II_dimension,
+                                                          deal_II_scalar_vectorized>;
+
+template struct dealii::internal::FEFaceEvaluationGatherFactory<
+  deal_II_dimension,
+  deal_II_scalar_vectorized::value_type,
+  deal_II_scalar_vectorized>;
+
+template struct dealii::internal::CellwiseInverseMassFactory<deal_II_dimension,
+                                                             deal_II_scalar_vectorized>;
+
+
+#else
+
+
 template struct dealii::internal::FEEvaluationFactory<deal_II_dimension,
                                                       deal_II_scalar_vectorized::value_type,
                                                       deal_II_scalar_vectorized>;
@@ -38,5 +59,8 @@ template struct dealii::internal::FEFaceEvaluationFactory<deal_II_dimension,
 template struct dealii::internal::CellwiseInverseMassFactory<deal_II_dimension,
                                                              deal_II_scalar_vectorized::value_type,
                                                              deal_II_scalar_vectorized>;
+
+
+#endif
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Once https://github.com/dealii/dealii/pull/13056 gets merged, we need this change to compile ExaDG.