### PR TITLE
Add test case for flow around sphere

### DIFF
--- a/applications/incompressible_navier_stokes/flow_past_sphere/CMakeLists.txt
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/CMakeLists.txt
@@ -1,0 +1,3 @@
+PROJECT(incompressible_flow_past_sphere)
+
+EXADG_PICKUP_EXE(solver.cpp incompressible_flow_past_sphere solver)

--- a/applications/incompressible_navier_stokes/flow_past_sphere/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/application.h
@@ -1,0 +1,422 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef APPLICATIONS_INCOMPRESSIBLE_NAVIER_STOKES_TEST_CASES_FLOW_PAST_SPHERE_H_
+#define APPLICATIONS_INCOMPRESSIBLE_NAVIER_STOKES_TEST_CASES_FLOW_PAST_SPHERE_H_
+
+#include "include/grid.h"
+
+namespace ExaDG
+{
+namespace IncNS
+{
+using namespace dealii;
+using namespace FlowPastSphere;
+
+template<int dim>
+class InflowBC : public Function<dim>
+{
+public:
+  InflowBC() : Function<dim>(dim, 0.0)
+  {
+  }
+
+  virtual double
+  value(Point<dim> const &, unsigned int const component = 0) const final
+  {
+    if(component == 0)
+      return 1.0;
+    else
+      return 0.0;
+  }
+};
+
+template<int dim>
+class PressureBC_dudt : public Function<dim>
+{
+public:
+  PressureBC_dudt() : Function<dim>(dim, 0.0)
+  {
+  }
+
+  virtual double
+  value(Point<dim> const &, unsigned int const = 0) const final
+  {
+    return 0.;
+  }
+};
+
+
+
+template<int dim, typename Number>
+class Application : public ApplicationBase<dim, Number>
+{
+public:
+  Application(std::string input_file, MPI_Comm const & comm)
+    : ApplicationBase<dim, Number>(input_file, comm)
+  {
+    // parse application-specific parameters
+    ParameterHandler prm;
+    add_parameters(prm);
+    prm.parse_input(input_file, "", true, true);
+  }
+
+  void
+  add_parameters(ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    // clang-format off
+    prm.enter_subsection("Application");
+    prm.add_parameter("CFL",        cfl_number, "CFL number.",      Patterns::Double(0.0, 1.0e6), true);
+    prm.add_parameter("Viscosity",  viscosity,  "Fluid viscosity.", Patterns::Double(0.0, 1e30),  false);
+    prm.leave_subsection();
+    // clang-format on
+  }
+
+  double viscosity = 1.e-3;
+
+  double cfl_number = 1.0;
+
+  // start and end time
+  // use a large value for test_case = 1 (steady problem)
+  // in order to not stop pseudo-timestepping approach before having converged
+  double const start_time = 0.0;
+  double const end_time   = 100.;
+
+  unsigned int refine_level = 0;
+
+  // solver tolerances
+  double const ABS_TOL = 1.e-12;
+  double const REL_TOL = 1.e-4;
+
+  double const ABS_TOL_LINEAR = 1.e-12;
+  double const REL_TOL_LINEAR = 1.e-2;
+
+  void
+  set_parameters(unsigned int const degree) final
+  {
+    // MATHEMATICAL MODEL
+    this->param.problem_type                = ProblemType::Unsteady;
+    this->param.equation_type               = EquationType::NavierStokes;
+    this->param.formulation_viscous_term    = FormulationViscousTerm::LaplaceFormulation;
+    this->param.formulation_convective_term = FormulationConvectiveTerm::DivergenceFormulation;
+    this->param.right_hand_side             = false;
+
+
+    // PHYSICAL QUANTITIES
+    this->param.start_time = start_time;
+    this->param.end_time   = end_time;
+    this->param.viscosity  = viscosity;
+
+
+    // TEMPORAL DISCRETIZATION
+    this->param.solver_type                     = SolverType::Unsteady;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
+    this->param.time_integrator_oif             = TimeIntegratorOIF::ExplRK2Stage2;
+    this->param.order_time_integrator           = 2;
+    this->param.start_with_low_order            = true;
+    this->param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
+    this->param.adaptive_time_stepping          = true;
+    this->param.max_velocity                    = 1.;
+    this->param.cfl                             = cfl_number;
+    this->param.cfl_oif                         = this->param.cfl;
+    this->param.cfl_exponent_fe_degree_velocity = 1.5;
+    this->param.time_step_size                  = 1.0e-3;
+    this->param.time_step_size_max              = 1.0e-2;
+
+    // output of solver information
+    this->param.solver_info_data.interval_time =
+      (this->param.end_time - this->param.start_time) / 20.0;
+
+    // pseudo-timestepping for steady-state problems
+    this->param.convergence_criterion_steady_problem =
+      ConvergenceCriterionSteadyProblem::SolutionIncrement;
+    this->param.abs_tol_steady = 1.e-12;
+    this->param.rel_tol_steady = 1.e-8;
+
+    // SPATIAL DISCRETIZATION
+    this->param.triangulation_type = TriangulationType::Distributed;
+    this->param.degree_u           = degree;
+    this->param.degree_p           = DegreePressure::MixedOrder;
+    this->param.mapping            = MappingType::Isoparametric;
+
+    // convective term
+    if(this->param.formulation_convective_term == FormulationConvectiveTerm::DivergenceFormulation)
+      this->param.upwind_factor = 0.5; // allows using larger CFL values for explicit formulations
+
+    // divergence penalty
+    this->param.use_divergence_penalty                     = true;
+    this->param.divergence_penalty_factor                  = 5.0e0;
+    this->param.use_continuity_penalty                     = true;
+    this->param.continuity_penalty_factor                  = this->param.divergence_penalty_factor;
+    this->param.continuity_penalty_components              = ContinuityPenaltyComponents::Normal;
+    this->param.continuity_penalty_use_boundary_data       = true;
+    this->param.apply_penalty_terms_in_postprocessing_step = true;
+
+    // viscous term
+    this->param.IP_formulation_viscous = InteriorPenaltyFormulation::SIPG;
+
+    // NUMERICAL PARAMETERS
+    this->param.implement_block_diagonal_preconditioner_matrix_free = false;
+    this->param.use_cell_based_face_loops                           = false;
+    this->param.quad_rule_linearization = QuadratureRuleLinearization::Overintegration32k;
+
+    // PROJECTION METHODS
+
+    // formulation
+    this->param.store_previous_boundary_values = true;
+
+    // pressure Poisson equation
+    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
+    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 30);
+    this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
+    this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
+    this->param.multigrid_data_pressure_poisson.p_sequence            = PSequenceType::Bisect;
+    this->param.multigrid_data_pressure_poisson.use_global_coarsening = true;
+    this->param.multigrid_data_pressure_poisson.smoother_data.smoother =
+      MultigridSmoother::Chebyshev;
+    this->param.multigrid_data_pressure_poisson.smoother_data.iterations = 4;
+    this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
+      MultigridCoarseGridSolver::AMG;
+    this->param.update_preconditioner_pressure_poisson = false;
+
+    // projection step
+    this->param.solver_projection                = SolverProjection::CG;
+    this->param.solver_data_projection           = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.preconditioner_projection        = PreconditionerProjection::InverseMassMatrix;
+    this->param.update_preconditioner_projection = false;
+
+    // HIGH-ORDER DUAL SPLITTING SCHEME
+
+    // formulations
+    this->param.order_extrapolation_pressure_nbc =
+      this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
+
+    // viscous step
+    this->param.solver_viscous                = SolverViscous::CG;
+    this->param.solver_data_viscous           = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.preconditioner_viscous        = PreconditionerViscous::InverseMassMatrix;
+    this->param.update_preconditioner_viscous = false;
+
+    // PRESSURE-CORRECTION SCHEME
+
+    // formulation
+    this->param.order_pressure_extrapolation = 1;
+    this->param.rotational_formulation       = true;
+
+    // momentum step
+
+    // Newton solver
+    this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
+
+    // linear solver
+    this->param.solver_momentum      = SolverMomentum::FGMRES;
+    this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+
+    this->param.update_preconditioner_momentum                   = true;
+    this->param.update_preconditioner_momentum_every_newton_iter = 10;
+    this->param.update_preconditioner_momentum_every_time_steps  = 10;
+
+    this->param.preconditioner_momentum = MomentumPreconditioner::Multigrid;
+    this->param.multigrid_operator_type_momentum =
+      MultigridOperatorType::ReactionConvectionDiffusion;
+    this->param.multigrid_data_momentum.type                   = MultigridType::phMG;
+    this->param.multigrid_data_momentum.smoother_data.smoother = MultigridSmoother::Jacobi;
+    this->param.multigrid_data_momentum.smoother_data.preconditioner =
+      PreconditionerSmoother::BlockJacobi;
+    this->param.multigrid_data_momentum.smoother_data.iterations        = 1;
+    this->param.multigrid_data_momentum.smoother_data.relaxation_factor = 0.7;
+    this->param.multigrid_data_momentum.coarse_problem.solver = MultigridCoarseGridSolver::GMRES;
+    this->param.multigrid_data_momentum.coarse_problem.preconditioner =
+      MultigridCoarseGridPreconditioner::BlockJacobi;
+
+    // COUPLED NAVIER-STOKES SOLVER
+
+    // nonlinear solver (Newton solver)
+    this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
+
+    // linear solver
+    this->param.solver_coupled      = SolverCoupled::FGMRES;
+    this->param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+
+    this->param.update_preconditioner_coupled                   = true;
+    this->param.update_preconditioner_coupled_every_newton_iter = 10;
+    this->param.update_preconditioner_coupled_every_time_steps  = 10;
+
+    // preconditioning linear solver
+    this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;
+
+    // preconditioner velocity/momentum block
+    this->param.preconditioner_velocity_block = MomentumPreconditioner::Multigrid;
+    this->param.multigrid_operator_type_velocity_block =
+      MultigridOperatorType::ReactionConvectionDiffusion;
+    this->param.multigrid_data_velocity_block.type                   = MultigridType::phMG;
+    this->param.multigrid_data_velocity_block.smoother_data.smoother = MultigridSmoother::Jacobi;
+    this->param.multigrid_data_velocity_block.smoother_data.preconditioner =
+      PreconditionerSmoother::BlockJacobi;
+    this->param.multigrid_data_velocity_block.smoother_data.iterations        = 1;
+    this->param.multigrid_data_velocity_block.smoother_data.relaxation_factor = 0.7;
+    this->param.multigrid_data_velocity_block.coarse_problem.solver =
+      MultigridCoarseGridSolver::GMRES;
+    this->param.multigrid_data_velocity_block.coarse_problem.preconditioner =
+      MultigridCoarseGridPreconditioner::BlockJacobi;
+
+    // preconditioner Schur-complement block
+    this->param.preconditioner_pressure_block =
+      SchurComplementPreconditioner::PressureConvectionDiffusion;
+    this->param.multigrid_data_pressure_block.type = MultigridType::cphMG;
+  }
+
+
+  std::shared_ptr<Grid<dim, Number>>
+  create_grid(GridData const & grid_data) final
+  {
+    std::shared_ptr<Grid<dim, Number>> grid =
+      std::make_shared<Grid<dim, Number>>(grid_data, this->mpi_comm);
+
+    this->refine_level = grid_data.n_refine_global;
+
+    if(auto tria_fully_dist =
+         dynamic_cast<parallel::fullydistributed::Triangulation<dim> *>(&*grid->triangulation))
+    {
+      auto const construction_data =
+        TriangulationDescription::Utilities::create_description_from_triangulation_in_groups<dim,
+                                                                                             dim>(
+          [&](dealii::Triangulation<dim, dim> & tria) mutable {
+            create_sphere_grid<dim>(tria, grid_data.n_refine_global);
+          },
+          [](dealii::Triangulation<dim, dim> & tria,
+             const MPI_Comm                    comm,
+             unsigned int const /* group_size */) {
+            GridTools::partition_triangulation(Utilities::MPI::n_mpi_processes(comm), tria);
+          },
+          tria_fully_dist->get_communicator(),
+          1 /* group size */);
+      tria_fully_dist->create_triangulation(construction_data);
+    }
+    else if(auto tria =
+              dynamic_cast<parallel::distributed::Triangulation<dim> *>(&*grid->triangulation))
+    {
+      create_sphere_grid<dim>(*tria, grid_data.n_refine_global);
+    }
+    else
+    {
+      AssertThrow(false, ExcMessage("Unknown triangulation!"));
+    }
+
+    return grid;
+  }
+
+  void
+  set_boundary_descriptor() final
+  {
+    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+
+    // fill boundary descriptor velocity
+    this->boundary_descriptor->velocity->dirichlet_bc.insert(pair(1, new InflowBC<dim>()));
+    this->boundary_descriptor->velocity->dirichlet_bc.insert(
+      pair(3, new Functions::ZeroFunction<dim>(dim)));
+    this->boundary_descriptor->velocity->symmetry_bc.insert(
+      pair(0, new Functions::ZeroFunction<dim>(dim)));
+    this->boundary_descriptor->velocity->neumann_bc.insert(
+      pair(2, new Functions::ZeroFunction<dim>(dim)));
+
+    // fill boundary descriptor pressure
+    this->boundary_descriptor->pressure->neumann_bc.insert(pair(1, new PressureBC_dudt<dim>()));
+    this->boundary_descriptor->pressure->neumann_bc.insert(pair(3, new PressureBC_dudt<dim>()));
+    this->boundary_descriptor->pressure->neumann_bc.insert(pair(0, new PressureBC_dudt<dim>()));
+    this->boundary_descriptor->pressure->dirichlet_bc.insert(
+      pair(2, new Functions::ZeroFunction<dim>(1)));
+  }
+
+  void
+  set_field_functions() final
+  {
+    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+  }
+
+  std::shared_ptr<PostProcessorBase<dim, Number>>
+  create_postprocessor() final
+  {
+    PostProcessorData<dim> pp_data;
+
+    std::string name = this->output_name + "_l" + std::to_string(this->refine_level) + "_k" +
+                       std::to_string(this->param.degree_u);
+
+    // write output for visualization of results
+    pp_data.output_data.write_output       = this->write_output;
+    pp_data.output_data.directory          = this->output_directory + "vtu/";
+    pp_data.output_data.filename           = name;
+    pp_data.output_data.start_time         = start_time;
+    pp_data.output_data.interval_time      = (end_time - start_time) / 50;
+    pp_data.output_data.write_divergence   = true;
+    pp_data.output_data.write_higher_order = true;
+    pp_data.output_data.write_vorticity    = true;
+    pp_data.output_data.write_q_criterion  = true;
+    pp_data.output_data.write_processor_id = true;
+    pp_data.output_data.write_surface_mesh = false;
+    pp_data.output_data.write_boundary_IDs = true;
+    pp_data.output_data.write_grid         = false;
+    pp_data.output_data.degree             = this->param.degree_u;
+
+    // lift and drag
+    pp_data.lift_and_drag_data.calculate = true;
+    pp_data.lift_and_drag_data.viscosity = viscosity;
+
+    pp_data.lift_and_drag_data.reference_value = 1.0 / 2.0;
+
+    // surface for calculation of lift and drag coefficients has boundary_ID = 2
+    pp_data.lift_and_drag_data.boundary_IDs.insert(3);
+
+    pp_data.lift_and_drag_data.directory     = this->output_directory;
+    pp_data.lift_and_drag_data.filename_lift = name + "_lift";
+    pp_data.lift_and_drag_data.filename_drag = name + "_drag";
+
+    // pressure difference
+    pp_data.pressure_difference_data.calculate = true;
+    Point<dim> point_1, point_2;
+    point_1[0]                               = -radius;
+    point_2[0]                               = radius;
+    pp_data.pressure_difference_data.point_1 = point_1;
+    pp_data.pressure_difference_data.point_2 = point_2;
+
+    pp_data.pressure_difference_data.directory = this->output_directory;
+    pp_data.pressure_difference_data.filename  = name + "_pressure_difference";
+
+    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
+    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+
+    return pp;
+  }
+};
+
+} // namespace IncNS
+
+} // namespace ExaDG
+
+#include <exadg/incompressible_navier_stokes/user_interface/implement_get_application.h>
+
+#endif /* APPLICATIONS_INCOMPRESSIBLE_NAVIER_STOKES_TEST_CASES_FLOW_PAST_CYLINDER_H_ */

--- a/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
@@ -1,0 +1,277 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef APPLICATIONS_GRID_TOOLS_MESH_FLOW_PAST_CYLINDER_H_
+#define APPLICATIONS_GRID_TOOLS_MESH_FLOW_PAST_CYLINDER_H_
+
+namespace ExaDG
+{
+using namespace dealii;
+
+namespace FlowPastSphere
+{
+double const       radius        = 0.5;
+double const       radius_next   = 2. * radius;
+double const       outer         = 3.8 * radius;
+unsigned int const length_factor = 5;
+
+template<int dim, int spacedim = dim>
+class SphericalManifoldBoundaryLayer : public Manifold<dim, spacedim>
+{
+public:
+  SphericalManifoldBoundaryLayer(double const radius, double const radius_next)
+    : radius(radius), radius_next(radius_next), stretch_factor(0.4)
+  {
+  }
+
+  virtual std::unique_ptr<Manifold<dim, spacedim>>
+  clone() const override
+  {
+    return std::make_unique<SphericalManifoldBoundaryLayer<dim, spacedim>>(radius, radius_next);
+  }
+
+  virtual Point<spacedim>
+  get_intermediate_point(const Point<spacedim> & p1,
+                         const Point<spacedim> & p2,
+                         const double            w) const override
+  {
+    return push_forward(spherical.get_intermediate_point(pull_back(p1), pull_back(p2), w));
+  }
+
+  virtual Point<spacedim>
+  get_new_point(const ArrayView<const Point<spacedim>> & vertices,
+                const ArrayView<const double> &          weights) const override
+  {
+    boost::container::small_vector<Point<spacedim>, 100> pulled_back_vertices;
+    for(Point<spacedim> const & vertex : vertices)
+      pulled_back_vertices.push_back(pull_back(vertex));
+    return push_forward(spherical.get_new_point(
+      ArrayView<const Point<spacedim>>(pulled_back_vertices.data(), vertices.size()), weights));
+  }
+
+  virtual void
+  get_new_points(const ArrayView<const Point<spacedim>> & surrounding_points,
+                 const Table<2, double> &                 weights,
+                 ArrayView<Point<spacedim>>               new_points) const override
+  {
+    boost::container::small_vector<Point<spacedim>, 100> pulled_back_vertices;
+    for(Point<spacedim> const & vertex : surrounding_points)
+      pulled_back_vertices.push_back(pull_back(vertex));
+    spherical.get_new_points(ArrayView<const Point<spacedim>>(pulled_back_vertices.data(),
+                                                              surrounding_points.size()),
+                             weights,
+                             new_points);
+    for(Point<spacedim> & point : new_points)
+      point = push_forward(point);
+  }
+
+private:
+  Point<spacedim>
+  push_forward(Point<spacedim> const & p) const
+  {
+    // apply transformation function
+    double const R = p.norm();
+    double const r = radius + (R - stretch_factor * radius) /
+                                (radius_next - stretch_factor * radius) * (R - radius);
+    return p * (r / R);
+  }
+
+  Point<spacedim>
+  pull_back(Point<spacedim> const & p) const
+  {
+    // inverse of the function above, using the positive root
+    double const r = p.norm();
+    double const c =
+      stretch_factor * radius * radius - (r - radius) * (radius_next - stretch_factor * radius);
+    double const b = (1 + stretch_factor) * radius;
+    double const R = 0.5 * b + std::sqrt(0.25 * b * b - c);
+    return p * (R / r);
+  }
+
+  SphericalManifold<spacedim> const spherical;
+  double const                      radius;
+  double const                      radius_next;
+  double const                      stretch_factor;
+};
+
+
+
+template<int dim>
+void
+create_sphere_grid(Triangulation<dim> & tria, unsigned int const n_refinements)
+{
+  Triangulation<dim> tria1, tria2, tria3, tria4, tria_ser;
+  GridGenerator::hyper_shell(tria1, Point<dim>(), radius, radius_next, 6);
+  GridGenerator::hyper_shell(tria2, Point<dim>(), radius_next, std::sqrt(dim) * outer, 6);
+
+  Point<dim> lower_left, upper_right;
+  lower_left[0] = outer;
+  for(unsigned int d = 1; d < dim; ++d)
+    lower_left[d] = -outer;
+  upper_right[0] = (1 + 2 * length_factor) * outer;
+  for(unsigned int d = 1; d < dim; ++d)
+    upper_right[d] = outer;
+  GridGenerator::subdivided_hyper_rectangle(
+    tria3, {length_factor, 1, 1}, lower_left, upper_right, false);
+  lower_left[0]  = -3 * outer;
+  upper_right[0] = -outer;
+  GridGenerator::subdivided_hyper_rectangle(tria4, {1, 1, 1}, lower_left, upper_right, false);
+
+  GridGenerator::merge_triangulations({&tria1, &tria2, &tria3, &tria4}, tria_ser);
+  tria_ser.reset_all_manifolds();
+  tria.set_all_manifold_ids(0);
+
+  // Set cells near sphere to spherical manifold for first round of refinement
+  for(auto const & cell : tria_ser.active_cell_iterators())
+  {
+    if(cell->index() < 6)
+      cell->set_all_manifold_ids(1);
+  }
+  const SphericalManifoldBoundaryLayer<dim> spherical_manifold(radius, radius_next);
+  tria_ser.set_manifold(1, spherical_manifold);
+
+  tria_ser.refine_global(1);
+
+  // Shift two points somewhat to generate a better balance in points
+  for(auto const & cell : tria_ser.active_cell_iterators())
+  {
+    if(std::abs(cell->vertex(0)[0] - outer) < 1e-10 && std::abs(cell->vertex(0)[1]) < 1e-10 &&
+       std::abs(cell->vertex(0)[2]) < 1e-10)
+      cell->vertex(0)[0] += 0.3 * (outer - radius_next);
+    else if(std::abs(cell->vertex(0)[0] - 0.5 * (outer + radius_next)) < 1e-10 &&
+            std::abs(cell->vertex(0)[1]) < 1e-10 && std::abs(cell->vertex(0)[2]) < 1e-10)
+      cell->vertex(0)[0] += 0.15 * (outer - radius_next);
+    else if(std::abs(cell->vertex(1)[0] + outer) < 1e-10 && std::abs(cell->vertex(1)[1]) < 1e-10 &&
+            std::abs(cell->vertex(1)[2]) < 1e-10)
+      cell->vertex(1)[0] -= 0.3 * (outer - radius_next);
+    else if(std::abs(cell->vertex(1)[0] + 0.5 * (outer + radius_next)) < 1e-10 &&
+            std::abs(cell->vertex(1)[1]) < 1e-10 && std::abs(cell->vertex(1)[2]) < 1e-10)
+      cell->vertex(1)[0] -= 0.15 * (outer - radius_next);
+  }
+
+  // Remove refinement to make sure all MPI ranks agree on this mesh
+  Triangulation<dim> tria_inner;
+  GridGenerator::flatten_triangulation(tria_ser, tria_inner);
+
+  // Create outer layer of cube cells
+  for(unsigned int d = 1; d < dim; ++d)
+    lower_left[d] = -2. * outer;
+  for(unsigned int d = 1; d < dim; ++d)
+    upper_right[d] = 2. * outer;
+  upper_right[0] = (1 + 2 * length_factor) * outer;
+  Triangulation<dim>        tria_rectangle;
+  std::vector<unsigned int> refinements(dim, 4);
+  refinements[0] = 2 * length_factor + 4;
+  GridGenerator::subdivided_hyper_rectangle(tria_rectangle, refinements, lower_left, upper_right);
+
+  // Remove cells present in inner mesh
+  std::set<typename Triangulation<dim>::active_cell_iterator> cells_to_remove;
+  for(auto const & cell : tria_rectangle.active_cell_iterators())
+    if(outer - std::abs(cell->center()[1]) > 0. &&
+       (dim < 3 || (outer - std::abs(cell->center()[2]) > 0.)))
+      cells_to_remove.insert(cell);
+
+  Triangulation<dim> tria_outer;
+  GridGenerator::create_triangulation_with_removed_cells(tria_rectangle,
+                                                         cells_to_remove,
+                                                         tria_outer);
+
+  GridGenerator::merge_triangulations({&tria_inner, &tria_outer}, tria);
+
+  // Set manifold ids again on the final triangulation
+  tria.reset_all_manifolds();
+  for(auto const & cell : tria.active_cell_iterators())
+  {
+    if(cell->index() < 6 * 8)
+    {
+      cell->set_all_manifold_ids(1);
+      for(unsigned int v : cell->vertex_indices())
+        AssertThrow(cell->vertex(v).norm() < radius_next + 1e-10, ExcInternalError());
+    }
+  }
+  tria.set_manifold(1, spherical_manifold);
+
+  // Set boundary ids
+  for(auto const & cell : tria.cell_iterators())
+    for(unsigned int f = 0; f < cell->n_faces(); ++f)
+      if(cell->at_boundary(f))
+      {
+        // sphere -> id 3
+        if(std::abs(cell->face(f)->vertex(0).norm() - radius) < 1e-10)
+          cell->face(f)->set_boundary_id(3);
+        // inflow -> id 1
+        else if(std::abs(cell->face(f)->center()[0] + 3. * outer) < 1e-10)
+          cell->face(f)->set_boundary_id(1);
+        // symmetry -> id 0
+        else if(2. * outer - std::abs(cell->face(f)->center()[1]) < 1e-10 ||
+                (dim == 3 && (2. * outer - std::abs(cell->face(f)->center()[2]) < 1e-10)))
+          cell->face(f)->set_boundary_id(0);
+        // outflow -> id 2
+        else
+        {
+          AssertThrow(std::abs(cell->face(f)->center()[0] - (1 + 2 * length_factor) * outer) <
+                        1e-10,
+                      ExcInternalError());
+          cell->face(f)->set_boundary_id(2);
+        }
+      }
+
+  if(n_refinements > 0)
+  {
+    // In the first round, only refine cells in the inner part of the duct as
+    // the outer cells carry little information
+    for(auto const & cell : tria.active_cell_iterators())
+      if(cell->is_locally_owned())
+      {
+        if(outer - std::abs(cell->center()[1]) > 0. &&
+           (dim < 3 || (outer - std::abs(cell->center()[2]) > 0.)))
+          cell->set_refine_flag();
+      }
+    tria.execute_coarsening_and_refinement();
+
+    tria.refine_global(n_refinements - 1);
+  }
+
+  // Refine mesh adaptively once again in region around sphere and in the
+  // immediate wake
+  for(auto const & cell : tria.active_cell_iterators())
+    if(cell->is_locally_owned())
+    {
+      Point<dim> center = cell->center();
+      if(center[0] > 0 && center[0] < 4.5 * outer)
+      {
+        // Check radius of 2.5 * radius for (y,z) coordinates
+        const double radius_factor = center[0] < 0 ? 2.3 : 2.8;
+        center[0]                  = 0;
+        if(center.norm() < radius_factor * radius)
+          cell->set_refine_flag();
+      }
+      else if(center.norm() < radius_next)
+        cell->set_refine_flag();
+    }
+  tria.execute_coarsening_and_refinement();
+}
+
+
+} // namespace FlowPastSphere
+} // namespace ExaDG
+
+#endif /* APPLICATIONS_GRID_TOOLS_MESH_FLOW_PAST_CYLINDER_H_ */

--- a/applications/incompressible_navier_stokes/flow_past_sphere/input.json
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/input.json
@@ -1,0 +1,26 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "3",
+        "IsTest": "false"
+    },
+    "SpatialResolution": {
+        "DegreeMin": "3",
+        "DegreeMax": "3",
+        "RefineSpaceMin": "0",
+        "RefineSpaceMax": "0"
+    },
+    "TemporalResolution": {
+        "RefineTimeMin": "0",
+        "RefineTimeMax": "0"
+    },
+    "Application": {
+        "Viscosity": "0.001",
+        "CFL": "0.27"
+    },
+    "Output": {
+        "OutputDirectory": "output/",
+        "OutputName": "flow",
+        "WriteOutput": "false"
+    }
+}

--- a/applications/incompressible_navier_stokes/flow_past_sphere/solver.cpp
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/solver.cpp
@@ -1,0 +1,26 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// solver
+#include <exadg/incompressible_navier_stokes/solver.h>
+
+// application
+#include "application.h"


### PR DESCRIPTION
This PR suggests a new test case for the flow around a sphere. It is similar to the flow around a cylinder, but it stresses several different components of our implementation:
- By working on this test case, I observed that the orientation + refinement combination in deal.II was broken (which eventually led to https://github.com/dealii/dealii/pull/13101). This makes it useful to check ExaDG capabilities as well.
- There is still one potential issue (that I do not know how to fix yet), which happens when I have some hanging nodes in the front of the sphere. It could be related to the orientation (but no test in deal.II triggers), but also things like inf-sup or stabilization parameters somewhere.
- The test case demonstrates some more advanced manifold manipulations, doing a boundary-adapted mesh inside a `SphericalManifold`.
- I had initially intended to include `TransfiniteInterpolationManifold` but decided against it for the current implementation in deal.II as it increases costs.

We could think of giving the user more control about the adaptive refinement, which is something we might want to discuss.