### PR TITLE
Remove distribute_mg_dofs from field solvers

### DIFF
--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -289,12 +289,10 @@ Operator<dim, Number>::distribute_dofs()
 {
   // enumerate degrees of freedom
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs();
 
   if(needs_own_dof_handler_velocity())
   {
     dof_handler_velocity->distribute_dofs(*fe_velocity);
-    dof_handler_velocity->distribute_mg_dofs();
   }
 
   unsigned int const ndofs_per_cell = Utilities::pow(param.degree + 1, dim);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -235,11 +235,8 @@ SpatialOperatorBase<dim, Number>::distribute_dofs()
 {
   // enumerate degrees of freedom
   dof_handler_u.distribute_dofs(*fe_u);
-  dof_handler_u.distribute_mg_dofs();
   dof_handler_p.distribute_dofs(fe_p);
-  dof_handler_p.distribute_mg_dofs();
   dof_handler_u_scalar.distribute_dofs(fe_u_scalar);
-  dof_handler_u_scalar.distribute_mg_dofs(); // probably, we don't need this
 
   unsigned int const ndofs_per_cell_velocity = Utilities::pow(param.degree_u + 1, dim) * dim;
   unsigned int const ndofs_per_cell_pressure =

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -98,8 +98,6 @@ Operator<dim, Number, n_components>::distribute_dofs()
 
   dof_handler.distribute_dofs(*fe);
 
-  dof_handler.distribute_mg_dofs();
-
   // affine constraints only relevant for continuous FE discretization
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -785,9 +785,13 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
   }
   else // can only be used for triangulations without hanging nodes
   {
-    Assert(tria->has_hanging_nodes() == false,
-           ExcMessage(
-             "Hanging nodes are only supported with the option use_global_coarsening enabled."));
+    AssertThrow(tria->has_hanging_nodes() == false,
+                ExcMessage("Hanging nodes are only supported with the option "
+                           "use_global_coarsening enabled."));
+    AssertThrow(tria->all_reference_cells_are_hyper_cube(),
+                ExcMessage("This multigrid implementation is currently only available for "
+                           "hyper-cube elements. Other grids need to enable the option "
+                           "use_global_coarsening."));
 
     unsigned int const n_components = fe.n_components();
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -86,7 +86,6 @@ Operator<dim, Number>::distribute_dofs()
 {
   // enumerate degrees of freedom
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs();
 
   // affine constraints
   affine_constraints.clear();


### PR DESCRIPTION
Following what we discussed in https://github.com/exadg/exadg/pull/110#discussion_r783097083, I realized that we always create a `DoFHandler` copy inside the multigrid solver for which we call `distribute_mg_dofs`, https://github.com/exadg/exadg/blob/f2ff9d113b0898c8eb5d089b2ee5f0d3112c9297/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp#L799-L808 , because we do https://github.com/exadg/exadg/blob/f2ff9d113b0898c8eb5d089b2ee5f0d3112c9297/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp#L157-L168 .

Also, we only fill the constraints on the levels on this `DoFHandler`, which is called in the right order, https://github.com/exadg/exadg/blob/master/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp#L812

I ran tests in the convection-diffusion, structure and Poisson module, which all work for me. @nfehn do you agree or do you know what to check in a broader sense?