### PR TITLE
ALE: check for restarted simulation in postprocessing()

### DIFF
--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -714,9 +714,10 @@ TimeIntBDF<dim, Number>::postprocessing() const
   Timer timer;
   timer.restart();
 
-  // the mesh has to be at the correct position to allow a computation of
-  // errors at start_time
-  if(this->param.ale_formulation && this->get_time_step_number() == 1)
+  // To allow a computation of errors at start_time (= if time step number is 1 and if the
+  // simulation is not a restarted one), the mesh has to be at the correct position
+  if(this->param.ale_formulation && this->get_time_step_number() == 1 &&
+     !this->param.restarted_simulation)
   {
     pde_operator->move_grid_and_update_dependent_data_structures(this->get_time());
   }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -607,9 +607,10 @@ TimeIntBDF<dim, Number>::postprocessing() const
   Timer timer;
   timer.restart();
 
-  // the mesh has to be at the correct position to allow a computation of
-  // errors at start_time
-  if(this->param.ale_formulation && this->get_time_step_number() == 1)
+  // To allow a computation of errors at start_time (= if time step number is 1 and if the
+  // simulation is not a restarted one), the mesh has to be at the correct position
+  if(this->param.ale_formulation && this->get_time_step_number() == 1 &&
+     !this->param.restarted_simulation)
   {
     operator_base->move_grid_and_update_dependent_data_structures(this->get_time());
   }


### PR DESCRIPTION
Strictly speaking, `time_step_number == 1` is not identical to `time == start_time`. The reason behind is that in our implementation the time step number always start with 1 after a restart (which has, of course, reasons). 

Add `if(... && !restarted_simulation)` to correctly identify the initial time.