### PR TITLE
shift n_subdivisions_1d_hypercube from ApplicationBase to GridData

### DIFF
--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -247,7 +247,7 @@ public:
     create_periodic_box(grid->triangulation,
                         grid_data.n_refine_global,
                         grid->periodic_faces,
-                        this->n_subdivisions_1d_hypercube,
+                        grid_data.n_subdivisions_1d_hypercube,
                         left,
                         right,
                         curvilinear_mesh,

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -162,7 +162,7 @@ public:
     create_periodic_box(grid->triangulation,
                         grid_data.n_refine_global,
                         grid->periodic_faces,
-                        this->n_subdivisions_1d_hypercube,
+                        grid_data.n_subdivisions_1d_hypercube,
                         left,
                         right,
                         curvilinear_mesh,

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -125,7 +125,7 @@ public:
     // clang-format off
     prm.enter_subsection("Application");
       prm.add_parameter("MeshType",        mesh_type_string,                  "Type of mesh (Cartesian versus curvilinear).", Patterns::Selection("Cartesian|Curvilinear"));
-      prm.add_parameter("NCoarseCells1D",  this->n_subdivisions_1d_hypercube, "Number of cells per direction on coarse grid.", Patterns::Integer(1,5));
+      prm.add_parameter("NCoarseCells1D",  n_subdivisions_1d_hypercube,       "Number of cells per direction on coarse grid.", Patterns::Integer(1,5));
       prm.add_parameter("ExploitSymmetry", exploit_symmetry,                  "Exploit symmetry and reduce DoFs by a factor of 8?");
       prm.add_parameter("MovingMesh",      ALE,                               "Moving mesh?");
       prm.add_parameter("Inviscid",        inviscid,                          "Is this an inviscid simulation?");
@@ -139,6 +139,8 @@ public:
   // mesh type
   std::string mesh_type_string = "Cartesian";
   MeshType    mesh_type        = MeshType::Cartesian;
+
+  unsigned int n_subdivisions_1d_hypercube = 1;
 
   // inviscid limit
   bool inviscid = false;
@@ -382,7 +384,7 @@ public:
       create_periodic_box(grid->triangulation,
                           grid_data.n_refine_global,
                           grid->periodic_faces,
-                          this->n_subdivisions_1d_hypercube,
+                          n_subdivisions_1d_hypercube,
                           left,
                           right,
                           curvilinear_mesh,
@@ -391,7 +393,7 @@ public:
     else // symmetric box
     {
       GridGenerator::subdivided_hyper_cube(*grid->triangulation,
-                                           this->n_subdivisions_1d_hypercube,
+                                           n_subdivisions_1d_hypercube,
                                            0.0,
                                            right);
 
@@ -529,8 +531,8 @@ public:
     pp_data.kinetic_energy_spectrum_data.degree                        = this->param.degree_u;
     pp_data.kinetic_energy_spectrum_data.evaluation_points_per_cell    = (this->param.degree_u + 1);
     pp_data.kinetic_energy_spectrum_data.exploit_symmetry              = exploit_symmetry;
-    pp_data.kinetic_energy_spectrum_data.n_cells_1d_coarse_grid = this->n_subdivisions_1d_hypercube;
-    pp_data.kinetic_energy_spectrum_data.refine_level           = this->refine_level;
+    pp_data.kinetic_energy_spectrum_data.n_cells_1d_coarse_grid  = n_subdivisions_1d_hypercube;
+    pp_data.kinetic_energy_spectrum_data.refine_level            = this->refine_level;
     pp_data.kinetic_energy_spectrum_data.length_symmetric_domain = right;
     pp_data.kinetic_energy_spectrum_data.clear_file              = !read_restart;
 

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -196,7 +196,7 @@ public:
     create_periodic_box(grid->triangulation,
                         grid_data.n_refine_global,
                         grid->periodic_faces,
-                        this->n_subdivisions_1d_hypercube,
+                        grid_data.n_subdivisions_1d_hypercube,
                         left,
                         right,
                         curvilinear_mesh,

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -252,7 +252,7 @@ public:
     double const length = 1.0;
     double const left = -length, right = length;
     GridGenerator::subdivided_hyper_cube(*grid->triangulation,
-                                         this->n_subdivisions_1d_hypercube,
+                                         grid_data.n_subdivisions_1d_hypercube,
                                          left,
                                          right);
 

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -187,7 +187,7 @@ public:
     double const length = 1.0;
     double const left = -length, right = length;
     // choose a coarse grid with at least 2^dim elements to obtain a non-trivial coarse grid problem
-    unsigned int n_cells_1d = std::max((unsigned int)2, this->n_subdivisions_1d_hypercube);
+    unsigned int n_cells_1d = std::max((unsigned int)2, grid_data.n_subdivisions_1d_hypercube);
     GridGenerator::subdivided_hyper_cube(*grid->triangulation, n_cells_1d, left, right);
 
     if(mesh_type == MeshType::Cartesian)

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -121,7 +121,7 @@ public:
     create_periodic_box(grid->triangulation,
                         grid_data.n_refine_global,
                         grid->periodic_faces,
-                        this->n_subdivisions_1d_hypercube,
+                        grid_data.n_subdivisions_1d_hypercube,
                         left,
                         right,
                         curvilinear_mesh,

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -374,10 +374,10 @@ public:
       p2[2] = this->width;
 
     std::vector<unsigned int> repetitions(dim);
-    repetitions[0] = this->n_subdivisions_1d_hypercube;
-    repetitions[1] = this->n_subdivisions_1d_hypercube;
+    repetitions[0] = grid_data.n_subdivisions_1d_hypercube;
+    repetitions[1] = grid_data.n_subdivisions_1d_hypercube;
     if(dim == 3)
-      repetitions[2] = this->n_subdivisions_1d_hypercube;
+      repetitions[2] = grid_data.n_subdivisions_1d_hypercube;
 
     GridGenerator::subdivided_hyper_rectangle(*grid->triangulation, repetitions, p1, p2);
 

--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -49,7 +49,8 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                            unsigned int const                            degree,
                            unsigned int const                            refine_space,
                            unsigned int const                            refine_time,
-                           bool const                                    is_throughput_study)
+                           unsigned int const n_subdivisions_1d_hypercube,
+                           bool const         is_throughput_study)
 {
   Timer timer;
   timer.restart();
@@ -72,8 +73,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   // grid
   GridData grid_data;
-  grid_data.triangulation_type = application->get_parameters().triangulation_type;
-  grid_data.n_refine_global    = refine_space;
+  grid_data.triangulation_type          = application->get_parameters().triangulation_type;
+  grid_data.n_refine_global             = refine_space;
+  grid_data.n_subdivisions_1d_hypercube = n_subdivisions_1d_hypercube;
   grid_data.mapping_degree =
     get_mapping_degree(application->get_parameters().mapping, application->get_parameters().degree);
 

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -115,6 +115,7 @@ public:
   setup(std::shared_ptr<ApplicationBase<dim, Number>> application,
         unsigned int const                            degree,
         unsigned int const                            refine_space,
+        unsigned int const                            n_subdivisions_1d_hypercube,
         unsigned int const                            refine_time,
         bool const                                    is_throughput_study);
 

--- a/include/exadg/compressible_navier_stokes/solver.h
+++ b/include/exadg/compressible_navier_stokes/solver.h
@@ -83,7 +83,7 @@ run(std::string const & input_file,
   std::shared_ptr<CompNS::ApplicationBase<dim, Number>> application =
     CompNS::get_application<dim, Number>(input_file, mpi_comm);
 
-  driver->setup(application, degree, refine_space, refine_time, false);
+  driver->setup(application, degree, refine_space, 1, refine_time, false);
 
   driver->solve();
 

--- a/include/exadg/compressible_navier_stokes/throughput.h
+++ b/include/exadg/compressible_navier_stokes/throughput.h
@@ -87,10 +87,8 @@ run(ThroughputParameters const & throughput,
   std::shared_ptr<CompNS::ApplicationBase<dim, Number>> application =
     CompNS::get_application<dim, Number>(input_file, mpi_comm);
 
-  application->set_subdivisions_hypercube(n_cells_1d);
-
   unsigned int const refine_time = 0; // not used
-  driver->setup(application, degree, refine_space, refine_time, true);
+  driver->setup(application, degree, refine_space, n_cells_1d, refine_time, true);
 
 
   std::tuple<unsigned int, types::global_dof_index, double> wall_time =

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -61,7 +61,7 @@ public:
   }
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
-    : mpi_comm(comm), parameter_file(parameter_file), n_subdivisions_1d_hypercube(1)
+    : mpi_comm(comm), parameter_file(parameter_file)
   {
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
     field_functions     = std::make_shared<FieldFunctions<dim>>();
@@ -85,12 +85,6 @@ public:
 
   virtual std::shared_ptr<PostProcessorBase<dim, Number>>
   create_postprocessor() = 0;
-
-  void
-  set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)
-  {
-    n_subdivisions_1d_hypercube = n_subdivisions_1d;
-  }
 
   Parameters const &
   get_parameters() const
@@ -118,8 +112,6 @@ protected:
   std::shared_ptr<FieldFunctions<dim>>     field_functions;
 
   std::string parameter_file;
-
-  unsigned int n_subdivisions_1d_hypercube;
 
   std::string output_directory = "output/", output_name = "output";
   bool        write_output = false;

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -49,8 +49,9 @@ void
 Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                            unsigned int const                            degree,
                            unsigned int const                            refine_space,
-                           unsigned int const                            refine_time,
-                           bool const                                    is_throughput_study)
+                           unsigned int const n_subdivisions_1d_hypercube,
+                           unsigned int const refine_time,
+                           bool const         is_throughput_study)
 {
   Timer timer;
   timer.restart();
@@ -73,8 +74,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   // grid
   GridData grid_data;
-  grid_data.triangulation_type = application->get_parameters().triangulation_type;
-  grid_data.n_refine_global    = refine_space;
+  grid_data.triangulation_type          = application->get_parameters().triangulation_type;
+  grid_data.n_refine_global             = refine_space;
+  grid_data.n_subdivisions_1d_hypercube = n_subdivisions_1d_hypercube;
   grid_data.mapping_degree =
     get_mapping_degree(application->get_parameters().mapping, application->get_parameters().degree);
 

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -116,6 +116,7 @@ public:
   setup(std::shared_ptr<ApplicationBase<dim, Number>> application,
         unsigned int const                            degree,
         unsigned int const                            refine_space,
+        unsigned int const                            n_subdivisions_1d_hypercube,
         unsigned int const                            refine_time,
         bool const                                    is_throughput_study);
 

--- a/include/exadg/convection_diffusion/solver.h
+++ b/include/exadg/convection_diffusion/solver.h
@@ -89,7 +89,7 @@ run(std::string const & input_file,
   std::shared_ptr<ConvDiff::ApplicationBase<dim, Number>> application =
     ConvDiff::get_application<dim, Number>(input_file, mpi_comm);
 
-  solver->setup(application, degree, refine_space, refine_time, false);
+  solver->setup(application, degree, refine_space, 1, refine_time, false);
 
   solver->solve();
 

--- a/include/exadg/convection_diffusion/throughput.h
+++ b/include/exadg/convection_diffusion/throughput.h
@@ -94,10 +94,8 @@ run(ThroughputParameters const & throughput,
   std::shared_ptr<ConvDiff::ApplicationBase<dim, Number>> application =
     ConvDiff::get_application<dim, Number>(input_file, mpi_comm);
 
-  application->set_subdivisions_hypercube(n_cells_1d);
-
   unsigned int const refine_time = 0; // not used
-  driver->setup(application, degree, refine_space, refine_time, true);
+  driver->setup(application, degree, refine_space, n_cells_1d, refine_time, true);
 
 
   std::tuple<unsigned int, types::global_dof_index, double> wall_time =

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -56,7 +56,7 @@ public:
   }
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
-    : mpi_comm(comm), parameter_file(parameter_file), n_subdivisions_1d_hypercube(1)
+    : mpi_comm(comm), parameter_file(parameter_file)
   {
     field_functions     = std::make_shared<FieldFunctions<dim>>();
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
@@ -90,12 +90,6 @@ public:
   virtual std::shared_ptr<PostProcessorBase<dim, Number>>
   create_postprocessor() = 0;
 
-  void
-  set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)
-  {
-    n_subdivisions_1d_hypercube = n_subdivisions_1d;
-  }
-
   Parameters const &
   get_parameters() const
   {
@@ -122,8 +116,6 @@ protected:
   std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor;
 
   std::string parameter_file;
-
-  unsigned int n_subdivisions_1d_hypercube;
 
   std::string output_directory = "output/", output_name = "output";
   bool        write_output = false;

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -38,13 +38,19 @@ using namespace dealii;
 struct GridData
 {
   GridData()
-    : triangulation_type(TriangulationType::Distributed), n_refine_global(0), mapping_degree(1)
+    : triangulation_type(TriangulationType::Distributed),
+      n_refine_global(0),
+      n_subdivisions_1d_hypercube(1),
+      mapping_degree(1)
   {
   }
 
   TriangulationType triangulation_type;
 
   unsigned int n_refine_global;
+
+  // only relevant for hypercube geometry/mesh
+  unsigned int n_subdivisions_1d_hypercube;
 
   unsigned int mapping_degree;
 

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -48,8 +48,9 @@ void
 Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                            unsigned int const                            degree_velocity,
                            unsigned int const                            refine_space,
-                           unsigned int const                            refine_time,
-                           bool const                                    is_throughput_study)
+                           unsigned int const n_subdivisions_1d_hypercube,
+                           unsigned int const refine_time,
+                           bool const         is_throughput_study)
 {
   Timer timer;
   timer.restart();
@@ -72,9 +73,10 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   // grid
   GridData grid_data;
-  grid_data.triangulation_type = application->get_parameters().triangulation_type;
-  grid_data.n_refine_global    = refine_space;
-  grid_data.mapping_degree     = get_mapping_degree(application->get_parameters().mapping,
+  grid_data.triangulation_type          = application->get_parameters().triangulation_type;
+  grid_data.n_refine_global             = refine_space;
+  grid_data.n_subdivisions_1d_hypercube = n_subdivisions_1d_hypercube;
+  grid_data.mapping_degree              = get_mapping_degree(application->get_parameters().mapping,
                                                 application->get_parameters().degree_u);
 
   grid = application->create_grid(grid_data);

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -178,6 +178,7 @@ public:
   setup(std::shared_ptr<ApplicationBase<dim, Number>> application,
         unsigned int const                            degree,
         unsigned int const                            refine_space,
+        unsigned int const                            n_subdivisions_1d_hypercube,
         unsigned int const                            refine_time,
         bool const                                    is_throughput_study);
 

--- a/include/exadg/incompressible_navier_stokes/solver.h
+++ b/include/exadg/incompressible_navier_stokes/solver.h
@@ -83,7 +83,7 @@ run(std::string const & input_file,
   std::shared_ptr<IncNS::ApplicationBase<dim, Number>> application =
     IncNS::get_application<dim, Number>(input_file, mpi_comm);
 
-  driver->setup(application, degree, refine_space, refine_time, false);
+  driver->setup(application, degree, refine_space, 1, refine_time, false);
 
   driver->solve();
 

--- a/include/exadg/incompressible_navier_stokes/throughput.h
+++ b/include/exadg/incompressible_navier_stokes/throughput.h
@@ -89,10 +89,8 @@ run(ThroughputParameters const & throughput,
   std::shared_ptr<IncNS::ApplicationBase<dim, Number>> application =
     IncNS::get_application<dim, Number>(input_file, mpi_comm);
 
-  application->set_subdivisions_hypercube(n_cells_1d);
-
   unsigned int const refine_time = 0; // not used
-  driver->setup(application, degree, refine_space, refine_time, true);
+  driver->setup(application, degree, refine_space, n_cells_1d, refine_time, true);
 
   std::tuple<unsigned int, types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -66,7 +66,7 @@ public:
   }
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
-    : mpi_comm(comm), parameter_file(parameter_file), n_subdivisions_1d_hypercube(1)
+    : mpi_comm(comm), parameter_file(parameter_file)
   {
     field_functions     = std::make_shared<FieldFunctions<dim>>();
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
@@ -131,12 +131,6 @@ public:
                            "to use Poisson solver for mesh movement."));
   }
 
-  void
-  set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)
-  {
-    n_subdivisions_1d_hypercube = n_subdivisions_1d;
-  }
-
   Parameters const &
   get_parameters() const
   {
@@ -186,8 +180,6 @@ protected:
   std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> poisson_boundary_descriptor;
 
   std::string parameter_file;
-
-  unsigned int n_subdivisions_1d_hypercube;
 
   std::string output_directory = "output/", output_name = "output";
   bool        write_output = false;

--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -50,7 +50,8 @@ void
 Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                            unsigned int const                            degree,
                            unsigned int const                            refine_space,
-                           bool const                                    is_throughput_study)
+                           unsigned int const n_subdivisions_1d_hypercube,
+                           bool const         is_throughput_study)
 {
   Timer timer;
   timer.restart();
@@ -73,8 +74,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   // grid
   GridData grid_data;
-  grid_data.triangulation_type = application->get_parameters().triangulation_type;
-  grid_data.n_refine_global    = refine_space;
+  grid_data.triangulation_type          = application->get_parameters().triangulation_type;
+  grid_data.n_refine_global             = refine_space;
+  grid_data.n_subdivisions_1d_hypercube = n_subdivisions_1d_hypercube;
   grid_data.mapping_degree =
     get_mapping_degree(application->get_parameters().mapping, application->get_parameters().degree);
 

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -118,6 +118,7 @@ public:
   setup(std::shared_ptr<ApplicationBase<dim, Number>> application,
         unsigned int const                            degree,
         unsigned int const                            refine_space,
+        unsigned int const                            n_subdivisions_1d_hypercube,
         bool const                                    is_throughput_study);
 
   void

--- a/include/exadg/poisson/solver.h
+++ b/include/exadg/poisson/solver.h
@@ -83,9 +83,7 @@ run(std::vector<SolverResult> & results,
   std::shared_ptr<Poisson::ApplicationBase<dim, Number>> application =
     Poisson::get_application<dim, Number>(input_file, mpi_comm);
 
-  application->set_subdivisions_hypercube(n_cells_1d);
-
-  driver->setup(application, degree, refine_space, false);
+  driver->setup(application, degree, refine_space, n_cells_1d, false);
 
   driver->solve();
 

--- a/include/exadg/poisson/throughput.h
+++ b/include/exadg/poisson/throughput.h
@@ -93,9 +93,7 @@ run(ThroughputParameters const & throughput,
   std::shared_ptr<Poisson::ApplicationBase<dim, Number>> application =
     Poisson::get_application<dim, Number>(input_file, mpi_comm);
 
-  application->set_subdivisions_hypercube(n_cells_1d);
-
-  driver->setup(application, degree, refine_space, true);
+  driver->setup(application, degree, refine_space, n_cells_1d, true);
 
   std::tuple<unsigned int, types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -64,7 +64,7 @@ public:
   }
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
-    : mpi_comm(comm), parameter_file(parameter_file), n_subdivisions_1d_hypercube(1)
+    : mpi_comm(comm), parameter_file(parameter_file)
   {
     boundary_descriptor = std::make_shared<BoundaryDescriptor<0, dim>>();
     field_functions     = std::make_shared<FieldFunctions<dim>>();
@@ -88,12 +88,6 @@ public:
 
   virtual std::shared_ptr<Poisson::PostProcessorBase<dim, Number>>
   create_postprocessor() = 0;
-
-  void
-  set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)
-  {
-    n_subdivisions_1d_hypercube = n_subdivisions_1d;
-  }
 
   Parameters const &
   get_parameters() const
@@ -121,8 +115,6 @@ protected:
   std::shared_ptr<FieldFunctions<dim>>        field_functions;
 
   std::string parameter_file;
-
-  unsigned int n_subdivisions_1d_hypercube;
 
   std::string output_directory = "output/", output_name = "output";
   bool        write_output = false;

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -47,8 +47,9 @@ void
 Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
                            unsigned int const                            degree,
                            unsigned int const                            refine_space,
-                           unsigned int const                            refine_time,
-                           bool const                                    is_throughput_study)
+                           unsigned int const n_subdivisions_1d_hypercube,
+                           unsigned int const refine_time,
+                           bool const         is_throughput_study)
 {
   Timer timer;
   timer.restart();
@@ -71,8 +72,9 @@ Driver<dim, Number>::setup(std::shared_ptr<ApplicationBase<dim, Number>> app,
 
   // grid
   GridData grid_data;
-  grid_data.triangulation_type = application->get_parameters().triangulation_type;
-  grid_data.n_refine_global    = refine_space;
+  grid_data.triangulation_type          = application->get_parameters().triangulation_type;
+  grid_data.n_refine_global             = refine_space;
+  grid_data.n_subdivisions_1d_hypercube = n_subdivisions_1d_hypercube;
   grid_data.mapping_degree =
     get_mapping_degree(application->get_parameters().mapping, application->get_parameters().degree);
 

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -99,6 +99,7 @@ public:
   setup(std::shared_ptr<ApplicationBase<dim, Number>> application,
         unsigned int const                            degree,
         unsigned int const                            refine_space,
+        unsigned int const                            n_subdivisions_1d_hypercube,
         unsigned int const                            refine_time,
         bool const                                    is_throughput_study);
 

--- a/include/exadg/structure/solver.h
+++ b/include/exadg/structure/solver.h
@@ -88,7 +88,7 @@ run(std::string const & input_file,
   std::shared_ptr<Structure::ApplicationBase<dim, Number>> application =
     Structure::get_application<dim, Number>(input_file, mpi_comm);
 
-  driver->setup(application, degree, refine_space, refine_time, false);
+  driver->setup(application, degree, refine_space, 1, refine_time, false);
 
   driver->solve();
 

--- a/include/exadg/structure/throughput.h
+++ b/include/exadg/structure/throughput.h
@@ -93,9 +93,7 @@ run(ThroughputParameters const & throughput,
   std::shared_ptr<Structure::ApplicationBase<dim, Number>> application =
     Structure::get_application<dim, Number>(input_file, mpi_comm);
 
-  application->set_subdivisions_hypercube(n_cells_1d);
-
-  driver->setup(application, degree, refine_space, 0 /* refine time */, true);
+  driver->setup(application, degree, refine_space, n_cells_1d, 0 /* refine time */, true);
 
   std::tuple<unsigned int, types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -58,7 +58,7 @@ public:
   }
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
-    : mpi_comm(comm), parameter_file(parameter_file), n_subdivisions_1d_hypercube(1)
+    : mpi_comm(comm), parameter_file(parameter_file)
   {
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
     material_descriptor = std::make_shared<MaterialDescriptor>();
@@ -86,12 +86,6 @@ public:
 
   virtual std::shared_ptr<PostProcessor<dim, Number>>
   create_postprocessor() = 0;
-
-  void
-  set_subdivisions_hypercube(unsigned int const n_subdivisions_1d)
-  {
-    n_subdivisions_1d_hypercube = n_subdivisions_1d;
-  }
 
   Parameters const &
   get_parameters() const
@@ -126,8 +120,6 @@ protected:
   std::shared_ptr<FieldFunctions<dim>>     field_functions;
 
   std::string parameter_file;
-
-  unsigned int n_subdivisions_1d_hypercube;
 
   std::string output_directory = "output/", output_name = "output";
   bool        write_output = false;


### PR DESCRIPTION
Responsibilities should be clearer with this change. Shifting this parameter to the grid class has the advantage that the grid class knows how to deal with hex vs. simplex meshes for example.