### PR TITLE
rename solve_timestep() into do_timestep_solve() for consistency

### DIFF
--- a/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.cpp
@@ -236,7 +236,7 @@ TimeIntExplRK<Number>::postprocessing() const
 
 template<typename Number>
 void
-TimeIntExplRK<Number>::solve_timestep()
+TimeIntExplRK<Number>::do_timestep_solve()
 {
   Timer timer;
   timer.restart();

--- a/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.h
+++ b/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.h
@@ -83,7 +83,7 @@ private:
   postprocessing() const;
 
   void
-  solve_timestep();
+  do_timestep_solve() final;
 
   bool
   print_solver_info() const;

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -517,7 +517,7 @@ TimeIntBDF<dim, Number>::write_restart_vectors(boost::archive::binary_oarchive &
 
 template<int dim, typename Number>
 void
-TimeIntBDF<dim, Number>::solve_timestep()
+TimeIntBDF<dim, Number>::do_timestep_solve()
 {
   Timer timer;
   timer.restart();

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
@@ -77,65 +77,65 @@ public:
 
 private:
   void
-  allocate_vectors();
+  allocate_vectors() final;
 
   void
-  initialize_current_solution();
+  initialize_current_solution() final;
 
   void
-  initialize_former_solutions();
+  initialize_former_solutions() final;
 
   void
   initialize_vec_convective_term();
 
   double
-  calculate_time_step_size();
+  calculate_time_step_size() final;
 
   double
-  recalculate_time_step_size() const;
+  recalculate_time_step_size() const final;
 
   void
-  prepare_vectors_for_next_timestep();
+  prepare_vectors_for_next_timestep() final;
 
   void
   do_timestep_solve() final;
 
   void
-  initialize_oif();
+  initialize_oif() final;
 
   void
-  setup_derived();
+  setup_derived() final;
 
   void
   calculate_sum_alphai_ui_oif_substepping(VectorType & sum_alphai_ui,
                                           double const cfl,
-                                          double const cfl_oif);
+                                          double const cfl_oif) final;
 
   void
-  initialize_solution_oif_substepping(VectorType & solution_tilde_m, unsigned int i);
+  initialize_solution_oif_substepping(VectorType & solution_tilde_m, unsigned int i) final;
 
   void
   update_sum_alphai_ui_oif_substepping(VectorType &       sum_alphai_ui,
                                        VectorType const & u_tilde_i,
-                                       unsigned int       i);
+                                       unsigned int       i) final;
 
   void
   do_timestep_oif_substepping(VectorType & solution_tilde_mp,
                               VectorType & solution_tilde_m,
                               double const start_time,
-                              double const time_step_size);
+                              double const time_step_size) final;
 
   bool
-  print_solver_info() const;
+  print_solver_info() const final;
 
   void
-  read_restart_vectors(boost::archive::binary_iarchive & ia);
+  read_restart_vectors(boost::archive::binary_iarchive & ia) final;
 
   void
-  write_restart_vectors(boost::archive::binary_oarchive & oa) const;
+  write_restart_vectors(boost::archive::binary_oarchive & oa) const final;
 
   void
-  postprocessing() const;
+  postprocessing() const final;
 
   std::shared_ptr<Operator<dim, Number>> pde_operator;
 

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
@@ -98,7 +98,7 @@ private:
   prepare_vectors_for_next_timestep();
 
   void
-  solve_timestep();
+  do_timestep_solve() final;
 
   void
   initialize_oif();

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
@@ -341,7 +341,7 @@ TimeIntExplRK<Number>::print_solver_info() const
 
 template<typename Number>
 void
-TimeIntExplRK<Number>::solve_timestep()
+TimeIntExplRK<Number>::do_timestep_solve()
 {
   Timer timer;
   timer.restart();

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
@@ -84,7 +84,7 @@ private:
   print_solver_info() const;
 
   void
-  solve_timestep();
+  do_timestep_solve() final;
 
   void
   calculate_time_step_size();

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -151,7 +151,7 @@ TimeIntBDFCoupled<dim, Number>::set_pressure(VectorType const & pressure_in, uns
 
 template<int dim, typename Number>
 void
-TimeIntBDFCoupled<dim, Number>::solve_timestep()
+TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
 {
   Timer timer;
   timer.restart();
@@ -463,7 +463,7 @@ TimeIntBDFCoupled<dim, Number>::postprocessing_stability_analysis()
     solution[0].block(0).local_element(j) = 1.0;
 
     // solve time step
-    this->solve_timestep();
+    this->do_timestep_solve();
 
     // dst-vector velocity_np is j-th column of propagation matrix
     for(unsigned int i = 0; i < size; ++i)

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -71,10 +71,10 @@ public:
 
 private:
   void
-  setup_derived() final;
+  allocate_vectors() final;
 
   void
-  allocate_vectors() final;
+  setup_derived() final;
 
   void
   initialize_current_solution() final;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -83,7 +83,7 @@ private:
   initialize_former_solutions() final;
 
   void
-  solve_timestep() final;
+  do_timestep_solve() final;
 
   void
   solve_steady_problem() final;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -277,7 +277,7 @@ TimeIntBDFDualSplitting<dim, Number>::postprocessing_stability_analysis()
     velocity[0].local_element(j) = 1.0;
 
     // solve time step
-    this->solve_timestep();
+    this->do_timestep_solve();
 
     // dst-vector velocity_np is j-th column of propagation matrix
     for(unsigned int i = 0; i < size; ++i)
@@ -312,7 +312,7 @@ TimeIntBDFDualSplitting<dim, Number>::postprocessing_stability_analysis()
 
 template<int dim, typename Number>
 void
-TimeIntBDFDualSplitting<dim, Number>::solve_timestep()
+TimeIntBDFDualSplitting<dim, Number>::do_timestep_solve()
 {
   // pre-computations
   if(this->param.store_previous_boundary_values)

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -69,6 +69,9 @@ public:
 
 private:
   void
+  allocate_vectors() final;
+
+  void
   setup_derived() final;
 
   void
@@ -79,9 +82,6 @@ private:
 
   void
   do_timestep_solve() final;
-
-  void
-  allocate_vectors() final;
 
   void
   prepare_vectors_for_next_timestep() final;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -78,7 +78,7 @@ private:
   write_restart_vectors(boost::archive::binary_oarchive & oa) const final;
 
   void
-  solve_timestep() final;
+  do_timestep_solve() final;
 
   void
   allocate_vectors() final;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -284,7 +284,7 @@ TimeIntBDFPressureCorrection<dim, Number>::postprocessing_stability_analysis()
     velocity[0].local_element(j) = 1.0;
 
     // solve time step
-    this->solve_timestep();
+    this->do_timestep_solve();
 
     // dst-vector velocity_np is j-th column of propagation matrix
     for(unsigned int i = 0; i < size; ++i)
@@ -319,7 +319,7 @@ TimeIntBDFPressureCorrection<dim, Number>::postprocessing_stability_analysis()
 
 template<int dim, typename Number>
 void
-TimeIntBDFPressureCorrection<dim, Number>::solve_timestep()
+TimeIntBDFPressureCorrection<dim, Number>::do_timestep_solve()
 {
   // perform the sub-steps of the pressure-correction scheme
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -93,7 +93,7 @@ private:
   initialize_pressure_on_boundary();
 
   void
-  solve_timestep() final;
+  do_timestep_solve() final;
 
   void
   solve_steady_problem() final;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -69,19 +69,19 @@ public:
 
 private:
   void
-  update_time_integrator_constants() final;
+  allocate_vectors() final;
 
   void
-  allocate_vectors() final;
+  setup_derived() final;
+
+  void
+  update_time_integrator_constants() final;
 
   void
   initialize_current_solution() final;
 
   void
   initialize_former_solutions() final;
-
-  void
-  setup_derived() final;
 
   void
   read_restart_vectors(boost::archive::binary_iarchive & ia) final;

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -110,7 +110,7 @@ TimeIntGenAlpha<dim, Number>::advance_one_timestep_partitioned_solve(bool const 
 
 template<int dim, typename Number>
 void
-TimeIntGenAlpha<dim, Number>::solve_timestep()
+TimeIntGenAlpha<dim, Number>::do_timestep_solve()
 {
   // compute right-hand side in case of linear problems or "constant vector"
   // in case of nonlinear problems

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.h
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.h
@@ -91,7 +91,7 @@ public:
 
 private:
   void
-  solve_timestep() final;
+  do_timestep_solve() final;
 
   void
   prepare_vectors_for_next_timestep() final;

--- a/include/exadg/time_integration/explicit_runge_kutta.h
+++ b/include/exadg/time_integration/explicit_runge_kutta.h
@@ -68,7 +68,10 @@ public:
   }
 
   void
-  solve_timestep(VectorType & dst, VectorType & src, double const time, double const time_step)
+  solve_timestep(VectorType & dst,
+                 VectorType & src,
+                 double const time,
+                 double const time_step) final
   {
     if(order == 1) // explicit Euler method
     {
@@ -180,7 +183,7 @@ public:
   }
 
   unsigned int
-  get_order() const
+  get_order() const final
   {
     return order;
   }
@@ -238,7 +241,10 @@ public:
   }
 
   void
-  solve_timestep(VectorType & vec_np, VectorType & vec_n, double const time, double const time_step)
+  solve_timestep(VectorType & vec_np,
+                 VectorType & vec_n,
+                 double const time,
+                 double const time_step) final
   {
     if(!vec_tmp1.partitioners_are_globally_compatible(*vec_n.get_partitioner()))
     {
@@ -295,7 +301,7 @@ public:
   }
 
   unsigned int
-  get_order() const
+  get_order() const final
   {
     return 3;
   }
@@ -320,7 +326,10 @@ public:
   }
 
   void
-  solve_timestep(VectorType & vec_np, VectorType & vec_n, double const time, double const time_step)
+  solve_timestep(VectorType & vec_np,
+                 VectorType & vec_n,
+                 double const time,
+                 double const time_step) final
   {
     if(!vec_tmp1.partitioners_are_globally_compatible(*vec_n.get_partitioner()))
     {
@@ -388,7 +397,7 @@ public:
   }
 
   unsigned int
-  get_order() const
+  get_order() const final
   {
     return 4;
   }
@@ -412,7 +421,10 @@ public:
   }
 
   void
-  solve_timestep(VectorType & vec_np, VectorType & vec_n, double const time, double const time_step)
+  solve_timestep(VectorType & vec_np,
+                 VectorType & vec_n,
+                 double const time,
+                 double const time_step) final
   {
     if(!vec_tmp1.partitioners_are_globally_compatible(*vec_n.get_partitioner()))
     {
@@ -497,7 +509,7 @@ public:
   }
 
   unsigned int
-  get_order() const
+  get_order() const final
   {
     return 4;
   }
@@ -629,7 +641,7 @@ public:
   }
 
   unsigned int
-  get_order() const
+  get_order() const final
   {
     return 5;
   }
@@ -748,7 +760,7 @@ public:
   }
 
   unsigned int
-  get_order() const
+  get_order() const final
   {
     return order;
   }

--- a/include/exadg/time_integration/ssp_runge_kutta.h
+++ b/include/exadg/time_integration/ssp_runge_kutta.h
@@ -57,10 +57,10 @@ public:
   solve_timestep(VectorType & vec_np,
                  VectorType & vec_n,
                  double const time,
-                 double const time_step);
+                 double const time_step) final;
 
   unsigned int
-  get_order() const
+  get_order() const final
   {
     return order;
   }

--- a/include/exadg/time_integration/time_int_base.cpp
+++ b/include/exadg/time_integration/time_int_base.cpp
@@ -68,6 +68,16 @@ TimeIntBase::timeloop()
 }
 
 void
+TimeIntBase::advance_one_timestep()
+{
+  advance_one_timestep_pre_solve(true);
+
+  advance_one_timestep_solve();
+
+  advance_one_timestep_post_solve();
+}
+
+void
 TimeIntBase::advance_one_timestep_pre_solve(bool const print_header)
 {
   Timer timer;
@@ -98,7 +108,7 @@ TimeIntBase::advance_one_timestep_solve()
 
   if(started() && !finished())
   {
-    solve_timestep();
+    do_timestep_solve();
   }
 
   timer_tree->insert({"Timeloop"}, timer.wall_time());
@@ -123,16 +133,6 @@ TimeIntBase::advance_one_timestep_post_solve()
   }
 
   timer_tree->insert({"Timeloop"}, timer.wall_time());
-}
-
-void
-TimeIntBase::advance_one_timestep()
-{
-  advance_one_timestep_pre_solve(true);
-
-  advance_one_timestep_solve();
-
-  advance_one_timestep_post_solve();
 }
 
 void
@@ -175,7 +175,7 @@ TimeIntBase::do_timestep()
 {
   do_timestep_pre_solve(true);
 
-  solve_timestep();
+  do_timestep_solve();
 
   do_timestep_post_solve();
 }

--- a/include/exadg/time_integration/time_int_base.h
+++ b/include/exadg/time_integration/time_int_base.h
@@ -141,8 +141,12 @@ public:
 
 protected:
   /*
-   * Do one time step including different updates before and after the actual solution of the
-   * current time step.
+   * Do one time step including pre and post routines done before and after the actual solution of
+   * the current time step. Compared to the function advance_one_timestep(), do_timestep() is a raw
+   * version that does not call postprocessing routines, does not write output to pcout, and does
+   * not perform timer measurements within its sub-routines. The typical use case of do_timestep()
+   * is when using pseudo-timestepping to obtain the solution of a steady-state problem with a
+   * transient solver.
    */
   void
   do_timestep();

--- a/include/exadg/time_integration/time_int_base.h
+++ b/include/exadg/time_integration/time_int_base.h
@@ -76,13 +76,20 @@ public:
   finished() const;
 
   /*
-   * Performs the time loop from start_time to end_time.
+   * Performs the time loop from start_time to end_time by repeatingly calling
+   * advance_one_timestep().
    */
   void
   timeloop();
 
   /*
    * Perform only one time step (which is used when coupling different solvers, equations, etc.).
+   */
+  void
+  advance_one_timestep();
+
+  /*
+   * The main sub-routines of advance_one_timestep()
    */
   void
   advance_one_timestep_pre_solve(bool const print_header);
@@ -92,9 +99,6 @@ public:
 
   void
   advance_one_timestep_post_solve();
-
-  void
-  advance_one_timestep();
 
   /*
    * Reset the current time.
@@ -149,8 +153,11 @@ protected:
   virtual void
   do_timestep_pre_solve(bool const print_header) = 0;
 
+  /*
+   * The actual solution of the current time step
+   */
   virtual void
-  solve_timestep() = 0;
+  do_timestep_solve() = 0;
 
   /*
    * e.g., update of DoF vectors, increment time, adjust time step size, etc.

--- a/include/exadg/time_integration/time_int_bdf_base.h
+++ b/include/exadg/time_integration/time_int_bdf_base.h
@@ -65,7 +65,7 @@ public:
    * setup_derived() in which the setup of derived classes can be performed.
    */
   void
-  setup(bool const do_restart) override;
+  setup(bool const do_restart) final;
 
   /*
    * Pseudo-time-stepping for steady-state problems.
@@ -83,7 +83,7 @@ public:
    * Get the time step size.
    */
   double
-  get_time_step_size() const override;
+  get_time_step_size() const final;
 
   double
   get_time_step_size(int const index) const;
@@ -95,7 +95,7 @@ public:
    * size.
    */
   void
-  set_current_time_step_size(double const & time_step_size) override;
+  set_current_time_step_size(double const & time_step_size) final;
 
   /*
    * Get time at the end of the current time step.
@@ -109,10 +109,10 @@ protected:
    * current time step.
    */
   void
-  do_timestep_pre_solve(bool const print_header) override;
+  do_timestep_pre_solve(bool const print_header) final;
 
   void
-  do_timestep_post_solve() override;
+  do_timestep_post_solve() final;
 
   /*
    * Update the time integrator constants.
@@ -236,7 +236,7 @@ private:
    * Restart: read solution vectors (has to be implemented in derived classes).
    */
   void
-  do_read_restart(std::ifstream & in) override;
+  do_read_restart(std::ifstream & in) final;
 
   void
   read_restart_preamble(boost::archive::binary_iarchive & ia);
@@ -249,7 +249,7 @@ private:
    * state.
    */
   void
-  do_write_restart(std::string const & filename) const override;
+  do_write_restart(std::string const & filename) const final;
 
   void
   write_restart_preamble(boost::archive::binary_oarchive & oa) const;

--- a/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
+++ b/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
@@ -47,13 +47,13 @@ public:
                     bool const          is_test_);
 
   void
-  setup(bool const do_restart) override;
+  setup(bool const do_restart) final;
 
   double
-  get_time_step_size() const override;
+  get_time_step_size() const final;
 
   void
-  set_current_time_step_size(double const & time_step_size) override;
+  set_current_time_step_size(double const & time_step_size) final;
 
 protected:
   // solution vectors
@@ -67,10 +67,10 @@ protected:
 
 private:
   void
-  do_timestep_pre_solve(bool const print_header) override;
+  do_timestep_pre_solve(bool const print_header) final;
 
   void
-  do_timestep_post_solve() override;
+  do_timestep_post_solve() final;
 
   void
   prepare_vectors_for_next_timestep();
@@ -97,10 +97,10 @@ private:
   print_solver_info() const = 0;
 
   void
-  do_write_restart(std::string const & filename) const override;
+  do_write_restart(std::string const & filename) const final;
 
   void
-  do_read_restart(std::ifstream & in) override;
+  do_read_restart(std::ifstream & in) final;
 };
 
 } // namespace ExaDG

--- a/include/exadg/time_integration/time_int_gen_alpha_base.h
+++ b/include/exadg/time_integration/time_int_gen_alpha_base.h
@@ -49,10 +49,10 @@ public:
                       bool const           is_test_);
 
   double
-  get_time_step_size() const override;
+  get_time_step_size() const final;
 
   void
-  set_current_time_step_size(double const & time_step_size) override;
+  set_current_time_step_size(double const & time_step_size) final;
 
 protected:
   double
@@ -86,10 +86,10 @@ protected:
 
 private:
   void
-  do_timestep_pre_solve(bool const print_header) override;
+  do_timestep_pre_solve(bool const print_header) final;
 
   void
-  do_timestep_post_solve() override;
+  do_timestep_post_solve() final;
 
   virtual void
   prepare_vectors_for_next_timestep() = 0;


### PR DESCRIPTION
With this renaming, the functions `advance_one_timestep_...()` and `do_timestep_...()` are "consistent".

The `final` keyword was missing in some cases.