### PR TITLE
Simplex support for Poisson operator

### DIFF
--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -28,6 +28,14 @@ namespace ExaDG
 {
 namespace Poisson
 {
+enum class GridType
+{
+  Hypercube,
+  Simplex
+};
+
+GridType GRID_TYPE = GridType::Hypercube;
+
 double const FREQUENCY            = 3.0 * dealii::numbers::PI;
 bool const   USE_NEUMANN_BOUNDARY = true;
 
@@ -183,10 +191,25 @@ private:
     // choose a coarse grid with at least 2^dim elements to obtain a non-trivial coarse grid problem
     unsigned int n_cells_1d =
       std::max((unsigned int)2, this->param.grid.n_subdivisions_1d_hypercube);
-    dealii::GridGenerator::subdivided_hyper_cube(*this->grid->triangulation,
-                                                 n_cells_1d,
-                                                 left,
-                                                 right);
+
+    if(GRID_TYPE == GridType::Hypercube)
+    {
+      dealii::GridGenerator::subdivided_hyper_cube(*this->grid->triangulation,
+                                                   n_cells_1d,
+                                                   left,
+                                                   right);
+    }
+    else if(GRID_TYPE == GridType::Simplex)
+    {
+      dealii::GridGenerator::subdivided_hyper_cube_with_simplices(*this->grid->triangulation,
+                                                                  n_cells_1d,
+                                                                  left,
+                                                                  right);
+    }
+    else
+    {
+      AssertThrow(false, ExcNotImplemented());
+    }
 
     if(mesh_type == MeshType::Cartesian)
     {

--- a/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
@@ -229,6 +229,8 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::write_data(
     {
       this->precice->writeScalarData(write_data_id, coupling_nodes_ids[i], write_data[0]);
     }
+#else
+    (void)write_data_id;
 #endif
   }
 }

--- a/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
@@ -300,6 +300,7 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
                                             unrolled_local_data.data());
 #else
         (void)active_faces;
+        (void)write_data_id;
 #endif
       }
       else

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -45,11 +45,11 @@ all_reference_cells_are_simplices(Triangulation<dim> const & tria)
 #if DEAL_II_VERSION_GTE(10, 0, 0)
   return tria.all_reference_cells_are_simplex();
 #else
-  Assert(tria.reference_cells.size() > 0,
+  Assert(tria.get_reference_cells().size() > 0,
          ExcMessage("You can't ask about the kinds of reference "
                     "cells used by this triangulation if the "
                     "triangulation doesn't yet have any cells in it."));
-  return (tria.reference_cells.size() == 1 && tria.reference_cells[0].is_simplex());
+  return (tria.get_reference_cells().size() == 1 && tria.get_reference_cells()[0].is_simplex());
 #endif
 }
 

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -35,7 +35,6 @@
 
 namespace ExaDG
 {
-
 template<int dim>
 class Grid
 {

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -35,49 +35,8 @@
 
 namespace ExaDG
 {
-using namespace dealii;
 
-// helper functions since some functionality is not available in dealii release 9.3
 template<int dim>
-bool
-all_reference_cells_are_simplices(Triangulation<dim> const & tria)
-{
-#if DEAL_II_VERSION_GTE(10, 0, 0)
-  return tria.all_reference_cells_are_simplex();
-#else
-  Assert(tria.get_reference_cells().size() > 0,
-         ExcMessage("You can't ask about the kinds of reference "
-                    "cells used by this triangulation if the "
-                    "triangulation doesn't yet have any cells in it."));
-  return (tria.get_reference_cells().size() == 1 && tria.get_reference_cells()[0].is_simplex());
-#endif
-}
-
-struct GridData
-{
-  GridData()
-    : triangulation_type(TriangulationType::Distributed),
-      n_refine_global(0),
-      n_subdivisions_1d_hypercube(1),
-      mapping_degree(1)
-  {
-  }
-
-  TriangulationType triangulation_type;
-
-  unsigned int n_refine_global;
-
-  // only relevant for hypercube geometry/mesh
-  unsigned int n_subdivisions_1d_hypercube;
-
-  unsigned int mapping_degree;
-
-  // TODO: path to a grid file
-  // std::string grid_file;
-};
-
-template<int dim, typename Number>
->>>>>>> fix issue with dealii version 9.3
 class Grid
 {
 public:

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -35,7 +35,49 @@
 
 namespace ExaDG
 {
+using namespace dealii;
+
+// helper functions since some functionality is not available in dealii release 9.3
 template<int dim>
+bool
+all_reference_cells_are_simplices(Triangulation<dim> const & tria)
+{
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+  return tria.all_reference_cells_are_simplex();
+#else
+  Assert(tria.reference_cells.size() > 0,
+         ExcMessage("You can't ask about the kinds of reference "
+                    "cells used by this triangulation if the "
+                    "triangulation doesn't yet have any cells in it."));
+  return (tria.reference_cells.size() == 1 && tria.reference_cells[0].is_simplex());
+#endif
+}
+
+struct GridData
+{
+  GridData()
+    : triangulation_type(TriangulationType::Distributed),
+      n_refine_global(0),
+      n_subdivisions_1d_hypercube(1),
+      mapping_degree(1)
+  {
+  }
+
+  TriangulationType triangulation_type;
+
+  unsigned int n_refine_global;
+
+  // only relevant for hypercube geometry/mesh
+  unsigned int n_subdivisions_1d_hypercube;
+
+  unsigned int mapping_degree;
+
+  // TODO: path to a grid file
+  // std::string grid_file;
+};
+
+template<int dim, typename Number>
+>>>>>>> fix issue with dealii version 9.3
 class Grid
 {
 public:

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -22,6 +22,7 @@
 // deal.II
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_system.h>
 #ifdef DEAL_II_WITH_PETSC
 #  include <deal.II/lac/petsc_vector.h>
@@ -75,20 +76,52 @@ Operator<dim, n_components, Number>::distribute_dofs()
   if(n_components == 1)
   {
     if(param.spatial_discretization == SpatialDiscretization::DG)
-      fe = std::make_shared<dealii::FE_DGQ<dim>>(param.degree);
+    {
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<FE_DGQ<dim>>(param.degree);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<FE_SimplexDGP<dim>>(param.degree);
+      else
+        AssertThrow(false, ExcNotImplemented());
+    }
     else if(param.spatial_discretization == SpatialDiscretization::CG)
-      fe = std::make_shared<dealii::FE_Q<dim>>(param.degree);
+    {
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<FE_Q<dim>>(param.degree);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<FE_SimplexP<dim>>(param.degree);
+      else
+        AssertThrow(false, ExcNotImplemented());
+    }
     else
-      AssertThrow(false, ExcNotImplemented());
+    {
+      AssertThrow(false, ExcMessage("not implemented."));
+    }
   }
   else if(n_components == dim)
   {
     if(param.spatial_discretization == SpatialDiscretization::DG)
-      fe = std::make_shared<dealii::FESystem<dim>>(dealii::FE_DGQ<dim>(param.degree), dim);
+   {
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<FESystem<dim>>(FE_DGQ<dim>(param.degree), dim);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<FESystem<dim>>(FE_SimplexDGP<dim>(param.degree), dim);
+      else
+        AssertThrow(false, ExcNotImplemented());
+    }
     else if(param.spatial_discretization == SpatialDiscretization::CG)
-      fe = std::make_shared<dealii::FESystem<dim>>(dealii::FE_Q<dim>(param.degree), dim);
+    {
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<FESystem<dim>>(FE_Q<dim>(param.degree), dim);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<FESystem<dim>>(FE_SimplexP<dim>(param.degree), dim);
+      else
+        AssertThrow(false, ExcNotImplemented());
+    }
     else
-      AssertThrow(false, dealii::ExcMessage("not implemented."));
+    {
+      AssertThrow(false, ExcMessage("not implemented."));
+    }
   }
   else
   {
@@ -96,6 +129,9 @@ Operator<dim, n_components, Number>::distribute_dofs()
   }
 
   dof_handler.distribute_dofs(*fe);
+
+  // TODO: might need adjustments for simplices
+  dof_handler.distribute_mg_dofs();
 
   // affine constraints only relevant for continuous FE discretization
   if(param.spatial_discretization == SpatialDiscretization::CG)
@@ -171,7 +207,13 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
 
   matrix_free_data.insert_dof_handler(&dof_handler, get_dof_name());
   matrix_free_data.insert_constraint(&affine_constraints, get_dof_name());
-  matrix_free_data.insert_quadrature(dealii::QGauss<1>(param.degree + 1), get_quad_name());
+
+  if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+    matrix_free_data.insert_quadrature(QGauss<1>(param.degree + 1), get_quad_name());
+  else if(this->grid->triangulation->all_reference_cells_are_simplex())
+    matrix_free_data.insert_quadrature(QGaussSimplex<dim>(param.degree + 1), get_quad_name());
+  else
+    AssertThrow(false, ExcNotImplemented());
 
   // Create a Gauss-Lobatto quadrature rule for DirichletCached boundary conditions.
   // These quadrature points coincide with the nodes of the discretization, so that
@@ -184,7 +226,10 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
   if(param.spatial_discretization == SpatialDiscretization::CG &&
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
-    matrix_free_data.insert_quadrature(dealii::QGaussLobatto<1>(param.degree + 1),
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+                ExcNotImplemented());
+
+    matrix_free_data.insert_quadrature(QGaussLobatto<1>(param.degree + 1),
                                        get_quad_gauss_lobatto_name());
   }
 }
@@ -199,7 +244,12 @@ Operator<dim, n_components, Number>::setup_operators()
   laplace_operator_data.quad_index = get_quad_index();
   if(param.spatial_discretization == SpatialDiscretization::CG &&
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
+  {
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+                ExcNotImplemented());
+
     laplace_operator_data.quad_index_gauss_lobatto = get_quad_index_gauss_lobatto();
+  }
   laplace_operator_data.bc                    = boundary_descriptor;
   laplace_operator_data.use_cell_based_loops  = param.enable_cell_based_face_loops;
   laplace_operator_data.kernel_data.IP_factor = param.IP_factor;
@@ -257,16 +307,29 @@ Operator<dim, n_components, Number>::setup_solver()
   pcout << std::endl << "Setup Poisson solver ..." << std::endl;
 
   // initialize preconditioner
-  if(param.preconditioner == Poisson::Preconditioner::PointJacobi)
+  if(param.preconditioner == Poisson::Preconditioner::None)
   {
+    // do nothing
+  }
+  else if(param.preconditioner == Poisson::Preconditioner::PointJacobi)
+  {
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+                ExcNotImplemented());
+
     preconditioner = std::make_shared<JacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::BlockJacobi)
   {
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+                ExcNotImplemented());
+
     preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::Multigrid)
   {
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+                ExcNotImplemented());
+
     MultigridData mg_data;
     mg_data = param.multigrid_data;
 
@@ -303,11 +366,7 @@ Operator<dim, n_components, Number>::setup_solver()
   }
   else
   {
-    AssertThrow(param.preconditioner == Poisson::Preconditioner::None ||
-                  param.preconditioner == Poisson::Preconditioner::PointJacobi ||
-                  param.preconditioner == Poisson::Preconditioner::BlockJacobi ||
-                  param.preconditioner == Poisson::Preconditioner::Multigrid,
-                dealii::ExcMessage("Specified preconditioner is not implemented!"));
+    AssertThrow(false, ExcMessage("Specified preconditioner is not implemented!"));
   }
 
   if(param.solver == Poisson::Solver::CG)

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -77,50 +77,50 @@ Operator<dim, n_components, Number>::distribute_dofs()
   {
     if(param.spatial_discretization == SpatialDiscretization::DG)
     {
-      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
-        fe = std::make_shared<FE_DGQ<dim>>(param.degree);
-      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
-        fe = std::make_shared<FE_SimplexDGP<dim>>(param.degree);
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<dealii::FE_DGQ<dim>>(param.degree);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<dealii::FE_SimplexDGP<dim>>(param.degree);
       else
         AssertThrow(false, ExcNotImplemented());
     }
     else if(param.spatial_discretization == SpatialDiscretization::CG)
     {
-      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
-        fe = std::make_shared<FE_Q<dim>>(param.degree);
-      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
-        fe = std::make_shared<FE_SimplexP<dim>>(param.degree);
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<dealii::FE_Q<dim>>(param.degree);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<dealii::FE_SimplexP<dim>>(param.degree);
       else
         AssertThrow(false, ExcNotImplemented());
     }
     else
     {
-      AssertThrow(false, ExcMessage("not implemented."));
+      AssertThrow(false, ExcNotImplemented());
     }
   }
   else if(n_components == dim)
   {
     if(param.spatial_discretization == SpatialDiscretization::DG)
     {
-      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
-        fe = std::make_shared<FESystem<dim>>(FE_DGQ<dim>(param.degree), dim);
-      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
-        fe = std::make_shared<FESystem<dim>>(FE_SimplexDGP<dim>(param.degree), dim);
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<dealii::FESystem<dim>>(dealii::FE_DGQ<dim>(param.degree), dim);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<dealii::FESystem<dim>>(dealii::FE_SimplexDGP<dim>(param.degree), dim);
       else
         AssertThrow(false, ExcNotImplemented());
     }
     else if(param.spatial_discretization == SpatialDiscretization::CG)
     {
-      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
-        fe = std::make_shared<FESystem<dim>>(FE_Q<dim>(param.degree), dim);
-      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
-        fe = std::make_shared<FESystem<dim>>(FE_SimplexP<dim>(param.degree), dim);
+      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+        fe = std::make_shared<dealii::FESystem<dim>>(dealii::FE_Q<dim>(param.degree), dim);
+      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+        fe = std::make_shared<dealii::FESystem<dim>>(dealii::FE_SimplexP<dim>(param.degree), dim);
       else
         AssertThrow(false, ExcNotImplemented());
     }
     else
     {
-      AssertThrow(false, ExcMessage("not implemented."));
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
     }
   }
   else
@@ -209,9 +209,9 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
   matrix_free_data.insert_constraint(&affine_constraints, get_dof_name());
 
   if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
-    matrix_free_data.insert_quadrature(QGauss<1>(param.degree + 1), get_quad_name());
-  else if(all_reference_cells_are_simplices(*this->grid->triangulation))
-    matrix_free_data.insert_quadrature(QGaussSimplex<dim>(param.degree + 1), get_quad_name());
+    matrix_free_data.insert_quadrature(dealii::QGauss<1>(param.degree + 1), get_quad_name());
+  else if(this->grid->triangulation->all_reference_cells_are_simplex())
+    matrix_free_data.insert_quadrature(dealii::QGaussSimplex<dim>(param.degree + 1), get_quad_name());
   else
     AssertThrow(false, ExcNotImplemented());
 
@@ -226,10 +226,10 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
   if(param.spatial_discretization == SpatialDiscretization::CG &&
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
-    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
-                ExcNotImplemented());
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+        ExcNotImplemented());
 
-    matrix_free_data.insert_quadrature(QGaussLobatto<1>(param.degree + 1),
+    matrix_free_data.insert_quadrature(dealii::QGaussLobatto<1>(param.degree + 1),
                                        get_quad_gauss_lobatto_name());
   }
 }
@@ -245,8 +245,8 @@ Operator<dim, n_components, Number>::setup_operators()
   if(param.spatial_discretization == SpatialDiscretization::CG &&
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
-    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
-                ExcNotImplemented());
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+        ExcNotImplemented());
 
     laplace_operator_data.quad_index_gauss_lobatto = get_quad_index_gauss_lobatto();
   }
@@ -313,22 +313,22 @@ Operator<dim, n_components, Number>::setup_solver()
   }
   else if(param.preconditioner == Poisson::Preconditioner::PointJacobi)
   {
-    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
-                ExcNotImplemented());
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+        ExcNotImplemented());
 
     preconditioner = std::make_shared<JacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::BlockJacobi)
   {
-    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
-                ExcNotImplemented());
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+        ExcNotImplemented());
 
     preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::Multigrid)
   {
-    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
-                ExcNotImplemented());
+    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+        ExcNotImplemented());
 
     MultigridData mg_data;
     mg_data = param.multigrid_data;
@@ -366,7 +366,7 @@ Operator<dim, n_components, Number>::setup_solver()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified preconditioner is not implemented!"));
+    AssertThrow(false, dealii::ExcMessage("Specified preconditioner is not implemented!"));
   }
 
   if(param.solver == Poisson::Solver::CG)

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -77,18 +77,18 @@ Operator<dim, n_components, Number>::distribute_dofs()
   {
     if(param.spatial_discretization == SpatialDiscretization::DG)
     {
-      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
         fe = std::make_shared<FE_DGQ<dim>>(param.degree);
-      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
         fe = std::make_shared<FE_SimplexDGP<dim>>(param.degree);
       else
         AssertThrow(false, ExcNotImplemented());
     }
     else if(param.spatial_discretization == SpatialDiscretization::CG)
     {
-      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
         fe = std::make_shared<FE_Q<dim>>(param.degree);
-      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
         fe = std::make_shared<FE_SimplexP<dim>>(param.degree);
       else
         AssertThrow(false, ExcNotImplemented());
@@ -101,19 +101,19 @@ Operator<dim, n_components, Number>::distribute_dofs()
   else if(n_components == dim)
   {
     if(param.spatial_discretization == SpatialDiscretization::DG)
-   {
-      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+    {
+      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
         fe = std::make_shared<FESystem<dim>>(FE_DGQ<dim>(param.degree), dim);
-      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
         fe = std::make_shared<FESystem<dim>>(FE_SimplexDGP<dim>(param.degree), dim);
       else
         AssertThrow(false, ExcNotImplemented());
     }
     else if(param.spatial_discretization == SpatialDiscretization::CG)
     {
-      if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+      if(all_reference_cells_are_hyper_cubes(*this->grid->triangulation))
         fe = std::make_shared<FESystem<dim>>(FE_Q<dim>(param.degree), dim);
-      else if(this->grid->triangulation->all_reference_cells_are_simplex())
+      else if(all_reference_cells_are_simplices(*this->grid->triangulation))
         fe = std::make_shared<FESystem<dim>>(FE_SimplexP<dim>(param.degree), dim);
       else
         AssertThrow(false, ExcNotImplemented());
@@ -210,7 +210,7 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
 
   if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
     matrix_free_data.insert_quadrature(QGauss<1>(param.degree + 1), get_quad_name());
-  else if(this->grid->triangulation->all_reference_cells_are_simplex())
+  else if(all_reference_cells_are_simplices(*this->grid->triangulation))
     matrix_free_data.insert_quadrature(QGaussSimplex<dim>(param.degree + 1), get_quad_name());
   else
     AssertThrow(false, ExcNotImplemented());
@@ -226,7 +226,7 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
   if(param.spatial_discretization == SpatialDiscretization::CG &&
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
-    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
                 ExcNotImplemented());
 
     matrix_free_data.insert_quadrature(QGaussLobatto<1>(param.degree + 1),
@@ -245,7 +245,7 @@ Operator<dim, n_components, Number>::setup_operators()
   if(param.spatial_discretization == SpatialDiscretization::CG &&
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
-    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
                 ExcNotImplemented());
 
     laplace_operator_data.quad_index_gauss_lobatto = get_quad_index_gauss_lobatto();
@@ -313,21 +313,21 @@ Operator<dim, n_components, Number>::setup_solver()
   }
   else if(param.preconditioner == Poisson::Preconditioner::PointJacobi)
   {
-    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
                 ExcNotImplemented());
 
     preconditioner = std::make_shared<JacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::BlockJacobi)
   {
-    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
                 ExcNotImplemented());
 
     preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::Multigrid)
   {
-    AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
+    AssertThrow(all_reference_cells_are_hyper_cubes(*this->grid->triangulation),
                 ExcNotImplemented());
 
     MultigridData mg_data;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -131,7 +131,8 @@ Operator<dim, n_components, Number>::distribute_dofs()
   dof_handler.distribute_dofs(*fe);
 
   // TODO: might need adjustments for simplices
-  dof_handler.distribute_mg_dofs();
+  if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
+    dof_handler.distribute_mg_dofs();
 
   // affine constraints only relevant for continuous FE discretization
   if(param.spatial_discretization == SpatialDiscretization::CG)

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -211,7 +211,8 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
   if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
     matrix_free_data.insert_quadrature(dealii::QGauss<1>(param.degree + 1), get_quad_name());
   else if(this->grid->triangulation->all_reference_cells_are_simplex())
-    matrix_free_data.insert_quadrature(dealii::QGaussSimplex<dim>(param.degree + 1), get_quad_name());
+    matrix_free_data.insert_quadrature(dealii::QGaussSimplex<dim>(param.degree + 1),
+                                       get_quad_name());
   else
     AssertThrow(false, ExcNotImplemented());
 
@@ -227,7 +228,7 @@ Operator<dim, n_components, Number>::fill_matrix_free_data(
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
     AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
-        ExcNotImplemented());
+                ExcNotImplemented());
 
     matrix_free_data.insert_quadrature(dealii::QGaussLobatto<1>(param.degree + 1),
                                        get_quad_gauss_lobatto_name());
@@ -246,7 +247,7 @@ Operator<dim, n_components, Number>::setup_operators()
      not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
     AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
-        ExcNotImplemented());
+                ExcNotImplemented());
 
     laplace_operator_data.quad_index_gauss_lobatto = get_quad_index_gauss_lobatto();
   }
@@ -314,21 +315,21 @@ Operator<dim, n_components, Number>::setup_solver()
   else if(param.preconditioner == Poisson::Preconditioner::PointJacobi)
   {
     AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
-        ExcNotImplemented());
+                ExcNotImplemented());
 
     preconditioner = std::make_shared<JacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::BlockJacobi)
   {
     AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
-        ExcNotImplemented());
+                ExcNotImplemented());
 
     preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::Multigrid)
   {
     AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
-        ExcNotImplemented());
+                ExcNotImplemented());
 
     MultigridData mg_data;
     mg_data = param.multigrid_data;

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -35,6 +35,7 @@
 #include <exadg/poisson/user_interface/boundary_descriptor.h>
 #include <exadg/poisson/user_interface/field_functions.h>
 #include <exadg/poisson/user_interface/parameters.h>
+#include <exadg/utilities/exceptions.h>
 #include <exadg/utilities/output_parameters.h>
 #include <exadg/utilities/resolution_parameters.h>
 


### PR DESCRIPTION
Closes #103 

This PR replaces #110. Compared to #110, I added more Asserts in `Poisson::Operator`. Other parts of #110 have already been realized in other PRs.

I added a TODO in the code, since we still discuss in #110 how to deal with `distribute_mg_dofs()`.

This PR is still work-in-progress, but discussion might be helpful already right now.