### PR TITLE
a minor simplification in FTI::Driver related to ALE

### DIFF
--- a/include/exadg/convection_diffusion/user_interface/parameters.cpp
+++ b/include/exadg/convection_diffusion/user_interface/parameters.cpp
@@ -124,6 +124,9 @@ Parameters::check() const
   // moving mesh
   if(ale_formulation)
   {
+    AssertThrow(problem_type == ProblemType::Unsteady,
+                ExcMessage("Problem type has to be Unsteady when using ALE formulation."));
+
     AssertThrow(
       temporal_discretization == TemporalDiscretization::BDF &&
         (treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit ||

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -587,9 +587,8 @@ Driver<dim, Number>::solve() const
     /*
      * ALE: move the mesh and update dependent data structures
      */
-    if(application->get_parameters().solver_type == IncNS::SolverType::Unsteady)
-      if(application->get_parameters().ale_formulation) // moving mesh
-        ale_update();
+    if(application->get_parameters().ale_formulation)
+      ale_update();
 
     /*
      *  solve


### PR DESCRIPTION
If `ale_formulation == true` it is ensured automatically that

https://github.com/exadg/exadg/blob/683595d85527a036d36bc800e30f4f5261ac91a5/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp#L264-L267

