### PR TITLE
remove "using namespace dealii"

### DIFF
--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 // problem specific parameters
 double const DYN_VISCOSITY = 0.1;
 double const GAMMA         = 1.4;
@@ -55,19 +53,19 @@ enum class SolutionType
 SolutionType const SOLUTION_TYPE = SolutionType::Polynomial;
 
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
   Solution(unsigned int const n_components = dim + 2, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double       t  = this->get_time();
-    double const pi = numbers::PI;
+    double const pi = dealii::numbers::PI;
 
     double result = 0.0;
 
@@ -88,7 +86,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     if(component == 0)
@@ -106,21 +104,21 @@ public:
 
 
 template<int dim>
-class RightHandSideDensity : public Function<dim>
+class RightHandSideDensity : public dealii::Function<dim>
 {
 public:
   RightHandSideDensity(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)component;
 
     double t       = this->get_time();
-    double pi      = numbers::PI;
+    double pi      = dealii::numbers::PI;
     double sin_pix = sin(pi * p[0]);
     double cos_pix = cos(pi * p[0]);
     double sin_pit = sin(pi * t);
@@ -145,7 +143,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
     // clang-format on
 
@@ -154,19 +152,19 @@ public:
 };
 
 template<int dim>
-class RightHandSideVelocity : public Function<dim>
+class RightHandSideVelocity : public dealii::Function<dim>
 {
 public:
   RightHandSideVelocity(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double       t       = this->get_time();
-    double const pi      = numbers::PI;
+    double const pi      = dealii::numbers::PI;
     double const sin_pix = sin(pi * p[0]);
     double const cos_pix = cos(pi * p[0]);
     double const sin_pit = sin(pi * t);
@@ -203,7 +201,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
     // clang-format on
 
@@ -212,21 +210,21 @@ public:
 };
 
 template<int dim>
-class RightHandSideEnergy : public Function<dim>
+class RightHandSideEnergy : public dealii::Function<dim>
 {
 public:
   RightHandSideEnergy(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)component;
 
     double       t             = this->get_time();
-    double const pi            = numbers::PI;
+    double const pi            = dealii::numbers::PI;
     double const sin_pix       = sin(pi * p[0]);
     double const cos_pix       = cos(pi * p[0]);
     double const sin_pit       = sin(pi * t);
@@ -259,7 +257,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
     // clang-format on
 
@@ -279,19 +277,19 @@ public:
 };
 
 template<int dim>
-class VelocityBC : public Function<dim>
+class VelocityBC : public dealii::Function<dim>
 {
 public:
   VelocityBC(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double       t       = this->get_time();
-    double const pi      = numbers::PI;
+    double const pi      = dealii::numbers::PI;
     double       x3      = p[0] * p[0] * p[0];
     double       sin_pit = sin(pi * t);
     double       cos_pit = cos(pi * t);
@@ -308,7 +306,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return result;
@@ -316,20 +314,20 @@ public:
 };
 
 template<int dim>
-class DensityBC : public Function<dim>
+class DensityBC : public dealii::Function<dim>
 {
 public:
-  DensityBC(double const time = 0.) : Function<dim>(1, time)
+  DensityBC(double const time = 0.) : dealii::Function<dim>(1, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)component;
 
     double       t       = this->get_time();
-    double const pi      = numbers::PI;
+    double const pi      = dealii::numbers::PI;
     double       sin_pit = sin(pi * t);
     double       sin_pix = sin(pi * p[0]);
     double       x3      = p[0] * p[0] * p[0];
@@ -346,7 +344,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return result;
@@ -361,7 +359,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -426,11 +424,11 @@ public:
   {
     // hypercube volume is [left,right]^dim
     double const left = -1.0, right = 0.5;
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     for(auto cell : *this->grid->triangulation)
     {
-      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+      for(unsigned int face = 0; face < dealii::GeometryInfo<dim>::faces_per_cell; ++face)
       {
         if(std::fabs(cell.face(face)->center()(1) - left) < 1e-12)
         {
@@ -443,7 +441,7 @@ public:
       }
     }
 
-    GridTools::collect_periodic_faces(
+    dealii::GridTools::collect_periodic_faces(
       *this->grid->triangulation, 0 + 10, 1 + 10, 1, this->grid->periodic_faces);
     this->grid->triangulation->add_periodicity(this->grid->periodic_faces);
 
@@ -453,15 +451,16 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+                                                                                   pair;
+    typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;
 
     this->boundary_descriptor->density.dirichlet_bc.insert(pair(0, new DensityBC<dim>()));
     this->boundary_descriptor->velocity.dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
     this->boundary_descriptor->pressure.neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(1)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
     this->boundary_descriptor->energy.dirichlet_bc.insert(
-      pair(0, new Functions::ConstantFunction<dim>(E_0, 1)));
+      pair(0, new dealii::Functions::ConstantFunction<dim>(E_0, 1)));
     // set energy boundary variable
     this->boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 // problem specific parameters
 double const DYN_VISCOSITY  = 0.01;
 double const GAMMA          = 1.5;
@@ -47,16 +45,16 @@ double const L = 1.0;
  *  Analytical solutions
  */
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
   Solution(unsigned int const n_components = dim + 2, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double result = 0.0;
 
@@ -79,16 +77,16 @@ public:
  *  zero velocity at the wall boundaries
  */
 template<int dim>
-class VelocityBC : public Function<dim>
+class VelocityBC : public dealii::Function<dim>
 {
 public:
   VelocityBC(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double result = 0.0;
 
@@ -106,15 +104,15 @@ public:
  *  prescribe a constant temperature at the channel walls
  */
 template<int dim>
-class EnergyBC : public Function<dim>
+class EnergyBC : public dealii::Function<dim>
 {
 public:
-  EnergyBC(double const time = 0.) : Function<dim>(1, time)
+  EnergyBC(double const time = 0.) : dealii::Function<dim>(1, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)component;
 
@@ -132,7 +130,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -188,11 +186,11 @@ public:
   create_grid() final
   {
     std::vector<unsigned int> repetitions({1, 1});
-    Point<dim>                point1(0.0, 0.0), point2(L, H);
-    GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
-                                              repetitions,
-                                              point1,
-                                              point2);
+    dealii::Point<dim>        point1(0.0, 0.0), point2(L, H);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
+                                                      repetitions,
+                                                      point1,
+                                                      point2);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -200,14 +198,15 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+                                                                                   pair;
+    typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;
 
     this->boundary_descriptor->density.dirichlet_bc.insert(
-      pair(0, new Functions::ConstantFunction<dim>(RHO_0, 1)));
+      pair(0, new dealii::Functions::ConstantFunction<dim>(RHO_0, 1)));
     this->boundary_descriptor->velocity.dirichlet_bc.insert(pair(0, new VelocityBC<dim>()));
     this->boundary_descriptor->pressure.neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(1)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
     // energy: prescribe energy
     this->boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
@@ -218,9 +217,12 @@ public:
   set_field_functions() final
   {
     this->field_functions->initial_solution.reset(new Solution<dim>());
-    this->field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->right_hand_side_energy.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side_density.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->right_hand_side_energy.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 // set parameters according to Wiart et al. ("Assessment of discontinuous Galerkin method
 // for the simulation of vortical flows at high Reynolds number"):
 
@@ -57,16 +55,16 @@ double const MAX_VELOCITY        = V_0;
 double const CHARACTERISTIC_TIME = L / V_0;
 
 template<int dim>
-class InitialSolution : public Function<dim>
+class InitialSolution : public dealii::Function<dim>
 {
 public:
   InitialSolution(unsigned int const n_components = dim + 2, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & x, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & x, unsigned int const component = 0) const
   {
     double const u1 = V_0 * std::sin(x[0] / L) * std::cos(x[1] / L) * std::cos(x[2] / L);
     double const u2 = -V_0 * std::cos(x[0] / L) * std::sin(x[1] / L) * std::cos(x[2] / L);
@@ -107,7 +105,7 @@ string_to_enum(MeshType & enum_type, std::string const & string_type)
   // clang-format off
   if     (string_type == "Cartesian")   enum_type = MeshType::Cartesian;
   else if(string_type == "Curvilinear") enum_type = MeshType::Curvilinear;
-  else AssertThrow(false, ExcMessage("Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Not implemented."));
   // clang-format on
 }
 
@@ -119,7 +117,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -127,13 +125,13 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
     // clang-format off
      prm.enter_subsection("Application");
-       prm.add_parameter("MeshType", mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", Patterns::Selection("Cartesian|Curvilinear"));
+       prm.add_parameter("MeshType", mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", dealii::Patterns::Selection("Cartesian|Curvilinear"));
      prm.leave_subsection();
     // clang-format on
   }
@@ -222,7 +220,7 @@ public:
   void
   create_grid() final
   {
-    double const pi   = numbers::PI;
+    double const pi   = dealii::numbers::PI;
     double const left = -pi * L, right = pi * L;
     double const deformation = 0.1;
 
@@ -237,7 +235,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     create_periodic_box(this->grid->triangulation,
@@ -262,9 +260,12 @@ public:
   set_field_functions() final
   {
     this->field_functions->initial_solution.reset(new InitialSolution<dim>());
-    this->field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->right_hand_side_energy.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side_density.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->right_hand_side_energy.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -26,20 +26,18 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 // Example of a user defined function
 template<int dim>
-class MyFunction : public Function<dim>
+class MyFunction : public dealii::Function<dim>
 {
 public:
   MyFunction(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)p;
     (void)component;
@@ -56,7 +54,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -79,18 +77,19 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, EnergyBoundaryVariable>         pair_variable;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+                                                                                   pair;
+    typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;
 
     // these lines show exemplarily how the boundary descriptors are filled
     this->boundary_descriptor->density.dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(1)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
     this->boundary_descriptor->velocity.dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->pressure.neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(1)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
     this->boundary_descriptor->energy.dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(1)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
     // set energy boundary variable
     this->boundary_descriptor->energy.boundary_variable.insert(
       pair_variable(0, EnergyBoundaryVariable::Energy));
@@ -100,10 +99,14 @@ public:
   set_field_functions() final
   {
     // these lines show exemplarily how the field functions are filled
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(dim + 2));
-    this->field_functions->right_hand_side_density.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->right_hand_side_energy.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim + 2));
+    this->field_functions->right_hand_side_density.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->right_hand_side_energy.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -30,18 +30,16 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
-  Solution(double const diffusivity) : Function<dim>(1, 0.0), diffusivity(diffusivity)
+  Solution(double const diffusivity) : dealii::Function<dim>(1, 0.0), diffusivity(diffusivity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double phi_l = 1.0, phi_r = 0.0;
     double U = 1.0, L = 2.0;
@@ -65,7 +63,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -141,12 +139,12 @@ public:
   create_grid() final
   {
     // hypercube volume is [left,right]^dim
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     // set boundary indicator
     for(auto cell : *this->grid->triangulation)
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         if((std::fabs(cell.face(f)->center()(1) - left) < 1e-12) ||
            (std::fabs(cell.face(f)->center()(1) - right) < 1e-12) ||
@@ -164,20 +162,22 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Solution<dim>(diffusivity)));
-    this->boundary_descriptor->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    this->boundary_descriptor->neumann_bc.insert(
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
     std::vector<double> velocity = std::vector<double>(dim, 0.0);
     velocity[0]                  = 1.0;
-    this->field_functions->velocity.reset(new Functions::ConstantFunction<dim>(velocity));
+    this->field_functions->velocity.reset(new dealii::Functions::ConstantFunction<dim>(velocity));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 enum class VelocityType
 {
   Constant,
@@ -41,16 +39,16 @@ enum class VelocityType
 VelocityType const VELOCITY_TYPE = VelocityType::CircularZeroAtBoundary;
 
 template<int dim>
-class VelocityField : public Function<dim>
+class VelocityField : public dealii::Function<dim>
 {
 public:
   VelocityField(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & point, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & point, unsigned int const component = 0) const
   {
     double value = 0.0;
 
@@ -68,11 +66,12 @@ public:
         value = point[0];
       else
         AssertThrow(component <= 1,
-                    ExcMessage("Velocity field for 3-dimensional problem is not implemented!"));
+                    dealii::ExcMessage(
+                      "Velocity field for 3-dimensional problem is not implemented!"));
     }
     else if(VELOCITY_TYPE == VelocityType::CircularZeroAtBoundary)
     {
-      double const pi    = numbers::PI;
+      double const pi    = dealii::numbers::PI;
       double       sinx  = std::sin(pi * point[0]);
       double       siny  = std::sin(pi * point[1]);
       double       sin2x = std::sin(2. * pi * point[0]);
@@ -84,7 +83,8 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Invalid type of velocity field prescribed for this problem."));
+      AssertThrow(
+        false, dealii::ExcMessage("Invalid type of velocity field prescribed for this problem."));
     }
 
     return value;
@@ -99,7 +99,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -187,7 +187,7 @@ public:
   void
   create_grid() final
   {
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -195,16 +195,19 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
-    this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    this->boundary_descriptor->dirichlet_bc.insert(
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ConstantFunction<dim>(1.0, 1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(
+      new dealii::Functions::ConstantFunction<dim>(1.0, 1));
     this->field_functions->velocity.reset(new VelocityField<dim>());
   }
 

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 enum class BoundaryConditionType
 {
   HomogeneousDBC,
@@ -41,15 +39,15 @@ bool const RIGHT_HAND_SIDE =
   (BOUNDARY_TYPE == BoundaryConditionType::HomogeneousNBCWithRHS) ? true : false;
 
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
-  Solution(double const diffusivity) : Function<dim>(1, 0.0), diffusivity(diffusivity)
+  Solution(double const diffusivity) : dealii::Function<dim>(1, 0.0), diffusivity(diffusivity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double t      = this->get_time();
     double result = 1.0;
@@ -57,24 +55,24 @@ public:
     if(BOUNDARY_TYPE == BoundaryConditionType::HomogeneousDBC)
     {
       for(int d = 0; d < dim; d++)
-        result *= std::cos(p[d] * numbers::PI / 2.0);
-      result *= std::exp(-0.5 * diffusivity * pow(numbers::PI, 2.0) * t);
+        result *= std::cos(p[d] * dealii::numbers::PI / 2.0);
+      result *= std::exp(-0.5 * diffusivity * pow(dealii::numbers::PI, 2.0) * t);
     }
     else if(BOUNDARY_TYPE == BoundaryConditionType::HomogeneousNBC)
     {
       for(int d = 0; d < dim; d++)
-        result *= std::cos(p[d] * numbers::PI);
-      result *= std::exp(-2.0 * diffusivity * pow(numbers::PI, 2.0) * t);
+        result *= std::cos(p[d] * dealii::numbers::PI);
+      result *= std::exp(-2.0 * diffusivity * pow(dealii::numbers::PI, 2.0) * t);
     }
     else if(BOUNDARY_TYPE == BoundaryConditionType::HomogeneousNBCWithRHS)
     {
       for(int d = 0; d < dim; d++)
-        result *= std::cos(p[d] * numbers::PI) + 1.0;
-      result *= std::exp(-2.0 * diffusivity * pow(numbers::PI, 2.0) * t);
+        result *= std::cos(p[d] * dealii::numbers::PI) + 1.0;
+      result *= std::exp(-2.0 * diffusivity * pow(dealii::numbers::PI, 2.0) * t);
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return result;
@@ -85,15 +83,15 @@ private:
 };
 
 template<int dim>
-class RightHandSide : public Function<dim>
+class RightHandSide : public dealii::Function<dim>
 {
 public:
-  RightHandSide(double const diffusivity) : Function<dim>(1, 0.0), diffusivity(diffusivity)
+  RightHandSide(double const diffusivity) : dealii::Function<dim>(1, 0.0), diffusivity(diffusivity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double t      = this->get_time();
     double result = 0.0;
@@ -106,13 +104,13 @@ public:
     else if(BOUNDARY_TYPE == BoundaryConditionType::HomogeneousNBCWithRHS)
     {
       for(int d = 0; d < dim; ++d)
-        result += std::cos(p[d] * numbers::PI) + 1;
-      result *= -std::pow(numbers::PI, 2.0) * diffusivity *
-                std::exp(-2.0 * diffusivity * pow(numbers::PI, 2.0) * t);
+        result += std::cos(p[d] * dealii::numbers::PI) + 1;
+      result *= -std::pow(dealii::numbers::PI, 2.0) * diffusivity *
+                std::exp(-2.0 * diffusivity * pow(dealii::numbers::PI, 2.0) * t);
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return result;
@@ -130,7 +128,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -202,7 +200,7 @@ public:
   create_grid() final
   {
     // hypercube volume is [left,right]^dim
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -211,7 +209,8 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     if(BOUNDARY_TYPE == BoundaryConditionType::HomogeneousDBC)
     {
@@ -220,11 +219,12 @@ public:
     else if(BOUNDARY_TYPE == BoundaryConditionType::HomogeneousNBC ||
             BOUNDARY_TYPE == BoundaryConditionType::HomogeneousNBCWithRHS)
     {
-      this->boundary_descriptor->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+      this->boundary_descriptor->neumann_bc.insert(
+        pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 
@@ -233,7 +233,7 @@ public:
   {
     this->field_functions->initial_solution.reset(new Solution<dim>(diffusivity));
     this->field_functions->right_hand_side.reset(new RightHandSide<dim>(diffusivity));
-    this->field_functions->velocity.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -26,19 +26,17 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
   Solution(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     // The analytical solution is only known at t = start_time and t = end_time
 
@@ -52,27 +50,29 @@ public:
 };
 
 template<int dim>
-class VelocityField : public Function<dim>
+class VelocityField : public dealii::Function<dim>
 {
 public:
-  VelocityField(double const end_time) : Function<dim>(dim, 0.0), end_time(end_time)
+  VelocityField(double const end_time) : dealii::Function<dim>(dim, 0.0), end_time(end_time)
   {
   }
 
   double
-  value(Point<dim> const & point, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & point, unsigned int const component = 0) const
   {
     double value = 0.0;
     double t     = this->get_time();
 
     if(component == 0)
-      value = 4.0 * std::sin(numbers::PI * point[0]) * std::sin(numbers::PI * point[0]) *
-              std::sin(numbers::PI * point[1]) * std::cos(numbers::PI * point[1]) *
-              std::cos(numbers::PI * t / end_time);
+      value = 4.0 * std::sin(dealii::numbers::PI * point[0]) *
+              std::sin(dealii::numbers::PI * point[0]) * std::sin(dealii::numbers::PI * point[1]) *
+              std::cos(dealii::numbers::PI * point[1]) *
+              std::cos(dealii::numbers::PI * t / end_time);
     else if(component == 1)
-      value = -4.0 * std::sin(numbers::PI * point[0]) * std::cos(numbers::PI * point[0]) *
-              std::sin(numbers::PI * point[1]) * std::sin(numbers::PI * point[1]) *
-              std::cos(numbers::PI * t / end_time);
+      value = -4.0 * std::sin(dealii::numbers::PI * point[0]) *
+              std::cos(dealii::numbers::PI * point[0]) * std::sin(dealii::numbers::PI * point[1]) *
+              std::sin(dealii::numbers::PI * point[1]) *
+              std::cos(dealii::numbers::PI * t / end_time);
 
     return value;
   }
@@ -89,7 +89,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -152,7 +152,7 @@ public:
   void
   create_grid() final
   {
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -160,7 +160,8 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // problem with pure Dirichlet boundary conditions
     this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Solution<dim>()));
@@ -170,7 +171,7 @@ public:
   set_field_functions() final
   {
     this->field_functions->initial_solution.reset(new Solution<dim>());
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions->velocity.reset(new VelocityField<dim>(end_time));
   }
 

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -26,24 +26,22 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
   Solution(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double t = this->get_time();
 
     double radius   = 0.5;
-    double omega    = 2.0 * numbers::PI;
+    double omega    = 2.0 * dealii::numbers::PI;
     double center_x = -radius * std::sin(omega * t);
     double center_y = +radius * std::cos(omega * t);
     double result   = std::exp(-50 * pow(p[0] - center_x, 2.0) - 50 * pow(p[1] - center_y, 2.0));
@@ -53,23 +51,23 @@ public:
 };
 
 template<int dim>
-class VelocityField : public Function<dim>
+class VelocityField : public dealii::Function<dim>
 {
 public:
   VelocityField(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & point, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & point, unsigned int const component = 0) const
   {
     double value = 0.0;
 
     if(component == 0)
-      value = -point[1] * 2.0 * numbers::PI;
+      value = -point[1] * 2.0 * dealii::numbers::PI;
     else if(component == 1)
-      value = point[0] * 2.0 * numbers::PI;
+      value = point[0] * 2.0 * dealii::numbers::PI;
 
     return value;
   }
@@ -83,7 +81,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -181,7 +179,7 @@ public:
   void
   create_grid() final
   {
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -190,7 +188,8 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // problem with pure Dirichlet boundary conditions
     this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Solution<dim>()));
@@ -200,7 +199,7 @@ public:
   set_field_functions() final
   {
     this->field_functions->initial_solution.reset(new Solution<dim>());
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions->velocity.reset(new VelocityField<dim>());
   }
 

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -31,23 +31,21 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
   Solution(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double t = this->get_time();
 
-    double result = std::sin(numbers::PI * (p[0] - t));
+    double result = std::sin(dealii::numbers::PI * (p[0] - t));
 
     return result;
   }
@@ -61,7 +59,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -133,12 +131,12 @@ public:
   void
   create_grid() final
   {
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     // set boundary id of 1 at right boundary (outflow)
     for(auto cell : *this->grid->triangulation)
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         if((std::fabs(cell.face(f)->center()(0) - right) < 1e-12))
           cell.face(f)->set_boundary_id(1);
@@ -148,10 +146,10 @@ public:
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
 
-  std::shared_ptr<Function<dim>>
+  std::shared_ptr<dealii::Function<dim>>
   create_mesh_movement_function() final
   {
-    std::shared_ptr<Function<dim>> mesh_motion;
+    std::shared_ptr<dealii::Function<dim>> mesh_motion;
 
     MeshMovementData<dim> data;
     data.temporal                       = MeshMovementAdvanceInTime::Sin;
@@ -171,10 +169,12 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Solution<dim>()));
-    this->boundary_descriptor->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    this->boundary_descriptor->neumann_bc.insert(
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
 
@@ -182,10 +182,10 @@ public:
   set_field_functions() final
   {
     this->field_functions->initial_solution.reset(new Solution<dim>());
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
     std::vector<double> velocity = std::vector<double>(dim, 0.0);
     velocity[0]                  = 1.0;
-    this->field_functions->velocity.reset(new Functions::ConstantFunction<dim>(velocity));
+    this->field_functions->velocity.reset(new dealii::Functions::ConstantFunction<dim>(velocity));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -28,20 +28,18 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 //  Example of a user defined function
 template<int dim>
-class MyFunction : public Function<dim>
+class MyFunction : public dealii::Function<dim>
 {
 public:
   MyFunction(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)p;
     (void)component;
@@ -58,7 +56,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -80,16 +78,18 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
+    this->boundary_descriptor->dirichlet_bc.insert(
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->velocity.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -28,19 +28,17 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
-class Velocity : public Function<dim>
+class Velocity : public dealii::Function<dim>
 {
 public:
   Velocity(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     return p[component];
   }
@@ -58,7 +56,7 @@ string_to_enum(MeshType & enum_type, std::string const & string_type)
   // clang-format off
   if     (string_type == "Cartesian")   enum_type = MeshType::Cartesian;
   else if(string_type == "Curvilinear") enum_type = MeshType::Curvilinear;
-  else AssertThrow(false, ExcMessage("Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Not implemented."));
   // clang-format on
 }
 
@@ -70,7 +68,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -78,13 +76,13 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
     // clang-format off
     prm.enter_subsection("Application");
-      prm.add_parameter("MeshType",  mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", Patterns::Selection("Cartesian|Curvilinear"));
+      prm.add_parameter("MeshType",  mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", dealii::Patterns::Selection("Cartesian|Curvilinear"));
     prm.leave_subsection();
     // clang-format on
   }
@@ -152,7 +150,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     create_periodic_box(this->grid->triangulation,
@@ -174,8 +172,8 @@ public:
   set_field_functions() final
   {
     // these lines show exemplarily how the field functions are filled
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions->velocity.reset(new Velocity<dim>(dim));
   }
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace FSI
 {
-using namespace dealii;
-
 // set problem specific parameters
 #define TESTCASE 2
 
@@ -78,11 +76,11 @@ double const X_3    = X_C + R + L_FLAG * 1.6; // only relevant for mesh
 double const Y_3    = H / 3.0;                // only relevant for mesh
 
 // boundary conditions
-types::boundary_id const BOUNDARY_ID_WALLS    = 0;
-types::boundary_id const BOUNDARY_ID_INFLOW   = 1;
-types::boundary_id const BOUNDARY_ID_OUTFLOW  = 2;
-types::boundary_id const BOUNDARY_ID_CYLINDER = 3;
-types::boundary_id const BOUNDARY_ID_FLAG     = 4;
+dealii::types::boundary_id const BOUNDARY_ID_WALLS    = 0;
+dealii::types::boundary_id const BOUNDARY_ID_INFLOW   = 1;
+dealii::types::boundary_id const BOUNDARY_ID_OUTFLOW  = 2;
+dealii::types::boundary_id const BOUNDARY_ID_CYLINDER = 3;
+dealii::types::boundary_id const BOUNDARY_ID_FLAG     = 4;
 
 bool STRUCTURE_COVERS_FLAG_ONLY = true;
 
@@ -101,15 +99,15 @@ double const REL_TOL_LINEARIZED = 1.e-6;
 double const ABS_TOL_LINEARIZED = 1.e-12;
 
 template<int dim>
-class InflowBC : public Function<dim>
+class InflowBC : public dealii::Function<dim>
 {
 public:
-  InflowBC() : Function<dim>(dim, 0.0)
+  InflowBC() : dealii::Function<dim>(dim, 0.0)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)p;
     double result = 0.0;
@@ -121,27 +119,27 @@ public:
 
     if(component == 0)
       result = U_X_MAX * (y * (H - y) / std::pow(H / 2.0, 2.0)) *
-               ((t < T) ? 0.5 * (1.0 - std::cos(t * numbers::PI / T)) : 1.0);
+               ((t < T) ? 0.5 * (1.0 - std::cos(t * dealii::numbers::PI / T)) : 1.0);
 
     return result;
   }
 };
 
 template<int dim>
-class SpatiallyVaryingE : public Function<dim>
+class SpatiallyVaryingE : public dealii::Function<dim>
 {
 public:
-  SpatiallyVaryingE() : Function<dim>(1, 0.0)
+  SpatiallyVaryingE() : dealii::Function<dim>(1, 0.0)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)component;
 
     double const value =
-      (std::abs(p[1] - H / 2.) < H / 8.) ? std::cos(4.0 * p[1] / H * numbers::PI) : 0.0;
+      (std::abs(p[1] - H / 2.) < H / 8.) ? std::cos(4.0 * p[1] / H * dealii::numbers::PI) : 0.0;
     double result = 1. + 100. * value * value;
 
     return result;
@@ -156,7 +154,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -323,88 +321,92 @@ public:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
   }
 
-  void create_triangulation_fluid(Triangulation<2> & tria)
+  void create_triangulation_fluid(dealii::Triangulation<2> & tria)
   {
-    std::vector<Triangulation<2>> tria_vec;
+    std::vector<dealii::Triangulation<2>> tria_vec;
     tria_vec.resize(11);
 
-    GridGenerator::general_cell(tria_vec[0],
-                                {Point<2>(X_0, 0.0),
-                                 Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
-                                 Point<2>(X_0, H),
-                                 Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0))});
+    dealii::GridGenerator::general_cell(
+      tria_vec[0],
+      {dealii::Point<2>(X_0, 0.0),
+       dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
+       dealii::Point<2>(X_0, H),
+       dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0))});
 
-    GridGenerator::general_cell(tria_vec[1],
-                                {Point<2>(X_0, 0.0),
-                                 Point<2>(X_2, 0.0),
-                                 Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
-                                 Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0))});
+    dealii::GridGenerator::general_cell(
+      tria_vec[1],
+      {dealii::Point<2>(X_0, 0.0),
+       dealii::Point<2>(X_2, 0.0),
+       dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
+       dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0))});
 
-    GridGenerator::general_cell(tria_vec[2],
-                                {Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
-                                 Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
-                                 Point<2>(X_0, H),
-                                 Point<2>(X_2, H)});
+    dealii::GridGenerator::general_cell(
+      tria_vec[2],
+      {dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
+       dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
+       dealii::Point<2>(X_0, H),
+       dealii::Point<2>(X_2, H)});
 
-    GridGenerator::general_cell(tria_vec[3],
-                                {Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
-                                 Point<2>(X_2, 0.0),
-                                 Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))),
-                                          Y_C - T / 2.0),
-                                 Point<2>(X_2, Y_C - T / 2.0)});
+    dealii::GridGenerator::general_cell(
+      tria_vec[3],
+      {dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
+       dealii::Point<2>(X_2, 0.0),
+       dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
+       dealii::Point<2>(X_2, Y_C - T / 2.0)});
 
-    GridGenerator::general_cell(tria_vec[4],
-                                {Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))),
-                                          Y_C + T / 2.0),
-                                 Point<2>(X_2, Y_C + T / 2.0),
-                                 Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
-                                 Point<2>(X_2, H)});
+    dealii::GridGenerator::general_cell(
+      tria_vec[4],
+      {dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0),
+       dealii::Point<2>(X_2, Y_C + T / 2.0),
+       dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
+       dealii::Point<2>(X_2, H)});
 
-    GridGenerator::subdivided_hyper_rectangle(tria_vec[5],
-                                              {1, 1} /* subdivisions x,y */,
-                                              Point<2>(X_2, 0.0),
-                                              Point<2>(X_C + R + L_FLAG, Y_C - T / 2.0));
+    dealii::GridGenerator::subdivided_hyper_rectangle(tria_vec[5],
+                                                      {1, 1} /* subdivisions x,y */,
+                                                      dealii::Point<2>(X_2, 0.0),
+                                                      dealii::Point<2>(X_C + R + L_FLAG,
+                                                                       Y_C - T / 2.0));
 
-    GridGenerator::subdivided_hyper_rectangle(tria_vec[6],
-                                              {1, 1} /* subdivisions x,y */,
-                                              Point<2>(X_2, Y_C + T / 2.0),
-                                              Point<2>(X_C + R + L_FLAG, H));
+    dealii::GridGenerator::subdivided_hyper_rectangle(tria_vec[6],
+                                                      {1, 1} /* subdivisions x,y */,
+                                                      dealii::Point<2>(X_2, Y_C + T / 2.0),
+                                                      dealii::Point<2>(X_C + R + L_FLAG, H));
 
-    GridGenerator::general_cell(tria_vec[7],
-                                {Point<2>(X_C + R + L_FLAG, 0.0),
-                                 Point<2>(X_3, 0.0),
-                                 Point<2>(X_C + R + L_FLAG, Y_C - T / 2.0),
-                                 Point<2>(X_3, Y_3)});
+    dealii::GridGenerator::general_cell(tria_vec[7],
+                                        {dealii::Point<2>(X_C + R + L_FLAG, 0.0),
+                                         dealii::Point<2>(X_3, 0.0),
+                                         dealii::Point<2>(X_C + R + L_FLAG, Y_C - T / 2.0),
+                                         dealii::Point<2>(X_3, Y_3)});
 
-    GridGenerator::general_cell(tria_vec[8],
-                                {Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0),
-                                 Point<2>(X_3, 2.0 * Y_3),
-                                 Point<2>(X_C + R + L_FLAG, H),
-                                 Point<2>(X_3, H)});
+    dealii::GridGenerator::general_cell(tria_vec[8],
+                                        {dealii::Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0),
+                                         dealii::Point<2>(X_3, 2.0 * Y_3),
+                                         dealii::Point<2>(X_C + R + L_FLAG, H),
+                                         dealii::Point<2>(X_3, H)});
 
-    GridGenerator::general_cell(tria_vec[9],
-                                {Point<2>(X_C + R + L_FLAG, Y_C - T / 2.0),
-                                 Point<2>(X_3, Y_3),
-                                 Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0),
-                                 Point<2>(X_3, 2.0 * Y_3)});
+    dealii::GridGenerator::general_cell(tria_vec[9],
+                                        {dealii::Point<2>(X_C + R + L_FLAG, Y_C - T / 2.0),
+                                         dealii::Point<2>(X_3, Y_3),
+                                         dealii::Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0),
+                                         dealii::Point<2>(X_3, 2.0 * Y_3)});
 
-    GridGenerator::subdivided_hyper_rectangle(tria_vec[10],
-                                              {8, 3} /* subdivisions x,y */,
-                                              Point<2>(X_3, 0.0),
-                                              Point<2>(L, H));
+    dealii::GridGenerator::subdivided_hyper_rectangle(tria_vec[10],
+                                                      {8, 3} /* subdivisions x,y */,
+                                                      dealii::Point<2>(X_3, 0.0),
+                                                      dealii::Point<2>(L, H));
 
-    std::vector<Triangulation<2> const *> tria_vec_ptr(tria_vec.size());
+    std::vector<dealii::Triangulation<2> const *> tria_vec_ptr(tria_vec.size());
     for(unsigned int i = 0; i < tria_vec.size(); ++i)
       tria_vec_ptr[i] = &tria_vec[i];
 
-    GridGenerator::merge_triangulations(tria_vec_ptr, tria);
+    dealii::GridGenerator::merge_triangulations(tria_vec_ptr, tria);
   }
 
-  void create_triangulation_fluid(Triangulation<3> & tria)
+  void create_triangulation_fluid(dealii::Triangulation<3> & tria)
   {
     (void)tria;
 
-    AssertThrow(false, ExcMessage("not implemented."));
+    AssertThrow(false, dealii::ExcMessage("not implemented."));
   }
 
   void
@@ -419,13 +421,13 @@ public:
     std::vector<unsigned int> manifold_ids;
     std::vector<unsigned int> face_ids;
 
-    Point<dim> center;
+    dealii::Point<dim> center;
     center[0] = X_C;
     center[1] = Y_C;
 
     for(auto cell : this->fluid_grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         double const x   = cell->face(f)->center()(0);
         double const y   = cell->face(f)->center()(1);
@@ -458,10 +460,10 @@ public:
         }
 
         // manifold IDs
-        for(unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+        for(unsigned int f = 0; f < dealii::GeometryInfo<2>::faces_per_cell; ++f)
         {
           bool face_at_sphere_boundary = cell->face(f)->at_boundary();
-          for(unsigned int v = 0; v < GeometryInfo<2 - 1>::vertices_per_cell; ++v)
+          for(unsigned int v = 0; v < dealii::GeometryInfo<2 - 1>::vertices_per_cell; ++v)
           {
             if(std::abs(center.distance(cell->face(f)->vertex(v)) - R) > TOL)
               face_at_sphere_boundary = false;
@@ -478,7 +480,7 @@ public:
     }
 
     // generate vector of manifolds and apply manifold to all cells that have been marked
-    static std::vector<std::shared_ptr<Manifold<dim>>> manifold_vec;
+    static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
     manifold_vec.resize(manifold_ids.size());
 
     for(unsigned int i = 0; i < manifold_ids.size(); ++i)
@@ -487,8 +489,9 @@ public:
       {
         if(cell->manifold_id() == manifold_ids[i])
         {
-          manifold_vec[i] = std::shared_ptr<Manifold<dim>>(static_cast<Manifold<dim> *>(
-            new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
+          manifold_vec[i] =
+            std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
+              new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
           this->fluid_grid->triangulation->set_manifold(manifold_ids[i], *(manifold_vec[i]));
         }
       }
@@ -503,34 +506,35 @@ public:
     std::shared_ptr<IncNS::BoundaryDescriptor<dim>> boundary_descriptor =
       this->fluid_boundary_descriptor;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
       pair_fsi;
 
     // fill boundary descriptor velocity
     boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_WALLS, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_WALLS, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->velocity->dirichlet_bc.insert(
       pair(BOUNDARY_ID_INFLOW, new InflowBC<dim>()));
     boundary_descriptor->velocity->neumann_bc.insert(
-      pair(BOUNDARY_ID_OUTFLOW, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_OUTFLOW, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_CYLINDER, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_CYLINDER, new dealii::Functions::ZeroFunction<dim>(dim)));
     // fluid-structure interface
     boundary_descriptor->velocity->dirichlet_mortar_bc.insert(
       pair_fsi(BOUNDARY_ID_FLAG, new FunctionCached<1, dim>()));
 
     // fill boundary descriptor pressure
     boundary_descriptor->pressure->neumann_bc.insert(
-      pair(BOUNDARY_ID_WALLS, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_WALLS, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->pressure->neumann_bc.insert(
-      pair(BOUNDARY_ID_INFLOW, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_INFLOW, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_OUTFLOW, new Functions::ZeroFunction<dim>(1)));
+      pair(BOUNDARY_ID_OUTFLOW, new dealii::Functions::ZeroFunction<dim>(1)));
     boundary_descriptor->pressure->neumann_bc.insert(
-      pair(BOUNDARY_ID_CYLINDER, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_CYLINDER, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->pressure->neumann_bc.insert(
-      pair(BOUNDARY_ID_FLAG, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_FLAG, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
@@ -538,10 +542,11 @@ public:
   {
     std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions = this->fluid_field_functions;
 
-    field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_solution_velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_solution_pressure.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
@@ -598,18 +603,19 @@ public:
     std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor =
       this->ale_poisson_boundary_descriptor;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
       pair_fsi;
 
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_WALLS, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_WALLS, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_INFLOW, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_INFLOW, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_OUTFLOW, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_OUTFLOW, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_CYLINDER, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_CYLINDER, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fluid-structure interface
     boundary_descriptor->dirichlet_mortar_bc.insert(
@@ -623,8 +629,8 @@ public:
     std::shared_ptr<Poisson::FieldFunctions<dim>> field_functions =
       this->ale_poisson_field_functions;
 
-    field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(dim));
-    field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(dim));
+    field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   void
@@ -663,28 +669,29 @@ public:
     std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor =
       this->ale_elasticity_boundary_descriptor;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+                                                                                  pair;
+    typedef typename std::pair<dealii::types::boundary_id, dealii::ComponentMask> pair_mask;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
       pair_fsi;
 
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_WALLS, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_WALLS, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc_component_mask.insert(
-      pair_mask(BOUNDARY_ID_WALLS, ComponentMask()));
+      pair_mask(BOUNDARY_ID_WALLS, dealii::ComponentMask()));
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_INFLOW, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_INFLOW, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc_component_mask.insert(
-      pair_mask(BOUNDARY_ID_INFLOW, ComponentMask()));
+      pair_mask(BOUNDARY_ID_INFLOW, dealii::ComponentMask()));
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_OUTFLOW, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_OUTFLOW, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc_component_mask.insert(
-      pair_mask(BOUNDARY_ID_OUTFLOW, ComponentMask()));
+      pair_mask(BOUNDARY_ID_OUTFLOW, dealii::ComponentMask()));
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_CYLINDER, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_CYLINDER, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc_component_mask.insert(
-      pair_mask(BOUNDARY_ID_CYLINDER, ComponentMask()));
+      pair_mask(BOUNDARY_ID_CYLINDER, dealii::ComponentMask()));
 
     // fluid-structure interface
     boundary_descriptor->dirichlet_mortar_bc.insert(
@@ -699,14 +706,14 @@ public:
 
     using namespace Structure;
 
-    typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
+    typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
-    double const                   E       = 1.0;
-    double const                   poisson = 0.3;
-    std::shared_ptr<Function<dim>> E_function;
+    double const                           E       = 1.0;
+    double const                           poisson = 0.3;
+    std::shared_ptr<dealii::Function<dim>> E_function;
     E_function.reset(new SpatiallyVaryingE<dim>());
     material_descriptor->insert(
       Pair(0, new StVenantKirchhoffData<dim>(type, E, poisson, two_dim_type, E_function)));
@@ -718,9 +725,9 @@ public:
     std::shared_ptr<Structure::FieldFunctions<dim>> field_functions =
       this->ale_elasticity_field_functions;
 
-    field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
-    field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
-    field_functions->initial_velocity.reset(new Functions::ZeroFunction<dim>(dim));
+    field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_displacement.reset(new dealii::Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   // Structure
@@ -765,139 +772,141 @@ public:
     param.update_preconditioner_every_newton_iterations = 10;
   }
 
-  void create_triangulation_structure(Triangulation<2> & tria)
+  void create_triangulation_structure(dealii::Triangulation<2> & tria)
   {
     if(STRUCTURE_COVERS_FLAG_ONLY)
     {
-      GridGenerator::subdivided_hyper_rectangle(
+      dealii::GridGenerator::subdivided_hyper_rectangle(
         tria,
         {N_CELLS_FLAG_X, 1} /* subdivisions x,y */,
-        Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
-        Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0));
+        dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
+        dealii::Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0));
     }
     else
     {
-      std::vector<Triangulation<2>> tria_vec;
+      std::vector<dealii::Triangulation<2>> tria_vec;
 
       tria_vec.resize(12);
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[0],
-        {Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
-         Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
-         Point<2>(X_C + T / 2.0, Y_C - T),
-         Point<2>(X_C + T / 2.0 +
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C - T / 4.0)});
+        {dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
+         dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
+         dealii::Point<2>(X_C + T / 2.0, Y_C - T),
+         dealii::Point<2>(X_C + T / 2.0 +
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C - T / 4.0)});
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[1],
-        {Point<2>(X_C + T / 2.0, Y_C - T),
-         Point<2>(X_C + T / 2.0 +
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C - T / 4.0),
-         Point<2>(X_C + T / 2.0, Y_C + T),
-         Point<2>(X_C + T / 2.0 +
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C + T / 4.0)});
+        {dealii::Point<2>(X_C + T / 2.0, Y_C - T),
+         dealii::Point<2>(X_C + T / 2.0 +
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C - T / 4.0),
+         dealii::Point<2>(X_C + T / 2.0, Y_C + T),
+         dealii::Point<2>(X_C + T / 2.0 +
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C + T / 4.0)});
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[2],
-        {Point<2>(X_C + T / 2.0 +
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C - T / 4.0),
-         Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
-         Point<2>(X_C + T / 2.0 +
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C + T / 4.0),
-         Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0)});
+        {dealii::Point<2>(X_C + T / 2.0 +
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C - T / 4.0),
+         dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
+         dealii::Point<2>(X_C + T / 2.0 +
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C + T / 4.0),
+         dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0)});
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[3],
-        {Point<2>(X_C + T / 2.0 +
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C + T / 4.0),
-         Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0),
-         Point<2>(X_C + T / 2.0, Y_C + T),
-         Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0))});
+        {dealii::Point<2>(X_C + T / 2.0 +
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C + T / 4.0),
+         dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0),
+         dealii::Point<2>(X_C + T / 2.0, Y_C + T),
+         dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0))});
 
-      GridGenerator::general_cell(tria_vec[4],
-                                  {Point<2>(X_C - T / 2.0, Y_C - T),
-                                   Point<2>(X_C + T / 2.0, Y_C - T),
-                                   Point<2>(X_C - T / 2.0, Y_C + T),
-                                   Point<2>(X_C + T / 2.0, Y_C + T)});
+      dealii::GridGenerator::general_cell(tria_vec[4],
+                                          {dealii::Point<2>(X_C - T / 2.0, Y_C - T),
+                                           dealii::Point<2>(X_C + T / 2.0, Y_C - T),
+                                           dealii::Point<2>(X_C - T / 2.0, Y_C + T),
+                                           dealii::Point<2>(X_C + T / 2.0, Y_C + T)});
 
-      GridGenerator::general_cell(tria_vec[5],
-                                  {Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
-                                   Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
-                                   Point<2>(X_C - T / 2.0, Y_C - T),
-                                   Point<2>(X_C + T / 2.0, Y_C - T)});
+      dealii::GridGenerator::general_cell(
+        tria_vec[5],
+        {dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
+         dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
+         dealii::Point<2>(X_C - T / 2.0, Y_C - T),
+         dealii::Point<2>(X_C + T / 2.0, Y_C - T)});
 
-      GridGenerator::general_cell(tria_vec[6],
-                                  {Point<2>(X_C - T / 2.0, Y_C + T),
-                                   Point<2>(X_C + T / 2.0, Y_C + T),
-                                   Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
-                                   Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0))});
+      dealii::GridGenerator::general_cell(
+        tria_vec[6],
+        {dealii::Point<2>(X_C - T / 2.0, Y_C + T),
+         dealii::Point<2>(X_C + T / 2.0, Y_C + T),
+         dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
+         dealii::Point<2>(X_C + R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0))});
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[7],
-        {Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
-         Point<2>(X_C - T / 2.0, Y_C - T),
-         Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
-         Point<2>(X_C - T / 2.0 -
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C - T / 4.0)});
+        {dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C - R / std::sqrt(2.0)),
+         dealii::Point<2>(X_C - T / 2.0, Y_C - T),
+         dealii::Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
+         dealii::Point<2>(X_C - T / 2.0 -
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C - T / 4.0)});
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[8],
-        {Point<2>(X_C - T / 2.0 -
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C - T / 4.0),
-         Point<2>(X_C - T / 2.0, Y_C - T),
-         Point<2>(X_C - T / 2.0 -
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C + T / 4.0),
-         Point<2>(X_C - T / 2.0, Y_C + T)});
+        {dealii::Point<2>(X_C - T / 2.0 -
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C - T / 4.0),
+         dealii::Point<2>(X_C - T / 2.0, Y_C - T),
+         dealii::Point<2>(X_C - T / 2.0 -
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C + T / 4.0),
+         dealii::Point<2>(X_C - T / 2.0, Y_C + T)});
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[9],
-        {Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
-         Point<2>(X_C - T / 2.0 -
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C - T / 4.0),
-         Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0),
-         Point<2>(X_C - T / 2.0 -
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C + T / 4.0)});
+        {dealii::Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
+         dealii::Point<2>(X_C - T / 2.0 -
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C - T / 4.0),
+         dealii::Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0),
+         dealii::Point<2>(X_C - T / 2.0 -
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C + T / 4.0)});
 
-      GridGenerator::general_cell(
+      dealii::GridGenerator::general_cell(
         tria_vec[10],
-        {Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0),
-         Point<2>(X_C - T / 2.0 -
-                    (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
-                  Y_C + T / 4.0),
-         Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
-         Point<2>(X_C - T / 2.0, Y_C + T)});
+        {dealii::Point<2>(X_C - R * std::cos(std::asin(T / (2.0 * R))), Y_C + T / 2.0),
+         dealii::Point<2>(X_C - T / 2.0 -
+                            (X_C + R * std::cos(std::asin(T / (2.0 * R))) - (X_C + T / 2.0)) / 2.0,
+                          Y_C + T / 4.0),
+         dealii::Point<2>(X_C - R / std::sqrt(2.0), Y_C + R / std::sqrt(2.0)),
+         dealii::Point<2>(X_C - T / 2.0, Y_C + T)});
 
-      GridGenerator::subdivided_hyper_rectangle(
+      dealii::GridGenerator::subdivided_hyper_rectangle(
         tria_vec[11],
         {8, 1} /* subdivisions x,y */,
-        Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
-        Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0));
+        dealii::Point<2>(X_C + R * std::cos(std::asin(T / (2.0 * R))), Y_C - T / 2.0),
+        dealii::Point<2>(X_C + R + L_FLAG, Y_C + T / 2.0));
 
-      std::vector<Triangulation<2> const *> tria_vec_ptr(tria_vec.size());
+      std::vector<dealii::Triangulation<2> const *> tria_vec_ptr(tria_vec.size());
       for(unsigned int i = 0; i < tria_vec.size(); ++i)
         tria_vec_ptr[i] = &tria_vec[i];
 
-      GridGenerator::merge_triangulations(tria_vec_ptr, tria);
+      dealii::GridGenerator::merge_triangulations(tria_vec_ptr, tria);
     }
   }
 
-  void create_triangulation_structure(Triangulation<3> & tria)
+  void create_triangulation_structure(dealii::Triangulation<3> & tria)
   {
     (void)tria;
 
-    AssertThrow(false, ExcMessage("not implemented."));
+    AssertThrow(false, dealii::ExcMessage("not implemented."));
   }
 
   void
@@ -912,13 +921,13 @@ public:
     std::vector<unsigned int> manifold_ids;
     std::vector<unsigned int> face_ids;
 
-    Point<dim> center;
+    dealii::Point<dim> center;
     center[0] = X_C;
     center[1] = Y_C;
 
     for(auto cell : this->structure_grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         double const x   = cell->face(f)->center()(0);
         double const TOL = 1.e-12;
@@ -945,10 +954,10 @@ public:
         }
 
         // manifold IDs
-        for(unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+        for(unsigned int f = 0; f < dealii::GeometryInfo<2>::faces_per_cell; ++f)
         {
           bool face_at_sphere_boundary = cell->face(f)->at_boundary();
-          for(unsigned int v = 0; v < GeometryInfo<2 - 1>::vertices_per_cell; ++v)
+          for(unsigned int v = 0; v < dealii::GeometryInfo<2 - 1>::vertices_per_cell; ++v)
           {
             if(std::abs(center.distance(cell->face(f)->vertex(v)) - R) > TOL)
               face_at_sphere_boundary = false;
@@ -965,7 +974,7 @@ public:
     }
 
     // generate vector of manifolds and apply manifold to all cells that have been marked
-    static std::vector<std::shared_ptr<Manifold<dim>>> manifold_vec;
+    static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
     manifold_vec.resize(manifold_ids.size());
 
     for(unsigned int i = 0; i < manifold_ids.size(); ++i)
@@ -974,8 +983,9 @@ public:
       {
         if(cell->manifold_id() == manifold_ids[i])
         {
-          manifold_vec[i] = std::shared_ptr<Manifold<dim>>(static_cast<Manifold<dim> *>(
-            new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
+          manifold_vec[i] =
+            std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
+              new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
           this->structure_grid->triangulation->set_manifold(manifold_ids[i], *(manifold_vec[i]));
         }
       }
@@ -990,16 +1000,17 @@ public:
     std::shared_ptr<Structure::BoundaryDescriptor<dim>> boundary_descriptor =
       this->structure_boundary_descriptor;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+                                                                                  pair;
+    typedef typename std::pair<dealii::types::boundary_id, dealii::ComponentMask> pair_mask;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>>
       pair_fsi;
 
     boundary_descriptor->dirichlet_bc.insert(
-      pair(BOUNDARY_ID_CYLINDER, new Functions::ZeroFunction<dim>(dim)));
+      pair(BOUNDARY_ID_CYLINDER, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->dirichlet_bc_component_mask.insert(
-      pair_mask(BOUNDARY_ID_CYLINDER, ComponentMask()));
+      pair_mask(BOUNDARY_ID_CYLINDER, dealii::ComponentMask()));
 
     // fluid-structure interface
     boundary_descriptor->neumann_mortar_bc.insert(
@@ -1012,9 +1023,9 @@ public:
     std::shared_ptr<Structure::FieldFunctions<dim>> field_functions =
       this->structure_field_functions;
 
-    field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
-    field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
-    field_functions->initial_velocity.reset(new Functions::ZeroFunction<dim>(dim));
+    field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_displacement.reset(new dealii::Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   void
@@ -1025,7 +1036,7 @@ public:
 
     using namespace Structure;
 
-    typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
+    typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -26,20 +26,18 @@ namespace ExaDG
 {
 namespace FSI
 {
-using namespace dealii;
-
 //  Example of a user defined function
 template<int dim>
-class MyFunction : public Function<dim>
+class MyFunction : public dealii::Function<dim>
 {
 public:
   MyFunction(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)p;
     (void)component;
@@ -56,7 +54,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -86,21 +84,22 @@ public:
     std::shared_ptr<IncNS::BoundaryDescriptor<dim>> boundary_descriptor =
       this->fluid_boundary_descriptor;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // these lines show exemplarily how the boundary descriptors are filled
 
     // velocity
     boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->velocity->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // pressure
     boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(1)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
@@ -109,10 +108,11 @@ public:
     std::shared_ptr<IncNS::FieldFunctions<dim>> field_functions = this->fluid_field_functions;
 
     // these lines show exemplarily how the field functions are filled
-    field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_solution_velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
+    field_functions->initial_solution_pressure.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
@@ -144,11 +144,12 @@ public:
     std::shared_ptr<Poisson::BoundaryDescriptor<1, dim>> boundary_descriptor =
       this->ale_poisson_boundary_descriptor;
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // these lines show exemplarily how the boundary descriptors are filled
-    boundary_descriptor->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    boundary_descriptor->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->dirichlet_bc.insert(pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
+    boundary_descriptor->neumann_bc.insert(pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
@@ -158,8 +159,8 @@ public:
       this->ale_poisson_field_functions;
 
     // these lines show exemplarily how the field functions are filled
-    field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   void

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace FTI
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Application : public FTI::ApplicationBase<dim, Number>
 {
@@ -81,7 +79,7 @@ public:
     : FTI::ApplicationBase<dim, Number>(input_file, comm, 1)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -315,12 +313,12 @@ public:
   void
   create_grid() final
   {
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     // set boundary IDs: 0 by default, set left boundary to 1
     for(auto cell : this->grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         if((std::fabs(cell->face(f)->center()(0) - left) < 1e-12))
         {
@@ -339,10 +337,10 @@ public:
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
 
-  std::shared_ptr<Function<dim>>
+  std::shared_ptr<dealii::Function<dim>>
   create_mesh_movement_function() final
   {
-    std::shared_ptr<Function<dim>> mesh_motion;
+    std::shared_ptr<dealii::Function<dim>> mesh_motion;
 
     MeshMovementData<dim> data;
     data.temporal      = MeshMovementAdvanceInTime::Sin;
@@ -362,35 +360,40 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(2, new Functions::ZeroFunction<dim>(dim)));
+      pair(2, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(2, new Functions::ZeroFunction<dim>(dim)));
+      pair(2, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
     std::vector<double> gravity = std::vector<double>(dim, 0.0);
     gravity[1]                  = -g;
-    this->field_functions->gravitational_force.reset(new Functions::ConstantFunction<dim>(gravity));
+    this->field_functions->gravitational_force.reset(
+      new dealii::Functions::ConstantFunction<dim>(gravity));
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
@@ -417,25 +420,26 @@ public:
   void
   set_boundary_descriptor_scalar(unsigned int scalar_index = 0) final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->scalar_boundary_descriptor[scalar_index]->dirichlet_bc.insert(
-      pair(0, new Functions::ConstantFunction<dim>(T_ref)));
+      pair(0, new dealii::Functions::ConstantFunction<dim>(T_ref)));
     this->scalar_boundary_descriptor[scalar_index]->dirichlet_bc.insert(
-      pair(1, new Functions::ConstantFunction<dim>(T_ref + delta_T)));
+      pair(1, new dealii::Functions::ConstantFunction<dim>(T_ref + delta_T)));
     this->scalar_boundary_descriptor[scalar_index]->neumann_bc.insert(
-      pair(2, new Functions::ZeroFunction<dim>(1)));
+      pair(2, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions_scalar(unsigned int scalar_index = 0) final
   {
     this->scalar_field_functions[scalar_index]->initial_solution.reset(
-      new Functions::ConstantFunction<dim>(T_ref));
+      new dealii::Functions::ConstantFunction<dim>(T_ref));
     this->scalar_field_functions[scalar_index]->right_hand_side.reset(
-      new Functions::ZeroFunction<dim>(1));
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->scalar_field_functions[scalar_index]->velocity.reset(
-      new Functions::ZeroFunction<dim>(dim));
+      new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -26,39 +26,37 @@ namespace ExaDG
 {
 namespace FTI
 {
-using namespace dealii;
-
 template<int dim>
-class InitialTemperature : public Function<dim>
+class InitialTemperature : public dealii::Function<dim>
 {
 public:
   InitialTemperature(double const T_ref, double const delta_T, double const length)
-    : Function<dim>(1, 0.0), T_ref(T_ref), delta_T(delta_T), L(length)
+    : dealii::Function<dim>(1, 0.0), T_ref(T_ref), delta_T(delta_T), L(length)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component = 0*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component = 0*/) const
   {
     double radius = 0.0;
     if(dim == 2)
     {
-      Point<dim> center = Point<dim>(0.5 * L, 0.35 * L);
-      radius            = p.distance(center);
+      dealii::Point<dim> center = dealii::Point<dim>(0.5 * L, 0.35 * L);
+      radius                    = p.distance(center);
     }
     else if(dim == 3)
     {
-      Point<dim> center = Point<dim>(0.5 * L, 0.35 * L, 0.5 * L);
-      radius            = p.distance(center);
+      dealii::Point<dim> center = dealii::Point<dim>(0.5 * L, 0.35 * L, 0.5 * L);
+      radius                    = p.distance(center);
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     double const r_b = 0.25 * L;
     double const factor =
-      radius < r_b ? delta_T / 2.0 * (1 + std::cos(numbers::PI * radius / r_b)) : 0.0;
+      radius < r_b ? delta_T / 2.0 * (1 + std::cos(dealii::numbers::PI * radius / r_b)) : 0.0;
 
     return (T_ref + factor);
   }
@@ -103,7 +101,7 @@ public:
     : FTI::ApplicationBase<dim, Number>(input_file, comm, 1)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -324,20 +322,20 @@ public:
     if(dim == 2)
     {
       double const left = 0.0, right = L;
-      GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+      dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
     }
     else if(dim == 3)
     {
       std::vector<unsigned int> repetitions({1, 1, 1});
-      Point<dim>                point1(0.0, 0.0, 0.0), point2(L, 1.5 * L, L);
-      GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
-                                                repetitions,
-                                                point1,
-                                                point2);
+      dealii::Point<dim>        point1(0.0, 0.0, 0.0), point2(L, 1.5 * L, L);
+      dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
+                                                        repetitions,
+                                                        point1,
+                                                        point2);
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
@@ -346,27 +344,32 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
     std::vector<double> gravity = std::vector<double>(dim, 0.0);
     gravity[1]                  = -g;
-    this->field_functions->gravitational_force.reset(new Functions::ConstantFunction<dim>(gravity));
+    this->field_functions->gravitational_force.reset(
+      new dealii::Functions::ConstantFunction<dim>(gravity));
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
@@ -392,10 +395,11 @@ public:
   void
   set_boundary_descriptor_scalar(unsigned int scalar_index = 0) final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->scalar_boundary_descriptor[scalar_index]->dirichlet_bc.insert(
-      pair(0, new Functions::ConstantFunction<dim>(T_ref)));
+      pair(0, new dealii::Functions::ConstantFunction<dim>(T_ref)));
   }
 
   void
@@ -404,9 +408,9 @@ public:
     this->scalar_field_functions[scalar_index]->initial_solution.reset(
       new InitialTemperature<dim>(T_ref, delta_T, L));
     this->scalar_field_functions[scalar_index]->right_hand_side.reset(
-      new Functions::ZeroFunction<dim>(1));
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->scalar_field_functions[scalar_index]->velocity.reset(
-      new Functions::ZeroFunction<dim>(dim));
+      new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -26,20 +26,18 @@ namespace ExaDG
 {
 namespace FTI
 {
-using namespace dealii;
-
 // Example of a user defined function
 template<int dim>
-class MyFunction : public Function<dim>
+class MyFunction : public dealii::Function<dim>
 {
 public:
   MyFunction(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)p;
     (void)component;
@@ -56,7 +54,7 @@ public:
     : FTI::ApplicationBase<dim, Number>(input_file, comm, 1)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -90,28 +88,32 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->velocity->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(1)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<IncNS::PostProcessorBase<dim, Number>>
@@ -128,12 +130,13 @@ public:
   void
   set_boundary_descriptor_scalar(unsigned int scalar_index = 0) final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->scalar_boundary_descriptor[scalar_index]->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(1)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
     this->scalar_boundary_descriptor[scalar_index]->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(1)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
 
@@ -141,10 +144,11 @@ public:
   set_field_functions_scalar(unsigned int scalar_index = 0) final
   {
     this->scalar_field_functions[scalar_index]->initial_solution.reset(
-      new Functions::ZeroFunction<dim>(1));
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->scalar_field_functions[scalar_index]->right_hand_side.reset(
-      new Functions::ZeroFunction<dim>(1));
-    this->scalar_field_functions[scalar_index]->velocity.reset(new Functions::ZeroFunction<dim>(1));
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->scalar_field_functions[scalar_index]->velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<ConvDiff::PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -34,17 +34,15 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class InitialSolutionVelocity : public Function<dim>
+class InitialSolutionVelocity : public dealii::Function<dim>
 {
 public:
   InitialSolutionVelocity(double const max_velocity,
                           double const length,
                           double const height,
                           double const width)
-    : Function<dim>(dim, 0.0),
+    : dealii::Function<dim>(dim, 0.0),
       max_velocity(max_velocity),
       length(length),
       height(height),
@@ -53,9 +51,9 @@ public:
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
-    AssertThrow(dim == 3, ExcMessage("Dimension has to be dim==3."));
+    AssertThrow(dim == 3, dealii::ExcMessage("Dimension has to be dim==3."));
 
     double const x = p[0] / length;
     double const y = (p[1] - height / 2.0) / (height / 2.0);
@@ -99,16 +97,16 @@ private:
 };
 
 template<int dim>
-class InflowProfile : public Function<dim>
+class InflowProfile : public dealii::Function<dim>
 {
 public:
   InflowProfile(InflowDataStorage<dim> const & inflow_data_storage)
-    : Function<dim>(dim, 0.0), data(inflow_data_storage)
+    : dealii::Function<dim>(dim, 0.0), data(inflow_data_storage)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double result = linear_interpolation_2d_cartesian(
       p, data.y_values, data.z_values, data.velocity_values, component);
@@ -121,15 +119,15 @@ private:
 };
 
 template<int dim>
-class RightHandSide : public Function<dim>
+class RightHandSide : public dealii::Function<dim>
 {
 public:
-  RightHandSide() : Function<dim>(dim, 0.0)
+  RightHandSide() : dealii::Function<dim>(dim, 0.0)
   {
   }
 
   double
-  value(Point<dim> const & /*p*/, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & /*p*/, unsigned int const component = 0) const
   {
     double result = 0.0;
 
@@ -153,7 +151,7 @@ public:
     : ApplicationBasePrecursor<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -399,12 +397,13 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     // no slip boundaries at the upper and lower wall with ID=0
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // inflow boundary condition at left boundary with ID=2: prescribe velocity profile which
     // is obtained as the results of the precursor simulation
@@ -413,38 +412,39 @@ public:
 
     // outflow boundary condition at right boundary with ID=1
     this->boundary_descriptor->velocity->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     // no slip boundaries at the upper and lower wall with ID=0
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // inflow boundary condition at left boundary with ID=2
     // the inflow boundary condition is time dependent (du/dt != 0) but, for simplicity,
     // we assume that this is negligible when using the dual splitting scheme
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(2, new Functions::ZeroFunction<dim>(dim)));
+      pair(2, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // outflow boundary condition at right boundary with ID=1: set pressure to zero
     this->boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(1)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_boundary_descriptor_precursor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     // no slip boundaries at lower and upper wall with ID=0
     this->boundary_descriptor_pre->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     // no slip boundaries at lower and upper wall with ID=0
     this->boundary_descriptor_pre->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
@@ -456,10 +456,12 @@ public:
                                        Geometry::HEIGHT_CHANNEL,
                                        Geometry::WIDTH_CHANNEL));
     //  this->field_functions->initial_solution_velocity.reset(new
-    //  Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    //  dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   void
@@ -470,9 +472,10 @@ public:
                                        Geometry::LENGTH_CHANNEL,
                                        Geometry::HEIGHT_CHANNEL,
                                        Geometry::WIDTH_CHANNEL));
-    this->field_functions_pre->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions_pre->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions_pre->analytical_solution_pressure.reset(
-      new Functions::ZeroFunction<dim>(1));
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions_pre->right_hand_side.reset(new RightHandSide<dim>());
   }
 
@@ -518,9 +521,9 @@ public:
     quantity_reynolds->type = QuantityType::ReynoldsStresses;
 
     // skin friction
-    Tensor<1, dim, double> normal;
+    dealii::Tensor<1, dim, double> normal;
     normal[1] = 1.0;
-    Tensor<1, dim, double> tangent;
+    dealii::Tensor<1, dim, double> tangent;
     tangent[0] = 1.0;
     std::shared_ptr<QuantitySkinFriction<dim>> quantity_skin_friction;
     quantity_skin_friction.reset(new QuantitySkinFriction<dim>());
@@ -537,8 +540,9 @@ public:
     // mean pressure coefficient
     std::shared_ptr<QuantityPressureCoefficient<dim>> quantity_pressure_coeff;
     quantity_pressure_coeff.reset(new QuantityPressureCoefficient<dim>());
-    quantity_pressure_coeff->type            = QuantityType::PressureCoefficient;
-    quantity_pressure_coeff->reference_point = Point<dim>(Geometry::X1_COORDINATE_INFLOW, 0, 0);
+    quantity_pressure_coeff->type = QuantityType::PressureCoefficient;
+    quantity_pressure_coeff->reference_point =
+      dealii::Point<dim>(Geometry::X1_COORDINATE_INFLOW, 0, 0);
 
     // lines
     std::shared_ptr<LineHomogeneousAveraging<dim>> vel_0, vel_1, vel_2, vel_3, vel_4, vel_5, vel_6,
@@ -594,36 +598,36 @@ public:
     // begin and end points of all lines
     double const H   = Geometry::H;
     double const eps = 1.e-8;
-    vel_0->begin     = Point<dim>(Geometry::X1_COORDINATE_INFLOW + eps, 0, 0);
-    vel_0->end       = Point<dim>(Geometry::X1_COORDINATE_INFLOW + eps, 2 * H, 0);
-    vel_1->begin     = Point<dim>(0 * H, 0, 0);
-    vel_1->end       = Point<dim>(0 * H, 2 * H, 0);
-    vel_2->begin     = Point<dim>(1 * H, -1 * H, 0);
-    vel_2->end       = Point<dim>(1 * H, 2 * H, 0);
-    vel_3->begin     = Point<dim>(2 * H, -1 * H, 0);
-    vel_3->end       = Point<dim>(2 * H, 2 * H, 0);
-    vel_4->begin     = Point<dim>(3 * H, -1 * H, 0);
-    vel_4->end       = Point<dim>(3 * H, 2 * H, 0);
-    vel_5->begin     = Point<dim>(4 * H, -1 * H, 0);
-    vel_5->end       = Point<dim>(4 * H, 2 * H, 0);
-    vel_6->begin     = Point<dim>(5 * H, -1 * H, 0);
-    vel_6->end       = Point<dim>(5 * H, 2 * H, 0);
-    vel_7->begin     = Point<dim>(6 * H, -1 * H, 0);
-    vel_7->end       = Point<dim>(6 * H, 2 * H, 0);
-    vel_8->begin     = Point<dim>(7 * H, -1 * H, 0);
-    vel_8->end       = Point<dim>(7 * H, 2 * H, 0);
-    vel_9->begin     = Point<dim>(8 * H, -1 * H, 0);
-    vel_9->end       = Point<dim>(8 * H, 2 * H, 0);
-    vel_10->begin    = Point<dim>(9 * H, -1 * H, 0);
-    vel_10->end      = Point<dim>(9 * H, 2 * H, 0);
-    vel_11->begin    = Point<dim>(10 * H, -1 * H, 0);
-    vel_11->end      = Point<dim>(10 * H, 2 * H, 0);
-    Cp_1->begin      = Point<dim>(Geometry::X1_COORDINATE_INFLOW, 0, 0);
-    Cp_1->end        = Point<dim>(0, 0, 0);
-    Cp_2->begin      = Point<dim>(0, -H, 0);
-    Cp_2->end        = Point<dim>(Geometry::X1_COORDINATE_OUTFLOW, -H, 0);
-    Cf->begin        = Point<dim>(0, -H, 0);
-    Cf->end          = Point<dim>(Geometry::X1_COORDINATE_OUTFLOW, -H, 0);
+    vel_0->begin     = dealii::Point<dim>(Geometry::X1_COORDINATE_INFLOW + eps, 0, 0);
+    vel_0->end       = dealii::Point<dim>(Geometry::X1_COORDINATE_INFLOW + eps, 2 * H, 0);
+    vel_1->begin     = dealii::Point<dim>(0 * H, 0, 0);
+    vel_1->end       = dealii::Point<dim>(0 * H, 2 * H, 0);
+    vel_2->begin     = dealii::Point<dim>(1 * H, -1 * H, 0);
+    vel_2->end       = dealii::Point<dim>(1 * H, 2 * H, 0);
+    vel_3->begin     = dealii::Point<dim>(2 * H, -1 * H, 0);
+    vel_3->end       = dealii::Point<dim>(2 * H, 2 * H, 0);
+    vel_4->begin     = dealii::Point<dim>(3 * H, -1 * H, 0);
+    vel_4->end       = dealii::Point<dim>(3 * H, 2 * H, 0);
+    vel_5->begin     = dealii::Point<dim>(4 * H, -1 * H, 0);
+    vel_5->end       = dealii::Point<dim>(4 * H, 2 * H, 0);
+    vel_6->begin     = dealii::Point<dim>(5 * H, -1 * H, 0);
+    vel_6->end       = dealii::Point<dim>(5 * H, 2 * H, 0);
+    vel_7->begin     = dealii::Point<dim>(6 * H, -1 * H, 0);
+    vel_7->end       = dealii::Point<dim>(6 * H, 2 * H, 0);
+    vel_8->begin     = dealii::Point<dim>(7 * H, -1 * H, 0);
+    vel_8->end       = dealii::Point<dim>(7 * H, 2 * H, 0);
+    vel_9->begin     = dealii::Point<dim>(8 * H, -1 * H, 0);
+    vel_9->end       = dealii::Point<dim>(8 * H, 2 * H, 0);
+    vel_10->begin    = dealii::Point<dim>(9 * H, -1 * H, 0);
+    vel_10->end      = dealii::Point<dim>(9 * H, 2 * H, 0);
+    vel_11->begin    = dealii::Point<dim>(10 * H, -1 * H, 0);
+    vel_11->end      = dealii::Point<dim>(10 * H, 2 * H, 0);
+    Cp_1->begin      = dealii::Point<dim>(Geometry::X1_COORDINATE_INFLOW, 0, 0);
+    Cp_1->end        = dealii::Point<dim>(0, 0, 0);
+    Cp_2->begin      = dealii::Point<dim>(0, -H, 0);
+    Cp_2->end        = dealii::Point<dim>(Geometry::X1_COORDINATE_OUTFLOW, -H, 0);
+    Cf->begin        = dealii::Point<dim>(0, -H, 0);
+    Cf->end          = dealii::Point<dim>(Geometry::X1_COORDINATE_OUTFLOW, -H, 0);
 
     // set the number of points along the lines
     vel_0->n_points  = n_points_per_line;

--- a/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/include/geometry.h
@@ -28,9 +28,7 @@ namespace IncNS
 {
 namespace Geometry
 {
-using namespace dealii;
-
-double const PI = numbers::PI;
+double const PI = dealii::numbers::PI;
 
 // Height H
 double const H = 0.041;
@@ -119,7 +117,7 @@ inverse_grid_transform_y(double const & y)
 }
 
 template<int dim>
-class MyManifold : public ChartManifold<dim, dim, dim>
+class MyManifold : public dealii::ChartManifold<dim, dim, dim>
 {
 public:
   MyManifold()
@@ -130,11 +128,11 @@ public:
    *  push_forward operation that maps point xi in reference coordinates
    *  to point x in physical coordinates
    */
-  Point<dim>
-  push_forward(Point<dim> const & xi) const final
+  dealii::Point<dim>
+  push_forward(dealii::Point<dim> const & xi) const final
   {
-    Point<dim> x = xi;
-    x[1]         = grid_transform_y(xi[1]);
+    dealii::Point<dim> x = xi;
+    x[1]                 = grid_transform_y(xi[1]);
 
     return x;
   }
@@ -143,16 +141,16 @@ public:
    *  pull_back operation that maps point x in physical coordinates
    *  to point xi in reference coordinates
    */
-  Point<dim>
-  pull_back(Point<dim> const & x) const final
+  dealii::Point<dim>
+  pull_back(dealii::Point<dim> const & x) const final
   {
-    Point<dim> xi = x;
-    xi[1]         = inverse_grid_transform_y(x[1]);
+    dealii::Point<dim> xi = x;
+    xi[1]                 = inverse_grid_transform_y(x[1]);
 
     return xi;
   }
 
-  std::unique_ptr<Manifold<dim>>
+  std::unique_ptr<dealii::Manifold<dim>>
   clone() const final
   {
     return std::make_unique<MyManifold<dim>>();
@@ -161,46 +159,47 @@ public:
 
 template<int dim>
 void
-create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
-            unsigned int const                  n_refine_space,
-            std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
-              periodic_faces)
+create_grid(std::shared_ptr<dealii::Triangulation<dim>>              triangulation,
+            unsigned int const                                       n_refine_space,
+            std::vector<dealii::GridTools::PeriodicFacePair<
+              typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces)
 {
-  AssertThrow(dim == 3, ExcMessage("NotImplemented"));
+  AssertThrow(dim == 3, dealii::ExcMessage("NotImplemented"));
 
-  Triangulation<dim> tria_1, tria_2, tria_3;
+  dealii::Triangulation<dim> tria_1, tria_2, tria_3;
 
   // inflow part of BFS
-  GridGenerator::subdivided_hyper_rectangle(tria_1,
-                                            std::vector<unsigned int>({1, 1, 1}),
-                                            Point<dim>(-LENGTH_BFS_UP, 0.0, -WIDTH_BFS / 2.0),
-                                            Point<dim>(0.0, HEIGHT_BFS_INFLOW, WIDTH_BFS / 2.0));
+  dealii::GridGenerator::subdivided_hyper_rectangle(
+    tria_1,
+    std::vector<unsigned int>({1, 1, 1}),
+    dealii::Point<dim>(-LENGTH_BFS_UP, 0.0, -WIDTH_BFS / 2.0),
+    dealii::Point<dim>(0.0, HEIGHT_BFS_INFLOW, WIDTH_BFS / 2.0));
 
   // downstream part of BFS (upper)
-  GridGenerator::subdivided_hyper_rectangle(tria_2,
-                                            std::vector<unsigned int>({10, 1, 1}),
-                                            Point<dim>(0.0, 0.0, -WIDTH_BFS / 2.0),
-                                            Point<dim>(LENGTH_BFS_DOWN,
-                                                       HEIGHT_BFS_INFLOW,
-                                                       WIDTH_BFS / 2.0));
+  dealii::GridGenerator::subdivided_hyper_rectangle(tria_2,
+                                                    std::vector<unsigned int>({10, 1, 1}),
+                                                    dealii::Point<dim>(0.0, 0.0, -WIDTH_BFS / 2.0),
+                                                    dealii::Point<dim>(LENGTH_BFS_DOWN,
+                                                                       HEIGHT_BFS_INFLOW,
+                                                                       WIDTH_BFS / 2.0));
 
   // downstream part of BFS (lower = step)
-  GridGenerator::subdivided_hyper_rectangle(tria_3,
-                                            std::vector<unsigned int>({10, 1, 1}),
-                                            Point<dim>(0.0, 0.0, -WIDTH_BFS / 2.0),
-                                            Point<dim>(LENGTH_BFS_DOWN,
-                                                       -HEIGHT_BFS_STEP,
-                                                       WIDTH_BFS / 2.0));
+  dealii::GridGenerator::subdivided_hyper_rectangle(tria_3,
+                                                    std::vector<unsigned int>({10, 1, 1}),
+                                                    dealii::Point<dim>(0.0, 0.0, -WIDTH_BFS / 2.0),
+                                                    dealii::Point<dim>(LENGTH_BFS_DOWN,
+                                                                       -HEIGHT_BFS_STEP,
+                                                                       WIDTH_BFS / 2.0));
 
-  Triangulation<dim> tmp1;
-  GridGenerator::merge_triangulations(tria_1, tria_2, tmp1);
-  GridGenerator::merge_triangulations(tmp1, tria_3, *triangulation);
+  dealii::Triangulation<dim> tmp1;
+  dealii::GridGenerator::merge_triangulations(tria_1, tria_2, tmp1);
+  dealii::GridGenerator::merge_triangulations(tmp1, tria_3, *triangulation);
 
 
   // set boundary ID's
   for(auto cell : triangulation->active_cell_iterators())
   {
-    for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
     {
       // outflow boundary on the right has ID = 1
       if((std::fabs(cell->face(f)->center()(0) - X1_COORDINATE_OUTFLOW) < 1.e-12))
@@ -232,7 +231,7 @@ create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
   }
 
   // periodicity in z-direction
-  GridTools::collect_periodic_faces(*triangulation, 2 + 10, 3 + 10, 2, periodic_faces);
+  dealii::GridTools::collect_periodic_faces(*triangulation, 2 + 10, 3 + 10, 2, periodic_faces);
   triangulation->add_periodicity(periodic_faces);
 
   // perform global refinements
@@ -241,27 +240,27 @@ create_grid(std::shared_ptr<Triangulation<dim>> triangulation,
 
 template<int dim>
 void
-create_grid_precursor(
-  std::shared_ptr<Triangulation<dim>> triangulation,
-  unsigned int const                  n_refine_space,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
-    periodic_faces)
+create_grid_precursor(std::shared_ptr<dealii::Triangulation<dim>>              triangulation,
+                      unsigned int const                                       n_refine_space,
+                      std::vector<dealii::GridTools::PeriodicFacePair<
+                        typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces)
 {
-  AssertThrow(dim == 3, ExcMessage("NotImplemented"));
+  AssertThrow(dim == 3, dealii::ExcMessage("NotImplemented"));
 
-  Tensor<1, dim> dimensions;
+  dealii::Tensor<1, dim> dimensions;
   dimensions[0] = LENGTH_CHANNEL;
   dimensions[1] = HEIGHT_CHANNEL;
   dimensions[2] = WIDTH_CHANNEL;
 
-  Tensor<1, dim> center;
+  dealii::Tensor<1, dim> center;
   center[0] = -(LENGTH_BFS_UP + GAP_CHANNEL_BFS + LENGTH_CHANNEL / 2.0);
   center[1] = HEIGHT_CHANNEL / 2.0;
 
-  GridGenerator::subdivided_hyper_rectangle(*triangulation,
-                                            std::vector<unsigned int>({2, 1, 1}), // refinements
-                                            Point<dim>(center - dimensions / 2.0),
-                                            Point<dim>(center + dimensions / 2.0));
+  dealii::GridGenerator::subdivided_hyper_rectangle(*triangulation,
+                                                    std::vector<unsigned int>(
+                                                      {2, 1, 1}), // refinements
+                                                    dealii::Point<dim>(center - dimensions / 2.0),
+                                                    dealii::Point<dim>(center + dimensions / 2.0));
 
   if(use_grid_stretching_in_y_direction == true)
   {
@@ -280,7 +279,7 @@ create_grid_precursor(
   // set boundary ID's: periodicity
   for(auto cell : triangulation->active_cell_iterators())
   {
-    for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
     {
       // periodicity in x-direction
       if(std::fabs(cell->face(f)->center()(0) - (center[0] - dimensions[0] / 2.0)) < 1.e-12)
@@ -296,8 +295,8 @@ create_grid_precursor(
     }
   }
 
-  GridTools::collect_periodic_faces(*triangulation, 0 + 10, 1 + 10, 0, periodic_faces);
-  GridTools::collect_periodic_faces(*triangulation, 2 + 10, 3 + 10, 2, periodic_faces);
+  dealii::GridTools::collect_periodic_faces(*triangulation, 0 + 10, 1 + 10, 0, periodic_faces);
+  dealii::GridTools::collect_periodic_faces(*triangulation, 2 + 10, 3 + 10, 2, periodic_faces);
   triangulation->add_periodicity(periodic_faces);
 
   // perform global refinements: use one level finer for the channel

--- a/applications/incompressible_navier_stokes/backward_facing_step/include/inflow_data_storage.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/include/inflow_data_storage.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct InflowDataStorage
 {
@@ -47,8 +45,8 @@ struct InflowDataStorage
   void
   initialize_y_and_z_values()
   {
-    AssertThrow(n_points_y >= 2, ExcMessage("Variable n_points_y is invalid"));
-    AssertThrow(n_points_z >= 2, ExcMessage("Variable n_points_z is invalid"));
+    AssertThrow(n_points_y >= 2, dealii::ExcMessage("Variable n_points_y is invalid"));
+    AssertThrow(n_points_z >= 2, dealii::ExcMessage("Variable n_points_z is invalid"));
 
     for(unsigned int i = 0; i < n_points_y; ++i)
       y_values[i] = double(i) / double(n_points_y - 1) * Geometry::HEIGHT_CHANNEL;
@@ -61,14 +59,14 @@ struct InflowDataStorage
   void
   initialize_velocity_values()
   {
-    AssertThrow(n_points_y >= 2, ExcMessage("Variable n_points_y is invalid"));
-    AssertThrow(n_points_z >= 2, ExcMessage("Variable n_points_z is invalid"));
+    AssertThrow(n_points_y >= 2, dealii::ExcMessage("Variable n_points_y is invalid"));
+    AssertThrow(n_points_z >= 2, dealii::ExcMessage("Variable n_points_z is invalid"));
 
     for(unsigned int iy = 0; iy < n_points_y; ++iy)
     {
       for(unsigned int iz = 0; iz < n_points_z; ++iz)
       {
-        Tensor<1, dim, double> velocity;
+        dealii::Tensor<1, dim, double> velocity;
         velocity_values[iy * n_points_z + iz] = velocity;
       }
     }
@@ -77,9 +75,9 @@ struct InflowDataStorage
   unsigned int n_points_y;
   unsigned int n_points_z;
 
-  std::vector<double>                 y_values;
-  std::vector<double>                 z_values;
-  std::vector<Tensor<1, dim, double>> velocity_values;
+  std::vector<double>                         y_values;
+  std::vector<double>                         z_values;
+  std::vector<dealii::Tensor<1, dim, double>> velocity_values;
 };
 
 } // namespace IncNS

--- a/applications/incompressible_navier_stokes/backward_facing_step/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/include/postprocessor.h
@@ -34,8 +34,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct PostProcessorDataBFS
 {

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -26,21 +26,20 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class AnalyticalSolutionVelocity : public Function<dim>
+class AnalyticalSolutionVelocity : public dealii::Function<dim>
 {
 public:
-  AnalyticalSolutionVelocity(double const viscosity) : Function<dim>(dim, 0.0), nu(viscosity)
+  AnalyticalSolutionVelocity(double const viscosity)
+    : dealii::Function<dim>(dim, 0.0), nu(viscosity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double const t = this->get_time();
-    double const a = 0.25 * numbers::PI;
+    double const a = 0.25 * dealii::numbers::PI;
     double const d = 2 * a;
 
     double result = 0.0;
@@ -61,19 +60,19 @@ private:
 };
 
 template<int dim>
-class AnalyticalSolutionPressure : public Function<dim>
+class AnalyticalSolutionPressure : public dealii::Function<dim>
 {
 public:
   AnalyticalSolutionPressure(double const viscosity)
-    : Function<dim>(1 /*n_components*/, 0.0), nu(viscosity)
+    : dealii::Function<dim>(1 /*n_components*/, 0.0), nu(viscosity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double const t = this->get_time();
-    double const a = 0.25 * numbers::PI;
+    double const a = 0.25 * dealii::numbers::PI;
     double const d = 2 * a;
 
     // clang-format off
@@ -91,18 +90,18 @@ private:
 };
 
 template<int dim>
-class PressureBC_dudt : public Function<dim>
+class PressureBC_dudt : public dealii::Function<dim>
 {
 public:
-  PressureBC_dudt(double const viscosity) : Function<dim>(dim, 0.0), nu(viscosity)
+  PressureBC_dudt(double const viscosity) : dealii::Function<dim>(dim, 0.0), nu(viscosity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double const t = this->get_time();
-    double const a = 0.25 * numbers::PI;
+    double const a = 0.25 * dealii::numbers::PI;
     double const d = 2 * a;
 
     double result = 0.0;
@@ -130,7 +129,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -253,7 +252,7 @@ public:
   create_grid() final
   {
     double const left = -1.0, right = 1.0;
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -261,7 +260,8 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
       pair(0, new AnalyticalSolutionVelocity<dim>(viscosity)));
@@ -279,7 +279,7 @@ public:
       new AnalyticalSolutionPressure<dim>(viscosity));
     this->field_functions->analytical_solution_pressure.reset(
       new AnalyticalSolutionPressure<dim>(viscosity));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
@@ -36,7 +34,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -220,12 +218,12 @@ public:
   create_grid() final
   {
     double const left = 0.0, right = L;
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     // set boundary indicator
     for(auto cell : this->grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+      for(unsigned int face = 0; face < dealii::GeometryInfo<dim>::faces_per_cell; ++face)
       {
         if((std::fabs(cell->face(face)->center()(1) - L) < 1e-12))
           cell->face(face)->set_boundary_id(1);
@@ -240,30 +238,34 @@ public:
   {
     // all boundaries have ID = 0 by default -> Dirichlet boundaries
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     std::vector<double> velocity = std::vector<double>(dim, 0.0);
     velocity[0]                  = 1.0;
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(1, new Functions::ConstantFunction<dim>(velocity)));
+      pair(1, new dealii::Functions::ConstantFunction<dim>(velocity)));
 
     // fill boundary descriptor pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
@@ -303,8 +305,8 @@ public:
 
       // vertical line
       vert_line.reset(new Line<dim>());
-      vert_line->begin    = Point<dim>(0.5, 0.0);
-      vert_line->end      = Point<dim>(0.5, 1.0);
+      vert_line->begin    = dealii::Point<dim>(0.5, 0.0);
+      vert_line->end      = dealii::Point<dim>(0.5, 1.0);
       vert_line->name     = this->output_name + "_vert_line";
       vert_line->n_points = 100001; // 2001;
       vert_line->quantities.push_back(quantity_u);
@@ -313,8 +315,8 @@ public:
 
       // horizontal line
       hor_line.reset(new Line<dim>());
-      hor_line->begin    = Point<dim>(0.0, 0.5);
-      hor_line->end      = Point<dim>(1.0, 0.5);
+      hor_line->begin    = dealii::Point<dim>(0.0, 0.5);
+      hor_line->end      = dealii::Point<dim>(1.0, 0.5);
       hor_line->name     = this->output_name + "_hor_line";
       hor_line->n_points = 10001; // 2001;
       hor_line->quantities.push_back(quantity_u);

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -26,19 +26,17 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class AnalyticalSolutionVelocity : public Function<dim>
+class AnalyticalSolutionVelocity : public dealii::Function<dim>
 {
 public:
   AnalyticalSolutionVelocity(double const H, double const max_velocity)
-    : Function<dim>(dim, 0.0), H(H), max_velocity(max_velocity)
+    : dealii::Function<dim>(dim, 0.0), H(H), max_velocity(max_velocity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double result = 0.0;
 
@@ -60,7 +58,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -192,7 +190,7 @@ public:
   {
     std::vector<unsigned int> repetitions(dim, 1);
     repetitions[0] = 2;
-    Point<dim> point1, point2;
+    dealii::Point<dim> point1, point2;
     point1[0] = 0.0;
     point1[1] = -H / 2;
     if(dim == 3)
@@ -203,15 +201,15 @@ public:
     if(dim == 3)
       point2[2] = H;
 
-    GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
-                                              repetitions,
-                                              point1,
-                                              point2);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
+                                                      repetitions,
+                                                      point1,
+                                                      point2);
 
     // set boundary indicator
     for(auto cell : this->grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+      for(unsigned int face = 0; face < dealii::GeometryInfo<dim>::faces_per_cell; ++face)
       {
         if((std::fabs(cell->face(face)->center()(0) - L) < 1e-12))
           cell->face(face)->set_boundary_id(1);
@@ -224,28 +222,32 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
       pair(0, new AnalyticalSolutionVelocity<dim>(H, max_velocity)));
     this->boundary_descriptor->velocity->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(1)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
@@ -273,7 +275,7 @@ public:
 
     // ... pressure error
     pp_data.error_data_p.analytical_solution_available = true;
-    pp_data.error_data_p.analytical_solution.reset(new Functions::ZeroFunction<dim>(1));
+    pp_data.error_data_p.analytical_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
     pp_data.error_data_p.calculate_relative_errors = false;
     pp_data.error_data_p.error_calc_start_time     = start_time;
     pp_data.error_data_p.error_calc_interval_time  = (end_time - start_time) / 20;

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -34,22 +34,20 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class InitialSolutionVelocity : public Function<dim>
+class InitialSolutionVelocity : public dealii::Function<dim>
 {
 public:
   InitialSolutionVelocity(double const max_velocity)
-    : Function<dim>(dim, 0.0), max_velocity(max_velocity)
+    : dealii::Function<dim>(dim, 0.0), max_velocity(max_velocity)
   {
     srand(0); // initialize rand() to obtain reproducible results
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
-    AssertThrow(dim == 3, ExcMessage("Dimension has to be dim==3."));
+    AssertThrow(dim == 3, dealii::ExcMessage("Dimension has to be dim==3."));
 
     double result = 0.0;
 
@@ -77,9 +75,10 @@ public:
         double const phi    = std::atan2(p[1], p[0]);
         double const factor = 0.5;
 
-        double perturbation = factor * max_velocity_z * std::sin(4.0 * phi) *
-                                std::sin(8.0 * numbers::PI * p[2] / FDANozzle::LENGTH_PRECURSOR) +
-                              factor * max_velocity_z * ((double)rand() / RAND_MAX - 0.5) / 0.5;
+        double perturbation =
+          factor * max_velocity_z * std::sin(4.0 * phi) *
+            std::sin(8.0 * dealii::numbers::PI * p[2] / FDANozzle::LENGTH_PRECURSOR) +
+          factor * max_velocity_z * ((double)rand() / RAND_MAX - 0.5) / 0.5;
 
         // the perturbations should fulfill the Dirichlet boundary conditions
         perturbation *= (1.0 - pow(r / R, 6.0));
@@ -97,16 +96,16 @@ private:
 
 
 template<int dim>
-class InflowProfile : public Function<dim>
+class InflowProfile : public dealii::Function<dim>
 {
 public:
   InflowProfile(InflowDataStorage<dim> const & inflow_data_storage)
-    : Function<dim>(dim, 0.0), data(inflow_data_storage)
+    : dealii::Function<dim>(dim, 0.0), data(inflow_data_storage)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     // compute polar coordinates (r, phi) from point p
     // given in Cartesian coordinates (x, y) = inflow plane
@@ -130,16 +129,16 @@ private:
  *  Only relevant for precursor simulation.
  */
 template<int dim>
-class RightHandSide : public Function<dim>
+class RightHandSide : public dealii::Function<dim>
 {
 public:
   RightHandSide(FlowRateController const & flow_rate_controller)
-    : Function<dim>(dim, 0.0), flow_rate_controller(flow_rate_controller)
+    : dealii::Function<dim>(dim, 0.0), flow_rate_controller(flow_rate_controller)
   {
   }
 
   double
-  value(Point<dim> const & /*p*/, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & /*p*/, unsigned int const component = 0) const
   {
     double result = 0.0;
 
@@ -165,7 +164,7 @@ public:
     : ApplicationBasePrecursor<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -183,16 +182,16 @@ public:
       unsigned int degree       = 1;
       unsigned int refine_space = 0;
 
-      ParameterHandler prm;
+      dealii::ParameterHandler prm;
       // clang-format off
       prm.enter_subsection("General");
-        prm.add_parameter("DegreeMin",      degree,       "Polynomial degree of shape functions.", Patterns::Integer(1,15));
-        prm.add_parameter("RefineSpaceMin", refine_space, "Number of mesh refinements.",           Patterns::Integer(0,20));
+        prm.add_parameter("DegreeMin",      degree,       "Polynomial degree of shape functions.", dealii::Patterns::Integer(1,15));
+        prm.add_parameter("RefineSpaceMin", refine_space, "Number of mesh refinements.",           dealii::Patterns::Integer(0,20));
       prm.leave_subsection();
       // clang-format on
       prm.parse_input(input_file, "", true, true);
 
-      n_points = 20 * (degree + 1) * Utilities::pow(2, refine_space);
+      n_points = 20 * (degree + 1) * dealii::Utilities::pow(2, refine_space);
     }
 
     inflow_data_storage.reset(new InflowDataStorage<dim>(n_points,
@@ -208,8 +207,8 @@ public:
   // kinematic viscosity (same viscosity for all Reynolds numbers)
   double const viscosity = 3.31e-6;
 
-  double const area_inflow = FDANozzle::R_OUTER * FDANozzle::R_OUTER * numbers::PI;
-  double const area_throat = FDANozzle::R_INNER * FDANozzle::R_INNER * numbers::PI;
+  double const area_inflow = FDANozzle::R_OUTER * FDANozzle::R_OUTER * dealii::numbers::PI;
+  double const area_throat = FDANozzle::R_INNER * FDANozzle::R_INNER * dealii::numbers::PI;
 
   double const mean_velocity_throat = Re * viscosity / (2.0 * FDANozzle::R_INNER);
   double const target_flow_rate     = mean_velocity_throat * area_throat;
@@ -449,15 +448,15 @@ public:
   void
   create_grid_precursor() final
   {
-    Triangulation<2> tria_2d;
-    GridGenerator::hyper_ball(tria_2d, Point<2>(), FDANozzle::R_OUTER);
-    GridGenerator::extrude_triangulation(tria_2d,
-                                         FDANozzle::N_CELLS_AXIAL_PRECURSOR + 1,
-                                         FDANozzle::LENGTH_PRECURSOR,
-                                         *this->grid_pre->triangulation);
-    Tensor<1, dim> offset = Tensor<1, dim>();
-    offset[2]             = FDANozzle::Z1_PRECURSOR;
-    GridTools::shift(offset, *this->grid_pre->triangulation);
+    dealii::Triangulation<2> tria_2d;
+    dealii::GridGenerator::hyper_ball(tria_2d, dealii::Point<2>(), FDANozzle::R_OUTER);
+    dealii::GridGenerator::extrude_triangulation(tria_2d,
+                                                 FDANozzle::N_CELLS_AXIAL_PRECURSOR + 1,
+                                                 FDANozzle::LENGTH_PRECURSOR,
+                                                 *this->grid_pre->triangulation);
+    dealii::Tensor<1, dim> offset = dealii::Tensor<1, dim>();
+    offset[2]                     = FDANozzle::Z1_PRECURSOR;
+    dealii::GridTools::shift(offset, *this->grid_pre->triangulation);
 
     /*
      *  MANIFOLDS
@@ -470,12 +469,12 @@ public:
 
     for(auto cell : this->grid_pre->triangulation->active_cell_iterators())
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         bool face_at_sphere_boundary = true;
-        for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+        for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
         {
-          Point<dim> point = Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
+          dealii::Point<dim> point = dealii::Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
 
           if(std::abs((cell->face(f)->vertex(v) - point).norm() - FDANozzle::R_OUTER) > 1e-12)
             face_at_sphere_boundary = false;
@@ -491,7 +490,7 @@ public:
     }
 
     // generate vector of manifolds and apply manifold to all cells that have been marked
-    static std::vector<std::shared_ptr<Manifold<dim>>> manifold_vec;
+    static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
     manifold_vec.resize(manifold_ids.size());
 
     for(unsigned int i = 0; i < manifold_ids.size(); ++i)
@@ -500,8 +499,9 @@ public:
       {
         if(cell->manifold_id() == manifold_ids[i])
         {
-          manifold_vec[i] = std::shared_ptr<Manifold<dim>>(static_cast<Manifold<dim> *>(
-            new OneSidedCylindricalManifold<dim>(cell, face_ids[i], Point<dim>())));
+          manifold_vec[i] =
+            std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
+              new OneSidedCylindricalManifold<dim>(cell, face_ids[i], dealii::Point<dim>())));
           this->grid_pre->triangulation->set_manifold(manifold_ids[i], *(manifold_vec[i]));
         }
       }
@@ -512,7 +512,7 @@ public:
      */
     for(auto cell : this->grid_pre->triangulation->active_cell_iterators())
     {
-      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+      for(unsigned int face = 0; face < dealii::GeometryInfo<dim>::faces_per_cell; ++face)
       {
         // left boundary
         if((std::fabs(cell->face(face)->center()[2] - FDANozzle::Z1_PRECURSOR) < 1e-12))
@@ -528,7 +528,7 @@ public:
       }
     }
 
-    GridTools::collect_periodic_faces(
+    dealii::GridTools::collect_periodic_faces(
       *this->grid->triangulation, 0 + 10, 1 + 10, 2, this->grid_pre->periodic_faces);
     this->grid_pre->triangulation->add_periodicity(this->grid_pre->periodic_faces);
 
@@ -543,12 +543,13 @@ public:
     /*
      *  FILL BOUNDARY DESCRIPTORS
      */
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     // no slip boundaries at the upper and lower wall with ID=0
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // inflow boundary condition at left boundary with ID=1: prescribe velocity profile which
     // is obtained as the results of the simulation on DOMAIN 1
@@ -557,22 +558,22 @@ public:
 
     // outflow boundary condition at right boundary with ID=2
     this->boundary_descriptor->velocity->neumann_bc.insert(
-      pair(2, new Functions::ZeroFunction<dim>(dim)));
+      pair(2, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     // no slip boundaries at the upper and lower wall with ID=0
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // inflow boundary condition at left boundary with ID=1
     // the inflow boundary condition is time dependent (du/dt != 0) but, for simplicity,
     // we assume that this is negligible when using the dual splitting scheme
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // outflow boundary condition at right boundary with ID=2: set pressure to zero
     this->boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(2, new Functions::ZeroFunction<dim>(1)));
+      pair(2, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
@@ -581,17 +582,18 @@ public:
     /*
      *  FILL BOUNDARY DESCRIPTORS
      */
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     // no slip boundaries at lower and upper wall with ID=0
     this->boundary_descriptor_pre->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     // no slip boundaries at lower and upper wall with ID=0
     this->boundary_descriptor_pre->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
@@ -599,9 +601,11 @@ public:
   {
     this->field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(max_velocity));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   void
@@ -609,9 +613,10 @@ public:
   {
     this->field_functions_pre->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(max_velocity));
-    this->field_functions_pre->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions_pre->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions_pre->analytical_solution_pressure.reset(
-      new Functions::ZeroFunction<dim>(1));
+      new dealii::Functions::ZeroFunction<dim>(1));
     // prescribe body force for the turbulent pipe flow (precursor) to adjust the desired flow rate
     this->field_functions_pre->right_hand_side.reset(new RightHandSide<dim>(*flow_rate_controller));
   }
@@ -672,32 +677,32 @@ public:
            z_7 = 0.008, z_8 = 0.016, z_9 = 0.024, z_10 = 0.032, z_11 = 0.06, z_12 = 0.08;
 
     // begin and end points of all lines
-    axial_profile->begin      = Point<dim>(0, 0, FDANozzle::Z1_INFLOW);
-    axial_profile->end        = Point<dim>(0, 0, FDANozzle::Z2_OUTFLOW);
-    radial_profile_z1->begin  = Point<dim>(0, 0, z_1);
-    radial_profile_z1->end    = Point<dim>(FDANozzle::radius_function(z_1), 0, z_1);
-    radial_profile_z2->begin  = Point<dim>(0, 0, z_2);
-    radial_profile_z2->end    = Point<dim>(FDANozzle::radius_function(z_2), 0, z_2);
-    radial_profile_z3->begin  = Point<dim>(0, 0, z_3);
-    radial_profile_z3->end    = Point<dim>(FDANozzle::radius_function(z_3), 0, z_3);
-    radial_profile_z4->begin  = Point<dim>(0, 0, z_4);
-    radial_profile_z4->end    = Point<dim>(FDANozzle::radius_function(z_4), 0, z_4);
-    radial_profile_z5->begin  = Point<dim>(0, 0, z_5);
-    radial_profile_z5->end    = Point<dim>(FDANozzle::radius_function(z_5), 0, z_5);
-    radial_profile_z6->begin  = Point<dim>(0, 0, z_6);
-    radial_profile_z6->end    = Point<dim>(FDANozzle::radius_function(z_6), 0, z_6);
-    radial_profile_z7->begin  = Point<dim>(0, 0, z_7);
-    radial_profile_z7->end    = Point<dim>(FDANozzle::radius_function(z_7), 0, z_7);
-    radial_profile_z8->begin  = Point<dim>(0, 0, z_8);
-    radial_profile_z8->end    = Point<dim>(FDANozzle::radius_function(z_8), 0, z_8);
-    radial_profile_z9->begin  = Point<dim>(0, 0, z_9);
-    radial_profile_z9->end    = Point<dim>(FDANozzle::radius_function(z_9), 0, z_9);
-    radial_profile_z10->begin = Point<dim>(0, 0, z_10);
-    radial_profile_z10->end   = Point<dim>(FDANozzle::radius_function(z_10), 0, z_10);
-    radial_profile_z11->begin = Point<dim>(0, 0, z_11);
-    radial_profile_z11->end   = Point<dim>(FDANozzle::radius_function(z_11), 0, z_11);
-    radial_profile_z12->begin = Point<dim>(0, 0, z_12);
-    radial_profile_z12->end   = Point<dim>(FDANozzle::radius_function(z_12), 0, z_12);
+    axial_profile->begin      = dealii::Point<dim>(0, 0, FDANozzle::Z1_INFLOW);
+    axial_profile->end        = dealii::Point<dim>(0, 0, FDANozzle::Z2_OUTFLOW);
+    radial_profile_z1->begin  = dealii::Point<dim>(0, 0, z_1);
+    radial_profile_z1->end    = dealii::Point<dim>(FDANozzle::radius_function(z_1), 0, z_1);
+    radial_profile_z2->begin  = dealii::Point<dim>(0, 0, z_2);
+    radial_profile_z2->end    = dealii::Point<dim>(FDANozzle::radius_function(z_2), 0, z_2);
+    radial_profile_z3->begin  = dealii::Point<dim>(0, 0, z_3);
+    radial_profile_z3->end    = dealii::Point<dim>(FDANozzle::radius_function(z_3), 0, z_3);
+    radial_profile_z4->begin  = dealii::Point<dim>(0, 0, z_4);
+    radial_profile_z4->end    = dealii::Point<dim>(FDANozzle::radius_function(z_4), 0, z_4);
+    radial_profile_z5->begin  = dealii::Point<dim>(0, 0, z_5);
+    radial_profile_z5->end    = dealii::Point<dim>(FDANozzle::radius_function(z_5), 0, z_5);
+    radial_profile_z6->begin  = dealii::Point<dim>(0, 0, z_6);
+    radial_profile_z6->end    = dealii::Point<dim>(FDANozzle::radius_function(z_6), 0, z_6);
+    radial_profile_z7->begin  = dealii::Point<dim>(0, 0, z_7);
+    radial_profile_z7->end    = dealii::Point<dim>(FDANozzle::radius_function(z_7), 0, z_7);
+    radial_profile_z8->begin  = dealii::Point<dim>(0, 0, z_8);
+    radial_profile_z8->end    = dealii::Point<dim>(FDANozzle::radius_function(z_8), 0, z_8);
+    radial_profile_z9->begin  = dealii::Point<dim>(0, 0, z_9);
+    radial_profile_z9->end    = dealii::Point<dim>(FDANozzle::radius_function(z_9), 0, z_9);
+    radial_profile_z10->begin = dealii::Point<dim>(0, 0, z_10);
+    radial_profile_z10->end   = dealii::Point<dim>(FDANozzle::radius_function(z_10), 0, z_10);
+    radial_profile_z11->begin = dealii::Point<dim>(0, 0, z_11);
+    radial_profile_z11->end   = dealii::Point<dim>(FDANozzle::radius_function(z_11), 0, z_11);
+    radial_profile_z12->begin = dealii::Point<dim>(0, 0, z_12);
+    radial_profile_z12->end   = dealii::Point<dim>(FDANozzle::radius_function(z_12), 0, z_12);
 
     // number of points
     axial_profile->n_points      = n_points_line_axial;
@@ -741,7 +746,7 @@ public:
     radial_profile_z11->n_points_circumferential = n_points_line_circumferential;
     radial_profile_z12->n_points_circumferential = n_points_line_circumferential;
 
-    Tensor<1, dim, double> normal;
+    dealii::Tensor<1, dim, double> normal;
     normal[2]                         = 1.0;
     radial_profile_z1->normal_vector  = normal;
     radial_profile_z2->normal_vector  = normal;
@@ -858,7 +863,7 @@ public:
     pp_data_fda.mean_velocity_data.calculate = true;
     pp_data_fda.mean_velocity_data.directory = this->output_directory;
     pp_data_fda.mean_velocity_data.filename  = filename_flowrate;
-    Tensor<1, dim, double> direction;
+    dealii::Tensor<1, dim, double> direction;
     direction[2]                                 = 1.0;
     pp_data_fda.mean_velocity_data.direction     = direction;
     pp_data_fda.mean_velocity_data.write_to_file = true;

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
@@ -38,7 +36,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -85,24 +83,27 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // inflow
     this->boundary_descriptor->dirichlet_bc.insert(
-      pair(1, new Functions::ConstantFunction<dim>(1.0, 1)));
+      pair(1, new dealii::Functions::ConstantFunction<dim>(1.0, 1)));
 
     // outflow
-    this->boundary_descriptor->dirichlet_bc.insert(pair(2, new Functions::ZeroFunction<dim>(1)));
+    this->boundary_descriptor->dirichlet_bc.insert(
+      pair(2, new dealii::Functions::ZeroFunction<dim>(1)));
 
     // walls
-    this->boundary_descriptor->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
+    this->boundary_descriptor->neumann_bc.insert(
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/flow_rate_controller.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/flow_rate_controller.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 class FlowRateController
 {
 public:

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/grid.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/grid.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace FDANozzle
 {
-using namespace dealii;
-
 // radius
 double const R       = 0.002;
 double const R_INNER = R;
@@ -40,10 +38,10 @@ double const D       = 2.0 * R_OUTER;
 // lengths (dimensions in flow direction z)
 double const LENGTH_PRECURSOR = 8.0 * R_OUTER;
 double const LENGTH_INFLOW    = 8.0 * R_OUTER;
-double const LENGTH_CONE      = (R_OUTER - R_INNER) / std::tan(20.0 / 2.0 * numbers::PI / 180.0);
-double const LENGTH_THROAT    = 0.04;
-double const LENGTH_OUTFLOW   = 20.0 * R_OUTER;
-double const OFFSET           = 2.0 * R_OUTER;
+double const LENGTH_CONE = (R_OUTER - R_INNER) / std::tan(20.0 / 2.0 * dealii::numbers::PI / 180.0);
+double const LENGTH_THROAT  = 0.04;
+double const LENGTH_OUTFLOW = 20.0 * R_OUTER;
+double const OFFSET         = 2.0 * R_OUTER;
 
 // mesh parameters
 unsigned int const N_CELLS_AXIAL           = 2;
@@ -98,53 +96,53 @@ radius_function(double const z)
 template<int dim>
 void
 create_grid_and_set_boundary_ids_nozzle(
-  std::shared_ptr<Triangulation<dim>> triangulation,
-  unsigned int const                  n_refine_space,
-  std::vector<
-    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> & /*periodic_faces*/)
+  std::shared_ptr<dealii::Triangulation<dim>> triangulation,
+  unsigned int const                          n_refine_space,
+  std::vector<dealii::GridTools::PeriodicFacePair<
+    typename dealii::Triangulation<dim>::cell_iterator>> & /*periodic_faces*/)
 {
   /*
    *   Inflow
    */
-  Triangulation<2>   tria_2d_inflow;
-  Triangulation<dim> tria_inflow;
-  GridGenerator::hyper_ball(tria_2d_inflow, Point<2>(), R_OUTER);
+  dealii::Triangulation<2>   tria_2d_inflow;
+  dealii::Triangulation<dim> tria_inflow;
+  dealii::GridGenerator::hyper_ball(tria_2d_inflow, dealii::Point<2>(), R_OUTER);
 
-  GridGenerator::extrude_triangulation(tria_2d_inflow,
-                                       N_CELLS_AXIAL_INFLOW + 1,
-                                       LENGTH_INFLOW,
-                                       tria_inflow);
-  Tensor<1, dim> offset_inflow;
+  dealii::GridGenerator::extrude_triangulation(tria_2d_inflow,
+                                               N_CELLS_AXIAL_INFLOW + 1,
+                                               LENGTH_INFLOW,
+                                               tria_inflow);
+  dealii::Tensor<1, dim> offset_inflow;
   offset_inflow[2] = Z1_INFLOW;
-  GridTools::shift(offset_inflow, tria_inflow);
+  dealii::GridTools::shift(offset_inflow, tria_inflow);
 
-  Triangulation<dim> * current_tria = &tria_inflow;
+  dealii::Triangulation<dim> * current_tria = &tria_inflow;
 
   /*
    *   Cone
    */
-  Triangulation<2>   tria_2d_cone;
-  Triangulation<dim> tria_cone;
-  GridGenerator::hyper_ball(tria_2d_cone, Point<2>(), R_OUTER);
+  dealii::Triangulation<2>   tria_2d_cone;
+  dealii::Triangulation<dim> tria_cone;
+  dealii::GridGenerator::hyper_ball(tria_2d_cone, dealii::Point<2>(), R_OUTER);
 
-  GridGenerator::extrude_triangulation(tria_2d_cone,
-                                       N_CELLS_AXIAL_CONE + 1,
-                                       LENGTH_CONE,
-                                       tria_cone);
-  Tensor<1, dim> offset_cone;
+  dealii::GridGenerator::extrude_triangulation(tria_2d_cone,
+                                               N_CELLS_AXIAL_CONE + 1,
+                                               LENGTH_CONE,
+                                               tria_cone);
+  dealii::Tensor<1, dim> offset_cone;
   offset_cone[2] = Z1_CONE;
-  GridTools::shift(offset_cone, tria_cone);
+  dealii::GridTools::shift(offset_cone, tria_cone);
 
   // apply conical geometry: stretch vertex positions according to z-coordinate
   for(auto cell : tria_cone.active_cell_iterators())
   {
-    for(unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for(unsigned int v = 0; v < dealii::GeometryInfo<dim>::vertices_per_cell; ++v)
     {
       if(cell->vertex(v)[2] > Z1_CONE + 1.e-10)
       {
-        Point<dim>   point_2d;
-        double const z = cell->vertex(v)[2];
-        point_2d[2]    = z;
+        dealii::Point<dim> point_2d;
+        double const       z = cell->vertex(v)[2];
+        point_2d[2]          = z;
 
         // note that this value is onyl valid for the current dealii implementation of hyper_ball!!!
         if(std::abs((cell->vertex(v) - point_2d).norm() - 2.485281374239e-03 / 6.0e-3 * R_OUTER) <
@@ -163,17 +161,17 @@ create_grid_and_set_boundary_ids_nozzle(
   /*
    *   Throat
    */
-  Triangulation<2>   tria_2d_throat;
-  Triangulation<dim> tria_throat;
-  GridGenerator::hyper_ball(tria_2d_throat, Point<2>(), R_INNER);
+  dealii::Triangulation<2>   tria_2d_throat;
+  dealii::Triangulation<dim> tria_throat;
+  dealii::GridGenerator::hyper_ball(tria_2d_throat, dealii::Point<2>(), R_INNER);
 
-  GridGenerator::extrude_triangulation(tria_2d_throat,
-                                       N_CELLS_AXIAL_THROAT + 1,
-                                       LENGTH_THROAT,
-                                       tria_throat);
-  Tensor<1, dim> offset_throat;
+  dealii::GridGenerator::extrude_triangulation(tria_2d_throat,
+                                               N_CELLS_AXIAL_THROAT + 1,
+                                               LENGTH_THROAT,
+                                               tria_throat);
+  dealii::Tensor<1, dim> offset_throat;
   offset_throat[2] = Z1_THROAT;
-  GridTools::shift(offset_throat, tria_throat);
+  dealii::GridTools::shift(offset_throat, tria_throat);
 
   /*
    *   OUTFLOW
@@ -182,39 +180,41 @@ create_grid_and_set_boundary_ids_nozzle(
   double const       R_1            = R_INNER + 1.0 / 3.0 * (R_OUTER - R_INNER);
   double const       R_2            = R_INNER + 2.0 / 3.0 * (R_OUTER - R_INNER);
 
-  Triangulation<2> tria_2d_outflow_inner, circle_1, circle_2, circle_3, tria_tmp_2d_1,
+  dealii::Triangulation<2> tria_2d_outflow_inner, circle_1, circle_2, circle_3, tria_tmp_2d_1,
     tria_tmp_2d_2, tria_2d_outflow;
-  GridGenerator::hyper_ball(tria_2d_outflow_inner, Point<2>(), R_INNER);
+  dealii::GridGenerator::hyper_ball(tria_2d_outflow_inner, dealii::Point<2>(), R_INNER);
 
-  GridGenerator::hyper_shell(circle_1, Point<2>(), R_INNER, R_1, n_cells_circle, true);
-  GridTools::rotate(numbers::PI / 4, circle_1);
-  GridGenerator::hyper_shell(circle_2, Point<2>(), R_1, R_2, n_cells_circle, true);
-  GridTools::rotate(numbers::PI / 4, circle_2);
-  GridGenerator::hyper_shell(circle_3, Point<2>(), R_2, R_OUTER, n_cells_circle, true);
-  GridTools::rotate(numbers::PI / 4, circle_3);
+  dealii::GridGenerator::hyper_shell(
+    circle_1, dealii::Point<2>(), R_INNER, R_1, n_cells_circle, true);
+  dealii::GridTools::rotate(dealii::numbers::PI / 4, circle_1);
+  dealii::GridGenerator::hyper_shell(circle_2, dealii::Point<2>(), R_1, R_2, n_cells_circle, true);
+  dealii::GridTools::rotate(dealii::numbers::PI / 4, circle_2);
+  dealii::GridGenerator::hyper_shell(
+    circle_3, dealii::Point<2>(), R_2, R_OUTER, n_cells_circle, true);
+  dealii::GridTools::rotate(dealii::numbers::PI / 4, circle_3);
 
   // merge 2d triangulations
-  GridGenerator::merge_triangulations(tria_2d_outflow_inner, circle_1, tria_tmp_2d_1);
-  GridGenerator::merge_triangulations(circle_2, circle_3, tria_tmp_2d_2);
-  GridGenerator::merge_triangulations(tria_tmp_2d_1, tria_tmp_2d_2, tria_2d_outflow);
+  dealii::GridGenerator::merge_triangulations(tria_2d_outflow_inner, circle_1, tria_tmp_2d_1);
+  dealii::GridGenerator::merge_triangulations(circle_2, circle_3, tria_tmp_2d_2);
+  dealii::GridGenerator::merge_triangulations(tria_tmp_2d_1, tria_tmp_2d_2, tria_2d_outflow);
 
   // extrude in z-direction
-  Triangulation<dim> tria_outflow;
-  GridGenerator::extrude_triangulation(tria_2d_outflow,
-                                       N_CELLS_AXIAL_OUTFLOW + 1,
-                                       LENGTH_OUTFLOW,
-                                       tria_outflow);
-  Tensor<1, dim> offset_outflow;
+  dealii::Triangulation<dim> tria_outflow;
+  dealii::GridGenerator::extrude_triangulation(tria_2d_outflow,
+                                               N_CELLS_AXIAL_OUTFLOW + 1,
+                                               LENGTH_OUTFLOW,
+                                               tria_outflow);
+  dealii::Tensor<1, dim> offset_outflow;
   offset_outflow[2] = Z1_OUTFLOW;
-  GridTools::shift(offset_outflow, tria_outflow);
+  dealii::GridTools::shift(offset_outflow, tria_outflow);
 
   /*
    *  MERGE TRIANGULATIONS
    */
-  Triangulation<dim> tria_tmp, tria_tmp2;
-  GridGenerator::merge_triangulations(tria_inflow, tria_cone, tria_tmp);
-  GridGenerator::merge_triangulations(tria_tmp, tria_throat, tria_tmp2);
-  GridGenerator::merge_triangulations(tria_tmp2, tria_outflow, *triangulation);
+  dealii::Triangulation<dim> tria_tmp, tria_tmp2;
+  dealii::GridGenerator::merge_triangulations(tria_inflow, tria_cone, tria_tmp);
+  dealii::GridGenerator::merge_triangulations(tria_tmp, tria_throat, tria_tmp2);
+  dealii::GridGenerator::merge_triangulations(tria_tmp2, tria_outflow, *triangulation);
 
   /*
    *  MANIFOLDS
@@ -237,12 +237,12 @@ create_grid_and_set_boundary_ids_nozzle(
     // INFLOW
     if(cell->center()[2] < Z2_INFLOW)
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         bool face_at_sphere_boundary = true;
-        for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+        for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
         {
-          Point<dim> point = Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
+          dealii::Point<dim> point = dealii::Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
           if(std::abs((cell->face(f)->vertex(v) - point).norm() - R_OUTER) > 1e-12)
           {
             face_at_sphere_boundary = false;
@@ -260,13 +260,13 @@ create_grid_and_set_boundary_ids_nozzle(
     // CONE
     else if(cell->center()[2] > Z1_CONE && cell->center()[2] < Z2_CONE)
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         bool   face_at_sphere_boundary = true;
         double min_z                   = std::numeric_limits<double>::max();
         double max_z                   = -std::numeric_limits<double>::max();
 
-        for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+        for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
         {
           double const z = cell->face(f)->vertex(v)[2];
           if(z > max_z)
@@ -274,7 +274,7 @@ create_grid_and_set_boundary_ids_nozzle(
           if(z < min_z)
             min_z = z;
 
-          Point<dim> point = Point<dim>(0, 0, z);
+          dealii::Point<dim> point = dealii::Point<dim>(0, 0, z);
           if(std::abs((cell->face(f)->vertex(v) - point).norm() - radius_function(z)) > 1e-12)
           {
             face_at_sphere_boundary = false;
@@ -294,12 +294,12 @@ create_grid_and_set_boundary_ids_nozzle(
     // THROAT
     else if(cell->center()[2] > Z1_THROAT && cell->center()[2] < Z2_THROAT)
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         bool face_at_sphere_boundary = true;
-        for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+        for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
         {
-          Point<dim> point = Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
+          dealii::Point<dim> point = dealii::Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
           if(std::abs((cell->face(f)->vertex(v) - point).norm() - R_INNER) > 1e-12)
           {
             face_at_sphere_boundary = false;
@@ -317,19 +317,19 @@ create_grid_and_set_boundary_ids_nozzle(
     // OUTFLOW
     else if(cell->center()[2] > Z1_OUTFLOW && cell->center()[2] < Z2_OUTFLOW)
     {
-      Point<dim> point2 = Point<dim>(0, 0, cell->center()[2]);
+      dealii::Point<dim> point2 = dealii::Point<dim>(0, 0, cell->center()[2]);
 
       // cylindrical manifold for outer cell layers
       if((cell->center() - point2).norm() > R_INNER / std::sqrt(2.0))
         cell->set_all_manifold_ids(MANIFOLD_ID_CYLINDER);
 
       // one-sided cylindrical manifold for core region
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         bool face_at_sphere_boundary = true;
-        for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+        for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
         {
-          Point<dim> point = Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
+          dealii::Point<dim> point = dealii::Point<dim>(0, 0, cell->face(f)->vertex(v)[2]);
           if(std::abs((cell->face(f)->vertex(v) - point).norm() - R_INNER) > 1e-12 ||
              (cell->center() - point2).norm() > R_INNER / std::sqrt(2.0))
           {
@@ -347,13 +347,13 @@ create_grid_and_set_boundary_ids_nozzle(
     }
     else
     {
-      AssertThrow(false, ExcMessage("Should not arrive here."));
+      AssertThrow(false, dealii::ExcMessage("Should not arrive here."));
     }
   }
 
   // one-sided spherical manifold
   // generate vector of manifolds and apply manifold to all cells that have been marked
-  static std::vector<std::shared_ptr<Manifold<dim>>> manifold_vec;
+  static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
   manifold_vec.resize(manifold_ids.size());
 
   for(unsigned int i = 0; i < manifold_ids.size(); ++i)
@@ -362,16 +362,17 @@ create_grid_and_set_boundary_ids_nozzle(
     {
       if(cell->manifold_id() == manifold_ids[i])
       {
-        Point<dim> center = Point<dim>();
-        manifold_vec[i]   = std::shared_ptr<Manifold<dim>>(static_cast<Manifold<dim> *>(
-          new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
+        dealii::Point<dim> center = dealii::Point<dim>();
+        manifold_vec[i] =
+          std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
+            new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
         current_tria->set_manifold(manifold_ids[i], *(manifold_vec[i]));
       }
     }
   }
 
   // conical manifold
-  static std::vector<std::shared_ptr<Manifold<dim>>> manifold_vec_cone;
+  static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec_cone;
   manifold_vec_cone.resize(manifold_ids_cone.size());
 
   for(unsigned int i = 0; i < manifold_ids_cone.size(); ++i)
@@ -380,9 +381,9 @@ create_grid_and_set_boundary_ids_nozzle(
     {
       if(cell->manifold_id() == manifold_ids_cone[i])
       {
-        Point<dim> center    = Point<dim>();
-        manifold_vec_cone[i] = std::shared_ptr<Manifold<dim>>(
-          static_cast<Manifold<dim> *>(new OneSidedConicalManifold<dim>(
+        dealii::Point<dim> center = dealii::Point<dim>();
+        manifold_vec_cone[i]      = std::shared_ptr<dealii::Manifold<dim>>(
+          static_cast<dealii::Manifold<dim> *>(new OneSidedConicalManifold<dim>(
             cell, face_ids_cone[i], center, radius_0_cone[i], radius_1_cone[i])));
         current_tria->set_manifold(manifold_ids_cone[i], *(manifold_vec_cone[i]));
       }
@@ -390,9 +391,9 @@ create_grid_and_set_boundary_ids_nozzle(
   }
 
   // set cylindrical manifold
-  static std::shared_ptr<Manifold<dim>> cylinder_manifold;
-  cylinder_manifold = std::shared_ptr<Manifold<dim>>(
-    static_cast<Manifold<dim> *>(new MyCylindricalManifold<dim>(Point<dim>())));
+  static std::shared_ptr<dealii::Manifold<dim>> cylinder_manifold;
+  cylinder_manifold = std::shared_ptr<dealii::Manifold<dim>>(
+    static_cast<dealii::Manifold<dim> *>(new MyCylindricalManifold<dim>(dealii::Point<dim>())));
   current_tria->set_manifold(MANIFOLD_ID_CYLINDER, *cylinder_manifold);
 
   /*
@@ -400,7 +401,7 @@ create_grid_and_set_boundary_ids_nozzle(
    */
   for(auto cell : triangulation->active_cell_iterators())
   {
-    for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
     {
       // inflow boundary on the left has ID = 1
       if((std::fabs(cell->face(f)->center()[2] - Z1_INFLOW) < 1e-12))

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/inflow_data_storage.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/inflow_data_storage.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct InflowDataStorage
 {
@@ -55,8 +53,8 @@ struct InflowDataStorage
   void
   initialize_r_and_phi_values()
   {
-    AssertThrow(n_points_r >= 2, ExcMessage("Variable n_points_r is invalid"));
-    AssertThrow(n_points_phi >= 2, ExcMessage("Variable n_points_phi is invalid"));
+    AssertThrow(n_points_r >= 2, dealii::ExcMessage("Variable n_points_r is invalid"));
+    AssertThrow(n_points_phi >= 2, dealii::ExcMessage("Variable n_points_phi is invalid"));
 
     // 0 <= radius <= R_OUTER
     for(unsigned int i = 0; i < n_points_r; ++i)
@@ -64,20 +62,21 @@ struct InflowDataStorage
 
     // - pi <= phi <= pi
     for(unsigned int i = 0; i < n_points_phi; ++i)
-      phi_values[i] = -numbers::PI + double(i) / double(n_points_phi - 1) * 2.0 * numbers::PI;
+      phi_values[i] =
+        -dealii::numbers::PI + double(i) / double(n_points_phi - 1) * 2.0 * dealii::numbers::PI;
   }
 
   void
   initialize_velocity_values()
   {
-    AssertThrow(n_points_r >= 2, ExcMessage("Variable n_points_r is invalid"));
-    AssertThrow(n_points_phi >= 2, ExcMessage("Variable n_points_phi is invalid"));
+    AssertThrow(n_points_r >= 2, dealii::ExcMessage("Variable n_points_r is invalid"));
+    AssertThrow(n_points_phi >= 2, dealii::ExcMessage("Variable n_points_phi is invalid"));
 
     for(unsigned int iy = 0; iy < n_points_r; ++iy)
     {
       for(unsigned int iz = 0; iz < n_points_phi; ++iz)
       {
-        Tensor<1, dim, double> velocity;
+        dealii::Tensor<1, dim, double> velocity;
         // flow in z-direction
         velocity[2] = max_velocity * (1.0 - std::pow(r_values[iy] / R, 2.0));
 
@@ -97,8 +96,8 @@ struct InflowDataStorage
   void
   add_random_perturbations()
   {
-    AssertThrow(n_points_r >= 2, ExcMessage("Variable n_points_r is invalid"));
-    AssertThrow(n_points_phi >= 2, ExcMessage("Variable n_points_phi is invalid"));
+    AssertThrow(n_points_r >= 2, dealii::ExcMessage("Variable n_points_r is invalid"));
+    AssertThrow(n_points_phi >= 2, dealii::ExcMessage("Variable n_points_phi is invalid"));
 
     for(unsigned int iy = 0; iy < n_points_r; ++iy)
     {
@@ -120,9 +119,9 @@ struct InflowDataStorage
   bool const   use_random_perturbations;
   double const factor_random_perturbations;
 
-  std::vector<double>                 r_values;
-  std::vector<double>                 phi_values;
-  std::vector<Tensor<1, dim, double>> velocity_values;
+  std::vector<double>                         r_values;
+  std::vector<double>                         phi_values;
+  std::vector<dealii::Tensor<1, dim, double>> velocity_values;
 };
 
 } // namespace IncNS

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct PostProcessorDataFDA
 {
@@ -50,7 +48,7 @@ class PostProcessorFDA : public PostProcessor<dim, Number>
 public:
   typedef PostProcessor<dim, Number> Base;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef typename Base::Operator Operator;
 

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -32,22 +32,21 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
 using namespace FlowPastCylinder;
 
 template<int dim>
-class InflowBC : public Function<dim>
+class InflowBC : public dealii::Function<dim>
 {
 public:
-  InflowBC(double const                                Um,
-           double const                                H,
-           double const                                end_time,
-           unsigned int const                          test_case,
-           bool const                                  use_random_perturbations,
-           std::vector<double> const &                 y,
-           std::vector<double> const &                 z,
-           std::vector<Tensor<1, dim, double>> const & u)
-    : Function<dim>(dim, 0.0),
+  InflowBC(double const                                        Um,
+           double const                                        H,
+           double const                                        end_time,
+           unsigned int const                                  test_case,
+           bool const                                          use_random_perturbations,
+           std::vector<double> const &                         y,
+           std::vector<double> const &                         z,
+           std::vector<dealii::Tensor<1, dim, double>> const & u)
+    : dealii::Function<dim>(dim, 0.0),
       Um(Um),
       H(H),
       end_time(end_time),
@@ -60,17 +59,17 @@ public:
   }
 
   double
-  value(Point<dim> const & x, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & x, unsigned int const component = 0) const
   {
     double t      = this->get_time();
     double result = 0.0;
 
     if(component == 0)
     {
-      double const pi = numbers::PI;
-      double const T  = 1.0;
-      double       coefficient =
-        Utilities::fixed_power<dim - 1>(4.) * Um / Utilities::fixed_power<2 * dim - 2>(H);
+      double const pi          = dealii::numbers::PI;
+      double const T           = 1.0;
+      double       coefficient = dealii::Utilities::fixed_power<dim - 1>(4.) * Um /
+                           dealii::Utilities::fixed_power<2 * dim - 2>(H);
 
       if(test_case == 1)
         result = coefficient * x[1] * (H - x[1]);
@@ -80,7 +79,7 @@ public:
       else if(test_case == 3)
         result = coefficient * x[1] * (H - x[1]) * std::sin(pi * t / end_time);
       else
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
 
       if(dim == 3)
         result *= x[2] * (H - x[2]);
@@ -93,7 +92,7 @@ public:
           perturbation = linear_interpolation_1d(x[1], y_vector, u_vector, component);
         else if(dim == 3)
         {
-          Point<dim> point_3d;
+          dealii::Point<dim> point_3d;
           point_3d[0] = x[0];
           point_3d[1] = x[1];
           point_3d[2] = x[2];
@@ -102,7 +101,7 @@ public:
             linear_interpolation_2d_cartesian(point_3d, y_vector, z_vector, u_vector, component);
         }
         else
-          AssertThrow(false, ExcMessage("Not implemented."));
+          AssertThrow(false, dealii::ExcMessage("Not implemented."));
 
         result += perturbation;
       }
@@ -116,37 +115,37 @@ private:
   unsigned int const test_case;
 
   // perturbations
-  bool const                          use_random_perturbations;
-  std::vector<double> const &         y_vector;
-  std::vector<double> const &         z_vector;
-  std::vector<Tensor<1, dim, double>> u_vector;
+  bool const                                  use_random_perturbations;
+  std::vector<double> const &                 y_vector;
+  std::vector<double> const &                 z_vector;
+  std::vector<dealii::Tensor<1, dim, double>> u_vector;
 };
 
 template<int dim>
-class PressureBC_dudt : public Function<dim>
+class PressureBC_dudt : public dealii::Function<dim>
 {
 public:
   PressureBC_dudt(double const       Um,
                   double const       H,
                   double const       end_time,
                   unsigned int const test_case)
-    : Function<dim>(dim, 0.0), Um(Um), H(H), end_time(end_time), test_case(test_case)
+    : dealii::Function<dim>(dim, 0.0), Um(Um), H(H), end_time(end_time), test_case(test_case)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double t      = this->get_time();
     double result = 0.0;
 
     if(component == 0 && std::abs(p[0] - (dim == 2 ? L1 : 0.0)) < 1.e-12)
     {
-      double const pi = numbers::PI;
+      double const pi = dealii::numbers::PI;
 
-      double const T = 1.0;
-      double       coefficient =
-        Utilities::fixed_power<dim - 1>(4.) * Um / Utilities::fixed_power<2 * dim - 2>(H);
+      double const T           = 1.0;
+      double       coefficient = dealii::Utilities::fixed_power<dim - 1>(4.) * Um /
+                           dealii::Utilities::fixed_power<2 * dim - 2>(H);
 
       if(test_case == 2)
         result = coefficient * p[1] * (H - p[1]) *
@@ -174,7 +173,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -188,9 +187,9 @@ public:
   void
   initialize_y_and_z_values()
   {
-    AssertThrow(n_points_y >= 2, ExcMessage("Variable n_points_y is invalid"));
+    AssertThrow(n_points_y >= 2, dealii::ExcMessage("Variable n_points_y is invalid"));
     if(dim == 3)
-      AssertThrow(n_points_z >= 2, ExcMessage("Variable n_points_z is invalid"));
+      AssertThrow(n_points_z >= 2, dealii::ExcMessage("Variable n_points_z is invalid"));
 
     // 0 <= y <= H
     for(unsigned int i = 0; i < n_points_y; ++i)
@@ -205,23 +204,23 @@ public:
   void
   initialize_velocity_values()
   {
-    AssertThrow(n_points_y >= 2, ExcMessage("Variable n_points_y is invalid"));
+    AssertThrow(n_points_y >= 2, dealii::ExcMessage("Variable n_points_y is invalid"));
     if(dim == 3)
-      AssertThrow(n_points_z >= 2, ExcMessage("Variable n_points_z is invalid"));
+      AssertThrow(n_points_z >= 2, dealii::ExcMessage("Variable n_points_z is invalid"));
 
     for(unsigned int iy = 0; iy < n_points_y; ++iy)
     {
       for(unsigned int iz = 0; iz < n_points_z; ++iz)
       {
-        Tensor<1, dim, double> velocity;
+        dealii::Tensor<1, dim, double> velocity;
 
         if(use_perturbation == true)
         {
           // Add random perturbation
-          double const y = y_values[iy];
-          double const z = z_values[iz];
-          double       coefficient =
-            Utilities::fixed_power<dim - 1>(4.) * Um / Utilities::fixed_power<2 * dim - 2>(H);
+          double const y           = y_values[iy];
+          double const z           = z_values[iz];
+          double       coefficient = dealii::Utilities::fixed_power<dim - 1>(4.) * Um /
+                               dealii::Utilities::fixed_power<2 * dim - 2>(H);
           double perturbation =
             amplitude_perturbation * coefficient * ((double)rand() / RAND_MAX - 0.5) / 0.5;
           perturbation *= y * (H - y);
@@ -237,15 +236,15 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm) final
+  add_parameters(dealii::ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
     // clang-format off
     prm.enter_subsection("Application");
-      prm.add_parameter("TestCase",     test_case,            "Number of test case.", Patterns::Integer(1,3));
-      prm.add_parameter("CylinderType", cylinder_type_string, "Type of cylinder.",    Patterns::Selection("circular|square"));
-      prm.add_parameter("CFL",          cfl_number,           "CFL number.",          Patterns::Double(0.0, 1.0e6), true);
+      prm.add_parameter("TestCase",     test_case,            "Number of test case.", dealii::Patterns::Integer(1,3));
+      prm.add_parameter("CylinderType", cylinder_type_string, "Type of cylinder.",    dealii::Patterns::Selection("circular|square"));
+      prm.add_parameter("CFL",          cfl_number,           "CFL number.",          dealii::Patterns::Double(0.0, 1.0e6), true);
     prm.leave_subsection();
     // clang-format on
   }
@@ -282,8 +281,8 @@ public:
   std::vector<double> y_values = std::vector<double>(n_points_y);
   std::vector<double> z_values = std::vector<double>(n_points_z);
 
-  std::vector<Tensor<1, dim, double>> velocity_values =
-    std::vector<Tensor<1, dim, double>>(n_points_y * n_points_z);
+  std::vector<dealii::Tensor<1, dim, double>> velocity_values =
+    std::vector<dealii::Tensor<1, dim, double>>(n_points_y * n_points_z);
 
   // solver tolerances
   double const ABS_TOL = 1.e-12;
@@ -473,12 +472,12 @@ public:
   {
     this->refine_level = this->param.grid.n_refine_global;
 
-    if(auto tria_fully_dist = dynamic_cast<parallel::fullydistributed::Triangulation<dim> *>(
-         this->grid->triangulation.get()))
+    if(auto tria_fully_dist =
+         dynamic_cast<dealii::parallel::fullydistributed::Triangulation<dim> *>(
+           this->grid->triangulation.get()))
     {
-      auto const construction_data =
-        TriangulationDescription::Utilities::create_description_from_triangulation_in_groups<dim,
-                                                                                             dim>(
+      auto const construction_data = dealii::TriangulationDescription::Utilities::
+        create_description_from_triangulation_in_groups<dim, dim>(
           [&](dealii::Triangulation<dim, dim> & tria) mutable {
             create_cylinder_grid<dim>(tria,
                                       this->param.grid.n_refine_global,
@@ -489,16 +488,17 @@ public:
              const MPI_Comm                    comm,
              unsigned int const /* group_size */) {
             // metis partitioning
-            GridTools::partition_triangulation(Utilities::MPI::n_mpi_processes(comm), tria);
+            dealii::GridTools::partition_triangulation(
+              dealii::Utilities::MPI::n_mpi_processes(comm), tria);
             // p4est partitioning
-            //            GridTools::partition_triangulation_zorder(Utilities::MPI::n_mpi_processes(comm),
+            //            dealii::GridTools::partition_triangulation_zorder(dealii::Utilities::MPI::n_mpi_processes(comm),
             //            tria);
           },
           tria_fully_dist->get_communicator(),
           1 /* group size */);
       tria_fully_dist->create_triangulation(construction_data);
     }
-    else if(auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> *>(
+    else if(auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> *>(
               this->grid->triangulation.get()))
     {
       create_cylinder_grid<dim>(*tria,
@@ -508,14 +508,15 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Unknown triangulation!"));
+      AssertThrow(false, dealii::ExcMessage("Unknown triangulation!"));
     }
   }
 
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
@@ -523,9 +524,9 @@ public:
            new InflowBC<dim>(
              Um, H, end_time, test_case, use_perturbation, y_values, z_values, velocity_values)));
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(2, new Functions::ZeroFunction<dim>(dim)));
+      pair(2, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->velocity->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // fill boundary descriptor pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
@@ -533,16 +534,19 @@ public:
     this->boundary_descriptor->pressure->neumann_bc.insert(
       pair(2, new PressureBC_dudt<dim>(Um, H, end_time, test_case)));
     this->boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(1)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
@@ -588,13 +592,13 @@ public:
     pp_data.pressure_difference_data.calculate = true;
     if(dim == 2)
     {
-      Point<dim> point_1_2D((X_C - D / 2.0), Y_C), point_2_2D((X_C + D / 2.0), Y_C);
+      dealii::Point<dim> point_1_2D((X_C - D / 2.0), Y_C), point_2_2D((X_C + D / 2.0), Y_C);
       pp_data.pressure_difference_data.point_1 = point_1_2D;
       pp_data.pressure_difference_data.point_2 = point_2_2D;
     }
     else if(dim == 3)
     {
-      Point<dim> point_1_3D((X_C - D / 2.0), Y_C, H / 2.0),
+      dealii::Point<dim> point_1_3D((X_C - D / 2.0), Y_C, H / 2.0),
         point_2_3D((X_C + D / 2.0), Y_C, H / 2.0);
       pp_data.pressure_difference_data.point_1 = point_1_3D;
       pp_data.pressure_difference_data.point_2 = point_2_3D;

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -29,22 +29,20 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class AnalyticalSolutionVelocity : public Functions::ConstantFunction<dim>
+class AnalyticalSolutionVelocity : public dealii::Functions::ConstantFunction<dim>
 {
 public:
-  AnalyticalSolutionVelocity() : Functions::ConstantFunction<dim>(1.0, dim)
+  AnalyticalSolutionVelocity() : dealii::Functions::ConstantFunction<dim>(1.0, dim)
   {
   }
 };
 
 template<int dim>
-class AnalyticalSolutionPressure : public Functions::ConstantFunction<dim>
+class AnalyticalSolutionPressure : public dealii::Functions::ConstantFunction<dim>
 {
 public:
-  AnalyticalSolutionPressure() : Functions::ConstantFunction<dim>(1.0, 1)
+  AnalyticalSolutionPressure() : dealii::Functions::ConstantFunction<dim>(1.0, 1)
   {
   }
 };
@@ -57,13 +55,13 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
 
   void
-  add_parameters(ParameterHandler & prm) final
+  add_parameters(dealii::ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -72,7 +70,7 @@ public:
       prm.add_parameter("ALE",
                         ALE,
                         "Moving mesh (ALE).",
-                        Patterns::Bool());
+                        dealii::Patterns::Bool());
     prm.leave_subsection();
     // clang-format on
   }
@@ -258,15 +256,15 @@ public:
   void
   create_grid() final
   {
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
 
-  std::shared_ptr<Function<dim>>
+  std::shared_ptr<dealii::Function<dim>>
   create_mesh_movement_function() final
   {
-    std::shared_ptr<Function<dim>> mesh_motion;
+    std::shared_ptr<dealii::Function<dim>> mesh_motion;
 
     MeshMovementData<dim> data;
     data.temporal                       = MeshMovementAdvanceInTime::Sin;
@@ -286,7 +284,8 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
@@ -294,7 +293,7 @@ public:
 
     // fill boundary descriptor pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
@@ -304,7 +303,7 @@ public:
     this->field_functions->initial_solution_pressure.reset(new AnalyticalSolutionPressure<dim>());
     this->field_functions->analytical_solution_pressure.reset(
       new AnalyticalSolutionPressure<dim>());
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -26,23 +26,21 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class InitialSolutionVelocity : public Function<dim>
+class InitialSolutionVelocity : public dealii::Function<dim>
 {
 public:
   InitialSolutionVelocity(double const DELTA_0, double const U_INF, double const C_N)
-    : Function<dim>(dim, 0.0), DELTA_0(DELTA_0), U_INF(U_INF), C_N(C_N)
+    : dealii::Function<dim>(dim, 0.0), DELTA_0(DELTA_0), U_INF(U_INF), C_N(C_N)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double const x1 = p[0];
     double const x2 = p[1];
-    double const PI = numbers::PI;
+    double const PI = dealii::numbers::PI;
 
     // clang-format off
     double result = 0.0;
@@ -77,7 +75,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -213,19 +211,19 @@ public:
   void
   create_grid() final
   {
-    AssertThrow(dim == 2, ExcMessage("This application is only implemented for dim=2."));
+    AssertThrow(dim == 2, dealii::ExcMessage("This application is only implemented for dim=2."));
 
     std::vector<unsigned int> repetitions({1, 1});
-    Point<dim>                point1(0.0, 0.0), point2(L, L);
-    GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
-                                              repetitions,
-                                              point1,
-                                              point2);
+    dealii::Point<dim>        point1(0.0, 0.0), point2(L, L);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
+                                                      repetitions,
+                                                      point1,
+                                                      point2);
 
     // periodicity in x-direction
     for(auto cell : this->grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         if(std::fabs(cell->face(f)->center()(0) - 0.0) < 1e-12)
           cell->face(f)->set_boundary_id(1);
@@ -234,7 +232,7 @@ public:
       }
     }
 
-    GridTools::collect_periodic_faces(
+    dealii::GridTools::collect_periodic_faces(
       *this->grid->triangulation, 1, 2, 0, this->grid->periodic_faces);
     this->grid->triangulation->add_periodicity(this->grid->periodic_faces);
 
@@ -244,13 +242,14 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->boundary_descriptor->velocity->symmetry_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
 
@@ -259,9 +258,11 @@ public:
   {
     this->field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(DELTA_0, U_INF, C_N));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -30,20 +30,18 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class AnalyticalSolutionVelocity : public Function<dim>
+class AnalyticalSolutionVelocity : public dealii::Function<dim>
 {
 public:
   AnalyticalSolutionVelocity(double const                              H,
                              double const                              MAX_VELOCITY,
                              double const                              ALPHA,
                              double const                              EPSILON,
-                             FE_DGQ<1> const &                         FE,
+                             dealii::FE_DGQ<1> const &                 FE,
                              std::complex<double> const &              OMEGA,
                              std::vector<std::complex<double>> const & EIG_VEC)
-    : Function<dim>(dim, 0.0),
+    : dealii::Function<dim>(dim, 0.0),
       H(H),
       MAX_VELOCITY(MAX_VELOCITY),
       ALPHA(ALPHA),
@@ -55,7 +53,7 @@ public:
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double t      = this->get_time();
     double result = 0.0;
@@ -65,7 +63,7 @@ public:
     double const eta = 0.5 * (p[1] / H + 1.0);
 
     Assert(eta <= 1.0 + 1.e-12 and eta >= 0.0 - 1.e-12,
-           ExcMessage("Point in reference coordinates is invalid."));
+           dealii::ExcMessage("Point in reference coordinates is invalid."));
 
     double cos = std::cos(ALPHA * x - OMEGA.real() * t);
     double sin = std::sin(ALPHA * x - OMEGA.real() * t);
@@ -82,7 +80,7 @@ public:
       // evaluate derivative d(psi)/d(eta) in eta(y)
       std::complex<double> dpsi = 0;
       for(unsigned int i = 0; i < FE.get_degree() + 1; ++i)
-        dpsi += EIG_VEC[i] * FE.shape_grad(i, Point<1>(eta))[0];
+        dpsi += EIG_VEC[i] * FE.shape_grad(i, dealii::Point<1>(eta))[0];
 
       // multiply by d(eta)/dy to obtain derivative d(psi)/dy in physical space
       dpsi *= 0.5 / H;
@@ -97,7 +95,7 @@ public:
       // evaluate function psi in y
       std::complex<double> psi = 0;
       for(unsigned int i = 0; i < FE.get_degree() + 1; ++i)
-        psi += EIG_VEC[i] * FE.shape_value(i, Point<1>(eta));
+        psi += EIG_VEC[i] * FE.shape_value(i, dealii::Point<1>(eta));
 
       std::complex<double> i(0, 1);
       std::complex<double> perturbation_complex = -i * ALPHA * psi * exp * amplification;
@@ -107,7 +105,7 @@ public:
     }
     else
     {
-      Assert(false, ExcMessage("Orr-Sommerfeld problem is a 2-dimensional problem."));
+      Assert(false, dealii::ExcMessage("Orr-Sommerfeld problem is a 2-dimensional problem."));
     }
 
     return result;
@@ -119,7 +117,7 @@ private:
   double const ALPHA        = 1.0;
   double const EPSILON      = 1.0e-5;
 
-  FE_DGQ<1> const &                         FE;
+  dealii::FE_DGQ<1> const &                 FE;
   std::complex<double> const &              OMEGA;
   std::vector<std::complex<double>> const & EIG_VEC;
 };
@@ -130,16 +128,16 @@ private:
  *  right-hand side of the momentum equation of the Navier-Stokes equations
  */
 template<int dim>
-class RightHandSide : public Function<dim>
+class RightHandSide : public dealii::Function<dim>
 {
 public:
   RightHandSide(double const viscosity, double const max_velocity, double const H)
-    : Function<dim>(dim, 0.0), nu(viscosity), U_max(max_velocity), H(H)
+    : dealii::Function<dim>(dim, 0.0), nu(viscosity), U_max(max_velocity), H(H)
   {
   }
 
   double
-  value(Point<dim> const & /*p*/, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & /*p*/, unsigned int const component = 0) const
   {
     double result = 0.0;
 
@@ -166,7 +164,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -180,7 +178,7 @@ public:
   double const Re = 7500.0;
 
   double const H  = 1.0;
-  double const PI = numbers::PI;
+  double const PI = dealii::numbers::PI;
   double const L  = 2.0 * PI * H;
 
   double const MAX_VELOCITY = 1.0;
@@ -193,7 +191,7 @@ public:
   // do not use more than 300 due to conditioning of polynomials
   unsigned int const DEGREE_OS_SOLVER = 200;
 
-  FE_DGQ<1> FE = FE_DGQ<1>(DEGREE_OS_SOLVER);
+  dealii::FE_DGQ<1> FE = dealii::FE_DGQ<1>(DEGREE_OS_SOLVER);
 
   std::complex<double> OMEGA;
 
@@ -329,16 +327,16 @@ public:
   create_grid() final
   {
     std::vector<unsigned int> repetitions({1, 1});
-    Point<dim>                point1(0.0, -H), point2(L, H);
-    GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
-                                              repetitions,
-                                              point1,
-                                              point2);
+    dealii::Point<dim>        point1(0.0, -H), point2(L, H);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
+                                                      repetitions,
+                                                      point1,
+                                                      point2);
 
     // periodicity in x-direction
     for(auto cell : this->grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         if((std::fabs(cell->face(f)->center()(0) - 0.0) < 1e-12))
           cell->face(f)->set_boundary_id(0 + 10);
@@ -347,7 +345,7 @@ public:
       }
     }
 
-    GridTools::collect_periodic_faces(
+    dealii::GridTools::collect_periodic_faces(
       *this->grid->triangulation, 0 + 10, 1 + 10, 0, this->grid->periodic_faces);
     this->grid->triangulation->add_periodicity(this->grid->periodic_faces);
 
@@ -357,13 +355,14 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->boundary_descriptor->velocity->dirichlet_bc.insert(pair(
       0, new AnalyticalSolutionVelocity<dim>(H, MAX_VELOCITY, ALPHA, EPSILON, FE, OMEGA, EIG_VEC)));
 
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
   }
 
   void
@@ -371,8 +370,10 @@ public:
   {
     this->field_functions->initial_solution_velocity.reset(
       new AnalyticalSolutionVelocity<dim>(H, MAX_VELOCITY, ALPHA, EPSILON, FE, OMEGA, EIG_VEC));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions->right_hand_side.reset(
       new RightHandSide<dim>(VISCOSITY, MAX_VELOCITY, H));
   }

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/include/postprocessor.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct MyPostProcessorData
 {
@@ -44,7 +42,7 @@ class MyPostProcessor : public PostProcessor<dim, Number>
 public:
   typedef PostProcessor<dim, Number> Base;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef typename Base::Operator Operator;
 

--- a/applications/incompressible_navier_stokes/periodic_hill/include/flow_rate_controller.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/flow_rate_controller.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 class FlowRateController
 {
 public:

--- a/applications/incompressible_navier_stokes/periodic_hill/include/manifold.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/manifold.h
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 double
 m_to_mm(double coordinate)
 {
@@ -51,7 +49,7 @@ f(double x_m, double const H, double const LENGTH)
   double x = m_to_mm(x_m);
   double y = 0.0;
 
-  AssertThrow(x_m <= LENGTH / 2.0 + 1.e-12, ExcMessage("Parameter out of bounds."));
+  AssertThrow(x_m <= LENGTH / 2.0 + 1.e-12, dealii::ExcMessage("Parameter out of bounds."));
 
   if(x <= 9.0)
     y =
@@ -76,27 +74,31 @@ f(double x_m, double const H, double const LENGTH)
   else if(x > 54.0)
     y = -m_to_mm(H);
   else
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
 
   return mm_to_m(y);
 }
 
 template<int dim>
-class PeriodicHillManifold : public ChartManifold<dim>
+class PeriodicHillManifold : public dealii::ChartManifold<dim>
 {
 public:
   PeriodicHillManifold(double const H,
                        double const LENGTH,
                        double const HEIGHT,
                        double const GRID_STRETCH_FAC)
-    : ChartManifold<dim>(), H(H), LENGTH(LENGTH), HEIGHT(HEIGHT), GRID_STRETCH_FAC(GRID_STRETCH_FAC)
+    : dealii::ChartManifold<dim>(),
+      H(H),
+      LENGTH(LENGTH),
+      HEIGHT(HEIGHT),
+      GRID_STRETCH_FAC(GRID_STRETCH_FAC)
   {
   }
 
-  Point<dim>
-  push_forward(Point<dim> const & xi) const final
+  dealii::Point<dim>
+  push_forward(dealii::Point<dim> const & xi) const final
   {
-    Point<dim> x = xi;
+    dealii::Point<dim> x = xi;
 
     // transform y-coordinate only
     double const gamma           = GRID_STRETCH_FAC;
@@ -107,10 +109,10 @@ public:
     return x;
   }
 
-  Point<dim>
-  pull_back(Point<dim> const & x) const final
+  dealii::Point<dim>
+  pull_back(dealii::Point<dim> const & x) const final
   {
-    Point<dim> xi = x;
+    dealii::Point<dim> xi = x;
 
     // transform y-coordinate only
     double const f_x      = f(x[0], H, LENGTH);
@@ -121,7 +123,7 @@ public:
     return xi;
   }
 
-  std::unique_ptr<Manifold<dim>>
+  std::unique_ptr<dealii::Manifold<dim>>
   clone() const final
   {
     return std::make_unique<PeriodicHillManifold<dim>>(H, LENGTH, HEIGHT, GRID_STRETCH_FAC);

--- a/applications/incompressible_navier_stokes/periodic_hill/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/postprocessor.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct MyPostProcessorData
 {

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -32,25 +32,23 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
-class InitialSolutionVelocity : public Function<dim>
+class InitialSolutionVelocity : public dealii::Function<dim>
 {
 public:
   InitialSolutionVelocity(double const rho, double const delta)
-    : Function<dim>(dim, 0.0), rho(rho), delta(delta)
+    : dealii::Function<dim>(dim, 0.0), rho(rho), delta(delta)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double result = 0.0;
     if(component == 0)
       result = std::tanh(rho * (0.25 - std::abs(0.5 - p[1])));
     else if(component == 1)
-      result = delta * std::sin(2.0 * numbers::PI * p[0]);
+      result = delta * std::sin(2.0 * dealii::numbers::PI * p[0]);
 
     return result;
   }
@@ -67,7 +65,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -179,7 +177,7 @@ public:
   create_grid() final
   {
     double const left = 0.0, right = 1.0;
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     // use periodic boundary conditions
     // x-direction
@@ -189,9 +187,9 @@ public:
     this->grid->triangulation->begin()->face(2)->set_all_boundary_ids(2);
     this->grid->triangulation->begin()->face(3)->set_all_boundary_ids(3);
 
-    GridTools::collect_periodic_faces(
+    dealii::GridTools::collect_periodic_faces(
       *this->grid->triangulation, 0, 1, 0, this->grid->periodic_faces);
-    GridTools::collect_periodic_faces(
+    dealii::GridTools::collect_periodic_faces(
       *this->grid->triangulation, 2, 3, 1, this->grid->periodic_faces);
     this->grid->triangulation->add_periodicity(this->grid->periodic_faces);
 
@@ -209,9 +207,11 @@ public:
   {
     this->field_functions->initial_solution_velocity.reset(
       new InitialSolutionVelocity<dim>(rho, delta));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -26,22 +26,20 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // perform stability analysis and compute eigenvalue spectrum
 // For this analysis one has to use the BDF1 scheme and homogeneous boundary conditions!!!
 bool const STABILITY_ANALYSIS = false;
 
 template<int dim>
-class AnalyticalSolutionVelocity : public Function<dim>
+class AnalyticalSolutionVelocity : public dealii::Function<dim>
 {
 public:
-  AnalyticalSolutionVelocity(double const nu) : Function<dim>(dim, 0.0), viscosity(nu)
+  AnalyticalSolutionVelocity(double const nu) : dealii::Function<dim>(dim, 0.0), viscosity(nu)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double t      = this->get_time();
     double result = 0.0;
@@ -74,15 +72,15 @@ private:
 
 
 template<int dim>
-class AnalyticalSolutionPressure : public Function<dim>
+class AnalyticalSolutionPressure : public dealii::Function<dim>
 {
 public:
-  AnalyticalSolutionPressure(double const nu) : Function<dim>(1, 0.0), viscosity(nu)
+  AnalyticalSolutionPressure(double const nu) : dealii::Function<dim>(1, 0.0), viscosity(nu)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double t      = this->get_time();
     double result = 0.0;
@@ -107,15 +105,15 @@ private:
 };
 
 template<int dim>
-class PressureBC_dudt : public Function<dim>
+class PressureBC_dudt : public dealii::Function<dim>
 {
 public:
-  PressureBC_dudt(double const nu) : Function<dim>(dim, 0.0), viscosity(nu)
+  PressureBC_dudt(double const nu) : dealii::Function<dim>(dim, 0.0), viscosity(nu)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double t      = this->get_time();
     double result = 0.0;
@@ -154,7 +152,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -291,7 +289,7 @@ public:
   create_grid() final
   {
     double const left = -1.0, right = 1.0;
-    GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -302,7 +300,8 @@ public:
     // test case with pure Dirichlet boundary conditions for velocity
     // all boundaries have ID = 0 by default
 
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
@@ -322,7 +321,7 @@ public:
       new AnalyticalSolutionPressure<dim>(viscosity));
     this->field_functions->analytical_solution_pressure.reset(
       new AnalyticalSolutionPressure<dim>(viscosity));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/template/application.h
+++ b/applications/incompressible_navier_stokes/template/application.h
@@ -26,20 +26,18 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 //  Example of a user defined function
 template<int dim>
-class MyFunction : public Function<dim>
+class MyFunction : public dealii::Function<dim>
 {
 public:
   MyFunction(unsigned int const n_components = dim, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)p;
     (void)component;
@@ -56,7 +54,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -78,31 +76,35 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // these lines show how the boundary descriptors are filled
 
     // velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->velocity->neumann_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(dim)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // pressure
     this->boundary_descriptor->pressure->neumann_bc.insert(
-      pair(0, new Functions::ZeroFunction<dim>(dim)));
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->pressure->dirichlet_bc.insert(
-      pair(1, new Functions::ZeroFunction<dim>(1)));
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
     // these lines show how the field functions are filled
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/template_precursor/application.h
+++ b/applications/incompressible_navier_stokes/template_precursor/application.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Application : public ApplicationBasePrecursor<dim, Number>
 {
@@ -36,7 +34,7 @@ public:
     : ApplicationBasePrecursor<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -70,33 +68,39 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
   }
 
   void
   set_boundary_descriptor_precursor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   void
   set_field_functions_precursor() final
   {
     this->field_functions_pre->initial_solution_velocity.reset(
-      new Functions::ZeroFunction<dim>(dim));
-    this->field_functions_pre->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions_pre->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions_pre->analytical_solution_pressure.reset(
-      new Functions::ZeroFunction<dim>(1));
-    this->field_functions_pre->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions_pre->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -41,7 +41,7 @@ string_to_enum(MeshType & enum_type, std::string const & string_type)
   // clang-format off
   if     (string_type == "Cartesian")   enum_type = MeshType::Cartesian;
   else if(string_type == "Curvilinear") enum_type = MeshType::Curvilinear;
-  else AssertThrow(false, ExcMessage("Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Not implemented."));
   // clang-format on
 }
 
@@ -53,7 +53,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -61,13 +61,13 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm) final
+  add_parameters(dealii::ParameterHandler & prm) final
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
     // clang-format off
     prm.enter_subsection("Application");
-      prm.add_parameter("MeshType",  mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", Patterns::Selection("Cartesian|Curvilinear"));
+      prm.add_parameter("MeshType",  mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", dealii::Patterns::Selection("Cartesian|Curvilinear"));
     prm.leave_subsection();
     // clang-format on
   }
@@ -186,7 +186,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     create_periodic_box(this->grid->triangulation,
@@ -209,10 +209,13 @@ public:
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution_velocity.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_solution_pressure.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->analytical_solution_pressure.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_velocity.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->analytical_solution_pressure.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -31,8 +31,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 enum class MeshType
 {
   UniformCartesian,
@@ -42,19 +40,19 @@ enum class MeshType
 };
 
 template<int dim>
-class AnalyticalSolutionVelocity : public Function<dim>
+class AnalyticalSolutionVelocity : public dealii::Function<dim>
 {
 public:
   AnalyticalSolutionVelocity(double const u_x_max, double const viscosity)
-    : Function<dim>(dim, 0.0), u_x_max(u_x_max), viscosity(viscosity)
+    : dealii::Function<dim>(dim, 0.0), u_x_max(u_x_max), viscosity(viscosity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double const t  = this->get_time();
-    double const pi = numbers::PI;
+    double const pi = dealii::numbers::PI;
 
     double result = 0.0;
     if(component == 0)
@@ -70,19 +68,19 @@ private:
 };
 
 template<int dim>
-class AnalyticalSolutionPressure : public Function<dim>
+class AnalyticalSolutionPressure : public dealii::Function<dim>
 {
 public:
   AnalyticalSolutionPressure(double const u_x_max, double const viscosity)
-    : Function<dim>(1 /*n_components*/, 0.0), u_x_max(u_x_max), viscosity(viscosity)
+    : dealii::Function<dim>(1 /*n_components*/, 0.0), u_x_max(u_x_max), viscosity(viscosity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/) const
   {
     double const t  = this->get_time();
-    double const pi = numbers::PI;
+    double const pi = dealii::numbers::PI;
 
     double const result = -u_x_max * std::cos(2 * pi * p[0]) * std::cos(2 * pi * p[1]) *
                           std::exp(-8.0 * pi * pi * viscosity * t);
@@ -95,13 +93,13 @@ private:
 };
 
 template<int dim>
-class NeumannBoundaryVelocity : public Function<dim>
+class NeumannBoundaryVelocity : public dealii::Function<dim>
 {
 public:
   NeumannBoundaryVelocity(double const                 u_x_max,
                           double const                 viscosity,
                           FormulationViscousTerm const formulation_viscous)
-    : Function<dim>(dim, 0.0),
+    : dealii::Function<dim>(dim, 0.0),
       u_x_max(u_x_max),
       viscosity(viscosity),
       formulation_viscous(formulation_viscous)
@@ -109,10 +107,10 @@ public:
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double const t  = this->get_time();
-    double const pi = numbers::PI;
+    double const pi = dealii::numbers::PI;
 
     double result = 0.0;
     // clang-format off
@@ -156,7 +154,7 @@ public:
     {
       AssertThrow(formulation_viscous == FormulationViscousTerm::LaplaceFormulation ||
                   formulation_viscous == FormulationViscousTerm::DivergenceFormulation,
-                  ExcMessage("Specified formulation of viscous term is not implemented!"));
+                  dealii::ExcMessage("Specified formulation of viscous term is not implemented!"));
     }
     // clang-format on
 
@@ -183,12 +181,12 @@ public:
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double const t  = this->get_time();
-    double const pi = numbers::PI;
+    double const pi = dealii::numbers::PI;
 
-    Tensor<1, dim> const n = this->get_normal_vector();
+    dealii::Tensor<1, dim> const n = this->get_normal_vector();
 
     double result = 0.0;
     // prescribe F_nu(u) / nu = grad(u)
@@ -218,7 +216,7 @@ public:
     {
       AssertThrow(formulation_viscous == FormulationViscousTerm::LaplaceFormulation ||
                     formulation_viscous == FormulationViscousTerm::DivergenceFormulation,
-                  ExcMessage("Specified formulation of viscous term is not implemented!"));
+                  dealii::ExcMessage("Specified formulation of viscous term is not implemented!"));
     }
 
     return result;
@@ -231,19 +229,19 @@ private:
 
 
 template<int dim>
-class PressureBC_dudt : public Function<dim>
+class PressureBC_dudt : public dealii::Function<dim>
 {
 public:
   PressureBC_dudt(double const u_x_max, double const viscosity)
-    : Function<dim>(dim, 0.0), u_x_max(u_x_max), viscosity(viscosity)
+    : dealii::Function<dim>(dim, 0.0), u_x_max(u_x_max), viscosity(viscosity)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     double const t  = this->get_time();
-    double const pi = numbers::PI;
+    double const pi = dealii::numbers::PI;
 
     double result = 0.0;
     if(component == 0)
@@ -268,7 +266,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -486,37 +484,38 @@ public:
     if(ALE)
     {
       AssertThrow(mesh_type == MeshType::UniformCartesian,
-                  ExcMessage("Taylor vortex problem: Parameter mesh_type is invalid for ALE."));
+                  dealii::ExcMessage(
+                    "Taylor vortex problem: Parameter mesh_type is invalid for ALE."));
     }
 
     if(mesh_type == MeshType::UniformCartesian)
     {
       // Uniform Cartesian grid
-      GridGenerator::subdivided_hyper_cube(*this->grid->triangulation, 2, left, right);
+      dealii::GridGenerator::subdivided_hyper_cube(*this->grid->triangulation, 2, left, right);
     }
     else if(mesh_type == MeshType::ComplexSurfaceManifold)
     {
       // Complex Geometry
-      Triangulation<dim> tria1, tria2;
-      double const       radius = (right - left) * 0.25;
-      double const       width  = right - left;
-      GridGenerator::hyper_shell(
-        tria1, Point<dim>(), radius, 0.5 * width * std::sqrt(dim), 2 * dim);
+      dealii::Triangulation<dim> tria1, tria2;
+      double const               radius = (right - left) * 0.25;
+      double const               width  = right - left;
+      dealii::GridGenerator::hyper_shell(
+        tria1, dealii::Point<dim>(), radius, 0.5 * width * std::sqrt(dim), 2 * dim);
       tria1.reset_all_manifolds();
       if(dim == 2)
       {
-        GridTools::rotate(numbers::PI / 4, tria1);
+        dealii::GridTools::rotate(dealii::numbers::PI / 4, tria1);
       }
-      GridGenerator::hyper_ball(tria2, Point<dim>(), radius);
-      GridGenerator::merge_triangulations(tria1, tria2, *this->grid->triangulation);
+      dealii::GridGenerator::hyper_ball(tria2, dealii::Point<dim>(), radius);
+      dealii::GridGenerator::merge_triangulations(tria1, tria2, *this->grid->triangulation);
 
       this->grid->triangulation->set_all_manifold_ids(0);
       for(auto cell : this->grid->triangulation->active_cell_iterators())
       {
-        for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
         {
           bool face_at_sphere_boundary = true;
-          for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+          for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
           {
             if(std::abs(cell->face(f)->vertex(v).norm() - radius) > 1e-12)
               face_at_sphere_boundary = false;
@@ -527,7 +526,7 @@ public:
           }
         }
       }
-      static const SphericalManifold<dim> spherical_manifold;
+      static const dealii::SphericalManifold<dim> spherical_manifold;
       this->grid->triangulation->set_manifold(1, spherical_manifold);
 
       // refine globally due to boundary conditions for vortex problem
@@ -536,20 +535,20 @@ public:
     else if(mesh_type == MeshType::ComplexVolumeManifold)
     {
       // Complex Geometry
-      Triangulation<dim> tria1, tria2;
-      double const       radius = (right - left) * 0.25;
-      double const       width  = right - left;
-      Point<dim>         center = Point<dim>();
+      dealii::Triangulation<dim> tria1, tria2;
+      double const               radius = (right - left) * 0.25;
+      double const               width  = right - left;
+      dealii::Point<dim>         center = dealii::Point<dim>();
 
-      GridGenerator::hyper_shell(
-        tria1, Point<dim>(), radius, 0.5 * width * std::sqrt(dim), 2 * dim);
+      dealii::GridGenerator::hyper_shell(
+        tria1, dealii::Point<dim>(), radius, 0.5 * width * std::sqrt(dim), 2 * dim);
       tria1.reset_all_manifolds();
       if(dim == 2)
       {
-        GridTools::rotate(numbers::PI / 4, tria1);
+        dealii::GridTools::rotate(dealii::numbers::PI / 4, tria1);
       }
-      GridGenerator::hyper_ball(tria2, Point<dim>(), radius);
-      GridGenerator::merge_triangulations(tria1, tria2, *this->grid->triangulation);
+      dealii::GridGenerator::hyper_ball(tria2, dealii::Point<dim>(), radius);
+      dealii::GridGenerator::merge_triangulations(tria1, tria2, *this->grid->triangulation);
 
       // manifolds
       this->grid->triangulation->set_all_manifold_ids(0);
@@ -560,10 +559,10 @@ public:
 
       for(auto cell : this->grid->triangulation->active_cell_iterators())
       {
-        for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
         {
           bool face_at_sphere_boundary = true;
-          for(unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+          for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
           {
             if(std::abs(cell->face(f)->vertex(v).norm() - radius) > 1e-12)
               face_at_sphere_boundary = false;
@@ -579,7 +578,7 @@ public:
       }
 
       // generate vector of manifolds and apply manifold to all cells that have been marked
-      static std::vector<std::shared_ptr<Manifold<dim>>> manifold_vec;
+      static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
       manifold_vec.resize(manifold_ids.size());
 
       for(unsigned int i = 0; i < manifold_ids.size(); ++i)
@@ -588,8 +587,9 @@ public:
         {
           if(cell->manifold_id() == manifold_ids[i])
           {
-            manifold_vec[i] = std::shared_ptr<Manifold<dim>>(static_cast<Manifold<dim> *>(
-              new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
+            manifold_vec[i] =
+              std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
+                new OneSidedCylindricalManifold<dim>(cell, face_ids[i], center)));
             this->grid->triangulation->set_manifold(manifold_ids[i], *(manifold_vec[i]));
           }
         }
@@ -600,7 +600,7 @@ public:
     }
     else if(mesh_type == MeshType::Curvilinear)
     {
-      GridGenerator::subdivided_hyper_cube(*this->grid->triangulation, 2, left, right);
+      dealii::GridGenerator::subdivided_hyper_cube(*this->grid->triangulation, 2, left, right);
 
       this->grid->triangulation->set_all_manifold_ids(1);
       double const                     deformation = 0.1;
@@ -611,7 +611,7 @@ public:
 
     for(auto cell : this->grid->triangulation->active_cell_iterators())
     {
-      for(unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
       {
         if(((std::fabs(cell->face(f)->center()(0) - right) < 1e-12) &&
             (cell->face(f)->center()(1) < 0)) ||
@@ -633,7 +633,8 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // fill boundary descriptor velocity
     this->boundary_descriptor->velocity->dirichlet_bc.insert(
@@ -661,13 +662,13 @@ public:
       new AnalyticalSolutionPressure<dim>(u_x_max, viscosity));
     this->field_functions->analytical_solution_pressure.reset(
       new AnalyticalSolutionPressure<dim>(u_x_max, viscosity));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
-  std::shared_ptr<Function<dim>>
+  std::shared_ptr<dealii::Function<dim>>
   create_mesh_movement_function() final
   {
-    std::shared_ptr<Function<dim>> mesh_motion;
+    std::shared_ptr<dealii::Function<dim>> mesh_motion;
 
     MeshMovementData<dim> data;
     data.temporal                       = MeshMovementAdvanceInTime::Sin;
@@ -720,9 +721,10 @@ public:
   void
   set_boundary_descriptor_poisson() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
-    std::shared_ptr<Function<dim>> bc = this->create_mesh_movement_function();
+    std::shared_ptr<dealii::Function<dim>> bc = this->create_mesh_movement_function();
     this->poisson_boundary_descriptor->dirichlet_bc.insert(pair(0, bc));
     this->poisson_boundary_descriptor->dirichlet_bc.insert(pair(1, bc));
   }
@@ -730,8 +732,10 @@ public:
   void
   set_field_functions_poisson() final
   {
-    this->poisson_field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->poisson_field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->poisson_field_functions->initial_solution.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
+    this->poisson_field_functions->right_hand_side.reset(
+      new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -29,29 +29,27 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim>
-class CoefficientFunction : public Function<dim>
+class CoefficientFunction : public dealii::Function<dim>
 {
 public:
-  CoefficientFunction() : Function<dim>(1)
+  CoefficientFunction() : dealii::Function<dim>(1)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const c = 0) const
   {
     (void)c;
     return value<double>(p);
   }
 
-  Tensor<1, dim>
-  gradient(Point<dim> const & p, unsigned int const c = 0) const
+  dealii::Tensor<1, dim>
+  gradient(dealii::Point<dim> const & p, unsigned int const c = 0) const
   {
     (void)c;
     (void)p;
-    Tensor<1, dim> grad;
+    dealii::Tensor<1, dim> grad;
 
     return grad;
   }
@@ -72,84 +70,88 @@ template<int dim>
 class SolutionBase
 {
 protected:
-  static unsigned int const n_source_centers = 3;
-  static Point<dim> const   source_centers[n_source_centers];
-  static double const       width;
+  static unsigned int const       n_source_centers = 3;
+  static dealii::Point<dim> const source_centers[n_source_centers];
+  static double const             width;
 };
 
 
 template<>
-const Point<1> SolutionBase<1>::source_centers[SolutionBase<1>::n_source_centers] =
-  {Point<1>(-1.0 / 3.0), Point<1>(0.0), Point<1>(+1.0 / 3.0)};
+const dealii::Point<1> SolutionBase<1>::source_centers[SolutionBase<1>::n_source_centers] =
+  {dealii::Point<1>(-1.0 / 3.0), dealii::Point<1>(0.0), dealii::Point<1>(+1.0 / 3.0)};
 
 template<>
-Point<2> const SolutionBase<2>::source_centers[SolutionBase<2>::n_source_centers] =
-  {Point<2>(-0.5, +0.5), Point<2>(-0.5, -0.5), Point<2>(+0.5, -0.5)};
+dealii::Point<2> const SolutionBase<2>::source_centers[SolutionBase<2>::n_source_centers] =
+  {dealii::Point<2>(-0.5, +0.5), dealii::Point<2>(-0.5, -0.5), dealii::Point<2>(+0.5, -0.5)};
 
 template<>
-Point<3> const SolutionBase<3>::source_centers[SolutionBase<3>::n_source_centers] =
-  {Point<3>(-0.5, +0.5, 0.25), Point<3>(-0.6, -0.5, -0.125), Point<3>(+0.5, -0.5, 0.5)};
+dealii::Point<3> const SolutionBase<3>::source_centers[SolutionBase<3>::n_source_centers] = {
+  dealii::Point<3>(-0.5, +0.5, 0.25),
+  dealii::Point<3>(-0.6, -0.5, -0.125),
+  dealii::Point<3>(+0.5, -0.5, 0.5)};
 
 template<int dim>
 double const SolutionBase<dim>::width = 1. / 5.;
 
 template<int dim>
-class Solution : public Function<dim>, protected SolutionBase<dim>
+class Solution : public dealii::Function<dim>, protected SolutionBase<dim>
 {
 public:
-  Solution() : Function<dim>()
+  Solution() : dealii::Function<dim>()
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/ = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/ = 0) const
   {
     double return_value = 0;
     for(unsigned int i = 0; i < this->n_source_centers; ++i)
     {
-      const Tensor<1, dim> x_minus_xi = p - this->source_centers[i];
+      const dealii::Tensor<1, dim> x_minus_xi = p - this->source_centers[i];
       return_value += std::exp(-x_minus_xi.norm_square() / (this->width * this->width));
     }
 
-    return return_value / Utilities::fixed_power<dim>(std::sqrt(2. * numbers::PI) * this->width);
+    return return_value /
+           dealii::Utilities::fixed_power<dim>(std::sqrt(2. * dealii::numbers::PI) * this->width);
   }
 
-  Tensor<1, dim>
-  gradient(Point<dim> const & p, unsigned int const /*component*/ = 0) const
+  dealii::Tensor<1, dim>
+  gradient(dealii::Point<dim> const & p, unsigned int const /*component*/ = 0) const
   {
-    Tensor<1, dim> return_value;
+    dealii::Tensor<1, dim> return_value;
 
     for(unsigned int i = 0; i < this->n_source_centers; ++i)
     {
-      const Tensor<1, dim> x_minus_xi = p - this->source_centers[i];
+      const dealii::Tensor<1, dim> x_minus_xi = p - this->source_centers[i];
 
       return_value +=
         (-2 / (this->width * this->width) *
          std::exp(-x_minus_xi.norm_square() / (this->width * this->width)) * x_minus_xi);
     }
 
-    return return_value / Utilities::fixed_power<dim>(std::sqrt(2 * numbers::PI) * this->width);
+    return return_value /
+           dealii::Utilities::fixed_power<dim>(std::sqrt(2 * dealii::numbers::PI) * this->width);
   }
 };
 
 template<int dim>
-class RightHandSide : public Function<dim>, protected SolutionBase<dim>
+class RightHandSide : public dealii::Function<dim>, protected SolutionBase<dim>
 {
 public:
-  RightHandSide() : Function<dim>()
+  RightHandSide() : dealii::Function<dim>()
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const /*component*/ = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const /*component*/ = 0) const
   {
-    CoefficientFunction<dim> coefficient;
-    double const             coef         = coefficient.value(p);
-    const Tensor<1, dim>     coef_grad    = coefficient.gradient(p);
-    double                   return_value = 0;
+    CoefficientFunction<dim>     coefficient;
+    double const                 coef         = coefficient.value(p);
+    const dealii::Tensor<1, dim> coef_grad    = coefficient.gradient(p);
+    double                       return_value = 0;
     for(unsigned int i = 0; i < this->n_source_centers; ++i)
     {
-      const Tensor<1, dim> x_minus_xi = p - this->source_centers[i];
+      const dealii::Tensor<1, dim> x_minus_xi = p - this->source_centers[i];
 
       return_value += ((2 * dim * coef + 2 * (coef_grad)*x_minus_xi -
                         4 * coef * x_minus_xi.norm_square() / (this->width * this->width)) /
@@ -157,7 +159,8 @@ public:
                        std::exp(-x_minus_xi.norm_square() / (this->width * this->width)));
     }
 
-    return return_value / Utilities::fixed_power<dim>(std::sqrt(2 * numbers::PI) * this->width);
+    return return_value /
+           dealii::Utilities::fixed_power<dim>(std::sqrt(2 * dealii::numbers::PI) * this->width);
   }
 };
 
@@ -173,7 +176,7 @@ string_to_enum(MeshType & enum_type, std::string const & string_type)
   // clang-format off
   if     (string_type == "Cartesian")   enum_type = MeshType::Cartesian;
   else if(string_type == "Curvilinear") enum_type = MeshType::Curvilinear;
-  else AssertThrow(false, ExcMessage("Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Not implemented."));
   // clang-format on
 }
 
@@ -185,7 +188,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -193,14 +196,14 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
     // clang-format off
     prm.enter_subsection("Application");
-      prm.add_parameter("MeshType", mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", Patterns::Selection("Cartesian|Curvilinear"));
-      prm.add_parameter("GlobalCoarsening", global_coarsening, "Use Global Coarsening", Patterns::Bool());
+      prm.add_parameter("MeshType", mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", dealii::Patterns::Selection("Cartesian|Curvilinear"));
+      prm.add_parameter("GlobalCoarsening", global_coarsening, "Use Global Coarsening", dealii::Patterns::Bool());
     prm.leave_subsection();
     // clang-format on
   }
@@ -247,10 +250,10 @@ public:
   {
     double const length = 1.0;
     double const left = -length, right = length;
-    GridGenerator::subdivided_hyper_cube(*this->grid->triangulation,
-                                         this->param.grid.n_subdivisions_1d_hypercube,
-                                         left,
-                                         right);
+    dealii::GridGenerator::subdivided_hyper_cube(*this->grid->triangulation,
+                                                 this->param.grid.n_subdivisions_1d_hypercube,
+                                                 left,
+                                                 right);
 
     if(mesh_type == MeshType::Cartesian)
     {
@@ -268,12 +271,12 @@ public:
 
       for(auto cell : *this->grid->triangulation)
       {
-        for(unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for(unsigned int v = 0; v < dealii::GeometryInfo<dim>::vertices_per_cell; ++v)
         {
           if(vertex_touched[cell.vertex_index(v)] == false)
           {
-            Point<dim> & vertex                  = cell.vertex(v);
-            Point<dim>   new_point               = manifold.push_forward(vertex);
+            dealii::Point<dim> & vertex          = cell.vertex(v);
+            dealii::Point<dim>   new_point       = manifold.push_forward(vertex);
             vertex                               = new_point;
             vertex_touched[cell.vertex_index(v)] = true;
           }
@@ -282,7 +285,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("not implemented."));
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
     }
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
@@ -291,17 +294,19 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Solution<dim>()));
 
-    // this->boundary_descriptor->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    // this->boundary_descriptor->neumann_bc.insert(pair(1, new
+    // dealii::Functions::ZeroFunction<dim>(1)));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
     this->field_functions->right_hand_side.reset(new RightHandSide<dim>());
   }
 

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
@@ -39,7 +37,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -81,7 +79,7 @@ public:
     double const length = 1.0;
     double const left = -length, right = length;
 
-    GridGenerator::hyper_cube_slit(*this->grid->triangulation, left, right);
+    dealii::GridGenerator::hyper_cube_slit(*this->grid->triangulation, left, right);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -89,17 +87,18 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     this->boundary_descriptor->dirichlet_bc.insert(
-      pair(0, new Functions::SlitSingularityFunction<dim>()));
+      pair(0, new dealii::Functions::SlitSingularityFunction<dim>()));
   }
 
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>
@@ -113,7 +112,8 @@ public:
     pp_data.output_data.degree             = this->param.degree;
 
     pp_data.error_data.analytical_solution_available = true;
-    pp_data.error_data.analytical_solution.reset(new Functions::SlitSingularityFunction<dim>());
+    pp_data.error_data.analytical_solution.reset(
+      new dealii::Functions::SlitSingularityFunction<dim>());
 
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
     pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));

--- a/applications/poisson/template/application.h
+++ b/applications/poisson/template/application.h
@@ -25,20 +25,18 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 //  Example for a user defined function
 template<int dim>
-class MyFunction : public Function<dim>
+class MyFunction : public dealii::Function<dim>
 {
 public:
   MyFunction(unsigned int const n_components = 1, double const time = 0.)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const component = 0) const
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const
   {
     (void)p;
     (void)component;
@@ -55,7 +53,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -79,11 +77,14 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
 
     // these lines show exemplarily how the boundary descriptors are filled
-    this->boundary_descriptor->dirichlet_bc.insert(pair(0, new Functions::ZeroFunction<dim>(1)));
-    this->boundary_descriptor->neumann_bc.insert(pair(1, new Functions::ZeroFunction<dim>(1)));
+    this->boundary_descriptor->dirichlet_bc.insert(
+      pair(0, new dealii::Functions::ZeroFunction<dim>(1)));
+    this->boundary_descriptor->neumann_bc.insert(
+      pair(1, new dealii::Functions::ZeroFunction<dim>(1)));
   }
 
 
@@ -91,8 +92,8 @@ public:
   set_field_functions() final
   {
     // these lines show exemplarily how the field functions are filled
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 enum class MeshType
 {
   Cartesian,
@@ -43,7 +41,7 @@ string_to_enum(MeshType & enum_type, std::string const & string_type)
   // clang-format off
   if     (string_type == "Cartesian")   enum_type = MeshType::Cartesian;
   else if(string_type == "Curvilinear") enum_type = MeshType::Curvilinear;
-  else AssertThrow(false, ExcMessage("Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Not implemented."));
   // clang-format on
 }
 
@@ -55,7 +53,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
 
@@ -63,13 +61,13 @@ public:
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
     // clang-format off
     prm.enter_subsection("Application");
-      prm.add_parameter("MeshType", mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", Patterns::Selection("Cartesian|Curvilinear"));
+      prm.add_parameter("MeshType", mesh_type_string, "Type of mesh (Cartesian versus curvilinear).", dealii::Patterns::Selection("Cartesian|Curvilinear"));
     prm.leave_subsection();
     // clang-format on
   }
@@ -111,7 +109,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     create_periodic_box(this->grid->triangulation,
@@ -132,8 +130,8 @@ public:
   void
   set_field_functions() final
   {
-    this->field_functions->initial_solution.reset(new Functions::ZeroFunction<dim>(1));
-    this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(1));
+    this->field_functions->initial_solution.reset(new dealii::Functions::ZeroFunction<dim>(1));
+    this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -26,26 +26,24 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim>
-class DisplacementDBC : public Function<dim>
+class DisplacementDBC : public dealii::Function<dim>
 {
 public:
   DisplacementDBC(double const displacement, bool const unsteady, double const end_time)
-    : Function<dim>(dim), displacement(displacement), unsteady(unsteady), end_time(end_time)
+    : dealii::Function<dim>(dim), displacement(displacement), unsteady(unsteady), end_time(end_time)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     (void)p;
 
     double factor = 1.0;
 
     if(unsteady)
-      factor = std::pow(std::sin(this->get_time() * 2.0 * numbers::PI / end_time), 2.0);
+      factor = std::pow(std::sin(this->get_time() * 2.0 * dealii::numbers::PI / end_time), 2.0);
 
     if(c == 0)
       return displacement * factor;
@@ -60,15 +58,15 @@ private:
 };
 
 template<int dim>
-class VolumeForce : public Function<dim>
+class VolumeForce : public dealii::Function<dim>
 {
 public:
-  VolumeForce(double volume_force) : Function<dim>(dim), volume_force(volume_force)
+  VolumeForce(double volume_force) : dealii::Function<dim>(dim), volume_force(volume_force)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     (void)p;
 
@@ -83,17 +81,17 @@ private:
 };
 
 template<int dim>
-class AreaForce : public Function<dim>
+class AreaForce : public dealii::Function<dim>
 {
 public:
-  AreaForce(double areaforce) : Function<dim>(dim), areaforce(areaforce)
+  AreaForce(double areaforce) : dealii::Function<dim>(dim), areaforce(areaforce)
   {
   }
 
   double const areaforce;
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     (void)p;
 
@@ -106,18 +104,18 @@ public:
 
 // analytical solution (if a Neumann BC is used at the right boundary)
 template<int dim>
-class SolutionNBC : public Function<dim>
+class SolutionNBC : public dealii::Function<dim>
 {
 public:
   SolutionNBC(double length, double area_force, double volume_force, double E_modul)
-    : Function<dim>(dim),
+    : dealii::Function<dim>(dim),
       A(-volume_force / 2 / E_modul),
       B(+area_force / E_modul - length * 2 * this->A)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     if(c == 0)
       return A * p[0] * p[0] + B * p[0]; // displacement in x-direction
@@ -132,18 +130,18 @@ private:
 
 // analytical solution (if a Dirichlet BC is used at the right boundary)
 template<int dim>
-class SolutionDBC : public Function<dim>
+class SolutionDBC : public dealii::Function<dim>
 {
 public:
   SolutionDBC(double length, double displacement, double volume_force, double E_modul)
-    : Function<dim>(dim),
+    : dealii::Function<dim>(dim),
       A(-volume_force / 2 / E_modul),
       B(+displacement / length - this->A * length)
   {
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     if(c == 0)
       return A * p[0] * p[0] + B * p[0]; // displacement in x-direction
@@ -164,13 +162,13 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 
@@ -181,7 +179,7 @@ public:
     prm.add_parameter("Width",            width,            "Width of domain.");
     prm.add_parameter("UseVolumeForce",   use_volume_force, "Use volume force.");
     prm.add_parameter("VolumeForce",      volume_force,     "Volume force.");
-    prm.add_parameter("BoundaryType",     boundary_type,    "Type of boundary conditin, Dirichlet vs Neumann.", Patterns::Selection("Dirichlet|Neumann"));
+    prm.add_parameter("BoundaryType",     boundary_type,    "Type of boundary conditin, Dirichlet vs Neumann.", dealii::Patterns::Selection("Dirichlet|Neumann"));
     prm.add_parameter("Displacement",     displacement,     "Diplacement of right boundary in case of Dirichlet BC.");
     prm.add_parameter("Traction",         area_force,       "Traction acting on right boundary in case of Neumann BC.");
     prm.leave_subsection();
@@ -252,7 +250,7 @@ public:
   create_grid() final
   {
     // left-bottom-front and right-top-back point
-    Point<dim> p1, p2;
+    dealii::Point<dim> p1, p2;
 
     for(unsigned d = 0; d < dim; d++)
       p1[d] = 0.0;
@@ -268,11 +266,14 @@ public:
     if(dim == 3)
       repetitions[2] = this->repetitions2;
 
-    GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation, repetitions, p1, p2);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
+                                                      repetitions,
+                                                      p1,
+                                                      p2);
 
     for(auto cell : *this->grid->triangulation)
     {
-      for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+      for(unsigned int face = 0; face < dealii::GeometryInfo<dim>::faces_per_cell; ++face)
       {
         // left face
         if(std::fabs(cell.face(face)->center()(0) - 0.0) < 1e-8)
@@ -294,10 +295,12 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+                                                                                  pair;
+    typedef typename std::pair<dealii::types::boundary_id, dealii::ComponentMask> pair_mask;
 
-    this->boundary_descriptor->neumann_bc.insert(pair(0, new Functions::ZeroFunction<dim>(dim)));
+    this->boundary_descriptor->neumann_bc.insert(
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     // left face
     std::vector<bool> mask = {true, false};
@@ -306,7 +309,8 @@ public:
       mask.resize(3);
       mask[2] = true;
     }
-    this->boundary_descriptor->dirichlet_bc.insert(pair(1, new Functions::ZeroFunction<dim>(dim)));
+    this->boundary_descriptor->dirichlet_bc.insert(
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
     this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(1, mask));
 
     // right face
@@ -315,7 +319,8 @@ public:
       bool const unsteady = (this->param.problem_type == ProblemType::Unsteady);
       this->boundary_descriptor->dirichlet_bc.insert(
         pair(2, new DisplacementDBC<dim>(displacement, unsteady, end_time)));
-      this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(2, ComponentMask()));
+      this->boundary_descriptor->dirichlet_bc_component_mask.insert(
+        pair_mask(2, dealii::ComponentMask()));
     }
     else if(boundary_type == "Neumann")
     {
@@ -323,14 +328,14 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("not implemented."));
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
     }
   }
 
   void
   set_material_descriptor() final
   {
-    typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
+    typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
     MaterialType const type = MaterialType::StVenantKirchhoff;
     double const       E = E_modul, nu = 0.3;
@@ -346,10 +351,11 @@ public:
     if(use_volume_force)
       this->field_functions->right_hand_side.reset(new VolumeForce<dim>(this->volume_force));
     else
-      this->field_functions->right_hand_side.reset(new Functions::ZeroFunction<dim>(dim));
+      this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(dim));
 
-    this->field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
-    this->field_functions->initial_velocity.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_displacement.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
 
   std::shared_ptr<PostProcessor<dim, Number>>
@@ -379,7 +385,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("not implemented."));
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
     }
 
     std::shared_ptr<PostProcessor<dim, Number>> post(

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -46,8 +46,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 /*
  * Different formulations of function f(t).
  */
@@ -81,7 +79,7 @@ time_function(double const time, double const frequency)
   else if(function_type_time == FunctionTypeTime::SineSquared)
     time_factor = std::pow(std::sin(time * frequency), 2.0);
   else
-    AssertThrow(false, ExcMessage("not implemented"));
+    AssertThrow(false, dealii::ExcMessage("not implemented"));
 
   return time_factor;
 }
@@ -96,7 +94,7 @@ time_derivative(double const time, double const frequency)
   else if(function_type_time == FunctionTypeTime::SineSquared)
     time_factor = 2.0 * std::sin(time * frequency) * frequency * std::cos(time * frequency);
   else
-    AssertThrow(false, ExcMessage("not implemented"));
+    AssertThrow(false, dealii::ExcMessage("not implemented"));
 
   return time_factor;
 }
@@ -113,7 +111,7 @@ time_2nd_derivative(double const time, double const frequency)
       2.0 * frequency * frequency *
       (std::pow(std::cos(time * frequency), 2.0) - std::pow(std::sin(time * frequency), 2.0));
   else
-    AssertThrow(false, ExcMessage("not implemented"));
+    AssertThrow(false, dealii::ExcMessage("not implemented"));
 
   return time_factor;
 }
@@ -126,11 +124,11 @@ space_function(double const x, double const length, double const max_displacemen
   if(function_type_space == FunctionTypeSpace::Linear)
     space_factor = max_displacement * x / length;
   else if(function_type_space == FunctionTypeSpace::Sine)
-    space_factor = max_displacement * std::sin(x * length * 2.0 * numbers::PI);
+    space_factor = max_displacement * std::sin(x * length * 2.0 * dealii::numbers::PI);
   else if(function_type_space == FunctionTypeSpace::Exponential)
     space_factor = max_displacement * (std::exp(x / length) - 1.0) / (std::exp(1.0) - 1.0);
   else
-    AssertThrow(false, ExcMessage("not implemented"));
+    AssertThrow(false, dealii::ExcMessage("not implemented"));
 
   return space_factor;
 }
@@ -143,12 +141,12 @@ space_derivative(double const x, double const length, double const max_displacem
   if(function_type_space == FunctionTypeSpace::Linear)
     space_factor = max_displacement / length;
   else if(function_type_space == FunctionTypeSpace::Sine)
-    space_factor =
-      max_displacement * 2.0 * numbers::PI / length * std::cos(x / length * 2.0 * numbers::PI);
+    space_factor = max_displacement * 2.0 * dealii::numbers::PI / length *
+                   std::cos(x / length * 2.0 * dealii::numbers::PI);
   else if(function_type_space == FunctionTypeSpace::Exponential)
     space_factor = max_displacement / length * (std::exp(x / length)) / (std::exp(1.0) - 1.0);
   else
-    AssertThrow(false, ExcMessage("not implemented"));
+    AssertThrow(false, dealii::ExcMessage("not implemented"));
 
   return space_factor;
 }
@@ -161,26 +159,26 @@ space_2nd_derivative(double const x, double const length, double const max_displ
   if(function_type_space == FunctionTypeSpace::Linear)
     space_factor = 0.0;
   else if(function_type_space == FunctionTypeSpace::Sine)
-    space_factor = -max_displacement * std::pow(2.0 * numbers::PI / length, 2.0) *
-                   std::sin(x / length * 2.0 * numbers::PI);
+    space_factor = -max_displacement * std::pow(2.0 * dealii::numbers::PI / length, 2.0) *
+                   std::sin(x / length * 2.0 * dealii::numbers::PI);
   else if(function_type_space == FunctionTypeSpace::Exponential)
     space_factor =
       max_displacement / (length * length) * (std::exp(x / length)) / (std::exp(1.0) - 1.0);
   else
-    AssertThrow(false, ExcMessage("not implemented"));
+    AssertThrow(false, dealii::ExcMessage("not implemented"));
 
   return space_factor;
 }
 
 template<int dim>
-class Solution : public Function<dim>
+class Solution : public dealii::Function<dim>
 {
 public:
   Solution(double const max_displacement,
            double const length,
            bool const   unsteady,
            double const frequency)
-    : Function<dim>(dim),
+    : dealii::Function<dim>(dim),
       max_displacement(max_displacement),
       length(length),
       unsteady(unsteady),
@@ -189,7 +187,7 @@ public:
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     if(c == 0)
     {
@@ -208,14 +206,14 @@ private:
 };
 
 template<int dim>
-class InitialVelocity : public Function<dim>
+class InitialVelocity : public dealii::Function<dim>
 {
 public:
   InitialVelocity(double const max_displacement,
                   double const length,
                   bool const   unsteady,
                   double const frequency)
-    : Function<dim>(dim),
+    : dealii::Function<dim>(dim),
       max_displacement(max_displacement),
       length(length),
       unsteady(unsteady),
@@ -224,7 +222,7 @@ public:
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     if(c == 0)
     {
@@ -245,7 +243,7 @@ private:
 };
 
 template<int dim>
-class VolumeForce : public Function<dim>
+class VolumeForce : public dealii::Function<dim>
 {
 public:
   VolumeForce(double const max_displacement,
@@ -254,7 +252,7 @@ public:
               bool const   unsteady,
               double const frequency,
               double const f0)
-    : Function<dim>(dim),
+    : dealii::Function<dim>(dim),
       max_displacement(max_displacement),
       length(length),
       density(density),
@@ -265,7 +263,7 @@ public:
   }
 
   double
-  value(Point<dim> const & p, unsigned int const c) const
+  value(dealii::Point<dim> const & p, unsigned int const c) const
   {
     if(c == 0)
     {
@@ -304,7 +302,7 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
@@ -321,7 +319,7 @@ public:
   double const max_displacement = 0.1 * length;
   double const start_time       = 0.0;
   double const end_time         = 1.0;
-  double const frequency        = 3.0 / 2.0 * numbers::PI / end_time;
+  double const frequency        = 3.0 / 2.0 * dealii::numbers::PI / end_time;
 
   void
   set_parameters() final
@@ -359,7 +357,7 @@ public:
   create_grid() final
   {
     // left-bottom-front and right-top-back point
-    Point<dim> p1, p2;
+    dealii::Point<dim> p1, p2;
 
     for(unsigned d = 0; d < dim; d++)
       p1[d] = 0.0;
@@ -375,7 +373,10 @@ public:
     if(dim == 3)
       repetitions[2] = this->param.grid.n_subdivisions_1d_hypercube;
 
-    GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation, repetitions, p1, p2);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation,
+                                                      repetitions,
+                                                      p1,
+                                                      p2);
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -383,18 +384,20 @@ public:
   void
   set_boundary_descriptor() final
   {
-    typedef typename std::pair<types::boundary_id, std::shared_ptr<Function<dim>>> pair;
-    typedef typename std::pair<types::boundary_id, ComponentMask>                  pair_mask;
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+                                                                                  pair;
+    typedef typename std::pair<dealii::types::boundary_id, dealii::ComponentMask> pair_mask;
 
     this->boundary_descriptor->dirichlet_bc.insert(
       pair(0, new Solution<dim>(max_displacement, length, unsteady, frequency)));
-    this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(0, ComponentMask()));
+    this->boundary_descriptor->dirichlet_bc_component_mask.insert(
+      pair_mask(0, dealii::ComponentMask()));
   }
 
   void
   set_material_descriptor() final
   {
-    typedef std::pair<types::material_id, std::shared_ptr<MaterialData>> Pair;
+    typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
@@ -408,7 +411,8 @@ public:
   {
     this->field_functions->right_hand_side.reset(
       new VolumeForce<dim>(max_displacement, length, density, unsteady, frequency, f0));
-    this->field_functions->initial_displacement.reset(new Functions::ZeroFunction<dim>(dim));
+    this->field_functions->initial_displacement.reset(
+      new dealii::Functions::ZeroFunction<dim>(dim));
     this->field_functions->initial_velocity.reset(
       new InitialVelocity<dim>(max_displacement, length, unsteady, frequency));
   }

--- a/applications/structure/template/application.h
+++ b/applications/structure/template/application.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Application : public ApplicationBase<dim, Number>
 {
@@ -36,13 +34,13 @@ public:
     : ApplicationBase<dim, Number>(input_file, comm)
   {
     // parse application-specific parameters
-    ParameterHandler prm;
+    dealii::ParameterHandler prm;
     add_parameters(prm);
     prm.parse_input(input_file, "", true, true);
   }
 
   void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     ApplicationBase<dim, Number>::add_parameters(prm);
 

--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -33,15 +33,13 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 Driver<dim, Number>::Driver(MPI_Comm const &                              comm,
                             std::shared_ptr<ApplicationBase<dim, Number>> app,
                             bool const                                    is_test,
                             bool const                                    is_throughput_study)
   : mpi_comm(comm),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
     is_test(is_test),
     is_throughput_study(is_throughput_study),
     application(app)
@@ -53,7 +51,7 @@ template<int dim, typename Number>
 void
 Driver<dim, Number>::setup()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   pcout << std::endl << "Setting up compressible Navier-Stokes solver:" << std::endl;
@@ -72,7 +70,7 @@ Driver<dim, Number>::setup()
   matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
-  matrix_free = std::make_shared<MatrixFree<dim, Number>>();
+  matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
   matrix_free->reinit(*application->get_grid()->mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),
@@ -127,12 +125,13 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
   timer_tree.print_level(pcout, 2);
 
   // Throughput in DoFs/s per time step per core
-  types::global_dof_index const DoFs            = pde_operator->get_number_of_dofs();
-  unsigned int const            N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
-  unsigned int const            N_time_steps    = time_integrator->get_number_of_time_steps();
+  dealii::types::global_dof_index const DoFs = pde_operator->get_number_of_dofs();
+  unsigned int const N_mpi_processes         = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
+  unsigned int const N_time_steps            = time_integrator->get_number_of_time_steps();
 
-  Utilities::MPI::MinMaxAvg overall_time_data = Utilities::MPI::min_max_avg(total_time, mpi_comm);
-  double const              overall_time_avg  = overall_time_data.avg;
+  dealii::Utilities::MPI::MinMaxAvg overall_time_data =
+    dealii::Utilities::MPI::min_max_avg(total_time, mpi_comm);
+  double const overall_time_avg = overall_time_data.avg;
 
   print_throughput_unsteady(pcout, DoFs, overall_time_avg, N_time_steps, N_mpi_processes);
 
@@ -145,7 +144,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
 }
 
 template<int dim, typename Number>
-std::tuple<unsigned int, types::global_dof_index, double>
+std::tuple<unsigned int, dealii::types::global_dof_index, double>
 Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
                                     unsigned int const  n_repetitions_inner,
                                     unsigned int const  n_repetitions_outer) const
@@ -180,7 +179,7 @@ Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
     else if(operator_type == OperatorType::EvaluateOperatorExplicit)
       pde_operator->evaluate(dst, src, 0.0);
     else
-      AssertThrow(false, ExcMessage("Specified operator type not implemented"));
+      AssertThrow(false, dealii::ExcMessage("Specified operator type not implemented"));
   };
 
   // do the measurements
@@ -191,11 +190,11 @@ Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
                                                             mpi_comm);
 
   // calculate throughput
-  types::global_dof_index const dofs = pde_operator->get_number_of_dofs();
+  dealii::types::global_dof_index const dofs = pde_operator->get_number_of_dofs();
 
   double const throughput = (double)dofs / wall_time;
 
-  unsigned int const N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
+  unsigned int const N_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
 
   if(not(is_test))
   {
@@ -209,7 +208,7 @@ Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
 
   pcout << std::endl << " ... done." << std::endl << std::endl;
 
-  return std::tuple<unsigned int, types::global_dof_index, double>(
+  return std::tuple<unsigned int, dealii::types::global_dof_index, double>(
     application->get_parameters().degree, dofs, throughput);
 }
 

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -38,8 +38,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 // Select the operator to be applied
 enum class OperatorType
 {
@@ -68,7 +66,7 @@ enum_to_string(OperatorType const enum_type)
     case OperatorType::VectorUpdate:              string_type = "VectorUpdate";             break;
     case OperatorType::EvaluateOperatorExplicit:  string_type = "EvaluateOperatorExplicit"; break;
 
-    default:AssertThrow(false, ExcMessage("Not implemented.")); break;
+    default:AssertThrow(false, dealii::ExcMessage("Not implemented.")); break;
       // clang-format on
   }
 
@@ -86,7 +84,7 @@ string_to_enum(OperatorType & enum_type, std::string const string_type)
   else if(string_type == "InverseMassOperatorDstDst") enum_type = OperatorType::InverseMassOperatorDstDst;
   else if(string_type == "VectorUpdate")              enum_type = OperatorType::VectorUpdate;
   else if(string_type == "EvaluateOperatorExplicit")  enum_type = OperatorType::EvaluateOperatorExplicit;
-  else AssertThrow(false, ExcMessage("Unknown operator type. Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Unknown operator type. Not implemented."));
   // clang-format on
 }
 
@@ -97,7 +95,7 @@ get_dofs_per_element(std::string const & input_file,
 {
   (void)input_file;
 
-  unsigned int const dofs_per_element = (dim + 2) * Utilities::pow(degree + 1, dim);
+  unsigned int const dofs_per_element = (dim + 2) * dealii::Utilities::pow(degree + 1, dim);
 
   return dofs_per_element;
 }
@@ -106,7 +104,7 @@ template<int dim, typename Number = double>
 class Driver
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   Driver(MPI_Comm const &                              comm,
          std::shared_ptr<ApplicationBase<dim, Number>> application,
@@ -125,7 +123,7 @@ public:
   /*
    * Throughput study
    */
-  std::tuple<unsigned int, types::global_dof_index, double>
+  std::tuple<unsigned int, dealii::types::global_dof_index, double>
   apply_operator(std::string const & operator_type,
                  unsigned int const  n_repetitions_inner,
                  unsigned int const  n_repetitions_outer) const;
@@ -133,7 +131,7 @@ public:
 private:
   MPI_Comm const mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -143,8 +141,8 @@ private:
 
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   std::shared_ptr<Operator<dim, Number>> pde_operator;
 

--- a/include/exadg/compressible_navier_stokes/postprocessor/output_generator.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/output_generator.cpp
@@ -31,13 +31,11 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename VectorType>
 void
 write_output(OutputData const &                              output_data,
-             DoFHandler<dim> const &                         dof_handler,
-             Mapping<dim> const &                            mapping,
+             dealii::DoFHandler<dim> const &                 dof_handler,
+             dealii::Mapping<dim> const &                    mapping,
              VectorType const &                              solution_conserved,
              std::vector<SolutionField<dim, Number>> const & additional_fields,
              unsigned int const                              output_counter,
@@ -45,10 +43,10 @@ write_output(OutputData const &                              output_data,
 {
   std::string folder = output_data.directory, file = output_data.filename;
 
-  DataOutBase::VtkFlags flags;
+  dealii::DataOutBase::VtkFlags flags;
   flags.write_higher_order_cells = output_data.write_higher_order;
 
-  DataOut<dim> data_out;
+  dealii::DataOut<dim> data_out;
   data_out.set_flags(flags);
 
   // conserved variables
@@ -56,12 +54,13 @@ write_output(OutputData const &                              output_data,
   solution_names_conserved[0]       = "rho";
   solution_names_conserved[1 + dim] = "rho_E";
 
-  std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    solution_component_interpretation(dim + 2,
-                                      DataComponentInterpretation::component_is_part_of_vector);
+  std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+    solution_component_interpretation(
+      dim + 2, dealii::DataComponentInterpretation::component_is_part_of_vector);
 
-  solution_component_interpretation[0]       = DataComponentInterpretation::component_is_scalar;
-  solution_component_interpretation[1 + dim] = DataComponentInterpretation::component_is_scalar;
+  solution_component_interpretation[0] = dealii::DataComponentInterpretation::component_is_scalar;
+  solution_component_interpretation[1 + dim] =
+    dealii::DataComponentInterpretation::component_is_scalar;
 
 #if !DEAL_II_VERSION_GTE(10, 0, 0)
   solution_conserved.update_ghost_values();
@@ -89,18 +88,19 @@ write_output(OutputData const &                              output_data,
     else if(it->type == SolutionFieldType::vector)
     {
       std::vector<std::string> names(dim, it->name);
-      std::vector<DataComponentInterpretation::DataComponentInterpretation>
-        component_interpretation(dim, DataComponentInterpretation::component_is_part_of_vector);
+      std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+        component_interpretation(dim,
+                                 dealii::DataComponentInterpretation::component_is_part_of_vector);
 
       data_out.add_data_vector(*it->dof_handler, *it->vector, names, component_interpretation);
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 
-  data_out.build_patches(mapping, output_data.degree, DataOut<dim>::curved_inner_cells);
+  data_out.build_patches(mapping, output_data.degree, dealii::DataOut<dim>::curved_inner_cells);
 
   data_out.write_vtu_with_pvtu_record(folder, file, output_counter, mpi_comm, 4);
 }
@@ -113,9 +113,9 @@ OutputGenerator<dim, Number>::OutputGenerator(MPI_Comm const & comm)
 
 template<int dim, typename Number>
 void
-OutputGenerator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_in,
-                                    Mapping<dim> const &    mapping_in,
-                                    OutputData const &      output_data_in)
+OutputGenerator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_in,
+                                    dealii::Mapping<dim> const &    mapping_in,
+                                    OutputData const &              output_data_in)
 {
   dof_handler = &dof_handler_in;
   mapping     = &mapping_in;
@@ -155,7 +155,7 @@ OutputGenerator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_in,
     // processor_id
     if(output_data.write_processor_id)
     {
-      GridOut grid_out;
+      dealii::GridOut grid_out;
 
       grid_out.write_mesh_per_processor_as_vtu(dof_handler->get_triangulation(),
                                                output_data.directory + output_data.filename +
@@ -172,7 +172,8 @@ OutputGenerator<dim, Number>::evaluate(
   double const &                                  time,
   int const &                                     time_step_number)
 {
-  ConditionalOStream pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0);
+  dealii::ConditionalOStream pcout(std::cout,
+                                   dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0);
 
   if(output_data.write_output == true)
   {

--- a/include/exadg/compressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/output_generator.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 struct OutputData : public OutputDataBase
 {
   OutputData()
@@ -48,7 +46,7 @@ struct OutputData : public OutputDataBase
   }
 
   void
-  print(ConditionalOStream & pcout, bool unsteady)
+  print(dealii::ConditionalOStream & pcout, bool unsteady)
   {
     OutputDataBase::print(pcout, unsteady);
 
@@ -84,14 +82,14 @@ template<int dim, typename Number>
 class OutputGenerator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   OutputGenerator(MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const & dof_handler_in,
-        Mapping<dim> const &    mapping_in,
-        OutputData const &      output_data_in);
+  setup(dealii::DoFHandler<dim> const & dof_handler_in,
+        dealii::Mapping<dim> const &    mapping_in,
+        OutputData const &              output_data_in);
 
   void
   evaluate(VectorType const &                              solution_conserved,
@@ -105,9 +103,9 @@ private:
   unsigned int output_counter;
   bool         reset_counter;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler;
-  SmartPointer<Mapping<dim> const>    mapping;
-  OutputData                          output_data;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  OutputData                                          output_data;
 };
 
 } // namespace CompNS

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & postprocessor_data,
                                           MPI_Comm const &               comm)

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
@@ -34,8 +34,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim>
 struct PostProcessorData
 {
@@ -58,7 +56,7 @@ template<int dim, typename Number>
 class PostProcessor : public PostProcessorBase<dim, Number>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   PostProcessor(PostProcessorData<dim> const & postprocessor_data, MPI_Comm const & comm);
 
@@ -93,7 +91,7 @@ private:
 
   PostProcessorData<dim> pp_data;
 
-  SmartPointer<Operator<dim, Number> const> navier_stokes_operator;
+  dealii::SmartPointer<Operator<dim, Number> const> navier_stokes_operator;
 
   OutputGenerator<dim, Number>                 output_generator;
   ErrorCalculator<dim, Number>                 error_calculator;

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor_base.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor_base.h
@@ -32,13 +32,11 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<typename Number>
 class PostProcessorInterface
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   virtual ~PostProcessorInterface()
   {

--- a/include/exadg/compressible_navier_stokes/solver.h
+++ b/include/exadg/compressible_navier_stokes/solver.h
@@ -74,7 +74,7 @@ run(std::string const & input_file,
     MPI_Comm const &    mpi_comm,
     bool const          is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<CompNS::ApplicationBase<dim, Number>> application =
@@ -97,7 +97,7 @@ run(std::string const & input_file,
 int
 main(int argc, char ** argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+  dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   MPI_Comm mpi_comm(MPI_COMM_WORLD);
 
@@ -159,7 +159,8 @@ main(int argc, char ** argv)
           ExaDG::run<3, double>(
             input_file, degree, refine_space, refine_time, mpi_comm, general.is_test);
         else
-          AssertThrow(false, ExcMessage("Only dim = 2|3 and precision=float|double implemented."));
+          AssertThrow(false,
+                      dealii::ExcMessage("Only dim = 2|3 and precision=float|double implemented."));
       }
     }
   }

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/calculators.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/calculators.h
@@ -33,28 +33,26 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class VorticityCalculator
 {
 public:
   static unsigned int const number_vorticity_components = (dim == 2) ? 1 : dim;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef VorticityCalculator<dim, Number> This;
 
   typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
 
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   VorticityCalculator() : matrix_free(nullptr), dof_index(0), quad_index(0){};
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_in,
-             unsigned int const              quad_index_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_in,
+             unsigned int const                      quad_index_in)
   {
     matrix_free = &matrix_free_in;
     dof_index   = dof_index_in;
@@ -69,7 +67,7 @@ public:
 
 private:
   void
-  local_compute_vorticity(MatrixFree<dim, Number> const &               matrix_free,
+  local_compute_vorticity(dealii::MatrixFree<dim, Number> const &       matrix_free,
                           VectorType &                                  dst,
                           VectorType const &                            src,
                           std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -84,7 +82,7 @@ private:
 
       for(unsigned int q = 0; q < integrator.n_q_points; ++q)
       {
-        Tensor<1, number_vorticity_components, VectorizedArray<Number>> omega =
+        dealii::Tensor<1, number_vorticity_components, dealii::VectorizedArray<Number>> omega =
           integrator.get_curl(q);
 
         // omega_vector is a vector with dim components
@@ -102,9 +100,9 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
-  unsigned int                    dof_index;
-  unsigned int                    quad_index;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
+  unsigned int                            dof_index;
+  unsigned int                            quad_index;
 };
 
 
@@ -112,23 +110,23 @@ template<int dim, typename Number>
 class DivergenceCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef DivergenceCalculator<dim, Number> This;
 
   typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
   typedef CellIntegrator<dim, 1, Number>   CellIntegratorScalar;
 
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
   DivergenceCalculator()
     : matrix_free(nullptr), dof_index_vector(1), dof_index_scalar(2), quad_index(0){};
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_vector_in,
-             unsigned int const              dof_index_scalar_in,
-             unsigned int const              quad_index_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_vector_in,
+             unsigned int const                      dof_index_scalar_in,
+             unsigned int const                      quad_index_in)
   {
     matrix_free      = &matrix_free_in;
     dof_index_vector = dof_index_vector_in;
@@ -144,7 +142,7 @@ public:
 
 private:
   void
-  local_compute_divergence(MatrixFree<dim, Number> const &               matrix_free,
+  local_compute_divergence(dealii::MatrixFree<dim, Number> const &       matrix_free,
                            VectorType &                                  dst,
                            VectorType const &                            src,
                            std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -171,7 +169,7 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index_vector;
   unsigned int dof_index_scalar;
@@ -188,15 +186,15 @@ template<int dim, typename Number>
 class p_u_T_Calculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef p_u_T_Calculator<dim, Number> This;
 
   typedef CellIntegrator<dim, 1, Number>   CellIntegratorScalar;
   typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   p_u_T_Calculator()
     : matrix_free(nullptr),
@@ -210,13 +208,13 @@ public:
   }
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_all_in,
-             unsigned int const              dof_index_vector_in,
-             unsigned int const              dof_index_scalar_in,
-             unsigned int const              quad_index_in,
-             double const                    heat_capacity_ratio_in,
-             double const                    specific_gas_constant_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_all_in,
+             unsigned int const                      dof_index_vector_in,
+             unsigned int const                      dof_index_scalar_in,
+             unsigned int const                      quad_index_in,
+             double const                            heat_capacity_ratio_in,
+             double const                            specific_gas_constant_in)
   {
     matrix_free           = &matrix_free_in;
     dof_index_all         = dof_index_all_in;
@@ -230,8 +228,10 @@ public:
   void
   compute_pressure(VectorType & pressure, VectorType const & solution_conserved) const
   {
-    AssertThrow(heat_capacity_ratio > 0.0, ExcMessage("heat capacity ratio has not been set!"));
-    AssertThrow(specific_gas_constant > 0.0, ExcMessage("specific gas constant has not been set!"));
+    AssertThrow(heat_capacity_ratio > 0.0,
+                dealii::ExcMessage("heat capacity ratio has not been set!"));
+    AssertThrow(specific_gas_constant > 0.0,
+                dealii::ExcMessage("specific gas constant has not been set!"));
 
     matrix_free->cell_loop(&This::local_apply_pressure, this, pressure, solution_conserved);
   }
@@ -245,15 +245,17 @@ public:
   void
   compute_temperature(VectorType & temperature, VectorType const & solution_conserved) const
   {
-    AssertThrow(heat_capacity_ratio > 0.0, ExcMessage("heat capacity ratio has not been set!"));
-    AssertThrow(specific_gas_constant > 0.0, ExcMessage("specific gas constant has not been set!"));
+    AssertThrow(heat_capacity_ratio > 0.0,
+                dealii::ExcMessage("heat capacity ratio has not been set!"));
+    AssertThrow(specific_gas_constant > 0.0,
+                dealii::ExcMessage("specific gas constant has not been set!"));
 
     matrix_free->cell_loop(&This::local_apply_temperature, this, temperature, solution_conserved);
   }
 
 private:
   void
-  local_apply_pressure(MatrixFree<dim, Number> const &               matrix_free,
+  local_apply_pressure(dealii::MatrixFree<dim, Number> const &       matrix_free,
                        VectorType &                                  dst,
                        VectorType const &                            src,
                        std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -292,7 +294,7 @@ private:
         // compute derived quantities in quadrature point
         vector u = rho_u / rho;
 
-        scalar p = make_vectorized_array<Number>(heat_capacity_ratio - 1.0) *
+        scalar p = dealii::make_vectorized_array<Number>(heat_capacity_ratio - 1.0) *
                    (rho_E - 0.5 * rho * scalar_product(u, u));
 
         pressure.submit_value(p, q);
@@ -304,7 +306,7 @@ private:
   }
 
   void
-  local_apply_velocity(MatrixFree<dim, Number> const &               matrix_free,
+  local_apply_velocity(dealii::MatrixFree<dim, Number> const &       matrix_free,
                        VectorType &                                  dst,
                        VectorType const &                            src,
                        std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -347,7 +349,7 @@ private:
   }
 
   void
-  local_apply_temperature(MatrixFree<dim, Number> const &               matrix_free,
+  local_apply_temperature(dealii::MatrixFree<dim, Number> const &       matrix_free,
                           VectorType &                                  dst,
                           VectorType const &                            src,
                           std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -387,9 +389,9 @@ private:
         vector u = rho_u / rho;
         scalar E = rho_E / rho;
 
-        scalar T =
-          make_vectorized_array<Number>((heat_capacity_ratio - 1.0) / specific_gas_constant) *
-          (E - 0.5 * scalar_product(u, u));
+        scalar T = dealii::make_vectorized_array<Number>((heat_capacity_ratio - 1.0) /
+                                                         specific_gas_constant) *
+                   (E - 0.5 * scalar_product(u, u));
 
         temperature.submit_value(T, q);
       }
@@ -399,7 +401,7 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index_all;
   unsigned int dof_index_vector;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/interface.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/interface.h
@@ -30,13 +30,11 @@ namespace CompNS
 {
 namespace Interface
 {
-using namespace dealii;
-
 template<typename Number>
 class Operator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   Operator()
   {

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
@@ -39,74 +39,72 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    VectorizedArray<Number>
-    calculate_pressure(Tensor<1, dim, VectorizedArray<Number>> const & rho_u,
-                       Tensor<1, dim, VectorizedArray<Number>> const & u,
-                       VectorizedArray<Number> const &                 rho_E,
-                       Number const &                                  gamma)
+    dealii::VectorizedArray<Number>
+    calculate_pressure(dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & rho_u,
+                       dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & u,
+                       dealii::VectorizedArray<Number> const &                         rho_E,
+                       Number const &                                                  gamma)
 {
   return (gamma - 1.0) * (rho_E - 0.5 * scalar_product(rho_u, u));
 }
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
-  calculate_pressure(VectorizedArray<Number> const &                 rho,
-                     Tensor<1, dim, VectorizedArray<Number>> const & u,
-                     VectorizedArray<Number> const &                 E,
-                     Number const &                                  gamma)
+  dealii::VectorizedArray<Number>
+  calculate_pressure(dealii::VectorizedArray<Number> const &                         rho,
+                     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & u,
+                     dealii::VectorizedArray<Number> const &                         E,
+                     Number const &                                                  gamma)
 {
   return (gamma - 1.0) * rho * (E - 0.5 * scalar_product(u, u));
 }
 
 template<typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
-  calculate_temperature(VectorizedArray<Number> const & p,
-                        VectorizedArray<Number> const & rho,
-                        Number const &                  R)
+  dealii::VectorizedArray<Number>
+  calculate_temperature(dealii::VectorizedArray<Number> const & p,
+                        dealii::VectorizedArray<Number> const & rho,
+                        Number const &                          R)
 {
   return p / (rho * R);
 }
 
 template<int dim, typename Number>
-inline VectorizedArray<Number>
-calculate_energy(VectorizedArray<Number> const &                 T,
-                 Tensor<1, dim, VectorizedArray<Number>> const & u,
-                 Number const &                                  c_v)
+inline dealii::VectorizedArray<Number>
+calculate_energy(dealii::VectorizedArray<Number> const &                         T,
+                 dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & u,
+                 Number const &                                                  c_v)
 {
   return c_v * T + 0.5 * scalar_product(u, u);
 }
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<1, dim, VectorizedArray<Number>>
-  calculate_grad_E(VectorizedArray<Number> const &                 rho_inverse,
-                   VectorizedArray<Number> const &                 rho_E,
-                   Tensor<1, dim, VectorizedArray<Number>> const & grad_rho,
-                   Tensor<1, dim, VectorizedArray<Number>> const & grad_rho_E)
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+  calculate_grad_E(dealii::VectorizedArray<Number> const &                         rho_inverse,
+                   dealii::VectorizedArray<Number> const &                         rho_E,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & grad_rho,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & grad_rho_E)
 {
-  VectorizedArray<Number> E = rho_inverse * rho_E;
+  dealii::VectorizedArray<Number> E = rho_inverse * rho_E;
 
   return rho_inverse * (grad_rho_E - E * grad_rho);
 }
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<2, dim, VectorizedArray<Number>>
-  calculate_grad_u(VectorizedArray<Number> const &                 rho_inverse,
-                   Tensor<1, dim, VectorizedArray<Number>> const & rho_u,
-                   Tensor<1, dim, VectorizedArray<Number>> const & grad_rho,
-                   Tensor<2, dim, VectorizedArray<Number>> const & grad_rho_u)
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+  calculate_grad_u(dealii::VectorizedArray<Number> const &                         rho_inverse,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & rho_u,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & grad_rho,
+                   dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & grad_rho_u)
 {
-  Tensor<2, dim, VectorizedArray<Number>> out;
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> out;
   for(unsigned int d = 0; d < dim; ++d)
   {
-    VectorizedArray<Number> ud = rho_inverse * rho_u[d];
+    dealii::VectorizedArray<Number> ud = rho_inverse * rho_u[d];
     for(unsigned int e = 0; e < dim; ++e)
       out[d][e] = rho_inverse * (grad_rho_u[d][e] - ud * grad_rho[e]);
   }
@@ -116,25 +114,25 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
-    calculate_grad_T(Tensor<1, dim, VectorizedArray<Number>> const & grad_E,
-                     Tensor<1, dim, VectorizedArray<Number>> const & u,
-                     Tensor<2, dim, VectorizedArray<Number>> const & grad_u,
-                     Number const &                                  gamma,
-                     Number const &                                  R)
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+    calculate_grad_T(dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & grad_E,
+                     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & u,
+                     dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & grad_u,
+                     Number const &                                                  gamma,
+                     Number const &                                                  R)
 {
   return (gamma - 1.0) / R * (grad_E - u * grad_u);
 }
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<2, dim, VectorizedArray<Number>>
-    calculate_stress_tensor(Tensor<2, dim, VectorizedArray<Number>> const & grad_u,
-                            Number const &                                  viscosity)
+    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+    calculate_stress_tensor(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & grad_u,
+                            Number const & viscosity)
 {
-  VectorizedArray<Number> const divu = (2. / 3.) * trace(grad_u);
+  dealii::VectorizedArray<Number> const divu = (2. / 3.) * trace(grad_u);
 
-  Tensor<2, dim, VectorizedArray<Number>> out;
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> out;
   for(unsigned int d = 0; d < dim; ++d)
   {
     for(unsigned int e = 0; e < dim; ++e)
@@ -151,22 +149,23 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number, int rank>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<rank, dim, VectorizedArray<Number>>
-  calculate_exterior_value(Tensor<rank, dim, VectorizedArray<Number>> const & value_m,
-                           BoundaryType const                                 boundary_type,
-                           BoundaryDescriptorStd<dim> const &                 boundary_descriptor,
-                           types::boundary_id const &                         boundary_id,
-                           Point<dim, VectorizedArray<Number>> const &        q_point,
-                           Number const &                                     time)
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
+  calculate_exterior_value(
+    dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> const & value_m,
+    BoundaryType const                                                 boundary_type,
+    BoundaryDescriptorStd<dim> const &                                 boundary_descriptor,
+    dealii::types::boundary_id const &                                 boundary_id,
+    dealii::Point<dim, dealii::VectorizedArray<Number>> const &        q_point,
+    Number const &                                                     time)
 {
-  Tensor<rank, dim, VectorizedArray<Number>> value_p;
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> value_p;
 
   if(boundary_type == BoundaryType::Dirichlet)
   {
     auto bc = boundary_descriptor.dirichlet_bc.find(boundary_id)->second;
     auto g  = FunctionEvaluator<rank, dim, Number>::value(bc, q_point, time);
 
-    value_p = -value_m + Tensor<rank, dim, VectorizedArray<Number>>(2.0 * g);
+    value_p = -value_m + dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>(2.0 * g);
   }
   else if(boundary_type == BoundaryType::Neumann)
   {
@@ -174,7 +173,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   return value_p;
@@ -186,15 +185,16 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number, int rank>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<rank, dim, VectorizedArray<Number>>
-  calculate_exterior_normal_grad(Tensor<rank, dim, VectorizedArray<Number>> const & grad_M_normal,
-                                 BoundaryType const &                               boundary_type,
-                                 BoundaryDescriptorStd<dim> const &          boundary_descriptor,
-                                 types::boundary_id const &                  boundary_id,
-                                 Point<dim, VectorizedArray<Number>> const & q_point,
-                                 Number const &                              time)
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
+  calculate_exterior_normal_grad(
+    dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> const & grad_M_normal,
+    BoundaryType const &                                               boundary_type,
+    BoundaryDescriptorStd<dim> const &                                 boundary_descriptor,
+    dealii::types::boundary_id const &                                 boundary_id,
+    dealii::Point<dim, dealii::VectorizedArray<Number>> const &        q_point,
+    Number const &                                                     time)
 {
-  Tensor<rank, dim, VectorizedArray<Number>> grad_P_normal;
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> grad_P_normal;
 
   if(boundary_type == BoundaryType::Dirichlet)
   {
@@ -206,11 +206,12 @@ inline DEAL_II_ALWAYS_INLINE //
     auto bc = boundary_descriptor.neumann_bc.find(boundary_id)->second;
     auto h  = FunctionEvaluator<rank, dim, Number>::value(bc, q_point, time);
 
-    grad_P_normal = -grad_M_normal + Tensor<rank, dim, VectorizedArray<Number>>(2.0 * h);
+    grad_P_normal =
+      -grad_M_normal + dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>(2.0 * h);
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   return grad_P_normal;
@@ -221,18 +222,18 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
-    calculate_flux(Tensor<2, dim, VectorizedArray<Number>> const & momentum_flux_M,
-                   Tensor<2, dim, VectorizedArray<Number>> const & momentum_flux_P,
-                   Tensor<1, dim, VectorizedArray<Number>> const & rho_u_M,
-                   Tensor<1, dim, VectorizedArray<Number>> const & rho_u_P,
-                   VectorizedArray<Number> const &                 lambda,
-                   Tensor<1, dim, VectorizedArray<Number>> const & normal)
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+    calculate_flux(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & momentum_flux_M,
+                   dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & momentum_flux_P,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & rho_u_M,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & rho_u_P,
+                   dealii::VectorizedArray<Number> const &                         lambda,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normal)
 {
-  Tensor<1, dim, VectorizedArray<Number>> out;
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> out;
   for(unsigned int d = 0; d < dim; ++d)
   {
-    VectorizedArray<Number> sum = VectorizedArray<Number>();
+    dealii::VectorizedArray<Number> sum = dealii::VectorizedArray<Number>();
     for(unsigned int e = 0; e < dim; ++e)
       sum += (momentum_flux_M[d][e] + momentum_flux_P[d][e]) * normal[e];
     out[d] = 0.5 * (sum + lambda * (rho_u_M[d] - rho_u_P[d]));
@@ -246,15 +247,15 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    VectorizedArray<Number>
-    calculate_flux(Tensor<1, dim, VectorizedArray<Number>> const & flux_M,
-                   Tensor<1, dim, VectorizedArray<Number>> const & flux_P,
-                   VectorizedArray<Number> const &                 value_M,
-                   VectorizedArray<Number> const &                 value_P,
-                   VectorizedArray<Number> const &                 lambda,
-                   Tensor<1, dim, VectorizedArray<Number>> const & normal)
+    dealii::VectorizedArray<Number>
+    calculate_flux(dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & flux_M,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & flux_P,
+                   dealii::VectorizedArray<Number> const &                         value_M,
+                   dealii::VectorizedArray<Number> const &                         value_P,
+                   dealii::VectorizedArray<Number> const &                         lambda,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normal)
 {
-  Tensor<1, dim, VectorizedArray<Number>> average_flux = 0.5 * (flux_M + flux_P);
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> average_flux = 0.5 * (flux_M + flux_P);
 
   return average_flux * normal + 0.5 * lambda * (value_M - value_P);
 }
@@ -265,17 +266,17 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
-  calculate_lambda(VectorizedArray<Number> const &                 rho_m,
-                   VectorizedArray<Number> const &                 rho_p,
-                   Tensor<1, dim, VectorizedArray<Number>> const & u_m,
-                   Tensor<1, dim, VectorizedArray<Number>> const & u_p,
-                   VectorizedArray<Number> const &                 p_m,
-                   VectorizedArray<Number> const &                 p_p,
-                   Number const &                                  gamma)
+  dealii::VectorizedArray<Number>
+  calculate_lambda(dealii::VectorizedArray<Number> const &                         rho_m,
+                   dealii::VectorizedArray<Number> const &                         rho_p,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & u_m,
+                   dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & u_p,
+                   dealii::VectorizedArray<Number> const &                         p_m,
+                   dealii::VectorizedArray<Number> const &                         p_p,
+                   Number const &                                                  gamma)
 {
-  VectorizedArray<Number> lambda_m = u_m.norm() + std::sqrt(std::abs(gamma * p_m / rho_m));
-  VectorizedArray<Number> lambda_p = u_p.norm() + std::sqrt(std::abs(gamma * p_p / rho_p));
+  dealii::VectorizedArray<Number> lambda_m = u_m.norm() + std::sqrt(std::abs(gamma * p_m / rho_m));
+  dealii::VectorizedArray<Number> lambda_p = u_p.norm() + std::sqrt(std::abs(gamma * p_p / rho_p));
 
   return std::max(lambda_m, lambda_p);
 }
@@ -290,34 +291,34 @@ struct BodyForceOperatorData
   unsigned int dof_index;
   unsigned int quad_index;
 
-  std::shared_ptr<Function<dim>> rhs_rho;
-  std::shared_ptr<Function<dim>> rhs_u;
-  std::shared_ptr<Function<dim>> rhs_E;
+  std::shared_ptr<dealii::Function<dim>> rhs_rho;
+  std::shared_ptr<dealii::Function<dim>> rhs_u;
+  std::shared_ptr<dealii::Function<dim>> rhs_E;
 };
 
 template<int dim, typename Number>
 class BodyForceOperator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef BodyForceOperator<dim, Number> This;
 
   typedef CellIntegrator<dim, 1, Number>   CellIntegratorScalar;
   typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
-  typedef Point<dim, VectorizedArray<Number>>     point;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+  typedef dealii::Point<dim, dealii::VectorizedArray<Number>>     point;
 
   BodyForceOperator() : matrix_free(nullptr), eval_time(0.0)
   {
   }
 
   void
-  initialize(MatrixFree<dim, Number> const &    matrix_free_in,
-             BodyForceOperatorData<dim> const & data_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             BodyForceOperatorData<dim> const &      data_in)
   {
     this->matrix_free = &matrix_free_in;
     this->data        = data_in;
@@ -358,7 +359,7 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const &               matrix_free,
+  cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -392,7 +393,7 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   BodyForceOperatorData<dim> data;
 
@@ -413,7 +414,7 @@ template<int dim, typename Number>
 class MassOperator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef MassOperator<dim, Number> This;
 
@@ -425,7 +426,8 @@ public:
   }
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in, MassOperatorData const & data_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             MassOperatorData const &                data_in)
   {
     this->matrix_free = &matrix_free_in;
     this->data        = data_in;
@@ -447,7 +449,7 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const &               matrix_free,
+  cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -480,8 +482,8 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
-  MassOperatorData                data;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
+  MassOperatorData                        data;
 };
 
 template<int dim>
@@ -505,7 +507,7 @@ template<int dim, typename Number>
 class ConvectiveOperator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef ConvectiveOperator<dim, Number> This;
 
@@ -514,18 +516,18 @@ public:
   typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
   typedef FaceIntegrator<dim, dim, Number> FaceIntegratorVector;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
-  typedef Point<dim, VectorizedArray<Number>>     point;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+  typedef dealii::Point<dim, dealii::VectorizedArray<Number>>     point;
 
   ConvectiveOperator() : matrix_free(nullptr)
   {
   }
 
   void
-  initialize(MatrixFree<dim, Number> const &     matrix_free_in,
-             ConvectiveOperatorData<dim> const & data_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             ConvectiveOperatorData<dim> const &     data_in)
   {
     this->matrix_free = &matrix_free_in;
     this->data        = data_in;
@@ -635,16 +637,16 @@ public:
 
   inline DEAL_II_ALWAYS_INLINE //
     std::tuple<scalar, vector, scalar>
-    get_flux_boundary(FaceIntegratorScalar &         density,
-                      FaceIntegratorVector &         momentum,
-                      FaceIntegratorScalar &         energy,
-                      BoundaryType const &           boundary_type_density,
-                      BoundaryType const &           boundary_type_velocity,
-                      BoundaryType const &           boundary_type_pressure,
-                      BoundaryType const &           boundary_type_energy,
-                      EnergyBoundaryVariable const & boundary_variable,
-                      types::boundary_id const &     boundary_id,
-                      unsigned int const             q) const
+    get_flux_boundary(FaceIntegratorScalar &             density,
+                      FaceIntegratorVector &             momentum,
+                      FaceIntegratorScalar &             energy,
+                      BoundaryType const &               boundary_type_density,
+                      BoundaryType const &               boundary_type_velocity,
+                      BoundaryType const &               boundary_type_pressure,
+                      BoundaryType const &               boundary_type_energy,
+                      EnergyBoundaryVariable const &     boundary_variable,
+                      dealii::types::boundary_id const & boundary_id,
+                      unsigned int const                 q) const
   {
     vector normal = momentum.get_normal_vector(q);
 
@@ -685,7 +687,7 @@ public:
                                                           this->eval_time);
 
     // calculate E_P
-    scalar E_P = make_vectorized_array<Number>(0.0);
+    scalar E_P = dealii::make_vectorized_array<Number>(0.0);
     if(boundary_variable == EnergyBoundaryVariable::Energy)
     {
       E_P = calculate_exterior_value<dim, Number, 0>(E_M,
@@ -738,7 +740,7 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const &               matrix_free,
+  cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -774,7 +776,7 @@ private:
   }
 
   void
-  face_loop(MatrixFree<dim, Number> const &               matrix_free,
+  face_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & face_range) const
@@ -841,7 +843,7 @@ private:
   }
 
   void
-  boundary_face_loop(MatrixFree<dim, Number> const &               matrix_free,
+  boundary_face_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
                      VectorType &                                  dst,
                      VectorType const &                            src,
                      std::pair<unsigned int, unsigned int> const & face_range) const
@@ -861,7 +863,7 @@ private:
       energy.reinit(face);
       energy.gather_evaluate(src, true, false);
 
-      types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
+      dealii::types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
 
       BoundaryType boundary_type_density  = data.bc->density.get_boundary_type(boundary_id);
       BoundaryType boundary_type_velocity = data.bc->velocity.get_boundary_type(boundary_id);
@@ -894,7 +896,7 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   ConvectiveOperatorData<dim> data;
 
@@ -944,7 +946,7 @@ template<int dim, typename Number>
 class ViscousOperator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef ViscousOperator<dim, Number> This;
 
@@ -953,24 +955,24 @@ public:
   typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
   typedef FaceIntegrator<dim, dim, Number> FaceIntegratorVector;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
-  typedef Point<dim, VectorizedArray<Number>>     point;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+  typedef dealii::Point<dim, dealii::VectorizedArray<Number>>     point;
 
   ViscousOperator() : matrix_free(nullptr), degree(1)
   {
   }
 
   void
-  initialize(MatrixFree<dim, Number> const &  matrix_free_in,
-             ViscousOperatorData<dim> const & data_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             ViscousOperatorData<dim> const &        data_in)
   {
     this->matrix_free = &matrix_free_in;
     this->data        = data_in;
 
-    FiniteElement<dim> const & fe = matrix_free->get_dof_handler(data.dof_index).get_fe();
-    degree                        = fe.degree;
+    dealii::FiniteElement<dim> const & fe = matrix_free->get_dof_handler(data.dof_index).get_fe();
+    degree                                = fe.degree;
 
     gamma  = data.heat_capacity_ratio;
     R      = data.specific_gas_constant;
@@ -1126,16 +1128,16 @@ public:
 
   inline DEAL_II_ALWAYS_INLINE //
     std::tuple<scalar, vector, scalar>
-    get_gradient_flux_boundary(FaceIntegratorScalar &         density,
-                               FaceIntegratorVector &         momentum,
-                               FaceIntegratorScalar &         energy,
-                               scalar const &                 tau_IP,
-                               BoundaryType const &           boundary_type_density,
-                               BoundaryType const &           boundary_type_velocity,
-                               BoundaryType const &           boundary_type_energy,
-                               EnergyBoundaryVariable const & boundary_variable,
-                               types::boundary_id const &     boundary_id,
-                               unsigned int const             q) const
+    get_gradient_flux_boundary(FaceIntegratorScalar &             density,
+                               FaceIntegratorVector &             momentum,
+                               FaceIntegratorScalar &             energy,
+                               scalar const &                     tau_IP,
+                               BoundaryType const &               boundary_type_density,
+                               BoundaryType const &               boundary_type_velocity,
+                               BoundaryType const &               boundary_type_energy,
+                               EnergyBoundaryVariable const &     boundary_variable,
+                               dealii::types::boundary_id const & boundary_id,
+                               unsigned int const                 q) const
   {
     vector normal = momentum.get_normal_vector(q);
 
@@ -1188,7 +1190,7 @@ public:
     vector grad_rho_E_M = energy.get_gradient(q);
 
     scalar E_M = rho_inv_M * rho_E_M;
-    scalar E_P = make_vectorized_array<Number>(0.0);
+    scalar E_P = dealii::make_vectorized_array<Number>(0.0);
     if(boundary_variable == EnergyBoundaryVariable::Energy)
     {
       E_P = calculate_exterior_value<dim, Number, 0>(E_M,
@@ -1319,15 +1321,15 @@ public:
 
   inline DEAL_II_ALWAYS_INLINE //
     std::tuple<vector /*dummy_M*/, tensor /*value_flux_momentum_M*/, vector /*value_flux_energy_M*/>
-    get_value_flux_boundary(FaceIntegratorScalar &         density,
-                            FaceIntegratorVector &         momentum,
-                            FaceIntegratorScalar &         energy,
-                            BoundaryType const &           boundary_type_density,
-                            BoundaryType const &           boundary_type_velocity,
-                            BoundaryType const &           boundary_type_energy,
-                            EnergyBoundaryVariable const & boundary_variable,
-                            types::boundary_id const &     boundary_id,
-                            unsigned int const             q) const
+    get_value_flux_boundary(FaceIntegratorScalar &             density,
+                            FaceIntegratorVector &             momentum,
+                            FaceIntegratorScalar &             energy,
+                            BoundaryType const &               boundary_type_density,
+                            BoundaryType const &               boundary_type_velocity,
+                            BoundaryType const &               boundary_type_energy,
+                            EnergyBoundaryVariable const &     boundary_variable,
+                            dealii::types::boundary_id const & boundary_id,
+                            unsigned int const                 q) const
   {
     vector normal = momentum.get_normal_vector(q);
 
@@ -1359,7 +1361,7 @@ public:
     scalar rho_E_M = energy.get_value(q);
     scalar E_M     = rho_inv_M * rho_E_M;
 
-    scalar E_P = make_vectorized_array<Number>(0.0);
+    scalar E_P = dealii::make_vectorized_array<Number>(0.0);
     if(boundary_variable == EnergyBoundaryVariable::Energy)
     {
       E_P = calculate_exterior_value<dim, Number, 0>(E_M,
@@ -1412,7 +1414,7 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const &               matrix_free,
+  cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -1446,7 +1448,7 @@ private:
   }
 
   void
-  face_loop(MatrixFree<dim, Number> const &               matrix_free,
+  face_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & face_range) const
@@ -1526,7 +1528,7 @@ private:
   }
 
   void
-  boundary_face_loop(MatrixFree<dim, Number> const &               matrix_free,
+  boundary_face_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
                      VectorType &                                  dst,
                      VectorType const &                            src,
                      std::pair<unsigned int, unsigned int> const & face_range) const
@@ -1548,7 +1550,7 @@ private:
 
       scalar tau_IP = get_penalty_parameter(density);
 
-      types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
+      dealii::types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
 
       BoundaryType boundary_type_density  = data.bc->density.get_boundary_type(boundary_id);
       BoundaryType boundary_type_velocity = data.bc->velocity.get_boundary_type(boundary_id);
@@ -1596,7 +1598,7 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   ViscousOperatorData<dim> data;
 
@@ -1620,7 +1622,7 @@ private:
   // thermal conductivity
   Number lambda;
 
-  AlignedVector<VectorizedArray<Number>> array_penalty_parameter;
+  dealii::AlignedVector<dealii::VectorizedArray<Number>> array_penalty_parameter;
 
   mutable Number eval_time;
 };
@@ -1642,7 +1644,7 @@ template<int dim, typename Number>
 class CombinedOperator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef ConvectiveOperator<dim, Number> ConvectiveOp;
   typedef ViscousOperator<dim, Number>    ViscousOp;
@@ -1653,20 +1655,20 @@ public:
   typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
   typedef FaceIntegrator<dim, dim, Number> FaceIntegratorVector;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
-  typedef Point<dim, VectorizedArray<Number>>     point;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+  typedef dealii::Point<dim, dealii::VectorizedArray<Number>>     point;
 
   CombinedOperator() : matrix_free(nullptr), convective_operator(nullptr), viscous_operator(nullptr)
   {
   }
 
   void
-  initialize(MatrixFree<dim, Number> const &   matrix_free_in,
-             CombinedOperatorData<dim> const & data_in,
-             ConvectiveOp const &              convective_operator_in,
-             ViscousOp const &                 viscous_operator_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             CombinedOperatorData<dim> const &       data_in,
+             ConvectiveOp const &                    convective_operator_in,
+             ViscousOp const &                       viscous_operator_in)
   {
     this->matrix_free = &matrix_free_in;
     this->data        = data_in;
@@ -1697,7 +1699,7 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const &               matrix_free,
+  cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -1737,7 +1739,7 @@ private:
   }
 
   void
-  face_loop(MatrixFree<dim, Number> const &               matrix_free,
+  face_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
             VectorType &                                  dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & face_range) const
@@ -1819,7 +1821,7 @@ private:
   }
 
   void
-  boundary_face_loop(MatrixFree<dim, Number> const &               matrix_free,
+  boundary_face_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
                      VectorType &                                  dst,
                      VectorType const &                            src,
                      std::pair<unsigned int, unsigned int> const & face_range) const
@@ -1841,7 +1843,7 @@ private:
 
       scalar tau_IP = viscous_operator->get_penalty_parameter(density);
 
-      types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
+      dealii::types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
 
       BoundaryType boundary_type_density  = data.bc->density.get_boundary_type(boundary_id);
       BoundaryType boundary_type_velocity = data.bc->velocity.get_boundary_type(boundary_id);
@@ -1902,7 +1904,7 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   CombinedOperatorData<dim> data;
 

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -42,13 +42,11 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Operator : public dealii::Subscriptor, public Interface::Operator<Number>
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
   Operator(std::shared_ptr<Grid<dim> const>               grid,
@@ -62,10 +60,10 @@ public:
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
 
   void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data);
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data);
 
-  types::global_dof_index
+  dealii::types::global_dof_index
   get_number_of_dofs() const;
 
   // initialization of DoF vectors
@@ -107,22 +105,22 @@ public:
   apply_inverse_mass(VectorType & dst, VectorType const & src) const;
 
   // getters
-  MatrixFree<dim, Number> const &
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const;
 
-  Mapping<dim> const &
+  dealii::Mapping<dim> const &
   get_mapping() const;
 
-  FESystem<dim> const &
+  dealii::FESystem<dim> const &
   get_fe() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler_scalar() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler_vector() const;
 
   unsigned int
@@ -209,18 +207,18 @@ private:
    * Basic finite element ingredients.
    */
 
-  std::shared_ptr<FESystem<dim>> fe;        // all (dim+2) components: (rho, rho u, rho E)
-  std::shared_ptr<FESystem<dim>> fe_vector; // e.g. velocity
-  FE_DGQ<dim>                    fe_scalar; // scalar quantity, e.g, pressure
+  std::shared_ptr<dealii::FESystem<dim>> fe;        // all (dim+2) components: (rho, rho u, rho E)
+  std::shared_ptr<dealii::FESystem<dim>> fe_vector; // e.g. velocity
+  dealii::FE_DGQ<dim>                    fe_scalar; // scalar quantity, e.g, pressure
 
-  // Quadrature points
+  // dealii::Quadrature points
   unsigned int n_q_points_conv;
   unsigned int n_q_points_visc;
 
-  // DoFHandler
-  DoFHandler<dim> dof_handler;        // all (dim+2) components: (rho, rho u, rho E)
-  DoFHandler<dim> dof_handler_vector; // e.g. velocity
-  DoFHandler<dim> dof_handler_scalar; // scalar quantity, e.g, pressure
+  // dealii::DoFHandler
+  dealii::DoFHandler<dim> dof_handler;        // all (dim+2) components: (rho, rho u, rho E)
+  dealii::DoFHandler<dim> dof_handler_vector; // e.g. velocity
+  dealii::DoFHandler<dim> dof_handler_scalar; // scalar quantity, e.g, pressure
 
   std::string const dof_index_all    = "all_fields";
   std::string const dof_index_vector = "vector";
@@ -237,13 +235,13 @@ private:
   /*
    * Constraints.
    */
-  AffineConstraints<Number> constraint;
+  dealii::AffineConstraints<Number> constraint;
 
   /*
    * Matrix-free operator evaluation.
    */
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   /*
    * Basic operators.
@@ -275,7 +273,7 @@ private:
   /*
    * Output to screen.
    */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // wall time for operator evaluation
   mutable double wall_time_operator_evaluation;

--- a/include/exadg/compressible_navier_stokes/throughput.h
+++ b/include/exadg/compressible_navier_stokes/throughput.h
@@ -91,7 +91,7 @@ run(ThroughputParameters const & throughput,
 
   driver->setup();
 
-  std::tuple<unsigned int, types::global_dof_index, double> wall_time =
+  std::tuple<unsigned int, dealii::types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,
                            throughput.n_repetitions_inner,
                            throughput.n_repetitions_outer);
@@ -107,7 +107,7 @@ main(int argc, char ** argv)
   LIKWID_MARKER_INIT;
 #endif
 
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+  dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   MPI_Comm mpi_comm(MPI_COMM_WORLD);
 
@@ -165,7 +165,8 @@ main(int argc, char ** argv)
       ExaDG::run<3, double>(
         throughput, input_file, degree, refine_space, n_cells_1d, mpi_comm, general.is_test);
     else
-      AssertThrow(false, ExcMessage("Only dim = 2|3 and precision=float|double implemented."));
+      AssertThrow(false,
+                  dealii::ExcMessage("Only dim = 2|3 and precision=float|double implemented."));
   }
 
   if(not(general.is_test))

--- a/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<typename Number>
 TimeIntExplRK<Number>::TimeIntExplRK(
   std::shared_ptr<Operator>                       operator_in,
@@ -190,7 +188,8 @@ TimeIntExplRK<Number>::calculate_time_step_size()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified type of time step calculation is not implemented."));
+    AssertThrow(false,
+                dealii::ExcMessage("Specified type of time step calculation is not implemented."));
   }
 }
 
@@ -198,7 +197,7 @@ template<typename Number>
 double
 TimeIntExplRK<Number>::recalculate_time_step_size() const
 {
-  AssertThrow(false, ExcMessage("Currently no adaptive time stepping implemented."));
+  AssertThrow(false, dealii::ExcMessage("Currently no adaptive time stepping implemented."));
 
   return 1.0;
 }
@@ -213,7 +212,8 @@ TimeIntExplRK<Number>::detect_instabilities() const
     if(l2_norm > 1.e-12)
     {
       AssertThrow(l2_norm_new < 10. * l2_norm,
-                  ExcMessage("Instabilities detected. Norm of solution vector seems to explode."));
+                  dealii::ExcMessage(
+                    "Instabilities detected. Norm of solution vector seems to explode."));
     }
 
     l2_norm = l2_norm_new;
@@ -224,7 +224,7 @@ template<typename Number>
 void
 TimeIntExplRK<Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   detect_instabilities();
@@ -238,7 +238,7 @@ template<typename Number>
 void
 TimeIntExplRK<Number>::do_timestep_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   rk_time_integrator->solve_timestep(this->solution_np,

--- a/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.h
+++ b/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.h
@@ -35,8 +35,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 // forward declarations
 class Parameters;
 
@@ -53,7 +51,7 @@ template<typename Number>
 class TimeIntExplRK : public TimeIntExplRKBase<Number>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef Interface::Operator<Number> Operator;
 

--- a/include/exadg/compressible_navier_stokes/user_interface/analytical_solution.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/analytical_solution.h
@@ -28,12 +28,10 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim>
 struct AnalyticalSolution
 {
-  std::shared_ptr<Function<dim>> solution;
+  std::shared_ptr<dealii::Function<dim>> solution;
 };
 
 } // namespace CompNS

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -41,15 +41,12 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
-
 template<int dim, typename Number>
 class ApplicationBase
 {
 public:
   virtual void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     // clang-format off
     prm.enter_subsection("Output");
@@ -62,7 +59,7 @@ public:
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
     : mpi_comm(comm),
-      pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
       parameter_file(parameter_file)
   {
   }
@@ -144,7 +141,7 @@ public:
 protected:
   MPI_Comm const & mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   Parameters param;
 

--- a/include/exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/boundary_descriptor.h
@@ -22,7 +22,7 @@
 #ifndef INCLUDE_EXADG_COMPRESSIBLE_NAVIER_STOKES_USER_INTERFACE_BOUNDARY_DESCRIPTOR_H_
 #define INCLUDE_EXADG_COMPRESSIBLE_NAVIER_STOKES_USER_INTERFACE_BOUNDARY_DESCRIPTOR_H_
 
-using namespace dealii;
+
 
 // deal.II
 #include <deal.II/base/function.h>
@@ -36,9 +36,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
-
 enum class BoundaryType
 {
   Undefined,
@@ -49,28 +46,29 @@ enum class BoundaryType
 template<int dim>
 struct BoundaryDescriptorStd
 {
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> dirichlet_bc;
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> neumann_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> neumann_bc;
 
   // return the boundary type
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryType
-    get_boundary_type(types::boundary_id const & boundary_id) const
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
   {
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
       return BoundaryType::Dirichlet;
     else if(this->neumann_bc.find(boundary_id) != this->neumann_bc.end())
       return BoundaryType::Neumann;
 
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
 
     return BoundaryType::Undefined;
   }
 
   inline DEAL_II_ALWAYS_INLINE //
     void
-    verify_boundary_conditions(types::boundary_id const             boundary_id,
-                               std::set<types::boundary_id> const & periodic_boundary_ids) const
+    verify_boundary_conditions(
+      dealii::types::boundary_id const             boundary_id,
+      std::set<dealii::types::boundary_id> const & periodic_boundary_ids) const
   {
     unsigned int counter = 0;
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
@@ -82,24 +80,25 @@ struct BoundaryDescriptorStd
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())
       counter++;
 
-    AssertThrow(counter == 1, ExcMessage("Boundary face with non-unique boundary type found."));
+    AssertThrow(counter == 1,
+                dealii::ExcMessage("Boundary face with non-unique boundary type found."));
   }
 };
 
 template<int dim>
 struct BoundaryDescriptorEnergy : public BoundaryDescriptorStd<dim>
 {
-  std::map<types::boundary_id, EnergyBoundaryVariable> boundary_variable;
+  std::map<dealii::types::boundary_id, EnergyBoundaryVariable> boundary_variable;
 
   // return the boundary variable
   inline DEAL_II_ALWAYS_INLINE //
     EnergyBoundaryVariable
-    get_boundary_variable(types::boundary_id const & boundary_id) const
+    get_boundary_variable(dealii::types::boundary_id const & boundary_id) const
   {
     EnergyBoundaryVariable boundary_variable = this->boundary_variable.find(boundary_id)->second;
 
     AssertThrow(boundary_variable != EnergyBoundaryVariable::Undefined,
-                ExcMessage("Energy boundary variable is undefined!"));
+                dealii::ExcMessage("Energy boundary variable is undefined!"));
 
     return boundary_variable;
   }

--- a/include/exadg/compressible_navier_stokes/user_interface/enum_types.cpp
+++ b/include/exadg/compressible_navier_stokes/user_interface/enum_types.cpp
@@ -29,9 +29,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
-
 std::string
 enum_to_string(EquationType const enum_type)
 {
@@ -49,7 +46,7 @@ enum_to_string(EquationType const enum_type)
       string_type = "NavierStokes";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -91,7 +88,7 @@ enum_to_string(TemporalDiscretization const enum_type)
       string_type = "SSPRK";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -122,7 +119,7 @@ enum_to_string(TimeStepCalculation const enum_type)
       string_type = "CFLAndDiffusion";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -147,7 +144,7 @@ enum_to_string(QuadratureRule const enum_type)
       string_type = "2k over-integration";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/compressible_navier_stokes/user_interface/enum_types.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/enum_types.h
@@ -28,9 +28,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                                 MATHEMATICAL MODEL                                 */

--- a/include/exadg/compressible_navier_stokes/user_interface/field_functions.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/field_functions.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 template<int dim>
 struct FieldFunctions
 {
@@ -35,11 +33,11 @@ struct FieldFunctions
    * The function initial_solution_velocity is used to initialize the velocity field at the
    * beginning of the simulation.
    */
-  std::shared_ptr<Function<dim>> initial_solution;
+  std::shared_ptr<dealii::Function<dim>> initial_solution;
 
-  std::shared_ptr<Function<dim>> right_hand_side_density;
-  std::shared_ptr<Function<dim>> right_hand_side_velocity;
-  std::shared_ptr<Function<dim>> right_hand_side_energy;
+  std::shared_ptr<dealii::Function<dim>> right_hand_side_density;
+  std::shared_ptr<dealii::Function<dim>> right_hand_side_velocity;
+  std::shared_ptr<dealii::Function<dim>> right_hand_side_energy;
 };
 
 } // namespace CompNS

--- a/include/exadg/compressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/compressible_navier_stokes/user_interface/parameters.cpp
@@ -29,9 +29,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
-
 // standard constructor that initializes parameters with default values
 Parameters::Parameters()
   : // MATHEMATICAL MODEL
@@ -87,52 +84,53 @@ void
 Parameters::check() const
 {
   // MATHEMATICAL MODEL
-  AssertThrow(equation_type != EquationType::Undefined, ExcMessage("parameter must be defined"));
+  AssertThrow(equation_type != EquationType::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
 
 
   // PHYSICAL QUANTITIES
-  AssertThrow(end_time > start_time, ExcMessage("parameter must be defined"));
+  AssertThrow(end_time > start_time, dealii::ExcMessage("parameter must be defined"));
 
 
   // TEMPORAL DISCRETIZATION
   AssertThrow(temporal_discretization != TemporalDiscretization::Undefined,
-              ExcMessage("parameter must be defined"));
+              dealii::ExcMessage("parameter must be defined"));
 
   AssertThrow(calculation_of_time_step_size != TimeStepCalculation::Undefined,
-              ExcMessage("parameter must be defined"));
+              dealii::ExcMessage("parameter must be defined"));
 
   if(calculation_of_time_step_size == TimeStepCalculation::UserSpecified)
-    AssertThrow(time_step_size > 0.0, ExcMessage("parameter must be defined"));
+    AssertThrow(time_step_size > 0.0, dealii::ExcMessage("parameter must be defined"));
 
   if(temporal_discretization == TemporalDiscretization::ExplRK)
   {
     AssertThrow(order_time_integrator >= 1 && order_time_integrator <= 4,
-                ExcMessage("Specified order of time integrator ExplRK not implemented!"));
+                dealii::ExcMessage("Specified order of time integrator ExplRK not implemented!"));
   }
 
   if(temporal_discretization == TemporalDiscretization::SSPRK)
   {
-    AssertThrow(stages >= 1, ExcMessage("Specify number of RK stages!"));
+    AssertThrow(stages >= 1, dealii::ExcMessage("Specify number of RK stages!"));
   }
 
   if(calculation_of_time_step_size == TimeStepCalculation::CFLAndDiffusion)
   {
-    AssertThrow(max_velocity >= 0.0, ExcMessage("Invalid parameter max_velocity."));
-    AssertThrow(cfl_number > 0.0, ExcMessage("parameter must be defined"));
-    AssertThrow(diffusion_number > 0.0, ExcMessage("parameter must be defined"));
+    AssertThrow(max_velocity >= 0.0, dealii::ExcMessage("Invalid parameter max_velocity."));
+    AssertThrow(cfl_number > 0.0, dealii::ExcMessage("parameter must be defined"));
+    AssertThrow(diffusion_number > 0.0, dealii::ExcMessage("parameter must be defined"));
   }
 
 
   // SPATIAL DISCRETIZATION
   grid.check();
 
-  AssertThrow(degree > 0, ExcMessage("Polynomial degree must be larger than zero."));
+  AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
 
   if(use_combined_operator)
   {
     AssertThrow(
       n_q_points_convective == n_q_points_viscous,
-      ExcMessage(
+      dealii::ExcMessage(
         "For the combined operator, both convective and viscous terms have to be integrated with the same number of quadrature points."));
   }
 
@@ -141,7 +139,7 @@ Parameters::check() const
 
 
 void
-Parameters::print(ConditionalOStream const & pcout, std::string const & name) const
+Parameters::print(dealii::ConditionalOStream const & pcout, std::string const & name) const
 {
   pcout << std::endl << name << std::endl;
 
@@ -166,7 +164,7 @@ Parameters::print(ConditionalOStream const & pcout, std::string const & name) co
 }
 
 void
-Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout) const
+Parameters::print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Mathematical model:" << std::endl;
 
@@ -175,7 +173,7 @@ Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout
 }
 
 void
-Parameters::print_parameters_physical_quantities(ConditionalOStream const & pcout) const
+Parameters::print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Physical quantities:" << std::endl;
 
@@ -190,7 +188,7 @@ Parameters::print_parameters_physical_quantities(ConditionalOStream const & pcou
 }
 
 void
-Parameters::print_parameters_temporal_discretization(ConditionalOStream const & pcout) const
+Parameters::print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Temporal discretization:" << std::endl;
 
@@ -229,7 +227,7 @@ Parameters::print_parameters_temporal_discretization(ConditionalOStream const & 
 }
 
 void
-Parameters::print_parameters_spatial_discretization(ConditionalOStream const & pcout) const
+Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Spatial Discretization:" << std::endl;
 
@@ -244,7 +242,7 @@ Parameters::print_parameters_spatial_discretization(ConditionalOStream const & p
 }
 
 void
-Parameters::print_parameters_solver(ConditionalOStream const & /*pcout*/) const
+Parameters::print_parameters_solver(dealii::ConditionalOStream const & /*pcout*/) const
 {
   /*
   pcout << std::endl
@@ -253,7 +251,7 @@ Parameters::print_parameters_solver(ConditionalOStream const & /*pcout*/) const
 }
 
 void
-Parameters::print_parameters_numerical_parameters(ConditionalOStream const & pcout) const
+Parameters::print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Numerical parameters:" << std::endl;
 

--- a/include/exadg/compressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/parameters.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace CompNS
 {
-using namespace dealii;
-
 class Parameters
 {
 public:
@@ -44,26 +42,26 @@ public:
   check() const;
 
   void
-  print(ConditionalOStream const & pcout, std::string const & name) const;
+  print(dealii::ConditionalOStream const & pcout, std::string const & name) const;
 
 private:
   void
-  print_parameters_mathematical_model(ConditionalOStream const & pcout) const;
+  print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_physical_quantities(ConditionalOStream const & pcout) const;
+  print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_temporal_discretization(ConditionalOStream const & pcout) const;
+  print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_spatial_discretization(ConditionalOStream const & pcout) const;
+  print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_solver(ConditionalOStream const & pcout) const;
+  print_parameters_solver(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_numerical_parameters(ConditionalOStream const & pcout) const;
+  print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const;
 
 public:
   /**************************************************************************************/

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -52,8 +52,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 enum class OperatorType
 {
   MassOperator,
@@ -74,7 +72,7 @@ enum_to_string(OperatorType const enum_type)
     case OperatorType::ConvectiveOperator:              string_type = "ConvectiveOperator";              break;
     case OperatorType::DiffusiveOperator:               string_type = "DiffusiveOperator";               break;
     case OperatorType::MassConvectionDiffusionOperator: string_type = "MassConvectionDiffusionOperator"; break;
-    default: AssertThrow(false, ExcMessage("Not implemented.")); break;
+    default: AssertThrow(false, dealii::ExcMessage("Not implemented.")); break;
       // clang-format on
   }
 
@@ -89,7 +87,7 @@ string_to_enum(OperatorType & enum_type, std::string const string_type)
   else if(string_type == "ConvectiveOperator")              enum_type = OperatorType::ConvectiveOperator;
   else if(string_type == "DiffusiveOperator")               enum_type = OperatorType::DiffusiveOperator;
   else if(string_type == "MassConvectionDiffusionOperator") enum_type = OperatorType::MassConvectionDiffusionOperator;
-  else AssertThrow(false, ExcMessage("Unknown operator type. Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Unknown operator type. Not implemented."));
   // clang-format on
 }
 
@@ -100,7 +98,7 @@ get_dofs_per_element(std::string const & input_file,
 {
   (void)input_file;
 
-  unsigned int const dofs_per_element = Utilities::pow(degree + 1, dim);
+  unsigned int const dofs_per_element = dealii::Utilities::pow(degree + 1, dim);
 
   return dofs_per_element;
 }
@@ -126,7 +124,7 @@ public:
   /*
    * Throughput study
    */
-  std::tuple<unsigned int, types::global_dof_index, double>
+  std::tuple<unsigned int, dealii::types::global_dof_index, double>
   apply_operator(std::string const & operator_type,
                  unsigned int const  n_repetitions_inner,
                  unsigned int const  n_repetitions_outer) const;
@@ -139,7 +137,7 @@ private:
   MPI_Comm const mpi_comm;
 
   // output to std::cout
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -153,8 +151,8 @@ private:
   // moving mapping (ALE)
   std::shared_ptr<GridMotionBase<dim, Number>> grid_motion;
 
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   std::shared_ptr<Operator<dim, Number>> pde_operator;
 

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor.cpp
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor.cpp
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data_in,
                                           MPI_Comm const &               mpi_comm_in)
@@ -41,7 +39,7 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data
 template<int dim, typename Number>
 void
 PostProcessor<dim, Number>::setup(Operator<dim, Number> const & pde_operator,
-                                  Mapping<dim> const &          mapping)
+                                  dealii::Mapping<dim> const &  mapping)
 {
   error_calculator.setup(pde_operator.get_dof_handler(), mapping, pp_data.error_data);
 

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor.h
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor.h
@@ -36,8 +36,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
 struct PostProcessorData
 {
@@ -61,7 +59,7 @@ public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
   void
-  setup(Operator<dim, Number> const & pde_operator, Mapping<dim> const & mapping) override;
+  setup(Operator<dim, Number> const & pde_operator, dealii::Mapping<dim> const & mapping) override;
 
   void
   do_postprocessing(VectorType const & solution,

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor_base.h
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor_base.h
@@ -35,8 +35,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Operator;
 
@@ -44,7 +42,7 @@ template<typename Number>
 class PostProcessorInterface
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   virtual ~PostProcessorInterface()
   {
@@ -68,7 +66,7 @@ public:
   }
 
   virtual void
-  setup(Operator<dim, Number> const & pde_operator, Mapping<dim> const & mapping) = 0;
+  setup(Operator<dim, Number> const & pde_operator, dealii::Mapping<dim> const & mapping) = 0;
 };
 
 } // namespace ConvDiff

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -31,8 +31,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & mpi_comm)
   : Base(mpi_comm),
@@ -44,15 +42,16 @@ MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & m
 
 template<int dim, typename Number>
 void
-MultigridPreconditioner<dim, Number>::initialize(MultigridData const &               mg_data,
-                                                 Triangulation<dim> const *          tria,
-                                                 FiniteElement<dim> const &          fe,
-                                                 std::shared_ptr<Mapping<dim> const> mapping,
-                                                 PDEOperator const &                 pde_operator,
-                                                 MultigridOperatorType const & mg_operator_type,
-                                                 bool const                    mesh_is_moving,
-                                                 Map const *                   dirichlet_bc,
-                                                 PeriodicFacePairs const *     periodic_face_pairs)
+MultigridPreconditioner<dim, Number>::initialize(
+  MultigridData const &                       mg_data,
+  dealii::Triangulation<dim> const *          tria,
+  dealii::FiniteElement<dim> const &          fe,
+  std::shared_ptr<dealii::Mapping<dim> const> mapping,
+  PDEOperator const &                         pde_operator,
+  MultigridOperatorType const &               mg_operator_type,
+  bool const                                  mesh_is_moving,
+  Map const *                                 dirichlet_bc,
+  PeriodicFacePairs const *                   periodic_face_pairs)
 {
   this->pde_operator     = &pde_operator;
   this->mg_operator_type = mg_operator_type;
@@ -67,7 +66,7 @@ MultigridPreconditioner<dim, Number>::initialize(MultigridData const &          
   // operators should be "active" for the multigrid preconditioner, independently of
   // the actual equation type that is solved.
   AssertThrow(this->mg_operator_type != MultigridOperatorType::Undefined,
-              ExcMessage("Invalid parameter mg_operator_type."));
+              dealii::ExcMessage("Invalid parameter mg_operator_type."));
 
   if(this->mg_operator_type == MultigridOperatorType::ReactionDiffusion)
   {
@@ -88,7 +87,7 @@ MultigridPreconditioner<dim, Number>::initialize(MultigridData const &          
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   Base::initialize(
@@ -135,14 +134,14 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops && this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> const *>(
+    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
       &this->dof_handlers[level]->get_triangulation());
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, h_level);
   }
 
   matrix_free_data.insert_dof_handler(&(*this->dof_handlers[level]), "std_dof_handler");
   matrix_free_data.insert_constraint(&(*this->constraints[level]), "std_dof_handler");
-  matrix_free_data.insert_quadrature(QGauss<1>(this->level_info[level].degree() + 1),
+  matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
                                      "std_quadrature");
 
   if(data.convective_problem)
@@ -158,7 +157,7 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -199,11 +198,11 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
 template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize_dof_handler_and_constraints(
-  bool const                 operator_is_singular,
-  PeriodicFacePairs const *  periodic_face_pairs,
-  FiniteElement<dim> const & fe,
-  Triangulation<dim> const * tria,
-  Map const *                dirichlet_bc)
+  bool const                         operator_is_singular,
+  PeriodicFacePairs const *          periodic_face_pairs,
+  dealii::FiniteElement<dim> const & fe,
+  dealii::Triangulation<dim> const * tria,
+  Map const *                        dirichlet_bc)
 {
   Base::initialize_dof_handler_and_constraints(
     operator_is_singular, periodic_face_pairs, fe, tria, dirichlet_bc);
@@ -211,8 +210,8 @@ MultigridPreconditioner<dim, Number>::initialize_dof_handler_and_constraints(
   if(data.convective_problem &&
      data.convective_kernel_data.velocity_type == TypeVelocityField::DoFVector)
   {
-    FESystem<dim> fe_velocity(FE_DGQ<dim>(fe.degree), dim);
-    Map           dirichlet_bc_velocity;
+    dealii::FESystem<dim> fe_velocity(dealii::FE_DGQ<dim>(fe.degree), dim);
+    Map                   dirichlet_bc_velocity;
     this->do_initialize_dof_handler_and_constraints(false,
                                                     *periodic_face_pairs,
                                                     fe_velocity,

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 /*
  *  Multigrid preconditioner for scalar convection-diffusion equation.
  */
@@ -65,15 +63,15 @@ public:
    *  This function initializes the multigrid preconditioner.
    */
   void
-  initialize(MultigridData const &               mg_data,
-             Triangulation<dim> const *          tria,
-             FiniteElement<dim> const &          fe,
-             std::shared_ptr<Mapping<dim> const> mapping,
-             PDEOperator const &                 pde_operator,
-             MultigridOperatorType const &       mg_operator_type,
-             bool const                          mesh_is_moving,
-             Map const *                         dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *           periodic_face_pairs = nullptr);
+  initialize(MultigridData const &                       mg_data,
+             dealii::Triangulation<dim> const *          tria,
+             dealii::FiniteElement<dim> const &          fe,
+             std::shared_ptr<dealii::Mapping<dim> const> mapping,
+             PDEOperator const &                         pde_operator,
+             MultigridOperatorType const &               mg_operator_type,
+             bool const                                  mesh_is_moving,
+             Map const *                                 dirichlet_bc        = nullptr,
+             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
 
   /*
    *  This function updates the multigrid preconditioner.
@@ -91,11 +89,11 @@ private:
   initialize_operator(unsigned int const level) override;
 
   void
-  initialize_dof_handler_and_constraints(bool const                 operator_is_singular,
-                                         PeriodicFacePairs const *  periodic_face_pairs,
-                                         FiniteElement<dim> const & fe,
-                                         Triangulation<dim> const * tria,
-                                         Map const *                dirichlet_bc) override;
+  initialize_dof_handler_and_constraints(bool const                         operator_is_singular,
+                                         PeriodicFacePairs const *          periodic_face_pairs,
+                                         dealii::FiniteElement<dim> const & fe,
+                                         dealii::Triangulation<dim> const * tria,
+                                         Map const *                        dirichlet_bc) override;
 
   void
   initialize_transfer_operators() override;
@@ -152,9 +150,10 @@ private:
 
   std::shared_ptr<MGTransfer<VectorTypeMG>> transfers_velocity;
 
-  MGLevelObject<std::shared_ptr<DoFHandler<dim> const>>              dof_handlers_velocity;
-  MGLevelObject<std::shared_ptr<MGConstrainedDoFs>>                  constrained_dofs_velocity;
-  MGLevelObject<std::shared_ptr<AffineConstraints<MultigridNumber>>> constraints_velocity;
+  dealii::MGLevelObject<std::shared_ptr<dealii::DoFHandler<dim> const>> dof_handlers_velocity;
+  dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>>     constrained_dofs_velocity;
+  dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>>
+    constraints_velocity;
 
   CombinedOperatorData<dim> data;
 

--- a/include/exadg/convection_diffusion/solver.h
+++ b/include/exadg/convection_diffusion/solver.h
@@ -80,7 +80,7 @@ run(std::string const & input_file,
     MPI_Comm const &    mpi_comm,
     bool const          is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<ConvDiff::ApplicationBase<dim, Number>> application =

--- a/include/exadg/convection_diffusion/spatial_discretization/interface.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/interface.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 namespace ConvDiff
 {
 namespace Interface
@@ -40,7 +38,7 @@ template<typename Number>
 class Operator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   Operator()
   {
@@ -130,7 +128,7 @@ template<typename Number>
 class OperatorExplRK
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   OperatorExplRK(std::shared_ptr<ConvDiff::Interface::Operator<Number>> operator_in,
                  bool const                                             numerical_velocity_field_in)
@@ -188,7 +186,7 @@ template<typename Number>
 class OperatorOIF
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   OperatorOIF(std::shared_ptr<ConvDiff::Interface::Operator<Number>> operator_in,
               bool const                                             numerical_velocity_field_in)

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -44,13 +44,11 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Operator : public dealii::Subscriptor, public Interface::Operator<Number>
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
   /*
@@ -74,9 +72,9 @@ public:
    * of equations.
    */
   void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free_in,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data_in,
-        std::string const &                          dof_index_velocity_external_in = "");
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_in,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data_in,
+        std::string const &                              dof_index_velocity_external_in = "");
 
   /*
    * This function initializes operators, preconditioners, and solvers related to the solution of
@@ -277,16 +275,16 @@ public:
    * Setters and getters.
    */
 
-  MatrixFree<dim, Number> const &
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler_velocity() const;
 
-  types::global_dof_index
+  dealii::types::global_dof_index
   get_number_of_dofs() const;
 
   std::string
@@ -312,7 +310,7 @@ private:
   calculate_minimum_element_length() const;
 
   /*
-   * Initializes DoFHandlers.
+   * Initializes dealii::DoFHandlers.
    */
   void
   distribute_dofs();
@@ -376,19 +374,19 @@ private:
   /*
    * Basic finite element ingredients.
    */
-  FE_DGQ<dim>     fe;
-  DoFHandler<dim> dof_handler;
+  dealii::FE_DGQ<dim>     fe;
+  dealii::DoFHandler<dim> dof_handler;
 
   /*
    * Numerical velocity field.
    */
-  std::shared_ptr<FESystem<dim>>   fe_velocity;
-  std::shared_ptr<DoFHandler<dim>> dof_handler_velocity;
+  std::shared_ptr<dealii::FESystem<dim>>   fe_velocity;
+  std::shared_ptr<dealii::DoFHandler<dim>> dof_handler_velocity;
 
   /*
    * Constraints.
    */
-  AffineConstraints<Number> affine_constraints;
+  dealii::AffineConstraints<Number> affine_constraints;
 
   std::string const dof_index_std      = "conv_diff";
   std::string const dof_index_velocity = "conv_diff_velocity";
@@ -401,8 +399,8 @@ private:
   /*
    * Matrix-free operator evaluation.
    */
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
 
   /*
    * Basic operators.
@@ -435,7 +433,7 @@ private:
   /*
    * Output to screen.
    */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 };
 
 } // namespace ConvDiff

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 CombinedOperator<dim, Number>::CombinedOperator() : scaling_factor_mass(1.0)
 {
@@ -35,9 +33,10 @@ CombinedOperator<dim, Number>::CombinedOperator() : scaling_factor_mass(1.0)
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &   matrix_free,
-                                          AffineConstraints<Number> const & affine_constraints,
-                                          CombinedOperatorData<dim> const & data)
+CombinedOperator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const &   matrix_free,
+  dealii::AffineConstraints<Number> const & affine_constraints,
+  CombinedOperatorData<dim> const &         data)
 {
   operator_data = data;
 
@@ -77,8 +76,8 @@ CombinedOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &   matr
 template<int dim, typename Number>
 void
 CombinedOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                           matrix_free,
-  AffineConstraints<Number> const &                         affine_constraints,
+  dealii::MatrixFree<dim, Number> const &                   matrix_free,
+  dealii::AffineConstraints<Number> const &                 affine_constraints,
   CombinedOperatorData<dim> const &                         data,
   std::shared_ptr<Operators::ConvectiveKernel<dim, Number>> convective_kernel_in,
   std::shared_ptr<Operators::DiffusiveKernel<dim, Number>>  diffusive_kernel_in)
@@ -123,7 +122,7 @@ CombinedOperator<dim, Number>::update_after_grid_motion()
 }
 
 template<int dim, typename Number>
-LinearAlgebra::distributed::Vector<Number> const &
+dealii::LinearAlgebra::distributed::Vector<Number> const &
 CombinedOperator<dim, Number>::get_velocity() const
 {
   return convective_kernel->get_velocity();
@@ -195,9 +194,10 @@ CombinedOperator<dim, Number>::reinit_boundary_face(unsigned int const face) con
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_face_cell_based(unsigned int const       cell,
-                                                      unsigned int const       face,
-                                                      types::boundary_id const boundary_id) const
+CombinedOperator<dim, Number>::reinit_face_cell_based(
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -214,9 +214,9 @@ CombinedOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) con
   for(unsigned int q = 0; q < integrator.n_q_points; ++q)
   {
     vector gradient_flux;
-    scalar value_flux = make_vectorized_array<Number>(0.0);
+    scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
-    scalar value = make_vectorized_array<Number>(0.0);
+    scalar value = dealii::make_vectorized_array<Number>(0.0);
     if(this->integrator_flags.cell_evaluate.value)
       value = integrator.get_value(q);
 
@@ -245,7 +245,7 @@ CombinedOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) con
       }
       else
       {
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
       }
     }
 
@@ -273,8 +273,8 @@ CombinedOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
 
     vector normal_m = integrator_m.get_normal_vector(q);
 
-    scalar value_flux_m = make_vectorized_array<Number>(0.0);
-    scalar value_flux_p = make_vectorized_array<Number>(0.0);
+    scalar value_flux_m = dealii::make_vectorized_array<Number>(0.0);
+    scalar value_flux_p = dealii::make_vectorized_array<Number>(0.0);
 
     if(operator_data.convective_problem)
     {
@@ -321,12 +321,12 @@ CombinedOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrator_
   for(unsigned int q = 0; q < integrator_m.n_q_points; ++q)
   {
     // set value_p to zero
-    scalar value_p = make_vectorized_array<Number>(0.0);
+    scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
     vector normal_m = integrator_m.get_normal_vector(q);
 
-    scalar value_flux = make_vectorized_array<Number>(0.0);
+    scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
     if(operator_data.convective_problem)
     {
@@ -338,7 +338,7 @@ CombinedOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrator_
     {
       // set exterior value to zero
       scalar normal_gradient_m = integrator_m.get_normal_derivative(q);
-      scalar normal_gradient_p = make_vectorized_array<Number>(0.0);
+      scalar normal_gradient_p = dealii::make_vectorized_array<Number>(0.0);
 
       value_flux += -diffusive_kernel->calculate_value_flux(normal_gradient_m,
                                                             normal_gradient_p,
@@ -368,12 +368,12 @@ CombinedOperator<dim, Number>::do_face_int_integral_cell_based(IntegratorFace & 
   for(unsigned int q = 0; q < integrator_m.n_q_points; ++q)
   {
     // set value_p to zero
-    scalar value_p = make_vectorized_array<Number>(0.0);
+    scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
     vector normal_m = integrator_m.get_normal_vector(q);
 
-    scalar value_flux = make_vectorized_array<Number>(0.0);
+    scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
     if(operator_data.convective_problem)
     {
@@ -393,7 +393,7 @@ CombinedOperator<dim, Number>::do_face_int_integral_cell_based(IntegratorFace & 
     {
       // set exterior value to zero
       scalar normal_gradient_m = integrator_m.get_normal_derivative(q);
-      scalar normal_gradient_p = make_vectorized_array<Number>(0.0);
+      scalar normal_gradient_p = dealii::make_vectorized_array<Number>(0.0);
 
       value_flux += -diffusive_kernel->calculate_value_flux(normal_gradient_m,
                                                             normal_gradient_p,
@@ -421,13 +421,13 @@ CombinedOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_
   for(unsigned int q = 0; q < integrator_p.n_q_points; ++q)
   {
     // set value_m to zero
-    scalar value_m = make_vectorized_array<Number>(0.0);
+    scalar value_m = dealii::make_vectorized_array<Number>(0.0);
     scalar value_p = integrator_p.get_value(q);
 
     // n⁺ = -n⁻
     vector normal_p = -integrator_p.get_normal_vector(q);
 
-    scalar value_flux = make_vectorized_array<Number>(0.0);
+    scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
     if(operator_data.convective_problem)
     {
@@ -438,7 +438,7 @@ CombinedOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_
     if(operator_data.diffusive_problem)
     {
       // set gradient_m to zero
-      scalar normal_gradient_m = make_vectorized_array<Number>(0.0);
+      scalar normal_gradient_m = dealii::make_vectorized_array<Number>(0.0);
       // minus sign to get the correct normal vector n⁺ = -n⁻
       scalar normal_gradient_p = -integrator_p.get_normal_derivative(q);
 
@@ -461,9 +461,10 @@ CombinedOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::do_boundary_integral(IntegratorFace &           integrator_m,
-                                                    OperatorType const &       operator_type,
-                                                    types::boundary_id const & boundary_id) const
+CombinedOperator<dim, Number>::do_boundary_integral(
+  IntegratorFace &                   integrator_m,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -481,7 +482,7 @@ CombinedOperator<dim, Number>::do_boundary_integral(IntegratorFace &           i
 
     vector normal_m = integrator_m.get_normal_vector(q);
 
-    scalar value_flux = make_vectorized_array<Number>(0.0);
+    scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
     if(operator_data.convective_problem)
     {

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
 struct CombinedOperatorData : public OperatorBaseData
 {
@@ -67,20 +65,20 @@ private:
 
   typedef typename Base::VectorType VectorType;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
 public:
   CombinedOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const &   matrix_free,
-             AffineConstraints<Number> const & affine_constraints,
-             CombinedOperatorData<dim> const & data);
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
+             dealii::AffineConstraints<Number> const & affine_constraints,
+             CombinedOperatorData<dim> const &         data);
 
   void
-  initialize(MatrixFree<dim, Number> const &                           matrix_free,
-             AffineConstraints<Number> const &                         affine_constraints,
+  initialize(dealii::MatrixFree<dim, Number> const &                   matrix_free,
+             dealii::AffineConstraints<Number> const &                 affine_constraints,
              CombinedOperatorData<dim> const &                         data,
              std::shared_ptr<Operators::ConvectiveKernel<dim, Number>> convective_kernel,
              std::shared_ptr<Operators::DiffusiveKernel<dim, Number>>  diffusive_kernel);
@@ -91,7 +89,7 @@ public:
   void
   update_after_grid_motion();
 
-  LinearAlgebra::distributed::Vector<Number> const &
+  dealii::LinearAlgebra::distributed::Vector<Number> const &
   get_velocity() const;
 
   void
@@ -117,9 +115,9 @@ private:
   reinit_boundary_face(unsigned int const face) const;
 
   void
-  reinit_face_cell_based(unsigned int const       cell,
-                         unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+  reinit_face_cell_based(unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const;
 
   void
   do_cell_integral(IntegratorCell & integrator) const;
@@ -134,9 +132,9 @@ private:
   do_face_ext_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
 
   void
-  do_boundary_integral(IntegratorFace &           integrator_m,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(IntegratorFace &                   integrator_m,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   // TODO can be removed later once matrix-free evaluation allows accessing neighboring data for
   // cell-based face loops

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
@@ -26,13 +26,11 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                           matrix_free,
-  AffineConstraints<Number> const &                         affine_constraints,
+  dealii::MatrixFree<dim, Number> const &                   matrix_free,
+  dealii::AffineConstraints<Number> const &                 affine_constraints,
   ConvectiveOperatorData<dim> const &                       data,
   std::shared_ptr<Operators::ConvectiveKernel<dim, Number>> kernel)
 {
@@ -60,7 +58,7 @@ ConvectiveOperator<dim, Number>::set_velocity_ptr(VectorType const & velocity_in
 }
 
 template<int dim, typename Number>
-LinearAlgebra::distributed::Vector<Number> const &
+dealii::LinearAlgebra::distributed::Vector<Number> const &
 ConvectiveOperator<dim, Number>::get_velocity() const
 {
   return kernel->get_velocity();
@@ -95,9 +93,10 @@ ConvectiveOperator<dim, Number>::reinit_boundary_face(unsigned int const face) c
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_cell_based(unsigned int const       cell,
-                                                        unsigned int const       face,
-                                                        types::boundary_id const boundary_id) const
+ConvectiveOperator<dim, Number>::reinit_face_cell_based(
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -125,7 +124,7 @@ ConvectiveOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) c
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -160,7 +159,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrato
   for(unsigned int q = 0; q < integrator_m.n_q_points; ++q)
   {
     // set value_p to zero
-    scalar value_p = make_vectorized_array<Number>(0.0);
+    scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
     vector normal_m = integrator_m.get_normal_vector(q);
@@ -185,7 +184,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral_cell_based(
   for(unsigned int q = 0; q < integrator_m.n_q_points; ++q)
   {
     // set value_p to zero
-    scalar value_p = make_vectorized_array<Number>(0.0);
+    scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
     vector normal_m = integrator_m.get_normal_vector(q);
@@ -214,7 +213,7 @@ ConvectiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
   for(unsigned int q = 0; q < integrator_p.n_q_points; ++q)
   {
     // set value_m to zero
-    scalar value_m = make_vectorized_array<Number>(0.0);
+    scalar value_m = dealii::make_vectorized_array<Number>(0.0);
     scalar value_p = integrator_p.get_value(q);
 
     // n⁺ = -n⁻
@@ -229,9 +228,10 @@ ConvectiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::do_boundary_integral(IntegratorFace &           integrator_m,
-                                                      OperatorType const &       operator_type,
-                                                      types::boundary_id const & boundary_id) const
+ConvectiveOperator<dim, Number>::do_boundary_integral(
+  IntegratorFace &                   integrator_m,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.cpp
@@ -26,13 +26,11 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
 DiffusiveOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                          matrix_free,
-  AffineConstraints<Number> const &                        affine_constraints,
+  dealii::MatrixFree<dim, Number> const &                  matrix_free,
+  dealii::AffineConstraints<Number> const &                affine_constraints,
   DiffusiveOperatorData<dim> const &                       data,
   std::shared_ptr<Operators::DiffusiveKernel<dim, Number>> kernel)
 {
@@ -72,9 +70,10 @@ DiffusiveOperator<dim, Number>::reinit_boundary_face(unsigned int const face) co
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::reinit_face_cell_based(unsigned int const       cell,
-                                                       unsigned int const       face,
-                                                       types::boundary_id const boundary_id) const
+DiffusiveOperator<dim, Number>::reinit_face_cell_based(
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -128,13 +127,13 @@ DiffusiveOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrator
   {
     // set exterior value to zero
     scalar value_m = integrator_m.get_value(q);
-    scalar value_p = make_vectorized_array<Number>(0.0);
+    scalar value_p = dealii::make_vectorized_array<Number>(0.0);
 
     scalar gradient_flux = kernel->calculate_gradient_flux(value_m, value_p);
 
     // set exterior value to zero
     scalar normal_gradient_m = integrator_m.get_normal_derivative(q);
-    scalar normal_gradient_p = make_vectorized_array<Number>(0.0);
+    scalar normal_gradient_p = dealii::make_vectorized_array<Number>(0.0);
 
     scalar value_flux =
       kernel->calculate_value_flux(normal_gradient_m, normal_gradient_p, value_m, value_p);
@@ -154,13 +153,13 @@ DiffusiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator
   for(unsigned int q = 0; q < integrator_p.n_q_points; ++q)
   {
     // set value_m to zero
-    scalar value_m = make_vectorized_array<Number>(0.0);
+    scalar value_m = dealii::make_vectorized_array<Number>(0.0);
     scalar value_p = integrator_p.get_value(q);
 
     scalar gradient_flux = kernel->calculate_gradient_flux(value_p, value_m);
 
     // set gradient_m to zero
-    scalar normal_gradient_m = make_vectorized_array<Number>(0.0);
+    scalar normal_gradient_m = dealii::make_vectorized_array<Number>(0.0);
     // minus sign to get the correct normal vector n⁺ = -n⁻
     scalar normal_gradient_p = -integrator_p.get_normal_derivative(q);
 
@@ -174,9 +173,10 @@ DiffusiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::do_boundary_integral(IntegratorFace &           integrator_m,
-                                                     OperatorType const &       operator_type,
-                                                     types::boundary_id const & boundary_id) const
+DiffusiveOperator<dim, Number>::do_boundary_integral(
+  IntegratorFace &                   integrator_m,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 namespace Operators
 {
 struct DiffusiveKernelData
@@ -50,38 +48,38 @@ template<int dim, typename Number>
 class DiffusiveKernel
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   typedef CellIntegrator<dim, 1, Number> IntegratorCell;
   typedef FaceIntegrator<dim, 1, Number> IntegratorFace;
 
 public:
-  DiffusiveKernel() : degree(1), tau(make_vectorized_array<Number>(0.0))
+  DiffusiveKernel() : degree(1), tau(dealii::make_vectorized_array<Number>(0.0))
   {
   }
 
   void
-  reinit(MatrixFree<dim, Number> const & matrix_free,
-         DiffusiveKernelData const &     data_in,
-         unsigned int const              dof_index)
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free,
+         DiffusiveKernelData const &             data_in,
+         unsigned int const                      dof_index)
   {
     data = data_in;
 
-    FiniteElement<dim> const & fe = matrix_free.get_dof_handler(dof_index).get_fe();
-    degree                        = fe.degree;
+    dealii::FiniteElement<dim> const & fe = matrix_free.get_dof_handler(dof_index).get_fe();
+    degree                                = fe.degree;
 
     calculate_penalty_parameter(matrix_free, dof_index);
 
     AssertThrow(data.diffusivity > (0.0 - std::numeric_limits<double>::epsilon()),
-                ExcMessage("Diffusivity is not set!"));
+                dealii::ExcMessage("Diffusivity is not set!"));
   }
 
   void
-  calculate_penalty_parameter(MatrixFree<dim, Number> const & matrix_free,
-                              unsigned int const              dof_index)
+  calculate_penalty_parameter(dealii::MatrixFree<dim, Number> const & matrix_free,
+                              unsigned int const                      dof_index)
   {
     IP::calculate_penalty_parameter<dim, Number>(array_penalty_parameter, matrix_free, dof_index);
   }
@@ -106,12 +104,13 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells = update_gradients | update_JxW_values;
+    flags.cells = dealii::update_gradients | dealii::update_JxW_values;
     if(compute_interior_face_integrals)
-      flags.inner_faces = update_gradients | update_JxW_values | update_normal_vectors;
+      flags.inner_faces =
+        dealii::update_gradients | dealii::update_JxW_values | dealii::update_normal_vectors;
     if(compute_boundary_face_integrals)
-      flags.boundary_faces =
-        update_gradients | update_JxW_values | update_normal_vectors | update_quadrature_points;
+      flags.boundary_faces = dealii::update_gradients | dealii::update_JxW_values |
+                             dealii::update_normal_vectors | dealii::update_quadrature_points;
 
     return flags;
   }
@@ -132,11 +131,11 @@ public:
   }
 
   void
-  reinit_face_cell_based(types::boundary_id const boundary_id,
-                         IntegratorFace &         integrator_m,
-                         IntegratorFace &         integrator_p) const
+  reinit_face_cell_based(dealii::types::boundary_id const boundary_id,
+                         IntegratorFace &                 integrator_m,
+                         IntegratorFace &                 integrator_p) const
   {
-    if(boundary_id == numbers::internal_face_boundary_id) // internal face
+    if(boundary_id == dealii::numbers::internal_face_boundary_id) // internal face
     {
       tau = std::max(integrator_m.read_cell_data(array_penalty_parameter),
                      integrator_p.read_cell_data(array_penalty_parameter)) *
@@ -188,7 +187,7 @@ private:
 
   unsigned int degree;
 
-  AlignedVector<scalar> array_penalty_parameter;
+  dealii::AlignedVector<scalar> array_penalty_parameter;
 
   mutable scalar tau;
 };
@@ -218,13 +217,13 @@ private:
   typedef typename Base::IntegratorCell IntegratorCell;
   typedef typename Base::IntegratorFace IntegratorFace;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
 public:
   void
-  initialize(MatrixFree<dim, Number> const &                          matrix_free,
-             AffineConstraints<Number> const &                        affine_constraints,
+  initialize(dealii::MatrixFree<dim, Number> const &                  matrix_free,
+             dealii::AffineConstraints<Number> const &                affine_constraints,
              DiffusiveOperatorData<dim> const &                       data,
              std::shared_ptr<Operators::DiffusiveKernel<dim, Number>> kernel);
 
@@ -239,9 +238,9 @@ private:
   reinit_boundary_face(unsigned int const face) const;
 
   void
-  reinit_face_cell_based(unsigned int const       cell,
-                         unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+  reinit_face_cell_based(unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const;
 
   void
   do_cell_integral(IntegratorCell & integrator) const;
@@ -256,9 +255,9 @@ private:
   do_face_ext_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
 
   void
-  do_boundary_integral(IntegratorFace &           integrator_m,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(IntegratorFace &                   integrator_m,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   DiffusiveOperatorData<dim> operator_data;
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/weak_boundary_conditions.h
@@ -31,8 +31,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 /*
  *  The following two functions calculate the interior_value/exterior_value
  *  depending on the operator type, the type of the boundary face
@@ -50,12 +48,12 @@ using namespace dealii;
  */
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
+  dealii::VectorizedArray<Number>
   calculate_interior_value(unsigned int const                     q,
                            FaceIntegrator<dim, 1, Number> const & integrator,
                            OperatorType const &                   operator_type)
 {
-  VectorizedArray<Number> value_m = make_vectorized_array<Number>(0.0);
+  dealii::VectorizedArray<Number> value_m = dealii::make_vectorized_array<Number>(0.0);
 
   if(operator_type == OperatorType::full || operator_type == OperatorType::homogeneous)
   {
@@ -67,7 +65,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+    AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
   }
 
   return value_m;
@@ -75,23 +73,23 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
-  calculate_exterior_value(VectorizedArray<Number> const &                value_m,
+  dealii::VectorizedArray<Number>
+  calculate_exterior_value(dealii::VectorizedArray<Number> const &        value_m,
                            unsigned int const                             q,
                            FaceIntegrator<dim, 1, Number> const &         integrator,
                            OperatorType const &                           operator_type,
                            BoundaryType const &                           boundary_type,
-                           types::boundary_id const                       boundary_id,
+                           dealii::types::boundary_id const               boundary_id,
                            std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor,
                            double const &                                 time)
 {
-  VectorizedArray<Number> value_p = make_vectorized_array<Number>(0.0);
+  dealii::VectorizedArray<Number> value_p = dealii::make_vectorized_array<Number>(0.0);
 
   if(boundary_type == BoundaryType::Dirichlet)
   {
     if(operator_type == OperatorType::full || operator_type == OperatorType::inhomogeneous)
     {
-      VectorizedArray<Number> g;
+      dealii::VectorizedArray<Number> g;
 
       auto bc       = boundary_descriptor->dirichlet_bc.find(boundary_id)->second;
       auto q_points = integrator.quadrature_point(q);
@@ -106,7 +104,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else if(boundary_type == BoundaryType::Neumann)
@@ -115,7 +113,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return value_p;
@@ -150,12 +148,12 @@ inline DEAL_II_ALWAYS_INLINE //
 // clang-format on
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
+  dealii::VectorizedArray<Number>
   calculate_interior_normal_gradient(unsigned int const                     q,
                                      FaceIntegrator<dim, 1, Number> const & integrator,
                                      OperatorType const &                   operator_type)
 {
-  VectorizedArray<Number> normal_gradient_m = make_vectorized_array<Number>(0.0);
+  dealii::VectorizedArray<Number> normal_gradient_m = dealii::make_vectorized_array<Number>(0.0);
 
   if(operator_type == OperatorType::full || operator_type == OperatorType::homogeneous)
   {
@@ -167,7 +165,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+    AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
   }
 
   return normal_gradient_m;
@@ -175,18 +173,18 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
+  dealii::VectorizedArray<Number>
   calculate_exterior_normal_gradient(
-    VectorizedArray<Number> const &                normal_gradient_m,
+    dealii::VectorizedArray<Number> const &        normal_gradient_m,
     unsigned int const                             q,
     FaceIntegrator<dim, 1, Number> const &         integrator,
     OperatorType const &                           operator_type,
     BoundaryType const &                           boundary_type,
-    types::boundary_id const                       boundary_id,
+    dealii::types::boundary_id const               boundary_id,
     std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor,
     double const &                                 time)
 {
-  VectorizedArray<Number> normal_gradient_p = make_vectorized_array<Number>(0.0);
+  dealii::VectorizedArray<Number> normal_gradient_p = dealii::make_vectorized_array<Number>(0.0);
 
   if(boundary_type == BoundaryType::Dirichlet)
   {
@@ -209,12 +207,12 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return normal_gradient_p;

--- a/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
@@ -28,13 +28,11 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class VelocityProjection
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef CellIntegrator<dim, dim, Number> IntegratorCell;
 
@@ -45,12 +43,12 @@ public:
    * (v_h, u_h)_Omega^e = (v_h, f)_Omega^e -> M * U = RHS -> U = M^{-1} * RHS
    */
   void
-  apply(MatrixFree<dim, Number> const &      matrix_free,
-        unsigned int const                   dof_index,
-        unsigned int const                   quad_index,
-        std::shared_ptr<Function<dim>> const function,
-        double const &                       time,
-        VectorType &                         vector)
+  apply(dealii::MatrixFree<dim, Number> const &      matrix_free,
+        unsigned int const                           dof_index,
+        unsigned int const                           quad_index,
+        std::shared_ptr<dealii::Function<dim>> const function,
+        double const &                               time,
+        VectorType &                                 vector)
   {
     this->dof_index  = dof_index;
     this->quad_index = quad_index;
@@ -69,10 +67,10 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const
   {
     (void)src;
 
@@ -95,10 +93,10 @@ private:
     }
   }
 
-  unsigned int                   dof_index;
-  unsigned int                   quad_index;
-  std::shared_ptr<Function<dim>> function;
-  double                         time;
+  unsigned int                           dof_index;
+  unsigned int                           quad_index;
+  std::shared_ptr<dealii::Function<dim>> function;
+  double                                 time;
 };
 
 } // namespace ExaDG

--- a/include/exadg/convection_diffusion/throughput.h
+++ b/include/exadg/convection_diffusion/throughput.h
@@ -98,7 +98,7 @@ run(ThroughputParameters const & throughput,
 
   driver->setup();
 
-  std::tuple<unsigned int, types::global_dof_index, double> wall_time =
+  std::tuple<unsigned int, dealii::types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,
                            throughput.n_repetitions_inner,
                            throughput.n_repetitions_outer);

--- a/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
+++ b/include/exadg/convection_diffusion/time_integration/create_time_integrator.h
@@ -57,7 +57,7 @@ create_time_integrator(std::shared_ptr<Operator<dim, Number>>          pde_opera
   {
     AssertThrow(parameters.temporal_discretization == TemporalDiscretization::ExplRK ||
                   parameters.temporal_discretization == TemporalDiscretization::BDF,
-                ExcMessage("Specified time integration scheme is not implemented!"));
+                dealii::ExcMessage("Specified time integration scheme is not implemented!"));
   }
 
   return time_integrator;

--- a/include/exadg/convection_diffusion/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/convection_diffusion/time_integration/driver_steady_problems.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<typename Number>
 DriverSteadyProblems<Number>::DriverSteadyProblems(
   std::shared_ptr<Operator>                       operator_,
@@ -42,7 +40,7 @@ DriverSteadyProblems<Number>::DriverSteadyProblems(
     param(param_),
     mpi_comm(mpi_comm_),
     is_test(is_test_),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
     timer_tree(new TimerTree()),
     postprocessor(postprocessor_)
 {
@@ -63,7 +61,7 @@ template<typename Number>
 void
 DriverSteadyProblems<Number>::solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessing();
@@ -105,7 +103,7 @@ template<typename Number>
 void
 DriverSteadyProblems<Number>::do_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   pcout << std::endl << "Solving steady state problem ..." << std::endl;
@@ -127,7 +125,7 @@ DriverSteadyProblems<Number>::do_solve()
       }
       else
       {
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
       }
     }
   }
@@ -155,7 +153,7 @@ template<typename Number>
 void
 DriverSteadyProblems<Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessor->do_postprocessing(solution);

--- a/include/exadg/convection_diffusion/time_integration/driver_steady_problems.h
+++ b/include/exadg/convection_diffusion/time_integration/driver_steady_problems.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 // forward declaration
 class Parameters;
 
@@ -51,7 +49,7 @@ template<typename Number>
 class DriverSteadyProblems
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef Interface::Operator<Number> Operator;
 
@@ -91,7 +89,7 @@ private:
 
   bool is_test;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   std::shared_ptr<TimerTree> timer_tree;
 

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -31,8 +31,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 TimeIntBDF<dim, Number>::TimeIntBDF(
   std::shared_ptr<Operator<dim, Number>>          operator_in,
@@ -109,7 +107,7 @@ TimeIntBDF<dim, Number>::initialize_oif()
   // Operator-integration-factor splitting
   if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::ExplicitOIF)
   {
-    AssertThrow(param.convective_problem(), ExcMessage("Invalid parameters"));
+    AssertThrow(param.convective_problem(), dealii::ExcMessage("Invalid parameters"));
 
     bool numerical_velocity_field =
       (param.get_type_velocity_field() == TypeVelocityField::DoFVector);
@@ -181,7 +179,7 @@ TimeIntBDF<dim, Number>::initialize_oif()
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -282,7 +280,7 @@ TimeIntBDF<dim, Number>::calculate_time_step_size()
   else if(param.calculation_of_time_step_size == TimeStepCalculation::CFL)
   {
     AssertThrow(param.convective_problem(),
-                ExcMessage("Specified type of time step calculation does not make sense!"));
+                dealii::ExcMessage("Specified type of time step calculation does not make sense!"));
 
     double time_step_global = pde_operator->calculate_time_step_cfl_global(this->get_time());
     time_step_global *= cfl;
@@ -346,7 +344,8 @@ TimeIntBDF<dim, Number>::calculate_time_step_size()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified type of time step calculation is not implemented."));
+    AssertThrow(false,
+                dealii::ExcMessage("Specified type of time step calculation is not implemented."));
   }
 
   if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::ExplicitOIF)
@@ -355,7 +354,7 @@ TimeIntBDF<dim, Number>::calculate_time_step_size()
     // of the OIF splitting approach is to overcome limitations of the CFL condition)
     AssertThrow(
       param.calculation_of_time_step_size == TimeStepCalculation::CFL,
-      ExcMessage(
+      dealii::ExcMessage(
         "Specified type of time step calculation is not compatible with OIF splitting approach!"));
 
     this->pcout << std::endl << "OIF substepping for convective term:" << std::endl << std::endl;
@@ -370,7 +369,7 @@ double
 TimeIntBDF<dim, Number>::recalculate_time_step_size() const
 {
   AssertThrow(param.calculation_of_time_step_size == TimeStepCalculation::CFL,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Adaptive time step is not implemented for this type of time step calculation."));
 
   double new_time_step_size = std::numeric_limits<double>::max();
@@ -382,7 +381,8 @@ TimeIntBDF<dim, Number>::recalculate_time_step_size() const
   }
   else // numerical velocity field
   {
-    AssertThrow(velocities[0] != nullptr, ExcMessage("Pointer velocities[0] is not initialized."));
+    AssertThrow(velocities[0] != nullptr,
+                dealii::ExcMessage("Pointer velocities[0] is not initialized."));
 
     VectorType u_relative = *velocities[0];
     if(param.ale_formulation == true)
@@ -519,7 +519,7 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::do_timestep_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // transport velocity
@@ -538,9 +538,9 @@ TimeIntBDF<dim, Number>::do_timestep_solve()
       else
       {
         AssertThrow(std::abs(times[0] - this->get_next_time()) < 1.e-12 * param.end_time,
-                    ExcMessage("Invalid assumption."));
+                    dealii::ExcMessage("Invalid assumption."));
         AssertThrow(velocities[0] != nullptr,
-                    ExcMessage("Pointer velocities[0] is not correctly initialized."));
+                    dealii::ExcMessage("Pointer velocities[0] is not correctly initialized."));
 
         velocity_np = *velocities[0];
       }
@@ -552,7 +552,7 @@ TimeIntBDF<dim, Number>::do_timestep_solve()
     }
     else
     {
-      AssertThrow(param.ale_formulation == false, ExcMessage("not implemented."));
+      AssertThrow(param.ale_formulation == false, dealii::ExcMessage("not implemented."));
     }
   }
 
@@ -711,7 +711,7 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // To allow a computation of errors at start_time (= if time step number is 1 and if the

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
@@ -31,8 +31,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 namespace ConvDiff
 {
 class Parameters;

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
@@ -31,8 +31,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<typename Number>
 TimeIntExplRK<Number>::TimeIntExplRK(
   std::shared_ptr<Interface::Operator<Number>>    operator_in,
@@ -206,7 +204,8 @@ TimeIntExplRK<Number>::calculate_time_step_size()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified type of time step calculation is not implemented."));
+    AssertThrow(false,
+                dealii::ExcMessage("Specified type of time step calculation is not implemented."));
   }
 }
 
@@ -216,7 +215,7 @@ TimeIntExplRK<Number>::recalculate_time_step_size() const
 {
   AssertThrow(param.calculation_of_time_step_size == TimeStepCalculation::CFL ||
                 param.calculation_of_time_step_size == TimeStepCalculation::CFLAndDiffusion,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Adaptive time step is not implemented for this type of time step calculation."));
 
   double new_time_step_size = std::numeric_limits<double>::max();
@@ -228,7 +227,8 @@ TimeIntExplRK<Number>::recalculate_time_step_size() const
   }
   else
   {
-    AssertThrow(velocities[0] != nullptr, ExcMessage("Pointer velocities[0] is not initialized."));
+    AssertThrow(velocities[0] != nullptr,
+                dealii::ExcMessage("Pointer velocities[0] is not initialized."));
 
     new_time_step_size = pde_operator->calculate_time_step_cfl_numerical_velocity(*velocities[0]);
     new_time_step_size *= cfl;
@@ -326,7 +326,7 @@ TimeIntExplRK<Number>::initialize_time_integrator()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 }
 
@@ -343,7 +343,7 @@ template<typename Number>
 void
 TimeIntExplRK<Number>::do_timestep_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(param.convective_problem())
@@ -372,7 +372,7 @@ template<typename Number>
 void
 TimeIntExplRK<Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessor->do_postprocessing(this->solution_n, this->time, this->time_step_number);

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
@@ -34,8 +34,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 // forward declarations
 class Parameters;
 
@@ -55,7 +53,7 @@ template<typename Number>
 class TimeIntExplRK : public TimeIntExplRKBase<Number>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   TimeIntExplRK(std::shared_ptr<Interface::Operator<Number>>    operator_in,
                 Parameters const &                              param_in,

--- a/include/exadg/convection_diffusion/user_interface/analytical_solution.h
+++ b/include/exadg/convection_diffusion/user_interface/analytical_solution.h
@@ -28,12 +28,10 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
 struct AnalyticalSolution
 {
-  std::shared_ptr<Function<dim>> solution;
+  std::shared_ptr<dealii::Function<dim>> solution;
 };
 
 } // namespace ConvDiff

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -37,14 +37,12 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class ApplicationBase
 {
 public:
   virtual void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     // clang-format off
     prm.enter_subsection("Output");
@@ -57,7 +55,7 @@ public:
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
     : mpi_comm(comm),
-      pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
       parameter_file(parameter_file)
   {
   }
@@ -109,11 +107,11 @@ public:
     set_field_functions();
   }
 
-  virtual std::shared_ptr<Function<dim>>
+  virtual std::shared_ptr<dealii::Function<dim>>
   create_mesh_movement_function()
   {
-    std::shared_ptr<Function<dim>> mesh_motion =
-      std::make_shared<Functions::ZeroFunction<dim>>(dim);
+    std::shared_ptr<dealii::Function<dim>> mesh_motion =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(dim);
 
     return mesh_motion;
   }
@@ -148,7 +146,7 @@ public:
 protected:
   MPI_Comm const & mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   Parameters param;
 

--- a/include/exadg/convection_diffusion/user_interface/boundary_descriptor.h
+++ b/include/exadg/convection_diffusion/user_interface/boundary_descriptor.h
@@ -36,8 +36,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 enum class BoundaryType
 {
   Undefined,
@@ -48,29 +46,30 @@ enum class BoundaryType
 template<int dim>
 struct BoundaryDescriptor
 {
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> dirichlet_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
 
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> neumann_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> neumann_bc;
 
   // returns the boundary type
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryType
-    get_boundary_type(types::boundary_id const & boundary_id) const
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
   {
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
       return BoundaryType::Dirichlet;
     else if(this->neumann_bc.find(boundary_id) != this->neumann_bc.end())
       return BoundaryType::Neumann;
 
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
 
     return BoundaryType::Undefined;
   }
 
   inline DEAL_II_ALWAYS_INLINE //
     void
-    verify_boundary_conditions(types::boundary_id const             boundary_id,
-                               std::set<types::boundary_id> const & periodic_boundary_ids) const
+    verify_boundary_conditions(
+      dealii::types::boundary_id const             boundary_id,
+      std::set<dealii::types::boundary_id> const & periodic_boundary_ids) const
   {
     unsigned int counter = 0;
     if(dirichlet_bc.find(boundary_id) != dirichlet_bc.end())
@@ -82,7 +81,8 @@ struct BoundaryDescriptor
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())
       counter++;
 
-    AssertThrow(counter == 1, ExcMessage("Boundary face with non-unique boundary type found."));
+    AssertThrow(counter == 1,
+                dealii::ExcMessage("Boundary face with non-unique boundary type found."));
   }
 };
 

--- a/include/exadg/convection_diffusion/user_interface/enum_types.cpp
+++ b/include/exadg/convection_diffusion/user_interface/enum_types.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                                 MATHEMATICAL MODEL                                 */
@@ -55,7 +53,7 @@ enum_to_string(ProblemType const enum_type)
       string_type = "Unsteady";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -82,7 +80,7 @@ enum_to_string(EquationType const enum_type)
       string_type = "ConvectionDiffusion";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -103,7 +101,7 @@ enum_to_string(FormulationConvectiveTerm const enum_type)
       string_type = "ConvectiveFormulation";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -143,7 +141,7 @@ enum_to_string(TemporalDiscretization const enum_type)
       string_type = "BDF";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -170,7 +168,7 @@ enum_to_string(TreatmentOfConvectiveTerm const enum_type)
       string_type = "Implicit";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -218,7 +216,7 @@ enum_to_string(TimeIntegratorRK const enum_type)
       string_type = "ExplRK5Stage9Reg2S";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -251,7 +249,7 @@ enum_to_string(TimeStepCalculation const enum_type)
       string_type = "MaxEfficiency";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -281,7 +279,7 @@ enum_to_string(NumericalFluxConvectiveOperator const enum_type)
       string_type = "LaxFriedrichsFlux";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -311,7 +309,7 @@ enum_to_string(Solver const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -344,7 +342,7 @@ enum_to_string(Preconditioner const enum_type)
       string_type = "Multigrid";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -371,7 +369,7 @@ enum_to_string(MultigridOperatorType const enum_type)
       string_type = "ReactionConvectionDiffusion";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/convection_diffusion/user_interface/enum_types.h
+++ b/include/exadg/convection_diffusion/user_interface/enum_types.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                                 MATHEMATICAL MODEL                                 */

--- a/include/exadg/convection_diffusion/user_interface/field_functions.h
+++ b/include/exadg/convection_diffusion/user_interface/field_functions.h
@@ -26,14 +26,12 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 template<int dim>
 struct FieldFunctions
 {
-  std::shared_ptr<Function<dim>> initial_solution;
-  std::shared_ptr<Function<dim>> right_hand_side;
-  std::shared_ptr<Function<dim>> velocity;
+  std::shared_ptr<dealii::Function<dim>> initial_solution;
+  std::shared_ptr<dealii::Function<dim>> right_hand_side;
+  std::shared_ptr<dealii::Function<dim>> velocity;
 };
 
 } // namespace ConvDiff

--- a/include/exadg/convection_diffusion/user_interface/parameters.cpp
+++ b/include/exadg/convection_diffusion/user_interface/parameters.cpp
@@ -27,8 +27,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 Parameters::Parameters()
   : // MATHEMATICAL MODEL
     problem_type(ProblemType::Undefined),
@@ -100,9 +98,11 @@ void
 Parameters::check() const
 {
   // MATHEMATICAL MODEL
-  AssertThrow(problem_type != ProblemType::Undefined, ExcMessage("parameter must be defined"));
+  AssertThrow(problem_type != ProblemType::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
 
-  AssertThrow(equation_type != EquationType::Undefined, ExcMessage("parameter must be defined"));
+  AssertThrow(equation_type != EquationType::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
 
   if(analytical_velocity_field)
   {
@@ -115,7 +115,7 @@ Parameters::check() const
       {
         AssertThrow(
           store_analytical_velocity_in_dof_vector == false,
-          ExcMessage(
+          dealii::ExcMessage(
             "This option is not implemented for explicit Runge-Kutta time stepping or BDF time stepping with OIF substepping."));
       }
     }
@@ -125,47 +125,49 @@ Parameters::check() const
   if(ale_formulation)
   {
     AssertThrow(problem_type == ProblemType::Unsteady,
-                ExcMessage("Problem type has to be Unsteady when using ALE formulation."));
+                dealii::ExcMessage("Problem type has to be Unsteady when using ALE formulation."));
 
     AssertThrow(
       temporal_discretization == TemporalDiscretization::BDF &&
         (treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit ||
          treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit),
-      ExcMessage("ALE formulation is not implemented for the specified type of time integration."));
+      dealii::ExcMessage(
+        "ALE formulation is not implemented for the specified type of time integration."));
 
     AssertThrow(equation_type == EquationType::Convection ||
                   equation_type == EquationType::ConvectionDiffusion,
-                ExcMessage("ALE formulation can only be used if the problem involves convection."));
+                dealii::ExcMessage(
+                  "ALE formulation can only be used if the problem involves convection."));
 
     if(analytical_velocity_field)
     {
       AssertThrow(
         store_analytical_velocity_in_dof_vector == true,
-        ExcMessage(
+        dealii::ExcMessage(
           "When using the ALE formulation, the velocity has to be stored in a DoF vector."));
     }
 
     AssertThrow(
       formulation_convective_term == FormulationConvectiveTerm::ConvectiveFormulation,
-      ExcMessage(
+      dealii::ExcMessage(
         "ALE formulation can only be used in combination with convective formulation of convective term."));
   }
 
   // PHYSICAL QUANTITIES
-  AssertThrow(end_time > start_time, ExcMessage("parameter must be defined"));
+  AssertThrow(end_time > start_time, dealii::ExcMessage("parameter must be defined"));
 
   // Set the diffusivity whenever the diffusive term is involved.
   if(equation_type == EquationType::Diffusion || equation_type == EquationType::ConvectionDiffusion)
   {
     AssertThrow(diffusivity > (0.0 - std::numeric_limits<double>::epsilon()),
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
   }
 
   // TEMPORAL DISCRETIZATION
   if(problem_type == ProblemType::Unsteady)
   {
     AssertThrow(temporal_discretization != TemporalDiscretization::Undefined,
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
 
     if(temporal_discretization == TemporalDiscretization::BDF)
     {
@@ -173,31 +175,31 @@ Parameters::check() const
          equation_type == EquationType::ConvectionDiffusion)
       {
         AssertThrow(treatment_of_convective_term != TreatmentOfConvectiveTerm::Undefined,
-                    ExcMessage("parameter must be defined"));
+                    dealii::ExcMessage("parameter must be defined"));
       }
     }
 
     if(temporal_discretization == TemporalDiscretization::ExplRK)
     {
       AssertThrow(time_integrator_rk != TimeIntegratorRK::Undefined,
-                  ExcMessage("parameter must be defined"));
+                  dealii::ExcMessage("parameter must be defined"));
     }
 
     AssertThrow(calculation_of_time_step_size != TimeStepCalculation::Undefined,
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
 
     if(calculation_of_time_step_size == TimeStepCalculation::UserSpecified)
-      AssertThrow(time_step_size > 0.0, ExcMessage("parameter must be defined"));
+      AssertThrow(time_step_size > 0.0, dealii::ExcMessage("parameter must be defined"));
 
     if(calculation_of_time_step_size == TimeStepCalculation::MaxEfficiency)
-      AssertThrow(c_eff > 0., ExcMessage("parameter must be defined"));
+      AssertThrow(c_eff > 0., dealii::ExcMessage("parameter must be defined"));
 
     if(calculation_of_time_step_size == TimeStepCalculation::CFL)
     {
       AssertThrow(
         equation_type == EquationType::Convection ||
           equation_type == EquationType::ConvectionDiffusion,
-        ExcMessage(
+        dealii::ExcMessage(
           "Type of time step calculation CFL does not make sense for the specified equation type."));
     }
 
@@ -206,7 +208,7 @@ Parameters::check() const
       AssertThrow(
         equation_type == EquationType::Diffusion ||
           equation_type == EquationType::ConvectionDiffusion,
-        ExcMessage(
+        dealii::ExcMessage(
           "Type of time step calculation Diffusion does not make sense for the specified equation type."));
     }
 
@@ -214,7 +216,7 @@ Parameters::check() const
     {
       AssertThrow(
         equation_type == EquationType::ConvectionDiffusion,
-        ExcMessage(
+        dealii::ExcMessage(
           "Type of time step calculation CFLAndDiffusion does not make sense for the specified equation type."));
     }
 
@@ -222,41 +224,41 @@ Parameters::check() const
     {
       AssertThrow(calculation_of_time_step_size == TimeStepCalculation::CFL ||
                     calculation_of_time_step_size == TimeStepCalculation::CFLAndDiffusion,
-                  ExcMessage(
+                  dealii::ExcMessage(
                     "Adaptive time stepping can only be used in combination with CFL condition."));
     }
 
     if(temporal_discretization == TemporalDiscretization::ExplRK)
     {
       AssertThrow(order_time_integrator >= 1 && order_time_integrator <= 4,
-                  ExcMessage("Specified order of time integrator ExplRK not implemented!"));
+                  dealii::ExcMessage("Specified order of time integrator ExplRK not implemented!"));
 
       // for the explicit RK method both the convective and the diffusive term are
       // treated explicitly -> one has to specify both the CFL-number and the Diffusion-number
       if(calculation_of_time_step_size == TimeStepCalculation::CFL ||
          calculation_of_time_step_size == TimeStepCalculation::CFLAndDiffusion)
       {
-        AssertThrow(cfl > 0., ExcMessage("parameter must be defined"));
+        AssertThrow(cfl > 0., dealii::ExcMessage("parameter must be defined"));
       }
       if(calculation_of_time_step_size == TimeStepCalculation::Diffusion ||
          calculation_of_time_step_size == TimeStepCalculation::CFLAndDiffusion)
       {
-        AssertThrow(diffusion_number > 0., ExcMessage("parameter must be defined"));
+        AssertThrow(diffusion_number > 0., dealii::ExcMessage("parameter must be defined"));
       }
     }
 
     if(temporal_discretization == TemporalDiscretization::BDF)
     {
       AssertThrow(order_time_integrator >= 1 && order_time_integrator <= 4,
-                  ExcMessage("Specified order of time integrator BDF not implemented!"));
+                  dealii::ExcMessage("Specified order of time integrator BDF not implemented!"));
 
       if(treatment_of_convective_term == TreatmentOfConvectiveTerm::ExplicitOIF)
       {
         AssertThrow(time_integrator_oif != TimeIntegratorRK::Undefined,
-                    ExcMessage("parameter must be defined"));
+                    dealii::ExcMessage("parameter must be defined"));
 
-        AssertThrow(cfl > 0., ExcMessage("parameter must be defined"));
-        AssertThrow(cfl_oif > 0., ExcMessage("parameter must be defined"));
+        AssertThrow(cfl > 0., dealii::ExcMessage("parameter must be defined"));
+        AssertThrow(cfl_oif > 0., dealii::ExcMessage("parameter must be defined"));
       }
     }
   }
@@ -264,35 +266,35 @@ Parameters::check() const
   // SPATIAL DISCRETIZATION
   grid.check();
 
-  AssertThrow(degree > 0, ExcMessage("Polynomial degree must be larger than zero."));
+  AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
 
   if(equation_type == EquationType::Convection ||
      equation_type == EquationType::ConvectionDiffusion)
   {
     AssertThrow(numerical_flux_convective_operator != NumericalFluxConvectiveOperator::Undefined,
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
   }
 
 
   // SOLVER
   if(temporal_discretization == TemporalDiscretization::BDF)
   {
-    AssertThrow(solver != Solver::Undefined, ExcMessage("parameter must be defined"));
+    AssertThrow(solver != Solver::Undefined, dealii::ExcMessage("parameter must be defined"));
 
     AssertThrow(preconditioner != Preconditioner::Undefined,
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
 
     if(preconditioner == Preconditioner::Multigrid)
     {
       AssertThrow(mg_operator_type != MultigridOperatorType::Undefined,
-                  ExcMessage("parameter must be defined"));
+                  dealii::ExcMessage("parameter must be defined"));
 
       if(treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit ||
          treatment_of_convective_term == TreatmentOfConvectiveTerm::ExplicitOIF)
       {
         AssertThrow(mg_operator_type != MultigridOperatorType::ReactionConvection &&
                       mg_operator_type != MultigridOperatorType::ReactionConvectionDiffusion,
-                    ExcMessage(
+                    dealii::ExcMessage(
                       "Invalid solver parameters. The convective term is treated explicitly."));
       }
 
@@ -301,7 +303,7 @@ Parameters::check() const
         if(equation_type == EquationType::Convection)
         {
           AssertThrow(mg_operator_type == MultigridOperatorType::ReactionConvection,
-                      ExcMessage(
+                      dealii::ExcMessage(
                         "Invalid solver parameters. A purely diffusive problem is considered."));
         }
       }
@@ -309,7 +311,7 @@ Parameters::check() const
       if(equation_type == EquationType::Diffusion)
       {
         AssertThrow(mg_operator_type == MultigridOperatorType::ReactionDiffusion,
-                    ExcMessage(
+                    dealii::ExcMessage(
                       "Invalid solver parameters. A purely diffusive problem is considered."));
       }
     }
@@ -317,19 +319,19 @@ Parameters::check() const
   else
   {
     AssertThrow(temporal_discretization == TemporalDiscretization::ExplRK,
-                ExcMessage("Not implemented"));
+                dealii::ExcMessage("Not implemented"));
   }
 
   if(implement_block_diagonal_preconditioner_matrix_free)
   {
     AssertThrow(
       use_cell_based_face_loops == true,
-      ExcMessage(
+      dealii::ExcMessage(
         "Cell based face loops have to be used for matrix-free implementation of block diagonal preconditioner."));
 
     AssertThrow(
       solver_block_diagonal != Elementwise::Solver::Undefined,
-      ExcMessage(
+      dealii::ExcMessage(
         "Invalid parameter. A solver type needs to be specified for elementwise matrix-free iterative solver."));
   }
 
@@ -386,7 +388,7 @@ Parameters::get_type_velocity_field() const
 }
 
 void
-Parameters::print(ConditionalOStream const & pcout, std::string const & name) const
+Parameters::print(dealii::ConditionalOStream const & pcout, std::string const & name) const
 {
   pcout << std::endl << name << std::endl;
 
@@ -413,7 +415,7 @@ Parameters::print(ConditionalOStream const & pcout, std::string const & name) co
 }
 
 void
-Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout) const
+Parameters::print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Mathematical model:" << std::endl;
 
@@ -433,7 +435,7 @@ Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout
 }
 
 void
-Parameters::print_parameters_physical_quantities(ConditionalOStream const & pcout) const
+Parameters::print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Physical quantities:" << std::endl;
 
@@ -451,7 +453,7 @@ Parameters::print_parameters_physical_quantities(ConditionalOStream const & pcou
 }
 
 void
-Parameters::print_parameters_temporal_discretization(ConditionalOStream const & pcout) const
+Parameters::print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Temporal discretization:" << std::endl;
 
@@ -512,7 +514,7 @@ Parameters::print_parameters_temporal_discretization(ConditionalOStream const & 
 }
 
 void
-Parameters::print_parameters_spatial_discretization(ConditionalOStream const & pcout) const
+Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Spatial Discretization:" << std::endl;
 
@@ -535,7 +537,7 @@ Parameters::print_parameters_spatial_discretization(ConditionalOStream const & p
 }
 
 void
-Parameters::print_parameters_solver(ConditionalOStream const & pcout) const
+Parameters::print_parameters_solver(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Solver:" << std::endl;
 
@@ -579,7 +581,7 @@ Parameters::print_parameters_solver(ConditionalOStream const & pcout) const
 
 
 void
-Parameters::print_parameters_numerical_parameters(ConditionalOStream const & pcout) const
+Parameters::print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Numerical parameters:" << std::endl;
 

--- a/include/exadg/convection_diffusion/user_interface/parameters.h
+++ b/include/exadg/convection_diffusion/user_interface/parameters.h
@@ -41,8 +41,6 @@ namespace ExaDG
 {
 namespace ConvDiff
 {
-using namespace dealii;
-
 class Parameters
 {
 public:
@@ -70,26 +68,26 @@ public:
 
   // print functions
   void
-  print(ConditionalOStream const & pcout, std::string const & name) const;
+  print(dealii::ConditionalOStream const & pcout, std::string const & name) const;
 
 private:
   void
-  print_parameters_mathematical_model(ConditionalOStream const & pcout) const;
+  print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_physical_quantities(ConditionalOStream const & pcout) const;
+  print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_temporal_discretization(ConditionalOStream const & pcout) const;
+  print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_spatial_discretization(ConditionalOStream const & pcout) const;
+  print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_solver(ConditionalOStream const & pcout) const;
+  print_parameters_solver(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_numerical_parameters(ConditionalOStream const & pcout) const;
+  print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const;
 
 public:
   /**************************************************************************************/
@@ -314,10 +312,10 @@ public:
 
   // In case that the velocity field is prescribed analytically, it might be advantageous
   // from the point of view of computational costs to store the velocity field in a DoF
-  // vector instead of repeatedly calling Function<dim>::value() whenever evaluating the
+  // vector instead of repeatedly calling dealii::Function<dim>::value() whenever evaluating the
   // operator in iterative solvers. In other words, depending on the computer hardware it
   // might be more efficient to load a DoF vector and interpolate into the quadrature points
-  // than calculating the velocity field by means of Function<dim>::value().
+  // than calculating the velocity field by means of dealii::Function<dim>::value().
   // This strategy makes only sense in case of steady state problems or unsteady problems
   // with an implicit treatment of the convective term, i.e., in cases where the convective
   // term has to be evaluated more than once at a given time t.

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -54,8 +54,6 @@ namespace ExaDG
 {
 namespace FSI
 {
-using namespace dealii;
-
 /*
  * Own implementation of matrix class.
  */
@@ -82,7 +80,7 @@ public:
   Number
   get(unsigned int const i, unsigned int const j) const
   {
-    AssertThrow(i < M && j < M, ExcMessage("Index exceeds matrix dimensions."));
+    AssertThrow(i < M && j < M, dealii::ExcMessage("Index exceeds matrix dimensions."));
 
     return data[i * M + j];
   }
@@ -90,7 +88,7 @@ public:
   void
   set(Number const value, unsigned int const i, unsigned int const j)
   {
-    AssertThrow(i < M && j < M, ExcMessage("Index exceeds matrix dimensions."));
+    AssertThrow(i < M && j < M, dealii::ExcMessage("Index exceeds matrix dimensions."));
 
     data[i * M + j] = value;
   }
@@ -239,7 +237,7 @@ template<int dim, typename Number>
 class Driver
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
   Driver(std::string const &                           input_file,
@@ -302,7 +300,7 @@ private:
   MPI_Comm const mpi_comm;
 
   // output to std::cout
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -313,8 +311,8 @@ private:
   /**************************************** STRUCTURE *****************************************/
 
   // matrix-free
-  std::shared_ptr<MatrixFreeData<dim, Number>> structure_matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     structure_matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     structure_matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> structure_matrix_free;
 
   // spatial discretization
   std::shared_ptr<Structure::Operator<dim, Number>> structure_operator;
@@ -334,8 +332,8 @@ private:
   std::shared_ptr<GridMotionBase<dim, Number>> fluid_grid_motion;
 
   // matrix-free
-  std::shared_ptr<MatrixFreeData<dim, Number>> fluid_matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     fluid_matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     fluid_matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> fluid_matrix_free;
 
   // spatial discretization
   std::shared_ptr<IncNS::SpatialOperatorBase<dim, Number>> fluid_operator;
@@ -352,8 +350,8 @@ private:
   /************************************ ALE - MOVING MESH *************************************/
 
   // use a PDE solver for moving mesh problem
-  std::shared_ptr<MatrixFreeData<dim, Number>> ale_matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     ale_matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     ale_matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> ale_matrix_free;
 
   // Poisson-type mesh motion
   std::shared_ptr<Poisson::Operator<dim, Number, dim>> ale_poisson_operator;

--- a/include/exadg/fluid_structure_interaction/solver.h
+++ b/include/exadg/fluid_structure_interaction/solver.h
@@ -54,22 +54,22 @@ struct ResolutionParameters
       prm.add_parameter("DegreeFluid",
                         degree_fluid,
                         "Polynomial degree of fluid (velocity).",
-                        Patterns::Integer(1,EXADG_DEGREE_MAX),
+                        dealii::Patterns::Integer(1,EXADG_DEGREE_MAX),
                         true);
       prm.add_parameter("DegreeStructure",
                         degree_structure,
                         "Polynomial degree of structural problem.",
-                        Patterns::Integer(1,EXADG_DEGREE_MAX),
+                        dealii::Patterns::Integer(1,EXADG_DEGREE_MAX),
                         true);
       prm.add_parameter("RefineFluid",
                         refine_fluid,
                         "Number of mesh refinements (fluid).",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
       prm.add_parameter("RefineStructure",
                         refine_structure,
                         "Number of mesh refinements (structure).",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
     prm.leave_subsection();
     // clang-format on
@@ -116,7 +116,7 @@ template<int dim, typename Number>
 void
 run(std::string const & input_file, MPI_Comm const & mpi_comm, bool const is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<FSI::ApplicationBase<dim, Number>> application =

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -56,14 +56,12 @@ namespace ExaDG
 {
 namespace FSI
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class ApplicationBase
 {
 public:
   virtual void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     // clang-format off
     prm.enter_subsection("Output");
@@ -76,7 +74,7 @@ public:
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
     : mpi_comm(comm),
-      pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
       parameter_file(parameter_file)
   {
   }
@@ -111,7 +109,7 @@ public:
     structure_param.check();
     // Some FSI specific Asserts
     AssertThrow(structure_param.pull_back_traction == true,
-                ExcMessage("Invalid parameter in context of fluid-structure interaction."));
+                dealii::ExcMessage("Invalid parameter in context of fluid-structure interaction."));
     structure_param.print(pcout, "List of parameters for structure:");
 
     // grid
@@ -143,9 +141,9 @@ public:
 
     // Some FSI specific Asserts
     AssertThrow(fluid_param.problem_type == IncNS::ProblemType::Unsteady,
-                ExcMessage("Invalid parameter in context of fluid-structure interaction."));
+                dealii::ExcMessage("Invalid parameter in context of fluid-structure interaction."));
     AssertThrow(fluid_param.ale_formulation == true,
-                ExcMessage("Invalid parameter in context of fluid-structure interaction."));
+                dealii::ExcMessage("Invalid parameter in context of fluid-structure interaction."));
 
     // grid
     fluid_grid = std::make_shared<Grid<dim>>(fluid_param.grid, mpi_comm);
@@ -170,7 +168,7 @@ public:
       set_parameters_ale_poisson();
       ale_poisson_param.check();
       AssertThrow(ale_poisson_param.right_hand_side == false,
-                  ExcMessage("Parameter does not make sense in context of FSI."));
+                  dealii::ExcMessage("Parameter does not make sense in context of FSI."));
       ale_poisson_param.print(pcout, "List of parameters for ALE solver (Poisson):");
 
       // boundary conditions
@@ -188,7 +186,7 @@ public:
       set_parameters_ale_elasticity();
       ale_elasticity_param.check();
       AssertThrow(ale_elasticity_param.body_force == false,
-                  ExcMessage("Parameter does not make sense in context of FSI."));
+                  dealii::ExcMessage("Parameter does not make sense in context of FSI."));
       ale_elasticity_param.print(pcout, "List of parameters for ALE solver (elasticity):");
 
       // boundary conditions
@@ -206,7 +204,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("not implemented."));
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
     }
   }
 
@@ -315,7 +313,7 @@ public:
 protected:
   MPI_Comm const & mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // fluid
   IncNS::Parameters                               fluid_param;

--- a/include/exadg/functions_and_boundary_conditions/evaluate_functions.h
+++ b/include/exadg/functions_and_boundary_conditions/evaluate_functions.h
@@ -33,28 +33,26 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int rank, int dim, typename Number>
 struct FunctionEvaluator
 {
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<rank, dim, VectorizedArray<Number>>
-    value(std::shared_ptr<Function<dim>>              function,
-          Point<dim, VectorizedArray<Number>> const & q_points,
-          double const &                              time)
+    dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
+    value(std::shared_ptr<dealii::Function<dim>>                      function,
+          dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
+          double const &                                              time)
   {
     (void)function;
     (void)q_points;
     (void)time;
 
-    AssertThrow(false, ExcMessage("should not arrive here."));
+    AssertThrow(false, dealii::ExcMessage("should not arrive here."));
 
-    return Tensor<rank, dim, VectorizedArray<Number>>();
+    return dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>();
   }
 
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<rank, dim, VectorizedArray<Number>>
+    dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
     value(std::shared_ptr<FunctionCached<rank, dim>> function,
           unsigned int const                         face,
           unsigned int const                         q,
@@ -65,26 +63,26 @@ struct FunctionEvaluator
     (void)q;
     (void)quad_index;
 
-    AssertThrow(false, ExcMessage("should not arrive here."));
+    AssertThrow(false, dealii::ExcMessage("should not arrive here."));
 
-    return Tensor<rank, dim, VectorizedArray<Number>>();
+    return dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>();
   }
 
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<rank, dim, VectorizedArray<Number>>
-    value(std::shared_ptr<Function<dim>>                  function,
-          Point<dim, VectorizedArray<Number>> const &     q_points,
-          Tensor<1, dim, VectorizedArray<Number>> const & normals,
-          double const &                                  time)
+    dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
+    value(std::shared_ptr<dealii::Function<dim>>                          function,
+          dealii::Point<dim, dealii::VectorizedArray<Number>> const &     q_points,
+          dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normals,
+          double const &                                                  time)
   {
     (void)function;
     (void)q_points;
     (void)normals;
     (void)time;
 
-    AssertThrow(false, ExcMessage("not implemented."));
+    AssertThrow(false, dealii::ExcMessage("not implemented."));
 
-    return Tensor<rank, dim, VectorizedArray<Number>>();
+    return dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>();
   }
 };
 
@@ -92,17 +90,17 @@ template<int dim, typename Number>
 struct FunctionEvaluator<0, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<0, dim, VectorizedArray<Number>>
-    value(std::shared_ptr<Function<dim>>              function,
-          Point<dim, VectorizedArray<Number>> const & q_points,
-          double const &                              time)
+    dealii::Tensor<0, dim, dealii::VectorizedArray<Number>>
+    value(std::shared_ptr<dealii::Function<dim>>                      function,
+          dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
+          double const &                                              time)
   {
-    VectorizedArray<Number> value = make_vectorized_array<Number>(0.0);
+    dealii::VectorizedArray<Number> value = dealii::make_vectorized_array<Number>(0.0);
 
-    Number array[VectorizedArray<Number>::size()];
-    for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+    Number array[dealii::VectorizedArray<Number>::size()];
+    for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
     {
-      Point<dim> q_point;
+      dealii::Point<dim> q_point;
       for(unsigned int d = 0; d < dim; ++d)
         q_point[d] = q_points[d][v];
 
@@ -115,16 +113,16 @@ struct FunctionEvaluator<0, dim, Number>
   }
 
   static inline DEAL_II_ALWAYS_INLINE //
-      Tensor<0, dim, VectorizedArray<Number>>
+      dealii::Tensor<0, dim, dealii::VectorizedArray<Number>>
       value(std::shared_ptr<FunctionCached<0, dim>> function,
             unsigned int const                      face,
             unsigned int const                      q,
             unsigned int const                      quad_index)
   {
-    VectorizedArray<Number> value = make_vectorized_array<Number>(0.0);
+    dealii::VectorizedArray<Number> value = dealii::make_vectorized_array<Number>(0.0);
 
-    Number array[VectorizedArray<Number>::size()];
-    for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+    Number array[dealii::VectorizedArray<Number>::size()];
+    for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
     {
       array[v] = function->tensor_value(face, q, v, quad_index);
     }
@@ -138,19 +136,19 @@ template<int dim, typename Number>
 struct FunctionEvaluator<1, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
-    value(std::shared_ptr<Function<dim>>              function,
-          Point<dim, VectorizedArray<Number>> const & q_points,
-          double const &                              time)
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+    value(std::shared_ptr<dealii::Function<dim>>                      function,
+          dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
+          double const &                                              time)
   {
-    Tensor<1, dim, VectorizedArray<Number>> value;
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value;
 
     for(unsigned int d = 0; d < dim; ++d)
     {
-      Number array[VectorizedArray<Number>::size()];
-      for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+      Number array[dealii::VectorizedArray<Number>::size()];
+      for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
       {
-        Point<dim> q_point;
+        dealii::Point<dim> q_point;
         for(unsigned int d = 0; d < dim; ++d)
           q_point[d] = q_points[d][v];
 
@@ -164,24 +162,24 @@ struct FunctionEvaluator<1, dim, Number>
   }
 
   static inline DEAL_II_ALWAYS_INLINE //
-      Tensor<1, dim, VectorizedArray<Number>>
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
       value(std::shared_ptr<FunctionCached<1, dim>> function,
             unsigned int const                      face,
             unsigned int const                      q,
             unsigned int const                      quad_index)
   {
-    Tensor<1, dim, VectorizedArray<Number>> value;
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value;
 
-    Tensor<1, dim, Number> tensor_array[VectorizedArray<Number>::size()];
-    for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+    dealii::Tensor<1, dim, Number> tensor_array[dealii::VectorizedArray<Number>::size()];
+    for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
     {
       tensor_array[v] = function->tensor_value(face, q, v, quad_index);
     }
 
     for(unsigned int d = 0; d < dim; ++d)
     {
-      VectorizedArray<Number> array;
-      for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+      dealii::VectorizedArray<Number> array;
+      for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
         array[v] = tensor_array[v][d];
 
       value[d].load(&array[0]);
@@ -191,23 +189,23 @@ struct FunctionEvaluator<1, dim, Number>
   }
 
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
-    value(std::shared_ptr<Function<dim>>                  function,
-          Point<dim, VectorizedArray<Number>> const &     q_points,
-          Tensor<1, dim, VectorizedArray<Number>> const & normals,
-          double const &                                  time)
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+    value(std::shared_ptr<dealii::Function<dim>>                          function,
+          dealii::Point<dim, dealii::VectorizedArray<Number>> const &     q_points,
+          dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normals,
+          double const &                                                  time)
   {
     auto function_with_normal = std::dynamic_pointer_cast<FunctionWithNormal<dim>>(function);
 
-    Tensor<1, dim, VectorizedArray<Number>> value;
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value;
 
     for(unsigned int d = 0; d < dim; ++d)
     {
-      Number array[VectorizedArray<Number>::size()];
-      for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+      Number array[dealii::VectorizedArray<Number>::size()];
+      for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
       {
-        Point<dim>     q_point;
-        Tensor<1, dim> normal;
+        dealii::Point<dim>     q_point;
+        dealii::Tensor<1, dim> normal;
         for(unsigned int d = 0; d < dim; ++d)
         {
           q_point[d] = q_points[d][v];

--- a/include/exadg/functions_and_boundary_conditions/function_cached.h
+++ b/include/exadg/functions_and_boundary_conditions/function_cached.h
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  * Note:
  * The default argument "double" could be removed but this implies that all BoundaryDescriptors
@@ -37,36 +35,37 @@ class FunctionCached
 {
 private:
   typedef std::tuple<unsigned int /*face*/, unsigned int /*q*/, unsigned int /*v*/> Id;
-  typedef std::map<Id, types::global_dof_index>                                     MapVectorIndex;
-  typedef std::vector<Tensor<rank, dim, Number>>                                    ArrayTensor;
+  typedef std::map<Id, dealii::types::global_dof_index>                             MapVectorIndex;
+  typedef std::vector<dealii::Tensor<rank, dim, Number>>                            ArrayTensor;
 
 public:
   FunctionCached() : global_map_vector_index(nullptr), map_solution(nullptr)
   {
   }
 
-  Tensor<rank, dim, Number>
+  dealii::Tensor<rank, dim, Number>
   tensor_value(unsigned int const face,
                unsigned int const q,
                unsigned int const v,
                unsigned int const quad_index) const
   {
     Assert(global_map_vector_index != nullptr,
-           ExcMessage("Pointer global_map_vector_index is not initialized."));
+           dealii::ExcMessage("Pointer global_map_vector_index is not initialized."));
     Assert(global_map_vector_index->find(quad_index) != global_map_vector_index->end(),
-           ExcMessage("Specified quad_index does not exist in global_map_vector_index."));
+           dealii::ExcMessage("Specified quad_index does not exist in global_map_vector_index."));
 
-    Assert(map_solution != nullptr, ExcMessage("Pointer map_solution is not initialized."));
+    Assert(map_solution != nullptr, dealii::ExcMessage("Pointer map_solution is not initialized."));
     Assert(map_solution->find(quad_index) != map_solution->end(),
-           ExcMessage("Specified quad_index does not exist in map_solution."));
+           dealii::ExcMessage("Specified quad_index does not exist in map_solution."));
 
     MapVectorIndex const & map_vector_index = global_map_vector_index->find(quad_index)->second;
     ArrayTensor const &    array_solution   = map_solution->find(quad_index)->second;
 
-    Id                      id    = std::make_tuple(face, q, v);
-    types::global_dof_index index = map_vector_index.find(id)->second;
+    Id                              id    = std::make_tuple(face, q, v);
+    dealii::types::global_dof_index index = map_vector_index.find(id)->second;
 
-    Assert(index < array_solution.size(), ExcMessage("Index exceeds dimensions of vector."));
+    Assert(index < array_solution.size(),
+           dealii::ExcMessage("Index exceeds dimensions of vector."));
 
     return array_solution[index];
   }

--- a/include/exadg/functions_and_boundary_conditions/function_with_normal.h
+++ b/include/exadg/functions_and_boundary_conditions/function_with_normal.h
@@ -24,18 +24,16 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  * Class that extends the Function class of deal.II by the possibility of using normal vectors.
  */
 
 template<int dim>
-class FunctionWithNormal : public Function<dim>
+class FunctionWithNormal : public dealii::Function<dim>
 {
 public:
   FunctionWithNormal(unsigned int const n_components, double const time)
-    : Function<dim>(n_components, time)
+    : dealii::Function<dim>(n_components, time)
   {
   }
 
@@ -43,19 +41,19 @@ public:
   {
   }
 
-  void set_normal_vector(Tensor<1, dim> normal_vector_in)
+  void set_normal_vector(dealii::Tensor<1, dim> normal_vector_in)
   {
     normal_vector = normal_vector_in;
   }
 
-  Tensor<1, dim>
+  dealii::Tensor<1, dim>
   get_normal_vector() const
   {
     return normal_vector;
   }
 
 private:
-  Tensor<1, dim> normal_vector;
+  dealii::Tensor<1, dim> normal_vector;
 };
 
 } // namespace ExaDG

--- a/include/exadg/functions_and_boundary_conditions/linear_interpolation.cpp
+++ b/include/exadg/functions_and_boundary_conditions/linear_interpolation.cpp
@@ -23,14 +23,12 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 Number
-linear_interpolation_1d(double const &                              y,
-                        std::vector<Number> const &                 y_values,
-                        std::vector<Tensor<1, dim, Number>> const & solution_values,
-                        unsigned int const &                        component)
+linear_interpolation_1d(double const &                                      y,
+                        std::vector<Number> const &                         y_values,
+                        std::vector<dealii::Tensor<1, dim, Number>> const & solution_values,
+                        unsigned int const &                                component)
 {
   Number result = 0.0;
 
@@ -39,7 +37,7 @@ linear_interpolation_1d(double const &                              y,
   unsigned int const n_points_y = y_values.size();
 
   AssertThrow((y_values[0] - tol < y) && (y < y_values[n_points_y - 1] + tol),
-              ExcMessage("invalid point found."));
+              dealii::ExcMessage("invalid point found."));
 
   // interpolate y-coordinates
   unsigned int iy = 0;
@@ -57,7 +55,7 @@ linear_interpolation_1d(double const &                              y,
 
   AssertThrow(-1.e-12 < weight_yp && weight_yp < 1. + 1e-12 && -1.e-12 < weight_ym &&
                 weight_ym < 1. + 1e-12,
-              ExcMessage("invalid weights when interpolating solution in 1D."));
+              dealii::ExcMessage("invalid weights when interpolating solution in 1D."));
 
   result =
     weight_ym * solution_values[iy - 1][component] + weight_yp * solution_values[iy][component];
@@ -66,38 +64,39 @@ linear_interpolation_1d(double const &                              y,
 }
 
 template float
-linear_interpolation_1d(double const &                           y,
-                        std::vector<float> const &               y_values,
-                        std::vector<Tensor<1, 2, float>> const & solution_values,
-                        unsigned int const &                     component);
+linear_interpolation_1d(double const &                                   y,
+                        std::vector<float> const &                       y_values,
+                        std::vector<dealii::Tensor<1, 2, float>> const & solution_values,
+                        unsigned int const &                             component);
 
 template double
-linear_interpolation_1d(double const &                            y,
-                        std::vector<double> const &               y_values,
-                        std::vector<Tensor<1, 2, double>> const & solution_values,
-                        unsigned int const &                      component);
+linear_interpolation_1d(double const &                                    y,
+                        std::vector<double> const &                       y_values,
+                        std::vector<dealii::Tensor<1, 2, double>> const & solution_values,
+                        unsigned int const &                              component);
 
 template float
-linear_interpolation_1d(double const &                           y,
-                        std::vector<float> const &               y_values,
-                        std::vector<Tensor<1, 3, float>> const & solution_values,
-                        unsigned int const &                     component);
+linear_interpolation_1d(double const &                                   y,
+                        std::vector<float> const &                       y_values,
+                        std::vector<dealii::Tensor<1, 3, float>> const & solution_values,
+                        unsigned int const &                             component);
 
 template double
-linear_interpolation_1d(double const &                            y,
-                        std::vector<double> const &               y_values,
-                        std::vector<Tensor<1, 3, double>> const & solution_values,
-                        unsigned int const &                      component);
+linear_interpolation_1d(double const &                                    y,
+                        std::vector<double> const &                       y_values,
+                        std::vector<dealii::Tensor<1, 3, double>> const & solution_values,
+                        unsigned int const &                              component);
 
 template<int dim, typename Number>
 Number
-linear_interpolation_2d_cartesian(Point<dim> const &                          point,
-                                  std::vector<Number> const &                 y_values,
-                                  std::vector<Number> const &                 z_values,
-                                  std::vector<Tensor<1, dim, Number>> const & solution_values,
-                                  unsigned int const &                        component)
+linear_interpolation_2d_cartesian(
+  dealii::Point<dim> const &                          point,
+  std::vector<Number> const &                         y_values,
+  std::vector<Number> const &                         z_values,
+  std::vector<dealii::Tensor<1, dim, Number>> const & solution_values,
+  unsigned int const &                                component)
 {
-  AssertThrow(dim == 3, ExcMessage("not implemented"));
+  AssertThrow(dim == 3, dealii::ExcMessage("not implemented"));
 
   Number result = 0.0;
 
@@ -107,11 +106,11 @@ linear_interpolation_2d_cartesian(Point<dim> const &                          po
   unsigned int const n_points_z = z_values.size();
 
   // make sure that point does not exceed bounds
-  Point<dim> p = point;
+  dealii::Point<dim> p = point;
 
   AssertThrow((y_values[0] - tol < p[1]) && (p[1] < y_values[n_points_y - 1] + tol) &&
                 (z_values[0] - tol < p[2]) && (p[2] < z_values[n_points_z - 1] + tol),
-              ExcMessage("invalid point found."));
+              dealii::ExcMessage("invalid point found."));
 
   // interpolate y and z-coordinates
   unsigned int iy = 0, iz = 0;
@@ -137,7 +136,7 @@ linear_interpolation_2d_cartesian(Point<dim> const &                          po
   AssertThrow(-1.e-12 < weight_yp && weight_yp < 1. + 1e-12 && -1.e-12 < weight_ym &&
                 weight_ym < 1. + 1e-12 && -1.e-12 < weight_zp && weight_zp < 1. + 1e-12 &&
                 -1.e-12 < weight_zm && weight_zm < 1. + 1e-12,
-              ExcMessage("invalid weights when interpolating solution in 2D."));
+              dealii::ExcMessage("invalid weights when interpolating solution in 2D."));
 
   result = weight_ym * weight_zm * solution_values[(iy - 1) * n_points_z + (iz - 1)][component] +
            weight_ym * weight_zp * solution_values[(iy - 1) * n_points_z + (iz)][component] +
@@ -147,47 +146,48 @@ linear_interpolation_2d_cartesian(Point<dim> const &                          po
   return result;
 }
 
-template float
-  linear_interpolation_2d_cartesian(Point<2> const &                         point,
-                                    std::vector<float> const &               y_values,
-                                    std::vector<float> const &               z_values,
-                                    std::vector<Tensor<1, 2, float>> const & solution_values,
-                                    unsigned int const &                     component);
+template float linear_interpolation_2d_cartesian(
+  dealii::Point<2> const &                         point,
+  std::vector<float> const &                       y_values,
+  std::vector<float> const &                       z_values,
+  std::vector<dealii::Tensor<1, 2, float>> const & solution_values,
+  unsigned int const &                             component);
 
-template double
-  linear_interpolation_2d_cartesian(Point<2> const &                          point,
-                                    std::vector<double> const &               y_values,
-                                    std::vector<double> const &               z_values,
-                                    std::vector<Tensor<1, 2, double>> const & solution_values,
-                                    unsigned int const &                      component);
+template double linear_interpolation_2d_cartesian(
+  dealii::Point<2> const &                          point,
+  std::vector<double> const &                       y_values,
+  std::vector<double> const &                       z_values,
+  std::vector<dealii::Tensor<1, 2, double>> const & solution_values,
+  unsigned int const &                              component);
 
-template float
-  linear_interpolation_2d_cartesian(Point<3> const &                         point,
-                                    std::vector<float> const &               y_values,
-                                    std::vector<float> const &               z_values,
-                                    std::vector<Tensor<1, 3, float>> const & solution_values,
-                                    unsigned int const &                     component);
+template float linear_interpolation_2d_cartesian(
+  dealii::Point<3> const &                         point,
+  std::vector<float> const &                       y_values,
+  std::vector<float> const &                       z_values,
+  std::vector<dealii::Tensor<1, 3, float>> const & solution_values,
+  unsigned int const &                             component);
 
-template double
-  linear_interpolation_2d_cartesian(Point<3> const &                          point,
-                                    std::vector<double> const &               y_values,
-                                    std::vector<double> const &               z_values,
-                                    std::vector<Tensor<1, 3, double>> const & solution_values,
-                                    unsigned int const &                      component);
+template double linear_interpolation_2d_cartesian(
+  dealii::Point<3> const &                          point,
+  std::vector<double> const &                       y_values,
+  std::vector<double> const &                       z_values,
+  std::vector<dealii::Tensor<1, 3, double>> const & solution_values,
+  unsigned int const &                              component);
 
 /*
  *  2D interpolation for cylindrical cross-sections
  */
 template<int dim, typename Number>
 Number
-linear_interpolation_2d_cylindrical(Number const                                r_in,
-                                    Number const                                phi,
-                                    std::vector<Number> const &                 r_values,
-                                    std::vector<Number> const &                 phi_values,
-                                    std::vector<Tensor<1, dim, Number>> const & solution_values,
-                                    unsigned int const &                        component)
+linear_interpolation_2d_cylindrical(
+  Number const                                        r_in,
+  Number const                                        phi,
+  std::vector<Number> const &                         r_values,
+  std::vector<Number> const &                         phi_values,
+  std::vector<dealii::Tensor<1, dim, Number>> const & solution_values,
+  unsigned int const &                                component)
 {
-  AssertThrow(dim == 3, ExcMessage("not implemented"));
+  AssertThrow(dim == 3, dealii::ExcMessage("not implemented"));
 
   Number result = 0.0;
 
@@ -203,7 +203,7 @@ linear_interpolation_2d_cylindrical(Number const                                
 
   AssertThrow(r > (r_values[0] - tol) && r < (r_values[n_points_r - 1] + tol) &&
                 phi > (phi_values[0] - tol) && phi < (phi_values[n_points_phi - 1] + tol),
-              ExcMessage("invalid point found."));
+              dealii::ExcMessage("invalid point found."));
 
   // interpolate r and phi-coordinates
   unsigned int i_r = 0, i_phi = 0;
@@ -224,7 +224,7 @@ linear_interpolation_2d_cylindrical(Number const                                
     i_phi++;
 
   AssertThrow(i_r > 0 && i_r < n_points_r && i_phi > 0 && i_phi < n_points_phi,
-              ExcMessage("Invalid point found"));
+              dealii::ExcMessage("Invalid point found"));
 
   Number const weight_r_p = (r - r_values[i_r - 1]) / (r_values[i_r] - r_values[i_r - 1]);
   Number const weight_r_m = 1 - weight_r_p;
@@ -235,7 +235,7 @@ linear_interpolation_2d_cylindrical(Number const                                
   AssertThrow(-1.e-12 < weight_r_p && weight_r_p < 1. + 1e-12 && -1.e-12 < weight_r_m &&
                 weight_r_m < 1. + 1e-12 && -1.e-12 < weight_phi_p && weight_phi_p < 1. + 1e-12 &&
                 -1.e-12 < weight_phi_m && weight_phi_m < 1. + 1e-12,
-              ExcMessage("invalid weights when interpolating solution in 2D."));
+              dealii::ExcMessage("invalid weights when interpolating solution in 2D."));
 
   result =
     weight_r_m * weight_phi_m * solution_values[(i_r - 1) * n_points_phi + (i_phi - 1)][component] +
@@ -247,35 +247,39 @@ linear_interpolation_2d_cylindrical(Number const                                
 }
 
 template float
-linear_interpolation_2d_cylindrical(float const                              r_in,
-                                    float const                              phi,
-                                    std::vector<float> const &               r_values,
-                                    std::vector<float> const &               phi_values,
-                                    std::vector<Tensor<1, 2, float>> const & solution_values,
-                                    unsigned int const &                     component);
+linear_interpolation_2d_cylindrical(
+  float const                                      r_in,
+  float const                                      phi,
+  std::vector<float> const &                       r_values,
+  std::vector<float> const &                       phi_values,
+  std::vector<dealii::Tensor<1, 2, float>> const & solution_values,
+  unsigned int const &                             component);
 
 template double
-linear_interpolation_2d_cylindrical(double const                              r_in,
-                                    double const                              phi,
-                                    std::vector<double> const &               r_values,
-                                    std::vector<double> const &               phi_values,
-                                    std::vector<Tensor<1, 2, double>> const & solution_values,
-                                    unsigned int const &                      component);
+linear_interpolation_2d_cylindrical(
+  double const                                      r_in,
+  double const                                      phi,
+  std::vector<double> const &                       r_values,
+  std::vector<double> const &                       phi_values,
+  std::vector<dealii::Tensor<1, 2, double>> const & solution_values,
+  unsigned int const &                              component);
 
 template float
-linear_interpolation_2d_cylindrical(float const                              r_in,
-                                    float const                              phi,
-                                    std::vector<float> const &               r_values,
-                                    std::vector<float> const &               phi_values,
-                                    std::vector<Tensor<1, 3, float>> const & solution_values,
-                                    unsigned int const &                     component);
+linear_interpolation_2d_cylindrical(
+  float const                                      r_in,
+  float const                                      phi,
+  std::vector<float> const &                       r_values,
+  std::vector<float> const &                       phi_values,
+  std::vector<dealii::Tensor<1, 3, float>> const & solution_values,
+  unsigned int const &                             component);
 
 template double
-linear_interpolation_2d_cylindrical(double const                              r_in,
-                                    double const                              phi,
-                                    std::vector<double> const &               r_values,
-                                    std::vector<double> const &               phi_values,
-                                    std::vector<Tensor<1, 3, double>> const & solution_values,
-                                    unsigned int const &                      component);
+linear_interpolation_2d_cylindrical(
+  double const                                      r_in,
+  double const                                      phi,
+  std::vector<double> const &                       r_values,
+  std::vector<double> const &                       phi_values,
+  std::vector<dealii::Tensor<1, 3, double>> const & solution_values,
+  unsigned int const &                              component);
 
 } // namespace ExaDG

--- a/include/exadg/functions_and_boundary_conditions/linear_interpolation.h
+++ b/include/exadg/functions_and_boundary_conditions/linear_interpolation.h
@@ -26,36 +26,36 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 Number
-linear_interpolation_1d(double const &                              y,
-                        std::vector<Number> const &                 y_values,
-                        std::vector<Tensor<1, dim, Number>> const & solution_values,
-                        unsigned int const &                        component);
+linear_interpolation_1d(double const &                                      y,
+                        std::vector<Number> const &                         y_values,
+                        std::vector<dealii::Tensor<1, dim, Number>> const & solution_values,
+                        unsigned int const &                                component);
 
 /*
  *  2D interpolation for rectangular cross-sections
  */
 template<int dim, typename Number>
 Number
-linear_interpolation_2d_cartesian(Point<dim> const &                          point,
-                                  std::vector<Number> const &                 y_values,
-                                  std::vector<Number> const &                 z_values,
-                                  std::vector<Tensor<1, dim, Number>> const & solution_values,
-                                  unsigned int const &                        component);
+linear_interpolation_2d_cartesian(
+  dealii::Point<dim> const &                          point,
+  std::vector<Number> const &                         y_values,
+  std::vector<Number> const &                         z_values,
+  std::vector<dealii::Tensor<1, dim, Number>> const & solution_values,
+  unsigned int const &                                component);
 
 /*
  *  2D interpolation for cylindrical cross-sections
  */
 template<int dim, typename Number>
 Number
-linear_interpolation_2d_cylindrical(Number const                                r_in,
-                                    Number const                                phi,
-                                    std::vector<Number> const &                 r_values,
-                                    std::vector<Number> const &                 phi_values,
-                                    std::vector<Tensor<1, dim, Number>> const & solution_values,
-                                    unsigned int const &                        component);
+linear_interpolation_2d_cylindrical(
+  Number const                                        r_in,
+  Number const                                        phi,
+  std::vector<Number> const &                         r_values,
+  std::vector<Number> const &                         phi_values,
+  std::vector<dealii::Tensor<1, dim, Number>> const & solution_values,
+  unsigned int const &                                component);
 
 } // namespace ExaDG

--- a/include/exadg/functions_and_boundary_conditions/verify_boundary_conditions.h
+++ b/include/exadg/functions_and_boundary_conditions/verify_boundary_conditions.h
@@ -27,18 +27,16 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename BoundaryDescriptor>
 void
 verify_boundary_conditions(BoundaryDescriptor const & boundary_descriptor, Grid<dim> const & grid)
 {
   // fill set with periodic boundary ids
-  std::set<types::boundary_id> periodic_boundary_ids;
+  std::set<dealii::types::boundary_id> periodic_boundary_ids;
   for(auto periodic_pair : grid.periodic_faces)
   {
     AssertThrow(periodic_pair.cell[0]->level() == 0,
-                ExcMessage("Received periodic face pair on non-zero level"));
+                dealii::ExcMessage("Received periodic face pair on non-zero level"));
 
     periodic_boundary_ids.insert(
       periodic_pair.cell[0]->face(periodic_pair.face_idx[0])->boundary_id());
@@ -53,7 +51,7 @@ verify_boundary_conditions(BoundaryDescriptor const & boundary_descriptor, Grid<
     {
       if(cell.at_boundary(f))
       {
-        types::boundary_id const boundary_id = cell.face(f)->boundary_id();
+        dealii::types::boundary_id const boundary_id = cell.face(f)->boundary_id();
         boundary_descriptor.verify_boundary_conditions(boundary_id, periodic_boundary_ids);
       }
     }

--- a/include/exadg/grid/calculate_characteristic_element_length.h
+++ b/include/exadg/grid/calculate_characteristic_element_length.h
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  *  This function calculates the characteristic element length h
  *  defined as h = min_{e=1,...,N_el} h_e, where h_e is the
@@ -36,11 +34,11 @@ using namespace dealii;
  */
 template<int dim>
 inline double
-calculate_minimum_vertex_distance(Triangulation<dim> const & triangulation,
-                                  MPI_Comm const &           mpi_comm)
+calculate_minimum_vertex_distance(dealii::Triangulation<dim> const & triangulation,
+                                  MPI_Comm const &                   mpi_comm)
 {
-  typename Triangulation<dim>::active_cell_iterator cell = triangulation.begin_active(),
-                                                    endc = triangulation.end();
+  typename dealii::Triangulation<dim>::active_cell_iterator cell = triangulation.begin_active(),
+                                                            endc = triangulation.end();
 
   double diameter = 0.0, min_cell_diameter = std::numeric_limits<double>::max();
 
@@ -54,7 +52,8 @@ calculate_minimum_vertex_distance(Triangulation<dim> const & triangulation,
     }
   }
 
-  double const global_min_cell_diameter = -Utilities::MPI::max(-min_cell_diameter, mpi_comm);
+  double const global_min_cell_diameter =
+    -dealii::Utilities::MPI::max(-min_cell_diameter, mpi_comm);
 
   return global_min_cell_diameter;
 }

--- a/include/exadg/grid/calculate_maximum_aspect_ratio.h
+++ b/include/exadg/grid/calculate_maximum_aspect_ratio.h
@@ -30,23 +30,21 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
 inline double
-calculate_maximum_vertex_distance(typename Triangulation<dim>::active_cell_iterator & cell)
+calculate_maximum_vertex_distance(typename dealii::Triangulation<dim>::active_cell_iterator & cell)
 {
   double maximum_vertex_distance = 0.0;
 
   for(const unsigned int i : cell->vertex_indices())
   {
-    Point<dim> & ref_vertex = cell->vertex(i);
+    dealii::Point<dim> & ref_vertex = cell->vertex(i);
     // start the loop with the second vertex!
     for(const unsigned int j : cell->vertex_indices())
     {
       if(j != i)
       {
-        Point<dim> & vertex     = cell->vertex(j);
+        dealii::Point<dim> & vertex = cell->vertex(j);
         maximum_vertex_distance = std::max(maximum_vertex_distance, vertex.distance(ref_vertex));
       }
     }
@@ -59,16 +57,17 @@ calculate_maximum_vertex_distance(typename Triangulation<dim>::active_cell_itera
  * This is a rather naive version of computing the aspect ratio as this version does not
  * detect all modes of deformation (e.g., parallelogram with small angle, assuming that both
  * sides of the parallelogram have the same length, the aspect ratio would tend to a value of
- * 2 if the angle goes to zero!). Instead, the version GridTools::compute_maximum_aspect_ratio()
- * that relies on the computation of singular values of the Jacobian should be used.
+ * 2 if the angle goes to zero!). Instead, the version
+ * dealii::GridTools::compute_maximum_aspect_ratio() that relies on the computation of singular
+ * values of the Jacobian should be used.
  */
 template<int dim>
 inline double
-calculate_aspect_ratio_vertex_distance(Triangulation<dim> const & triangulation,
-                                       MPI_Comm const &           mpi_comm)
+calculate_aspect_ratio_vertex_distance(dealii::Triangulation<dim> const & triangulation,
+                                       MPI_Comm const &                   mpi_comm)
 {
-  typename Triangulation<dim>::active_cell_iterator cell = triangulation.begin_active(),
-                                                    endc = triangulation.end();
+  typename dealii::Triangulation<dim>::active_cell_iterator cell = triangulation.begin_active(),
+                                                            endc = triangulation.end();
 
   double max_aspect_ratio = 0.0;
 
@@ -86,7 +85,7 @@ calculate_aspect_ratio_vertex_distance(Triangulation<dim> const & triangulation,
     }
   }
 
-  double const global_max_aspect_ratio = Utilities::MPI::max(max_aspect_ratio, mpi_comm);
+  double const global_max_aspect_ratio = dealii::Utilities::MPI::max(max_aspect_ratio, mpi_comm);
 
   return global_max_aspect_ratio;
 }

--- a/include/exadg/grid/deformed_cube_manifold.h
+++ b/include/exadg/grid/deformed_cube_manifold.h
@@ -26,10 +26,8 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
-class DeformedCubeManifold : public ChartManifold<dim, dim, dim>
+class DeformedCubeManifold : public dealii::ChartManifold<dim, dim, dim>
 {
 public:
   DeformedCubeManifold(double const       left,
@@ -40,45 +38,47 @@ public:
   {
   }
 
-  Point<dim>
-  push_forward(Point<dim> const & chart_point) const override
+  dealii::Point<dim>
+  push_forward(dealii::Point<dim> const & chart_point) const override
   {
     double sinval = deformation;
     for(unsigned int d = 0; d < dim; ++d)
-      sinval *= std::sin(frequency * numbers::PI * (chart_point(d) - left) / (right - left));
-    Point<dim> space_point;
+      sinval *=
+        std::sin(frequency * dealii::numbers::PI * (chart_point(d) - left) / (right - left));
+    dealii::Point<dim> space_point;
     for(unsigned int d = 0; d < dim; ++d)
       space_point(d) = chart_point(d) + sinval;
     return space_point;
   }
 
-  Point<dim>
-  pull_back(Point<dim> const & space_point) const override
+  dealii::Point<dim>
+  pull_back(dealii::Point<dim> const & space_point) const override
   {
-    Point<dim> x = space_point;
-    Point<dim> one;
+    dealii::Point<dim> x = space_point;
+    dealii::Point<dim> one;
     for(unsigned int d = 0; d < dim; ++d)
       one(d) = 1.;
 
     // Newton iteration to solve the nonlinear equation given by the point
-    Tensor<1, dim> sinvals;
+    dealii::Tensor<1, dim> sinvals;
     for(unsigned int d = 0; d < dim; ++d)
-      sinvals[d] = std::sin(frequency * numbers::PI * (x(d) - left) / (right - left));
+      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x(d) - left) / (right - left));
 
     double sinval = deformation;
     for(unsigned int d = 0; d < dim; ++d)
       sinval *= sinvals[d];
-    Tensor<1, dim> residual = space_point - x - sinval * one;
-    unsigned int   its      = 0;
+    dealii::Tensor<1, dim> residual = space_point - x - sinval * one;
+    unsigned int           its      = 0;
     while(residual.norm() > 1e-12 && its < 100)
     {
-      Tensor<2, dim> jacobian;
+      dealii::Tensor<2, dim> jacobian;
       for(unsigned int d = 0; d < dim; ++d)
         jacobian[d][d] = 1.;
       for(unsigned int d = 0; d < dim; ++d)
       {
-        double sinval_der = deformation * frequency / (right - left) * numbers::PI *
-                            std::cos(frequency * numbers::PI * (x(d) - left) / (right - left));
+        double sinval_der =
+          deformation * frequency / (right - left) * dealii::numbers::PI *
+          std::cos(frequency * dealii::numbers::PI * (x(d) - left) / (right - left));
         for(unsigned int e = 0; e < dim; ++e)
           if(e != d)
             sinval_der *= sinvals[e];
@@ -89,7 +89,7 @@ public:
       x += invert(jacobian) * residual;
 
       for(unsigned int d = 0; d < dim; ++d)
-        sinvals[d] = std::sin(frequency * numbers::PI * (x(d) - left) / (right - left));
+        sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x(d) - left) / (right - left));
 
       sinval = deformation;
       for(unsigned int d = 0; d < dim; ++d)
@@ -97,11 +97,11 @@ public:
       residual = space_point - x - sinval * one;
       ++its;
     }
-    AssertThrow(residual.norm() < 1e-12, ExcMessage("Newton for point did not converge."));
+    AssertThrow(residual.norm() < 1e-12, dealii::ExcMessage("Newton for point did not converge."));
     return x;
   }
 
-  std::unique_ptr<Manifold<dim>>
+  std::unique_ptr<dealii::Manifold<dim>>
   clone() const override
   {
     return std::make_unique<DeformedCubeManifold<dim>>(left, right, deformation, frequency);

--- a/include/exadg/grid/enum_types.cpp
+++ b/include/exadg/grid/enum_types.cpp
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 std::string
 enum_to_string(TriangulationType const enum_type)
 {
@@ -46,7 +44,7 @@ enum_to_string(TriangulationType const enum_type)
       string_type = "FullyDistributed";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -73,7 +71,7 @@ enum_to_string(MappingType const enum_type)
       string_type = "Isoparametric";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/grid/enum_types.h
+++ b/include/exadg/grid/enum_types.h
@@ -46,7 +46,7 @@ std::string
 enum_to_string(TriangulationType const enum_type);
 
 /*
- *  Mapping type (polynomial degree)
+ *  dealii::Mapping type (polynomial degree)
  */
 enum class MappingType
 {

--- a/include/exadg/grid/enum_types.h
+++ b/include/exadg/grid/enum_types.h
@@ -46,7 +46,7 @@ std::string
 enum_to_string(TriangulationType const enum_type);
 
 /*
- *  dealii::Mapping type (polynomial degree)
+ *  Mapping type (polynomial degree)
  */
 enum class MappingType
 {

--- a/include/exadg/grid/find_all_active_cells_around_point.h
+++ b/include/exadg/grid/find_all_active_cells_around_point.h
@@ -24,32 +24,33 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
-std::vector<std::pair<typename Triangulation<dim>::active_cell_iterator, Point<dim>>>
-find_all_active_cells_around_point(Mapping<dim> const &                                mapping,
-                                   Triangulation<dim> const &                          tria,
-                                   Point<dim> const &                                  point,
-                                   double const                                        tolerance,
-                                   typename Triangulation<dim>::active_cell_iterator & cell_hint,
-                                   std::vector<bool> const &          marked_vertices,
-                                   GridTools::Cache<dim, dim> const & cache)
+std::vector<
+  std::pair<typename dealii::Triangulation<dim>::active_cell_iterator, dealii::Point<dim>>>
+find_all_active_cells_around_point(
+  dealii::Mapping<dim> const &                                mapping,
+  dealii::Triangulation<dim> const &                          tria,
+  dealii::Point<dim> const &                                  point,
+  double const                                                tolerance,
+  typename dealii::Triangulation<dim>::active_cell_iterator & cell_hint,
+  std::vector<bool> const &                                   marked_vertices,
+  dealii::GridTools::Cache<dim, dim> const &                  cache)
 {
-  typedef std::pair<typename Triangulation<dim>::active_cell_iterator, Point<dim>> Pair;
+  typedef std::pair<typename dealii::Triangulation<dim>::active_cell_iterator, dealii::Point<dim>>
+    Pair;
 
   std::vector<Pair> adjacent_cells;
 
-  Pair first_cell =
-    GridTools::find_active_cell_around_point(cache, point, cell_hint, marked_vertices, tolerance);
+  Pair first_cell = dealii::GridTools::find_active_cell_around_point(
+    cache, point, cell_hint, marked_vertices, tolerance);
 
   if(first_cell.first != tria.end())
   {
     // update cell_hint to have a good hint when the function is called next time
     cell_hint = first_cell.first;
 
-    adjacent_cells =
-      GridTools::find_all_active_cells_around_point(mapping, tria, point, tolerance, first_cell);
+    adjacent_cells = dealii::GridTools::find_all_active_cells_around_point(
+      mapping, tria, point, tolerance, first_cell);
   }
 
   return adjacent_cells;
@@ -58,13 +59,13 @@ find_all_active_cells_around_point(Mapping<dim> const &                         
 template<int dim>
 unsigned int
 n_locally_owned_active_cells_around_point(
-  Triangulation<dim> const &                               tria,
-  Mapping<dim> const &                                     mapping,
-  Point<dim> const &                                       point,
-  double const                                             tolerance,
-  typename Triangulation<dim, dim>::active_cell_iterator & cell_hint,
-  std::vector<bool> const &                                marked_vertices,
-  GridTools::Cache<dim, dim> const &                       cache)
+  dealii::Triangulation<dim> const &                               tria,
+  dealii::Mapping<dim> const &                                     mapping,
+  dealii::Point<dim> const &                                       point,
+  double const                                                     tolerance,
+  typename dealii::Triangulation<dim, dim>::active_cell_iterator & cell_hint,
+  std::vector<bool> const &                                        marked_vertices,
+  dealii::GridTools::Cache<dim, dim> const &                       cache)
 {
   auto adjacent_cells = find_all_active_cells_around_point(
     mapping, tria, point, tolerance, cell_hint, marked_vertices, cache);

--- a/include/exadg/grid/get_dynamic_mapping.h
+++ b/include/exadg/grid/get_dynamic_mapping.h
@@ -33,7 +33,7 @@ namespace ExaDG
  * initialized).
  */
 template<int dim, typename Number>
-std::shared_ptr<Mapping<dim> const>
+std::shared_ptr<dealii::Mapping<dim> const>
 get_dynamic_mapping(std::shared_ptr<Grid<dim> const>                        grid,
                     std::shared_ptr<GridMotionInterface<dim, Number> const> grid_motion)
 {
@@ -43,7 +43,8 @@ get_dynamic_mapping(std::shared_ptr<Grid<dim> const>                        grid
   }
   else
   {
-    AssertThrow(grid->mapping.get() != 0, ExcMessage("Uninitialized mapping object detected."));
+    AssertThrow(grid->mapping.get() != 0,
+                dealii::ExcMessage("Uninitialized mapping object detected."));
 
     return grid->mapping;
   }

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -33,15 +33,13 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
 class Grid
 {
 public:
-  typedef
-    typename std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-      PeriodicFaces;
+  typedef typename std::vector<
+    dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
+    PeriodicFaces;
 
   /**
    * Constructor.
@@ -51,33 +49,34 @@ public:
     // triangulation
     if(data.triangulation_type == TriangulationType::Serial)
     {
-      AssertDimension(Utilities::MPI::n_mpi_processes(mpi_comm), 1);
-      triangulation = std::make_shared<Triangulation<dim>>();
+      AssertDimension(dealii::Utilities::MPI::n_mpi_processes(mpi_comm), 1);
+      triangulation = std::make_shared<dealii::Triangulation<dim>>();
     }
     else if(data.triangulation_type == TriangulationType::Distributed)
     {
-      triangulation = std::make_shared<parallel::distributed::Triangulation<dim>>(
+      triangulation = std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(
         mpi_comm,
         dealii::Triangulation<dim>::none,
-        parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+        dealii::parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
     }
     else if(data.triangulation_type == TriangulationType::FullyDistributed)
     {
-      triangulation = std::make_shared<parallel::fullydistributed::Triangulation<dim>>(mpi_comm);
+      triangulation =
+        std::make_shared<dealii::parallel::fullydistributed::Triangulation<dim>>(mpi_comm);
     }
     else
     {
-      AssertThrow(false, ExcMessage("Invalid parameter triangulation_type."));
+      AssertThrow(false, dealii::ExcMessage("Invalid parameter triangulation_type."));
     }
 
     // mapping
-    mapping = std::make_shared<MappingQGeneric<dim>>(data.mapping_degree);
+    mapping = std::make_shared<dealii::MappingQGeneric<dim>>(data.mapping_degree);
   }
 
   /**
    * dealii::Triangulation.
    */
-  std::shared_ptr<Triangulation<dim>> triangulation;
+  std::shared_ptr<dealii::Triangulation<dim>> triangulation;
 
   /**
    * dealii::GridTools::PeriodicFacePair's.
@@ -87,7 +86,7 @@ public:
   /**
    * dealii::Mapping.
    */
-  std::shared_ptr<Mapping<dim>> mapping;
+  std::shared_ptr<dealii::Mapping<dim>> mapping;
 };
 
 } // namespace ExaDG

--- a/include/exadg/grid/grid_data.h
+++ b/include/exadg/grid/grid_data.h
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct GridData
 {
   GridData()
@@ -45,7 +43,7 @@ struct GridData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "Triangulation type", enum_to_string(triangulation_type));
 

--- a/include/exadg/grid/grid_motion_base.h
+++ b/include/exadg/grid/grid_motion_base.h
@@ -28,8 +28,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /**
  * Base class for moving grid problems.
  */
@@ -37,21 +35,21 @@ template<int dim, typename Number>
 class GridMotionBase : public GridMotionInterface<dim, Number>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   /**
    * Constructor.
    */
-  GridMotionBase(std::shared_ptr<Mapping<dim> const> mapping_undeformed,
-                 unsigned int const                  mapping_degree_q_cache,
-                 Triangulation<dim> const &          triangulation)
+  GridMotionBase(std::shared_ptr<dealii::Mapping<dim> const> mapping_undeformed,
+                 unsigned int const                          mapping_degree_q_cache,
+                 dealii::Triangulation<dim> const &          triangulation)
     : mapping_undeformed(mapping_undeformed)
   {
-    // Make sure that MappingQCache is initialized correctly. An empty dof-vector is used and,
-    // hence, no displacements are added to the reference configuration described by
+    // Make sure that dealii::MappingQCache is initialized correctly. An empty dof-vector is used
+    // and, hence, no displacements are added to the reference configuration described by
     // mapping_undeformed.
-    DoFHandler<dim> dof_handler(triangulation);
-    VectorType      displacement_vector;
+    dealii::DoFHandler<dim> dof_handler(triangulation);
+    VectorType              displacement_vector;
     moving_mapping = std::make_shared<MappingDoFVector<dim, Number>>(mapping_degree_q_cache);
     moving_mapping->initialize_mapping_q_cache(mapping_undeformed,
                                                displacement_vector,
@@ -59,13 +57,13 @@ public:
   }
 
   void
-  fill_grid_coordinates_vector(VectorType &            grid_coordinates,
-                               DoFHandler<dim> const & dof_handler) const final
+  fill_grid_coordinates_vector(VectorType &                    grid_coordinates,
+                               dealii::DoFHandler<dim> const & dof_handler) const final
   {
     moving_mapping->fill_grid_coordinates_vector(grid_coordinates, dof_handler);
   }
 
-  std::shared_ptr<Mapping<dim> const>
+  std::shared_ptr<dealii::Mapping<dim> const>
   get_mapping() const final
   {
     return moving_mapping;
@@ -73,7 +71,7 @@ public:
 
 protected:
   // mapping describing undeformed reference state
-  std::shared_ptr<Mapping<dim> const> mapping_undeformed;
+  std::shared_ptr<dealii::Mapping<dim> const> mapping_undeformed;
 
   // time-dependent mapping describing deformed state
   std::shared_ptr<MappingDoFVector<dim, Number>> moving_mapping;

--- a/include/exadg/grid/grid_motion_elasticity.h
+++ b/include/exadg/grid/grid_motion_elasticity.h
@@ -32,8 +32,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /**
  * Class for moving grid problems based on a pseudo-solid grid motion technique.
  */
@@ -41,12 +39,12 @@ template<int dim, typename Number>
 class GridMotionElasticity : public GridMotionBase<dim, Number>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   /**
    * Constructor.
    */
-  GridMotionElasticity(std::shared_ptr<Mapping<dim> const>               mapping_undeformed,
+  GridMotionElasticity(std::shared_ptr<dealii::Mapping<dim> const>       mapping_undeformed,
                        std::shared_ptr<Structure::Operator<dim, Number>> structure_operator,
                        Structure::Parameters const &                     structure_parameters)
     : GridMotionBase<dim, Number>(mapping_undeformed,
@@ -56,7 +54,7 @@ public:
       pde_operator(structure_operator),
       param(structure_parameters),
       pcout(std::cout,
-            Utilities::MPI::this_mpi_process(
+            dealii::Utilities::MPI::this_mpi_process(
               structure_operator->get_dof_handler().get_communicator()) == 0),
       iterations({0, {0, 0}})
   {
@@ -69,7 +67,7 @@ public:
   void
   update(double const time, bool const print_solver_info) override
   {
-    Timer timer;
+    dealii::Timer timer;
     timer.restart();
 
     if(param.large_deformation) // nonlinear problem
@@ -159,7 +157,7 @@ private:
   // costs by allowing larger tolerances
   VectorType displacement;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   std::pair<
     unsigned int /* calls */,

--- a/include/exadg/grid/grid_motion_interface.h
+++ b/include/exadg/grid/grid_motion_interface.h
@@ -29,8 +29,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /**
  * Pure-virtual interface class for moving grid functionality.
  */
@@ -38,7 +36,7 @@ template<int dim, typename Number>
 class GridMotionInterface
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   /**
    * Destructor.
@@ -59,21 +57,21 @@ public:
   virtual void
   print_iterations() const
   {
-    AssertThrow(false, ExcMessage("Has to be overwritten by derived classes."));
+    AssertThrow(false, dealii::ExcMessage("Has to be overwritten by derived classes."));
   }
 
   /**
    * Extract the grid coordinates of the current mesh configuration and fill a dof-vector given a
-   * corresponding DoFHandler object.
+   * corresponding dealii::DoFHandler object.
    */
   virtual void
-  fill_grid_coordinates_vector(VectorType &            grid_coordinates,
-                               DoFHandler<dim> const & dof_handler) const = 0;
+  fill_grid_coordinates_vector(VectorType &                    grid_coordinates,
+                               dealii::DoFHandler<dim> const & dof_handler) const = 0;
 
   /**
    * Return a shared pointer to dealii::Mapping<dim>.
    */
-  virtual std::shared_ptr<Mapping<dim> const>
+  virtual std::shared_ptr<dealii::Mapping<dim> const>
   get_mapping() const = 0;
 };
 

--- a/include/exadg/grid/grid_motion_poisson.h
+++ b/include/exadg/grid/grid_motion_poisson.h
@@ -32,8 +32,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /**
  * Class for moving grid problems based on a Poisson-type grid motion technique.
  */
@@ -41,12 +39,12 @@ template<int dim, typename Number>
 class GridMotionPoisson : public GridMotionBase<dim, Number>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   /**
    * Constructor.
    */
-  GridMotionPoisson(std::shared_ptr<Mapping<dim> const>                  mapping_undeformed,
+  GridMotionPoisson(std::shared_ptr<dealii::Mapping<dim> const>          mapping_undeformed,
                     std::shared_ptr<Poisson::Operator<dim, Number, dim>> poisson_operator)
     : GridMotionBase<dim, Number>(mapping_undeformed,
                                   // extract mapping_degree_moving from Poisson operator
@@ -54,7 +52,7 @@ public:
                                   poisson_operator->get_dof_handler().get_triangulation()),
       poisson(poisson_operator),
       pcout(std::cout,
-            Utilities::MPI::this_mpi_process(
+            dealii::Utilities::MPI::this_mpi_process(
               poisson_operator->get_dof_handler().get_communicator()) == 0),
       iterations({0, 0})
   {
@@ -67,7 +65,7 @@ public:
   void
   update(double const time, bool const print_solver_info) override
   {
-    Timer timer;
+    dealii::Timer timer;
     timer.restart();
 
     VectorType rhs;
@@ -115,7 +113,7 @@ private:
   // costs by allowing larger tolerances
   VectorType displacement;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   std::pair<unsigned int /* calls */, unsigned long long /* iteration counts */> iterations;
 };

--- a/include/exadg/grid/mapping_dof_vector.h
+++ b/include/exadg/grid/mapping_dof_vector.h
@@ -40,31 +40,29 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /**
- * A mapping class based on MappingQCache equipped with practical interfaces that can be used to
- * initialize the mapping.
+ * A mapping class based on dealii::MappingQCache equipped with practical interfaces that can be
+ * used to initialize the mapping.
  *
  * The two functions fill_grid_coordinates_vector() and initialize_mapping_q_cache() should become
- * member functions of MappingQCache in dealii, rendering this class superfluous in ExaDG.
+ * member functions of dealii::MappingQCache in dealii, rendering this class superfluous in ExaDG.
  */
 template<int dim, typename Number>
-class MappingDoFVector : public MappingQCache<dim>
+class MappingDoFVector : public dealii::MappingQCache<dim>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   /**
    * Constructor.
    */
   MappingDoFVector(unsigned int const mapping_degree_q_cache)
-    : MappingQCache<dim>(mapping_degree_q_cache)
+    : dealii::MappingQCache<dim>(mapping_degree_q_cache)
   {
     hierarchic_to_lexicographic_numbering =
-      FETools::hierarchic_to_lexicographic_numbering<dim>(mapping_degree_q_cache);
+      dealii::FETools::hierarchic_to_lexicographic_numbering<dim>(mapping_degree_q_cache);
     lexicographic_to_hierarchic_numbering =
-      Utilities::invert_permutation(hierarchic_to_lexicographic_numbering);
+      dealii::Utilities::invert_permutation(hierarchic_to_lexicographic_numbering);
   }
 
   /**
@@ -75,30 +73,31 @@ public:
   }
 
   /**
-   * Extract the grid coordinates of the current mesh configuration described by the MappingQCache
-   * object and fill a dof-vector given a corresponding DoFHandler object.
+   * Extract the grid coordinates of the current mesh configuration described by the
+   * dealii::MappingQCache object and fill a dof-vector given a corresponding dealii::DoFHandler
+   * object.
    */
   void
-  fill_grid_coordinates_vector(VectorType &            grid_coordinates,
-                               DoFHandler<dim> const & dof_handler) const
+  fill_grid_coordinates_vector(VectorType &                    grid_coordinates,
+                               dealii::DoFHandler<dim> const & dof_handler) const
   {
-    // use the deformed state described by the MappingQCache object (*this)
+    // use the deformed state described by the dealii::MappingQCache object (*this)
     fill_grid_coordinates_vector(*this, grid_coordinates, dof_handler);
   }
 
   /**
    * Extract the grid coordinates for a given external mapping and fill a
-   * dof-vector given a corresponding DoFHandler object.
+   * dof-vector given a corresponding dealii::DoFHandler object.
    */
   void
-  fill_grid_coordinates_vector(Mapping<dim> const &    mapping,
-                               VectorType &            grid_coordinates,
-                               DoFHandler<dim> const & dof_handler) const
+  fill_grid_coordinates_vector(dealii::Mapping<dim> const &    mapping,
+                               VectorType &                    grid_coordinates,
+                               dealii::DoFHandler<dim> const & dof_handler) const
   {
     if(grid_coordinates.size() != dof_handler.n_dofs())
     {
-      IndexSet relevant_dofs_grid;
-      DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs_grid);
+      dealii::IndexSet relevant_dofs_grid;
+      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs_grid);
       grid_coordinates.reinit(dof_handler.locally_owned_dofs(),
                               relevant_dofs_grid,
                               dof_handler.get_communicator());
@@ -108,24 +107,24 @@ public:
       grid_coordinates = 0;
     }
 
-    FiniteElement<dim> const & fe = dof_handler.get_fe();
+    dealii::FiniteElement<dim> const & fe = dof_handler.get_fe();
 
-    // Set up FEValues with base element and the Gauss-Lobatto quadrature to
+    // Set up dealii::FEValues with base element and the Gauss-Lobatto quadrature to
     // reduce setup cost, as we only use the geometry information (this means
     // we need to call fe_values.reinit(cell) with Triangulation::cell_iterator
-    // rather than DoFHandler::cell_iterator).
-    FE_Nothing<dim> dummy_fe;
-    FEValues<dim>   fe_values(mapping,
-                            dummy_fe,
-                            QGaussLobatto<dim>(fe.degree + 1),
-                            update_quadrature_points);
+    // rather than dealii::DoFHandler::cell_iterator).
+    dealii::FE_Nothing<dim> dummy_fe;
+    dealii::FEValues<dim>   fe_values(mapping,
+                                    dummy_fe,
+                                    dealii::QGaussLobatto<dim>(fe.degree + 1),
+                                    dealii::update_quadrature_points);
 
-    std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+    std::vector<dealii::types::global_dof_index> dof_indices(fe.dofs_per_cell);
 
     std::vector<std::array<unsigned int, dim>> component_to_system_index(
       fe.base_element(0).dofs_per_cell);
 
-    if(fe.dofs_per_vertex > 0) // FE_Q
+    if(fe.dofs_per_vertex > 0) // dealii::FE_Q
     {
       for(unsigned int i = 0; i < fe.dofs_per_cell; ++i)
       {
@@ -134,7 +133,7 @@ public:
           [fe.system_to_component_index(i).first] = i;
       }
     }
-    else // FE_DGQ
+    else // dealii::FE_DGQ
     {
       for(unsigned int i = 0; i < fe.dofs_per_cell; ++i)
       {
@@ -147,11 +146,11 @@ public:
     {
       if(!cell->is_artificial())
       {
-        fe_values.reinit(typename Triangulation<dim>::cell_iterator(cell));
+        fe_values.reinit(typename dealii::Triangulation<dim>::cell_iterator(cell));
         cell->get_dof_indices(dof_indices);
         for(unsigned int i = 0; i < fe_values.n_quadrature_points; ++i)
         {
-          Point<dim> const point = fe_values.quadrature_point(i);
+          dealii::Point<dim> const point = fe_values.quadrature_point(i);
           for(unsigned int d = 0; d < dim; ++d)
           {
             if(grid_coordinates.get_partitioner()->in_local_range(
@@ -168,10 +167,10 @@ public:
   }
 
   /**
-   * Initializes the MappingQCache object by providing a mapping that describes an undeformed
-   * reference configuration and a displacement dof-vector (with a corresponding DoFHandler object)
-   * that describes the displacement of the mesh compared to that reference configuration. There are
-   * two special cases:
+   * Initializes the dealii::MappingQCache object by providing a mapping that describes an
+   * undeformed reference configuration and a displacement dof-vector (with a corresponding
+   * dealii::DoFHandler object) that describes the displacement of the mesh compared to that
+   * reference configuration. There are two special cases:
    *
    * If the mapping pointer is invalid, this implies that the references coordinates are interpreted
    * as zero, i.e., the displacement vector describes the absolute coordinates of the grid points.
@@ -180,17 +179,17 @@ public:
    * be added to the grid coordinates of the reference configuration described by mapping.
    */
   void
-  initialize_mapping_q_cache(std::shared_ptr<Mapping<dim> const> mapping,
-                             VectorType const &                  displacement_vector,
-                             DoFHandler<dim> const &             dof_handler)
+  initialize_mapping_q_cache(std::shared_ptr<dealii::Mapping<dim> const> mapping,
+                             VectorType const &                          displacement_vector,
+                             dealii::DoFHandler<dim> const &             dof_handler)
   {
-    AssertThrow(MultithreadInfo::n_threads() == 1, ExcNotImplemented());
+    AssertThrow(dealii::MultithreadInfo::n_threads() == 1, dealii::ExcNotImplemented());
 
     VectorType displacement_vector_ghosted;
     if(dof_handler.n_dofs() > 0 && displacement_vector.size() == dof_handler.n_dofs())
     {
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+      dealii::IndexSet locally_relevant_dofs;
+      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
       displacement_vector_ghosted.reinit(dof_handler.locally_owned_dofs(),
                                          locally_relevant_dofs,
                                          dof_handler.get_communicator());
@@ -198,24 +197,27 @@ public:
       displacement_vector_ghosted.update_ghost_values();
     }
 
-    std::shared_ptr<FEValues<dim>> fe_values;
+    std::shared_ptr<dealii::FEValues<dim>> fe_values;
 
-    FE_Nothing<dim> fe_nothing;
+    dealii::FE_Nothing<dim> fe_nothing;
     if(mapping.get() != 0)
     {
-      fe_values = std::make_shared<FEValues<dim>>(*mapping,
-                                                  fe_nothing,
-                                                  QGaussLobatto<dim>(this->get_degree() + 1),
-                                                  update_quadrature_points);
+      fe_values =
+        std::make_shared<dealii::FEValues<dim>>(*mapping,
+                                                fe_nothing,
+                                                dealii::QGaussLobatto<dim>(this->get_degree() + 1),
+                                                dealii::update_quadrature_points);
     }
 
     // update mapping according to mesh deformation described by displacement vector
-    MappingQCache<dim>::initialize(
+    dealii::MappingQCache<dim>::initialize(
       dof_handler.get_triangulation(),
-      [&](const typename Triangulation<dim>::cell_iterator & cell_tria) -> std::vector<Point<dim>> {
-        unsigned int const scalar_dofs_per_cell = Utilities::pow(this->get_degree() + 1, dim);
+      [&](const typename dealii::Triangulation<dim>::cell_iterator & cell_tria)
+        -> std::vector<dealii::Point<dim>> {
+        unsigned int const scalar_dofs_per_cell =
+          dealii::Utilities::pow(this->get_degree() + 1, dim);
 
-        std::vector<Point<dim>> grid_coordinates(scalar_dofs_per_cell);
+        std::vector<dealii::Point<dim>> grid_coordinates(scalar_dofs_per_cell);
 
         if(mapping.get() != 0)
         {
@@ -233,27 +235,27 @@ public:
         if(dof_handler.n_dofs() > 0 && displacement_vector.size() > 0 && cell_tria->is_active() &&
            !cell_tria->is_artificial())
         {
-          FiniteElement<dim> const & fe = dof_handler.get_fe();
+          dealii::FiniteElement<dim> const & fe = dof_handler.get_fe();
           AssertThrow(fe.element_multiplicity(0) == dim,
-                      ExcMessage("Expected finite element with dim components."));
+                      dealii::ExcMessage("Expected finite element with dim components."));
 
-          typename DoFHandler<dim>::cell_iterator cell(&cell_tria->get_triangulation(),
-                                                       cell_tria->level(),
-                                                       cell_tria->index(),
-                                                       &dof_handler);
+          typename dealii::DoFHandler<dim>::cell_iterator cell(&cell_tria->get_triangulation(),
+                                                               cell_tria->level(),
+                                                               cell_tria->index(),
+                                                               &dof_handler);
 
-          std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+          std::vector<dealii::types::global_dof_index> dof_indices(fe.dofs_per_cell);
           cell->get_dof_indices(dof_indices);
 
           for(unsigned int i = 0; i < dof_indices.size(); ++i)
           {
             std::pair<unsigned int, unsigned int> const id = fe.system_to_component_index(i);
 
-            if(fe.dofs_per_vertex > 0) // FE_Q
+            if(fe.dofs_per_vertex > 0) // dealii::FE_Q
             {
               grid_coordinates[id.second][id.first] += displacement_vector_ghosted(dof_indices[i]);
             }
-            else // FE_DGQ
+            else // dealii::FE_DGQ
             {
               grid_coordinates[this->lexicographic_to_hierarchic_numbering[id.second]][id.first] +=
                 displacement_vector_ghosted(dof_indices[i]);
@@ -269,6 +271,7 @@ public:
   std::vector<unsigned int> lexicographic_to_hierarchic_numbering;
 };
 
+
 namespace MappingTools
 {
 /**
@@ -278,22 +281,23 @@ namespace MappingTools
  */
 template<int dim, typename Number>
 void
-initialize_multigrid(std::shared_ptr<MappingDoFVector<dim, Number>> mapping_multigrid,
-                     std::shared_ptr<MappingQCache<dim> const> &    mapping_q_cache,
-                     Triangulation<dim> const &                     triangulation)
+initialize_multigrid(std::shared_ptr<MappingDoFVector<dim, Number>>      mapping_multigrid,
+                     std::shared_ptr<dealii::MappingQCache<dim> const> & mapping_q_cache,
+                     dealii::Triangulation<dim> const &                  triangulation)
 {
-  AssertThrow(MultithreadInfo::n_threads() == 1, ExcNotImplemented());
+  AssertThrow(dealii::MultithreadInfo::n_threads() == 1, dealii::ExcNotImplemented());
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   // we have to project the solution onto all coarse levels of the triangulation
-  MGLevelObject<VectorType> grid_coordinates_all_levels, grid_coordinates_all_levels_ghosted;
-  unsigned int const        n_levels = triangulation.n_global_levels();
+  dealii::MGLevelObject<VectorType> grid_coordinates_all_levels,
+    grid_coordinates_all_levels_ghosted;
+  unsigned int const n_levels = triangulation.n_global_levels();
   grid_coordinates_all_levels.resize(0, n_levels - 1);
   grid_coordinates_all_levels_ghosted.resize(0, n_levels - 1);
 
-  FESystem<dim>   fe(FE_Q<dim>(mapping_q_cache->get_degree()), dim);
-  DoFHandler<dim> dof_handler(triangulation);
+  dealii::FESystem<dim>   fe(dealii::FE_Q<dim>(mapping_q_cache->get_degree()), dim);
+  dealii::DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
   dof_handler.distribute_mg_dofs();
   VectorType grid_coordinates_fine_level;
@@ -301,14 +305,14 @@ initialize_multigrid(std::shared_ptr<MappingDoFVector<dim, Number>> mapping_mult
                                                   grid_coordinates_fine_level,
                                                   dof_handler);
 
-  MGTransferMatrixFree<dim, Number> transfer;
+  dealii::MGTransferMatrixFree<dim, Number> transfer;
   transfer.build(dof_handler);
   transfer.interpolate_to_mg(dof_handler, grid_coordinates_all_levels, grid_coordinates_fine_level);
 
   for(unsigned int level = 0; level < n_levels; level++)
   {
-    IndexSet relevant_dofs;
-    DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, relevant_dofs);
+    dealii::IndexSet relevant_dofs;
+    dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, relevant_dofs);
 
     grid_coordinates_all_levels_ghosted[level].reinit(
       dof_handler.locally_owned_mg_dofs(level),
@@ -322,39 +326,40 @@ initialize_multigrid(std::shared_ptr<MappingDoFVector<dim, Number>> mapping_mult
   }
 
   AssertThrow(fe.element_multiplicity(0) == dim,
-              ExcMessage("Expected finite element with dim components."));
+              dealii::ExcMessage("Expected finite element with dim components."));
 
   // update mapping for all multigrid levels according to grid coordinates described by static
   // mapping
   mapping_multigrid->initialize(
     dof_handler.get_triangulation(),
-    [&](const typename Triangulation<dim>::cell_iterator & cell_tria) -> std::vector<Point<dim>> {
+    [&](const typename dealii::Triangulation<dim>::cell_iterator & cell_tria)
+      -> std::vector<dealii::Point<dim>> {
       unsigned int const level = cell_tria->level();
 
-      typename DoFHandler<dim>::cell_iterator cell(&cell_tria->get_triangulation(),
-                                                   level,
-                                                   cell_tria->index(),
-                                                   &dof_handler);
+      typename dealii::DoFHandler<dim>::cell_iterator cell(&cell_tria->get_triangulation(),
+                                                           level,
+                                                           cell_tria->index(),
+                                                           &dof_handler);
 
-      unsigned int const scalar_dofs_per_cell = Utilities::pow(fe.degree + 1, dim);
+      unsigned int const scalar_dofs_per_cell = dealii::Utilities::pow(fe.degree + 1, dim);
 
-      std::vector<Point<dim>> grid_coordinates(scalar_dofs_per_cell);
+      std::vector<dealii::Point<dim>> grid_coordinates(scalar_dofs_per_cell);
 
-      if(cell->level_subdomain_id() != numbers::artificial_subdomain_id)
+      if(cell->level_subdomain_id() != dealii::numbers::artificial_subdomain_id)
       {
-        std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+        std::vector<dealii::types::global_dof_index> dof_indices(fe.dofs_per_cell);
         cell->get_mg_dof_indices(dof_indices);
 
         for(unsigned int i = 0; i < dof_indices.size(); ++i)
         {
           std::pair<unsigned int, unsigned int> const id = fe.system_to_component_index(i);
 
-          if(fe.dofs_per_vertex > 0) // FE_Q
+          if(fe.dofs_per_vertex > 0) // dealii::FE_Q
           {
             grid_coordinates[id.second][id.first] =
               grid_coordinates_all_levels_ghosted[level](dof_indices[i]);
           }
-          else // FE_DGQ
+          else // dealii::FE_DGQ
           {
             grid_coordinates[mapping_multigrid->lexicographic_to_hierarchic_numbering[id.second]]
                             [id.first] = grid_coordinates_all_levels_ghosted[level](dof_indices[i]);
@@ -373,16 +378,16 @@ initialize_multigrid(std::shared_ptr<MappingDoFVector<dim, Number>> mapping_mult
 template<int dim, typename Number>
 void
 initialize_multigrid(
-  std::vector<std::shared_ptr<MappingDoFVector<dim, Number>>> & coarse_grid_mappings,
-  std::shared_ptr<MappingQCache<dim> const> &                   mapping_q_cache,
-  std::vector<std::shared_ptr<Triangulation<dim> const>> &      coarse_grid_triangulations)
+  std::vector<std::shared_ptr<MappingDoFVector<dim, Number>>> &    coarse_grid_mappings,
+  std::shared_ptr<dealii::MappingQCache<dim> const> &              mapping_q_cache,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> & coarse_grid_triangulations)
 {
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  FESystem<dim>                          fe(FE_Q<dim>(mapping_q_cache->get_degree()), dim);
-  unsigned int const                     n_h_levels = coarse_grid_triangulations.size();
-  std::vector<DoFHandler<dim>>           coarse_grid_dof_handlers(n_h_levels);
-  std::vector<AffineConstraints<Number>> coarse_grid_constraints(n_h_levels);
+  dealii::FESystem<dim>                fe(dealii::FE_Q<dim>(mapping_q_cache->get_degree()), dim);
+  unsigned int const                   n_h_levels = coarse_grid_triangulations.size();
+  std::vector<dealii::DoFHandler<dim>> coarse_grid_dof_handlers(n_h_levels);
+  std::vector<dealii::AffineConstraints<Number>> coarse_grid_constraints(n_h_levels);
   for(unsigned int i = 0; i < n_h_levels; ++i)
   {
     coarse_grid_dof_handlers[i].reinit(*coarse_grid_triangulations[i]);
@@ -390,7 +395,7 @@ initialize_multigrid(
     // constraints are irrelevant for interpolation
     coarse_grid_constraints[i].close();
   }
-  MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> transfers(0, n_h_levels - 1);
+  dealii::MGLevelObject<dealii::MGTwoLevelTransfer<dim, VectorType>> transfers(0, n_h_levels - 1);
   for(unsigned int i = 1; i < n_h_levels; ++i)
   {
     transfers[i].reinit_geometric_transfer(coarse_grid_dof_handlers[i],
@@ -402,9 +407,9 @@ initialize_multigrid(
   // a function that initializes the dof-vector for a given level and dof_handler
   const std::function<void(const unsigned int, VectorType &)> initialize_dof_vector =
     [&](const unsigned int h_level, VectorType & vector) {
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(coarse_grid_dof_handlers[h_level],
-                                              locally_relevant_dofs);
+      dealii::IndexSet locally_relevant_dofs;
+      dealii::DoFTools::extract_locally_relevant_dofs(coarse_grid_dof_handlers[h_level],
+                                                      locally_relevant_dofs);
       vector.reinit(coarse_grid_dof_handlers[h_level].locally_owned_dofs(),
                     locally_relevant_dofs,
                     coarse_grid_dof_handlers[h_level].get_communicator());
@@ -413,7 +418,7 @@ initialize_multigrid(
   dealii::MGTransferGlobalCoarsening<dim, VectorType> mg_transfer_global_coarsening(
     transfers, initialize_dof_vector);
 
-  MGLevelObject<VectorType> coarse_grid_coordinates(0, n_h_levels - 1);
+  dealii::MGLevelObject<VectorType> coarse_grid_coordinates(0, n_h_levels - 1);
 
   coarse_grid_mappings.resize(n_h_levels);
   coarse_grid_mappings[n_h_levels - 1] =
@@ -426,9 +431,9 @@ initialize_multigrid(
     coarse_grid_dof_handlers[n_h_levels - 1]);
 
   // transfer grid coordinates to coarser h-levels
-  // the DoFHandler object will not be used for global coarsening
-  DoFHandler<dim> dof_handler_dummy;
-  VectorType      vector_copy(coarse_grid_coordinates[n_h_levels - 1]);
+  // the dealii::DoFHandler object will not be used for global coarsening
+  dealii::DoFHandler<dim> dof_handler_dummy;
+  VectorType              vector_copy(coarse_grid_coordinates[n_h_levels - 1]);
   mg_transfer_global_coarsening.interpolate_to_mg(dof_handler_dummy,
                                                   coarse_grid_coordinates,
                                                   vector_copy);
@@ -440,7 +445,7 @@ initialize_multigrid(
       std::make_shared<MappingDoFVector<dim, Number>>(mapping_q_cache->get_degree());
 
     // coarse_grid_coordinates describes absolute coordinates -> use an uninitialized mapping
-    std::shared_ptr<Mapping<dim> const> mapping_dummy;
+    std::shared_ptr<dealii::Mapping<dim> const> mapping_dummy;
     coarse_grid_mappings[h_level]->initialize_mapping_q_cache(mapping_dummy,
                                                               coarse_grid_coordinates[h_level],
                                                               coarse_grid_dof_handlers[h_level]);

--- a/include/exadg/grid/mesh_movement_functions.h
+++ b/include/exadg/grid/mesh_movement_functions.h
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 enum class MeshMovementAdvanceInTime
 {
   Undefined,
@@ -57,7 +55,7 @@ struct MeshMovementData
 
   MeshMovementAdvanceInTime temporal;
   MeshMovementShape         shape;
-  Tensor<1, dim>            dimensions;
+  dealii::Tensor<1, dim>    dimensions;
   double                    amplitude;
   double                    period;
   double                    t_start;
@@ -66,11 +64,11 @@ struct MeshMovementData
 };
 
 template<int dim>
-class CubeMeshMovementFunctions : public Function<dim>
+class CubeMeshMovementFunctions : public dealii::Function<dim>
 {
 public:
   CubeMeshMovementFunctions(MeshMovementData<dim> const & data_in)
-    : Function<dim>(dim),
+    : dealii::Function<dim>(dim),
       data(data_in),
       width(data_in.dimensions[0]),
       left(-1.0 / 2.0 * width),
@@ -81,7 +79,7 @@ public:
   }
 
   double
-  value(Point<dim> const & x, unsigned int const coordinate_direction = 0) const override
+  value(dealii::Point<dim> const & x, unsigned int const coordinate_direction = 0) const override
   {
     double displacement = 0.0;
 
@@ -92,15 +90,15 @@ public:
 
 private:
   double
-  compute_displacement_share(Point<dim> const & x,
-                             unsigned int const coordinate_direction = 0) const
+  compute_displacement_share(dealii::Point<dim> const & x,
+                             unsigned int const         coordinate_direction = 0) const
   {
     double solution = 0.0;
 
     switch(data.shape)
     {
       case MeshMovementShape::Undefined:
-        AssertThrow(false, ExcMessage("Undefined parameter MeshMovementShape."));
+        AssertThrow(false, dealii::ExcMessage("Undefined parameter MeshMovementShape."));
         break;
 
       case MeshMovementShape::Sin:
@@ -157,7 +155,7 @@ private:
         break;
 
       default:
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
         break;
     }
 
@@ -172,7 +170,7 @@ private:
     switch(data.temporal)
     {
       case MeshMovementAdvanceInTime::Undefined:
-        AssertThrow(false, ExcMessage("Undefined parameter MeshMovementAdvanceInTime."));
+        AssertThrow(false, dealii::ExcMessage("Undefined parameter MeshMovementAdvanceInTime."));
         break;
 
       case MeshMovementAdvanceInTime::SinSquared:
@@ -184,14 +182,14 @@ private:
         break;
 
       default:
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
         break;
     }
     return solution;
   }
 
 protected:
-  double const                pi = numbers::PI;
+  double const                pi = dealii::numbers::PI;
   MeshMovementData<dim> const data;
   double const                width;
   double const                left;
@@ -201,11 +199,11 @@ protected:
 };
 
 template<int dim>
-class RectangleMeshMovementFunctions : public Function<dim>
+class RectangleMeshMovementFunctions : public dealii::Function<dim>
 {
 public:
   RectangleMeshMovementFunctions(MeshMovementData<dim> const & data_in)
-    : Function<dim>(dim),
+    : dealii::Function<dim>(dim),
       data(data_in),
       length(data_in.dimensions[0]),
       height(data_in.dimensions[1]),
@@ -216,10 +214,10 @@ public:
   }
 
   double
-  value(Point<dim> const & x_in, unsigned int const coordinate_direction = 0) const override
+  value(dealii::Point<dim> const & x_in, unsigned int const coordinate_direction = 0) const override
   {
     // For 2D and 3D the coordinate system is set differently
-    Point<dim> x = x_in;
+    dealii::Point<dim> x = x_in;
     if(dim == 2)
       x[0] -= length / 2.0;
 
@@ -232,15 +230,15 @@ public:
 
 private:
   double
-  compute_displacement_share(Point<dim> const & x,
-                             unsigned int const coordinate_direction = 0) const
+  compute_displacement_share(dealii::Point<dim> const & x,
+                             unsigned int const         coordinate_direction = 0) const
   {
     double solution = 0.0;
 
     switch(data.shape)
     {
       case MeshMovementShape::Undefined:
-        AssertThrow(false, ExcMessage("Undefined parameter MeshMovementShape."));
+        AssertThrow(false, dealii::ExcMessage("Undefined parameter MeshMovementShape."));
         break;
 
       case MeshMovementShape::Sin:
@@ -256,7 +254,7 @@ private:
         break;
 
       default:
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
         break;
     }
 
@@ -271,7 +269,7 @@ private:
     switch(data.temporal)
     {
       case MeshMovementAdvanceInTime::Undefined:
-        AssertThrow(false, ExcMessage("Undefined parameter MeshMovementAdvanceInTime."));
+        AssertThrow(false, dealii::ExcMessage("Undefined parameter MeshMovementAdvanceInTime."));
         break;
 
       case MeshMovementAdvanceInTime::SinSquared:
@@ -283,14 +281,14 @@ private:
         break;
 
       default:
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
         break;
     }
     return solution;
   }
 
 protected:
-  double const                pi = numbers::PI;
+  double const                pi = dealii::numbers::PI;
   MeshMovementData<dim> const data;
   double const                length;
   double const                height;

--- a/include/exadg/grid/periodic_box.h
+++ b/include/exadg/grid/periodic_box.h
@@ -32,22 +32,19 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
 void
-create_periodic_box(
-  std::shared_ptr<Triangulation<dim>> triangulation,
-  unsigned int const                  n_refine_space,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> &
-                     periodic_faces,
-  unsigned int const n_subdivisions,
-  double const       left,
-  double const       right,
-  bool const         curvilinear_mesh = false,
-  double const       deformation      = 0.1)
+create_periodic_box(std::shared_ptr<dealii::Triangulation<dim>>              triangulation,
+                    unsigned int const                                       n_refine_space,
+                    std::vector<dealii::GridTools::PeriodicFacePair<
+                      typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces,
+                    unsigned int const                                       n_subdivisions,
+                    double const                                             left,
+                    double const                                             right,
+                    bool const   curvilinear_mesh = false,
+                    double const deformation      = 0.1)
 {
-  GridGenerator::subdivided_hyper_cube(*triangulation, n_subdivisions, left, right);
+  dealii::GridGenerator::subdivided_hyper_cube(*triangulation, n_subdivisions, left, right);
 
   if(curvilinear_mesh)
   {
@@ -58,7 +55,7 @@ create_periodic_box(
 
     std::vector<bool> vertex_touched(triangulation->n_vertices(), false);
 
-    for(typename Triangulation<dim>::cell_iterator cell = triangulation->begin();
+    for(typename dealii::Triangulation<dim>::cell_iterator cell = triangulation->begin();
         cell != triangulation->end();
         ++cell)
     {
@@ -66,8 +63,8 @@ create_periodic_box(
       {
         if(vertex_touched[cell->vertex_index(v)] == false)
         {
-          Point<dim> & vertex                   = cell->vertex(v);
-          Point<dim>   new_point                = manifold.push_forward(vertex);
+          dealii::Point<dim> & vertex           = cell->vertex(v);
+          dealii::Point<dim>   new_point        = manifold.push_forward(vertex);
           vertex                                = new_point;
           vertex_touched[cell->vertex_index(v)] = true;
         }
@@ -75,8 +72,8 @@ create_periodic_box(
     }
   }
 
-  typename Triangulation<dim>::cell_iterator cell = triangulation->begin(),
-                                             endc = triangulation->end();
+  typename dealii::Triangulation<dim>::cell_iterator cell = triangulation->begin(),
+                                                     endc = triangulation->end();
   for(; cell != endc; ++cell)
   {
     for(const unsigned int face_number : cell->face_indices())
@@ -99,10 +96,13 @@ create_periodic_box(
     }
   }
 
-  GridTools::collect_periodic_faces(*triangulation, 0, 1, 0 /*x-direction*/, periodic_faces);
-  GridTools::collect_periodic_faces(*triangulation, 2, 3, 1 /*y-direction*/, periodic_faces);
+  dealii::GridTools::collect_periodic_faces(
+    *triangulation, 0, 1, 0 /*x-direction*/, periodic_faces);
+  dealii::GridTools::collect_periodic_faces(
+    *triangulation, 2, 3, 1 /*y-direction*/, periodic_faces);
   if(dim == 3)
-    GridTools::collect_periodic_faces(*triangulation, 4, 5, 2 /*z-direction*/, periodic_faces);
+    dealii::GridTools::collect_periodic_faces(
+      *triangulation, 4, 5, 2 /*z-direction*/, periodic_faces);
 
   triangulation->add_periodicity(periodic_faces);
 

--- a/include/exadg/incompressible_flow_with_transport/driver.h
+++ b/include/exadg/incompressible_flow_with_transport/driver.h
@@ -51,8 +51,6 @@ namespace ExaDG
 {
 namespace FTI
 {
-using namespace dealii;
-
 template<int dim, typename Number = double>
 class Driver
 {
@@ -90,7 +88,7 @@ private:
   MPI_Comm const mpi_comm;
 
   // output to std::cout
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -111,8 +109,8 @@ private:
   // INCOMPRESSIBLE NAVIER-STOKES
 
   //  MatrixFree
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   std::shared_ptr<IncNS::SpatialOperatorBase<dim, Number>> fluid_operator;
 
@@ -135,7 +133,7 @@ private:
 
   std::vector<std::shared_ptr<TimeIntBase>> scalar_time_integrator;
 
-  mutable LinearAlgebra::distributed::Vector<Number> temperature;
+  mutable dealii::LinearAlgebra::distributed::Vector<Number> temperature;
 
   /*
    * Computation time (wall clock time).

--- a/include/exadg/incompressible_flow_with_transport/solver.h
+++ b/include/exadg/incompressible_flow_with_transport/solver.h
@@ -74,7 +74,7 @@ template<int dim, typename Number>
 void
 run(std::string const & input_file, MPI_Comm const & mpi_comm, bool const is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<FTI::ApplicationBase<dim, Number>> application =

--- a/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
+++ b/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
@@ -37,14 +37,12 @@ class Mesh;
 
 namespace FTI
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class ApplicationBase : public IncNS::ApplicationBase<dim, Number>
 {
 public:
   virtual void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     // clang-format off
     prm.enter_subsection("Output");
@@ -94,17 +92,17 @@ public:
 
       // some additional parameter checks
       AssertThrow(scalar_param[i].ale_formulation == this->param.ale_formulation,
-                  ExcMessage(
+                  dealii::ExcMessage(
                     "Parameter ale_formulation is different for fluid field and scalar field"));
 
       AssertThrow(
         scalar_param[i].adaptive_time_stepping == this->param.adaptive_time_stepping,
-        ExcMessage(
+        dealii::ExcMessage(
           "The option adaptive_time_stepping has to be consistent for fluid and scalar transport solvers."));
 
       scalar_param[i].print(this->pcout,
-                            "List of parameters for scalar quantity " + Utilities::to_string(i) +
-                              ":");
+                            "List of parameters for scalar quantity " +
+                              dealii::Utilities::to_string(i) + ":");
 
       // boundary conditions
       scalar_boundary_descriptor[i] = std::make_shared<ConvDiff::BoundaryDescriptor<dim>>();

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -41,8 +41,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // Note: Make sure that the correct time integration scheme is selected in the input file that is
 //       compatible with the OperatorType specified here. This also includes the treatment of the
 //       convective term (explicit/implicit), e.g., specifying VelocityConvDiffOperator together
@@ -79,7 +77,7 @@ enum_to_string(OperatorType const enum_type)
     case OperatorType::VelocityConvDiffOperator: string_type = "VelocityConvDiffOperator"; break;
     case OperatorType::InverseMassOperator:      string_type = "InverseMassOperator";      break;
 
-    default:AssertThrow(false, ExcMessage("Not implemented.")); break;
+    default:AssertThrow(false, dealii::ExcMessage("Not implemented.")); break;
       // clang-format on
   }
 
@@ -98,7 +96,7 @@ string_to_enum(OperatorType & enum_type, std::string const string_type)
   else if(string_type == "ProjectionOperator")        enum_type = OperatorType::ProjectionOperator;
   else if(string_type == "VelocityConvDiffOperator")  enum_type = OperatorType::VelocityConvDiffOperator;
   else if(string_type == "InverseMassOperator")       enum_type = OperatorType::InverseMassOperator;
-  else AssertThrow(false, ExcMessage("Unknown operator type. Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Unknown operator type. Not implemented."));
   // clang-format on
 }
 
@@ -115,14 +113,14 @@ get_dofs_per_element(std::string const & input_file,
     prm.add_parameter("PressureDegree",
                       pressure_degree,
                       "Degree of pressure shape functions.",
-                      Patterns::Selection("MixedOrder|EqualOrder"),
+                      dealii::Patterns::Selection("MixedOrder|EqualOrder"),
                       true);
   prm.leave_subsection();
   prm.enter_subsection("Throughput");
     prm.add_parameter("OperatorType",
                       operator_type_string,
                       "Type of operator.",
-                      Patterns::Anything(),
+                      dealii::Patterns::Anything(),
                       true);
   prm.leave_subsection();
   // clang-format on
@@ -131,14 +129,14 @@ get_dofs_per_element(std::string const & input_file,
   OperatorType operator_type;
   string_to_enum(operator_type, operator_type_string);
 
-  unsigned int const velocity_dofs_per_element = dim * Utilities::pow(degree + 1, dim);
+  unsigned int const velocity_dofs_per_element = dim * dealii::Utilities::pow(degree + 1, dim);
   unsigned int       pressure_dofs_per_element = 1;
   if(pressure_degree == "MixedOrder")
-    pressure_dofs_per_element = Utilities::pow(degree, dim);
+    pressure_dofs_per_element = dealii::Utilities::pow(degree, dim);
   else if(pressure_degree == "EqualOrder")
-    pressure_dofs_per_element = Utilities::pow(degree + 1, dim);
+    pressure_dofs_per_element = dealii::Utilities::pow(degree + 1, dim);
   else
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
 
   if(operator_type == OperatorType::CoupledNonlinearResidual ||
      operator_type == OperatorType::CoupledLinearized)
@@ -161,7 +159,7 @@ get_dofs_per_element(std::string const & input_file,
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   return 0;
@@ -188,7 +186,7 @@ public:
   /*
    * Throughput study
    */
-  std::tuple<unsigned int, types::global_dof_index, double>
+  std::tuple<unsigned int, dealii::types::global_dof_index, double>
   apply_operator(std::string const & operator_type,
                  unsigned int const  n_repetitions_inner,
                  unsigned int const  n_repetitions_outer) const;
@@ -201,7 +199,7 @@ private:
   MPI_Comm const mpi_comm;
 
   // output to std::cout
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -217,14 +215,14 @@ private:
 
   // solve mesh deformation by a Poisson problem
   std::shared_ptr<MatrixFreeData<dim, Number>>         poisson_matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>             poisson_matrix_free;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>>     poisson_matrix_free;
   std::shared_ptr<Poisson::Operator<dim, Number, dim>> poisson_operator;
 
   /*
    * MatrixFree
    */
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   /*
    * Spatial discretization

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.cpp
@@ -29,15 +29,13 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DriverPrecursor<dim, Number>::DriverPrecursor(
   MPI_Comm const &                                       comm,
   std::shared_ptr<ApplicationBasePrecursor<dim, Number>> app,
   bool const                                             is_test)
   : mpi_comm(comm),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
     is_test(is_test),
     application(app),
     use_adaptive_time_stepping(false)
@@ -109,7 +107,7 @@ template<int dim, typename Number>
 void
 DriverPrecursor<dim, Number>::setup()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   pcout << std::endl << "Setting up incompressible Navier-Stokes solver:" << std::endl;
@@ -142,7 +140,7 @@ DriverPrecursor<dim, Number>::setup()
   matrix_free_data_pre = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data_pre->append(pde_operator_pre);
 
-  matrix_free_pre = std::make_shared<MatrixFree<dim, Number>>();
+  matrix_free_pre = std::make_shared<dealii::MatrixFree<dim, Number>>();
   if(application->get_parameters_precursor().use_cell_based_face_loops)
     Categorization::do_cell_based_loops(*application->get_grid_precursor()->triangulation,
                                         matrix_free_data_pre->data);
@@ -156,7 +154,7 @@ DriverPrecursor<dim, Number>::setup()
   matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
-  matrix_free = std::make_shared<MatrixFree<dim, Number>>();
+  matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
   if(application->get_parameters().use_cell_based_face_loops)
     Categorization::do_cell_based_loops(*application->get_grid()->triangulation,
                                         matrix_free_data->data);
@@ -273,10 +271,11 @@ DriverPrecursor<dim, Number>::print_performance_results(double const total_time)
   timer_tree.print_level(pcout, 2);
 
   // Computational costs in CPUh
-  unsigned int const N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
+  unsigned int const N_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
 
-  Utilities::MPI::MinMaxAvg total_time_data = Utilities::MPI::min_max_avg(total_time, mpi_comm);
-  double const              total_time_avg  = total_time_data.avg;
+  dealii::Utilities::MPI::MinMaxAvg total_time_data =
+    dealii::Utilities::MPI::min_max_avg(total_time, mpi_comm);
+  double const total_time_avg = total_time_data.avg;
 
   print_costs(pcout, total_time_avg, N_mpi_processes);
 

--- a/include/exadg/incompressible_navier_stokes/driver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/driver_precursor.h
@@ -38,8 +38,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class DriverPrecursor
 {
@@ -68,7 +66,7 @@ private:
   MPI_Comm const mpi_comm;
 
   // output to std::cout
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -79,8 +77,8 @@ private:
   /*
    * MatrixFree
    */
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data_pre, matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free_pre, matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data_pre, matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_pre, matrix_free;
 
   /*
    * Spatial discretization

--- a/include/exadg/incompressible_navier_stokes/postprocessor/divergence_and_mass_error.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/divergence_and_mass_error.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DivergenceAndMassErrorCalculator<dim, Number>::DivergenceAndMassErrorCalculator(
   MPI_Comm const & comm)
@@ -48,10 +46,11 @@ DivergenceAndMassErrorCalculator<dim, Number>::DivergenceAndMassErrorCalculator(
 
 template<int dim, typename Number>
 void
-DivergenceAndMassErrorCalculator<dim, Number>::setup(MatrixFree<dim, Number> const & matrix_free_in,
-                                                     unsigned int const              dof_index_in,
-                                                     unsigned int const              quad_index_in,
-                                                     MassConservationData const &    data_in)
+DivergenceAndMassErrorCalculator<dim, Number>::setup(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_in,
+  unsigned int const                      quad_index_in,
+  MassConservationData const &            data_in)
 {
   matrix_free = &matrix_free_in;
   dof_index   = dof_index_in;
@@ -80,12 +79,12 @@ DivergenceAndMassErrorCalculator<dim, Number>::evaluate(VectorType const & veloc
 template<int dim, typename Number>
 void
 DivergenceAndMassErrorCalculator<dim, Number>::do_evaluate(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType const &              velocity,
-  Number &                        div_error,
-  Number &                        div_error_reference,
-  Number &                        mass_error,
-  Number &                        mass_error_reference)
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType const &                      velocity,
+  Number &                                div_error,
+  Number &                                div_error_reference,
+  Number &                                mass_error,
+  Number &                                mass_error_reference)
 {
   std::vector<Number> dst(4, 0.0);
   matrix_free.loop(&This::local_compute_div,
@@ -95,16 +94,16 @@ DivergenceAndMassErrorCalculator<dim, Number>::do_evaluate(
                    dst,
                    velocity);
 
-  div_error            = Utilities::MPI::sum(dst.at(0), mpi_comm);
-  div_error_reference  = Utilities::MPI::sum(dst.at(1), mpi_comm);
-  mass_error           = Utilities::MPI::sum(dst.at(2), mpi_comm);
-  mass_error_reference = Utilities::MPI::sum(dst.at(3), mpi_comm);
+  div_error            = dealii::Utilities::MPI::sum(dst.at(0), mpi_comm);
+  div_error_reference  = dealii::Utilities::MPI::sum(dst.at(1), mpi_comm);
+  mass_error           = dealii::Utilities::MPI::sum(dst.at(2), mpi_comm);
+  mass_error_reference = dealii::Utilities::MPI::sum(dst.at(3), mpi_comm);
 }
 
 template<int dim, typename Number>
 void
 DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div(
-  MatrixFree<dim, Number> const &               matrix_free,
+  dealii::MatrixFree<dim, Number> const &       matrix_free,
   std::vector<Number> &                         dst,
   VectorType const &                            source,
   const std::pair<unsigned int, unsigned int> & cell_range)
@@ -120,8 +119,8 @@ DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div(
     integrator.read_dof_values(source);
     integrator.evaluate(true, true);
 
-    scalar div_vec = make_vectorized_array<Number>(0.);
-    scalar ref_vec = make_vectorized_array<Number>(0.);
+    scalar div_vec = dealii::make_vectorized_array<Number>(0.);
+    scalar ref_vec = dealii::make_vectorized_array<Number>(0.);
 
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
@@ -130,7 +129,7 @@ DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div(
       div_vec += integrator.JxW(q) * std::abs(integrator.get_divergence(q));
     }
 
-    // sum over entries of VectorizedArray, but only over those that are "active"
+    // sum over entries of dealii::VectorizedArray, but only over those that are "active"
     for(unsigned int v = 0; v < matrix_free.n_active_entries_per_cell_batch(cell); ++v)
     {
       div += div_vec[v];
@@ -145,7 +144,7 @@ DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div(
 template<int dim, typename Number>
 void
 DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div_face(
-  MatrixFree<dim, Number> const &               matrix_free,
+  dealii::MatrixFree<dim, Number> const &       matrix_free,
   std::vector<Number> &                         dst,
   VectorType const &                            source,
   const std::pair<unsigned int, unsigned int> & face_range)
@@ -165,8 +164,8 @@ DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div_face(
     integrator_p.read_dof_values(source);
     integrator_p.evaluate(true, false);
 
-    scalar diff_mass_flux_vec = make_vectorized_array<Number>(0.);
-    scalar mean_mass_flux_vec = make_vectorized_array<Number>(0.);
+    scalar diff_mass_flux_vec = dealii::make_vectorized_array<Number>(0.);
+    scalar mean_mass_flux_vec = dealii::make_vectorized_array<Number>(0.);
 
     for(unsigned int q = 0; q < integrator_m.n_q_points; ++q)
     {
@@ -178,7 +177,7 @@ DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div_face(
                                      integrator_m.get_normal_vector(q));
     }
 
-    // sum over entries of VectorizedArray, but only over those that are "active"
+    // sum over entries of dealii::VectorizedArray, but only over those that are "active"
     for(unsigned int v = 0; v < matrix_free.n_active_entries_per_face_batch(face); ++v)
     {
       diff_mass_flux += diff_mass_flux_vec[v];
@@ -193,7 +192,7 @@ DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div_face(
 template<int dim, typename Number>
 void
 DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div_boundary_face(
-  MatrixFree<dim, Number> const &,
+  dealii::MatrixFree<dim, Number> const &,
   std::vector<Number> &,
   VectorType const &,
   const std::pair<unsigned int, unsigned int> &)
@@ -223,7 +222,7 @@ DivergenceAndMassErrorCalculator<dim, Number>::analyze_div_and_mass_error_unstea
       mass_error_normalized = mass_error;
 
     // write output file
-    if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+    if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
     {
       std::string filename = data.directory + data.filename + ".div_mass_error_timeseries";
 
@@ -260,7 +259,7 @@ DivergenceAndMassErrorCalculator<dim, Number>::analyze_div_and_mass_error_unstea
       mass_sample += mass_error_normalized;
 
       // write output file
-      if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+      if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
       {
         std::string filename = data.directory + data.filename + ".div_mass_error_average";
 
@@ -298,7 +297,7 @@ DivergenceAndMassErrorCalculator<dim, Number>::analyze_div_and_mass_error_steady
     mass_error_normalized = mass_error;
 
   // write output file
-  if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
   {
     std::string filename = data.directory + data.filename + ".div_mass_error";
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/divergence_and_mass_error.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/divergence_and_mass_error.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 struct MassConservationData
 {
   MassConservationData()
@@ -48,7 +46,7 @@ struct MassConservationData
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(calculate == true)
     {
@@ -72,23 +70,23 @@ template<int dim, typename Number>
 class DivergenceAndMassErrorCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef CellIntegrator<dim, dim, Number> CellIntegratorU;
   typedef FaceIntegrator<dim, dim, Number> FaceIntegratorU;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   typedef DivergenceAndMassErrorCalculator<dim, Number> This;
 
   DivergenceAndMassErrorCalculator(MPI_Comm const & comm);
 
   void
-  setup(MatrixFree<dim, Number> const & matrix_free_in,
-        unsigned int const              dof_index_in,
-        unsigned int const              quad_index_in,
-        MassConservationData const &    data_in);
+  setup(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+        unsigned int const                      dof_index_in,
+        unsigned int const                      quad_index_in,
+        MassConservationData const &            data_in);
 
   void
   evaluate(VectorType const & velocity, double const & time, int const & time_step_number);
@@ -107,28 +105,28 @@ private:
    *  Reference value for mass error: (1,|0.5(um + up)*n|)_dOmegaI
    */
   void
-  do_evaluate(MatrixFree<dim, Number> const & matrix_free,
-              VectorType const &              velocity,
-              Number &                        div_error,
-              Number &                        div_error_reference,
-              Number &                        mass_error,
-              Number &                        mass_error_reference);
+  do_evaluate(dealii::MatrixFree<dim, Number> const & matrix_free,
+              VectorType const &                      velocity,
+              Number &                                div_error,
+              Number &                                div_error_reference,
+              Number &                                mass_error,
+              Number &                                mass_error_reference);
 
   void
-  local_compute_div(MatrixFree<dim, Number> const &               data,
+  local_compute_div(dealii::MatrixFree<dim, Number> const &       data,
                     std::vector<Number> &                         dst,
                     VectorType const &                            source,
                     const std::pair<unsigned int, unsigned int> & cell_range);
 
   void
-  local_compute_div_face(MatrixFree<dim, Number> const &               data,
+  local_compute_div_face(dealii::MatrixFree<dim, Number> const &       data,
                          std::vector<Number> &                         dst,
                          VectorType const &                            source,
                          const std::pair<unsigned int, unsigned int> & face_range);
 
   // not needed
   void
-  local_compute_div_boundary_face(MatrixFree<dim, Number> const &,
+  local_compute_div_boundary_face(dealii::MatrixFree<dim, Number> const &,
                                   std::vector<Number> &,
                                   VectorType const &,
                                   const std::pair<unsigned int, unsigned int> &);
@@ -148,9 +146,9 @@ private:
   Number divergence_sample;
   Number mass_sample;
 
-  MatrixFree<dim, Number> const * matrix_free;
-  unsigned int                    dof_index, quad_index;
-  MassConservationData            data;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
+  unsigned int                            dof_index, quad_index;
+  MassConservationData                    data;
 };
 
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/flow_rate_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/flow_rate_calculator.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct FlowRateCalculatorData
 {
@@ -39,7 +37,7 @@ struct FlowRateCalculatorData
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(calculate == true)
     {
@@ -84,23 +82,23 @@ template<int dim, typename Number>
 class FlowRateCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef CellIntegrator<dim, dim, Number> CellIntegratorU;
   typedef FaceIntegrator<dim, dim, Number> FaceIntegratorU;
 
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
-  FlowRateCalculator(MatrixFree<dim, Number> const &     matrix_free_in,
-                     unsigned int const                  dof_index_in,
-                     unsigned int const                  quad_index_in,
-                     FlowRateCalculatorData<dim> const & data_in,
-                     MPI_Comm const &                    mpi_comm_in);
+  FlowRateCalculator(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                     unsigned int const                      dof_index_in,
+                     unsigned int const                      quad_index_in,
+                     FlowRateCalculatorData<dim> const &     data_in,
+                     MPI_Comm const &                        mpi_comm_in);
 
   Number
-  calculate_flow_rates(VectorType const &                     velocity,
-                       double const &                         time,
-                       std::map<types::boundary_id, Number> & flow_rates);
+  calculate_flow_rates(VectorType const &                             velocity,
+                       double const &                                 time,
+                       std::map<dealii::types::boundary_id, Number> & flow_rates);
 
 
 private:
@@ -108,13 +106,13 @@ private:
   write_output(Number const & value, double const & time, std::string const & name);
 
   void
-  do_calculate_flow_rates(VectorType const &                     velocity,
-                          std::map<types::boundary_id, Number> & flow_rates);
+  do_calculate_flow_rates(VectorType const &                             velocity,
+                          std::map<dealii::types::boundary_id, Number> & flow_rates);
 
-  FlowRateCalculatorData<dim> const & data;
-  MatrixFree<dim, Number> const &     matrix_free;
-  unsigned int                        dof_index, quad_index;
-  bool                                clear_files;
+  FlowRateCalculatorData<dim> const &     data;
+  dealii::MatrixFree<dim, Number> const & matrix_free;
+  unsigned int                            dof_index, quad_index;
+  bool                                    clear_files;
 
   MPI_Comm const mpi_comm;
 };

--- a/include/exadg/incompressible_navier_stokes/postprocessor/inflow_data_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/inflow_data_calculator.h
@@ -36,8 +36,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  * inflow data: use velocity at the outflow of one domain as inflow-BC for another domain
  *
@@ -67,7 +65,7 @@ struct InflowData
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(write_inflow_data == true)
     {
@@ -95,7 +93,7 @@ struct InflowData
   std::vector<double> * y_values;
   std::vector<double> * z_values;
   // and the velocity values at n_points_y*n_points_z points
-  std::vector<Tensor<1, dim, double>> * array;
+  std::vector<dealii::Tensor<1, dim, double>> * array;
 };
 
 template<int dim, typename Number>
@@ -105,20 +103,21 @@ public:
   InflowDataCalculator(InflowData<dim> const & inflow_data, MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const & dof_handler_velocity, Mapping<dim> const & mapping);
+  setup(dealii::DoFHandler<dim> const & dof_handler_velocity, dealii::Mapping<dim> const & mapping);
 
   void
-  calculate(LinearAlgebra::distributed::Vector<Number> const & velocity);
+  calculate(dealii::LinearAlgebra::distributed::Vector<Number> const & velocity);
 
 private:
-  SmartPointer<DoFHandler<dim> const> dof_handler_velocity;
-  SmartPointer<Mapping<dim> const>    mapping;
-  InflowData<dim>                     inflow_data;
-  bool                                inflow_data_has_been_initialized;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  InflowData<dim>                                     inflow_data;
+  bool                                                inflow_data_has_been_initialized;
 
   MPI_Comm const mpi_comm;
 
-  std::vector<std::vector<std::pair<std::vector<types::global_dof_index>, std::vector<Number>>>>
+  std::vector<
+    std::vector<std::pair<std::vector<dealii::types::global_dof_index>, std::vector<Number>>>>
     array_dof_indices_and_shape_values;
 
   std::vector<unsigned int> array_counter;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/kinetic_energy_dissipation_detailed.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/kinetic_energy_dissipation_detailed.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 KineticEnergyCalculatorDetailed<dim, Number>::KineticEnergyCalculatorDetailed(MPI_Comm const & comm)
   : KineticEnergyCalculator<dim, Number>(comm)
@@ -40,11 +38,11 @@ KineticEnergyCalculatorDetailed<dim, Number>::KineticEnergyCalculatorDetailed(MP
 template<int dim, typename Number>
 void
 KineticEnergyCalculatorDetailed<dim, Number>::setup(
-  NavierStokesOperator const &    navier_stokes_operator_in,
-  MatrixFree<dim, Number> const & matrix_free_in,
-  unsigned int const              dof_index_in,
-  unsigned int const              quad_index_in,
-  KineticEnergyData const &       kinetic_energy_data_in)
+  NavierStokesOperator const &            navier_stokes_operator_in,
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_in,
+  unsigned int const                      quad_index_in,
+  KineticEnergyData const &               kinetic_energy_data_in)
 {
   Base::setup(matrix_free_in, dof_index_in, quad_index_in, kinetic_energy_data_in);
 
@@ -60,7 +58,8 @@ KineticEnergyCalculatorDetailed<dim, Number>::evaluate(VectorType const & veloci
   if(this->data.calculate == true)
   {
     AssertThrow(time_step_number >= 0,
-                ExcMessage("This postprocessing tool can only be used for unsteady problems."));
+                dealii::ExcMessage(
+                  "This postprocessing tool can only be used for unsteady problems."));
 
     if(this->data.evaluate_individual_terms)
       calculate_detailed(velocity, time, time_step_number);
@@ -83,7 +82,7 @@ KineticEnergyCalculatorDetailed<dim, Number>::calculate_detailed(
     Number volume = this->integrate(
       *this->matrix_free, velocity, kinetic_energy, enstrophy, dissipation, max_vorticity);
 
-    AssertThrow(navier_stokes_operator != nullptr, ExcMessage("Invalid pointer."));
+    AssertThrow(navier_stokes_operator != nullptr, dealii::ExcMessage("Invalid pointer."));
     Number dissipation_convective =
       navier_stokes_operator->calculate_dissipation_convective_term(velocity, time) / volume;
     Number dissipation_viscous =
@@ -94,7 +93,7 @@ KineticEnergyCalculatorDetailed<dim, Number>::calculate_detailed(
       navier_stokes_operator->calculate_dissipation_continuity_term(velocity) / volume;
 
     // write output file
-    if(Utilities::MPI::this_mpi_process(this->mpi_comm) == 0)
+    if(dealii::Utilities::MPI::this_mpi_process(this->mpi_comm) == 0)
     {
       // clang-format off
       std::ostringstream filename;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/kinetic_energy_dissipation_detailed.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/kinetic_energy_dissipation_detailed.h
@@ -29,12 +29,10 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class KineticEnergyCalculatorDetailed : public KineticEnergyCalculator<dim, Number>
 {
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef KineticEnergyCalculator<dim, Number> Base;
 
@@ -44,11 +42,11 @@ public:
   KineticEnergyCalculatorDetailed(MPI_Comm const & comm);
 
   void
-  setup(NavierStokesOperator const &    navier_stokes_operator_in,
-        MatrixFree<dim, Number> const & matrix_free_in,
-        unsigned int const              dof_index_in,
-        unsigned int const              quad_index_in,
-        KineticEnergyData const &       kinetic_energy_data_in);
+  setup(NavierStokesOperator const &            navier_stokes_operator_in,
+        dealii::MatrixFree<dim, Number> const & matrix_free_in,
+        unsigned int const                      dof_index_in,
+        unsigned int const                      quad_index_in,
+        KineticEnergyData const &               kinetic_energy_data_in);
 
   void
   evaluate(VectorType const & velocity, double const & time, int const & time_step_number);
@@ -59,7 +57,7 @@ private:
                      double const       time,
                      unsigned int const time_step_number);
 
-  SmartPointer<NavierStokesOperator const> navier_stokes_operator;
+  dealii::SmartPointer<NavierStokesOperator const> navier_stokes_operator;
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 LinePlotCalculator<dim, Number>::LinePlotCalculator(MPI_Comm const & comm)
   : mpi_comm(comm), clear_files(true)
@@ -40,9 +38,9 @@ LinePlotCalculator<dim, Number>::LinePlotCalculator(MPI_Comm const & comm)
 
 template<int dim, typename Number>
 void
-LinePlotCalculator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_velocity_in,
-                                       DoFHandler<dim> const & dof_handler_pressure_in,
-                                       Mapping<dim> const &    mapping_in,
+LinePlotCalculator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_velocity_in,
+                                       dealii::DoFHandler<dim> const & dof_handler_pressure_in,
+                                       dealii::Mapping<dim> const &    mapping_in,
                                        LinePlotDataInstantaneous<dim> const & line_plot_data_in)
 {
   dof_handler_velocity = &dof_handler_velocity_in;
@@ -71,8 +69,8 @@ LinePlotCalculator<dim, Number>::evaluate(VectorType const & velocity,
         ++line)
     {
       // store all points along current line in a vector
-      unsigned int            n_points = (*line)->n_points;
-      std::vector<Point<dim>> points(n_points);
+      unsigned int                    n_points = (*line)->n_points;
+      std::vector<dealii::Point<dim>> points(n_points);
 
       // we consider straight lines with an equidistant distribution of points along the line
       for(unsigned int i = 0; i < n_points; ++i)
@@ -90,19 +88,19 @@ LinePlotCalculator<dim, Number>::evaluate(VectorType const & velocity,
       {
         if((*quantity)->type == QuantityType::Velocity)
         {
-          std::vector<Tensor<1, dim, Number>> solution_vector(n_points);
+          std::vector<dealii::Tensor<1, dim, Number>> solution_vector(n_points);
 
           // calculate velocity for all points along line
           for(unsigned int i = 0; i < n_points; ++i)
           {
-            Tensor<1, dim, Number> u;
+            dealii::Tensor<1, dim, Number> u;
             evaluate_vectorial_quantity_in_point(
               u, *dof_handler_velocity, *mapping, velocity, points[i], mpi_comm);
             solution_vector[i] = u;
           }
 
           // write output to file
-          if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+          if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
           {
             std::string filename = filename_prefix + "_velocity" + ".txt";
 
@@ -118,9 +116,11 @@ LinePlotCalculator<dim, Number>::evaluate(VectorType const & velocity,
 
             // headline
             for(unsigned int d = 0; d < dim; ++d)
-              f << std::setw(precision + 8) << std::left << "x_" + Utilities::int_to_string(d + 1);
+              f << std::setw(precision + 8) << std::left
+                << "x_" + dealii::Utilities::int_to_string(d + 1);
             for(unsigned int d = 0; d < dim; ++d)
-              f << std::setw(precision + 8) << std::left << "u_" + Utilities::int_to_string(d + 1);
+              f << std::setw(precision + 8) << std::left
+                << "u_" + dealii::Utilities::int_to_string(d + 1);
             f << std::endl;
 
             // loop over all points
@@ -152,7 +152,7 @@ LinePlotCalculator<dim, Number>::evaluate(VectorType const & velocity,
           }
 
           // write output to file
-          if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+          if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
           {
             std::string filename = filename_prefix + "_pressure" + ".txt";
 
@@ -168,7 +168,8 @@ LinePlotCalculator<dim, Number>::evaluate(VectorType const & velocity,
 
             // headline
             for(unsigned int d = 0; d < dim; ++d)
-              f << std::setw(precision + 8) << std::left << "x_" + Utilities::int_to_string(d + 1);
+              f << std::setw(precision + 8) << std::left
+                << "x_" + dealii::Utilities::int_to_string(d + 1);
             f << std::setw(precision + 8) << std::left << "p";
             f << std::endl;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  *  Evaluate quantities along lines.
  *
@@ -44,14 +42,14 @@ template<int dim, typename Number>
 class LinePlotCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   LinePlotCalculator(MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const &                dof_handler_velocity_in,
-        DoFHandler<dim> const &                dof_handler_pressure_in,
-        Mapping<dim> const &                   mapping_in,
+  setup(dealii::DoFHandler<dim> const &        dof_handler_velocity_in,
+        dealii::DoFHandler<dim> const &        dof_handler_pressure_in,
+        dealii::Mapping<dim> const &           mapping_in,
         LinePlotDataInstantaneous<dim> const & line_plot_data_in);
 
   void
@@ -62,9 +60,9 @@ private:
 
   mutable bool clear_files;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler_velocity;
-  SmartPointer<DoFHandler<dim> const> dof_handler_pressure;
-  SmartPointer<Mapping<dim> const>    mapping;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
 
   LinePlotDataInstantaneous<dim> data;
 };

--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics.h
@@ -37,8 +37,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  * This function calculates statistics along lines by averaging over time.
  *
@@ -64,16 +62,16 @@ template<int dim, typename Number>
 class LinePlotCalculatorStatistics
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef
-    typename std::vector<std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>>
-      TYPE;
+  typedef typename std::vector<
+    std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator, dealii::Point<dim>>>
+    TYPE;
 
-  LinePlotCalculatorStatistics(DoFHandler<dim> const & dof_handler_velocity_in,
-                               DoFHandler<dim> const & dof_handler_pressure_in,
-                               Mapping<dim> const &    mapping_in,
-                               MPI_Comm const &        mpi_comm_in);
+  LinePlotCalculatorStatistics(dealii::DoFHandler<dim> const & dof_handler_velocity_in,
+                               dealii::DoFHandler<dim> const & dof_handler_pressure_in,
+                               dealii::Mapping<dim> const &    mapping_in,
+                               MPI_Comm const &                mpi_comm_in);
 
   void
   setup(LinePlotDataStatistics<dim> const & line_plot_data_in);
@@ -112,28 +110,28 @@ private:
 
   mutable bool clear_files;
 
-  DoFHandler<dim> const & dof_handler_velocity;
-  DoFHandler<dim> const & dof_handler_pressure;
-  Mapping<dim> const &    mapping;
-  MPI_Comm                mpi_comm;
+  dealii::DoFHandler<dim> const & dof_handler_velocity;
+  dealii::DoFHandler<dim> const & dof_handler_pressure;
+  dealii::Mapping<dim> const &    mapping;
+  MPI_Comm                        mpi_comm;
 
   LinePlotDataStatistics<dim> data;
 
   // Global points
-  std::vector<std::vector<Point<dim>>> global_points;
+  std::vector<std::vector<dealii::Point<dim>>> global_points;
 
   bool cell_data_has_been_initialized;
 
   // For all lines: for all points along the line: for all relevant cells: dof index of first dof of
   // current cell and all shape function values
-  std::vector<
-    std::vector<std::vector<std::pair<std::vector<types::global_dof_index>, std::vector<Number>>>>>
+  std::vector<std::vector<
+    std::vector<std::pair<std::vector<dealii::types::global_dof_index>, std::vector<Number>>>>>
     cells_global_velocity;
 
   // For all lines: for all points along the line: for all relevant cells: dof index of first dof of
   // current cell and all shape function values
-  std::vector<
-    std::vector<std::vector<std::pair<std::vector<types::global_dof_index>, std::vector<Number>>>>>
+  std::vector<std::vector<
+    std::vector<std::pair<std::vector<dealii::types::global_dof_index>, std::vector<Number>>>>>
     cells_global_pressure;
 
   // number of samples for averaging in time
@@ -141,7 +139,7 @@ private:
 
   // Velocity quantities
   // For all lines: for all points along the line
-  std::vector<std::vector<Tensor<1, dim, Number>>> velocity_global;
+  std::vector<std::vector<dealii::Tensor<1, dim, Number>>> velocity_global;
 
   // Pressure quantities
   // For all lines: for all points along the line

--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp
@@ -30,14 +30,12 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 LinePlotCalculatorStatisticsHomogeneous<dim, Number>::LinePlotCalculatorStatisticsHomogeneous(
-  DoFHandler<dim> const & dof_handler_velocity_in,
-  DoFHandler<dim> const & dof_handler_pressure_in,
-  Mapping<dim> const &    mapping_in,
-  MPI_Comm const &        mpi_comm_in)
+  dealii::DoFHandler<dim> const & dof_handler_velocity_in,
+  dealii::DoFHandler<dim> const & dof_handler_pressure_in,
+  dealii::Mapping<dim> const &    mapping_in,
+  MPI_Comm const &                mpi_comm_in)
   : clear_files(true),
     dof_handler_velocity(dof_handler_velocity_in),
     dof_handler_pressure(dof_handler_pressure_in),
@@ -58,9 +56,9 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
 
   if(data.statistics_data.calculate)
   {
-    AssertThrow(dim == 3, ExcMessage("Not implemented."));
+    AssertThrow(dim == 3, dealii::ExcMessage("Not implemented."));
 
-    AssertThrow(data.line_data.lines.size() > 0, ExcMessage("Empty data"));
+    AssertThrow(data.line_data.lines.size() > 0, dealii::ExcMessage("Empty data"));
 
     global_points.resize(data.line_data.lines.size());
     cells_and_ref_points_velocity.resize(data.line_data.lines.size());
@@ -77,11 +75,11 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
     std::shared_ptr<LineHomogeneousAveraging<dim>> line_hom =
       std::dynamic_pointer_cast<LineHomogeneousAveraging<dim>>(data.line_data.lines[0]);
     AssertThrow(line_hom.get() != 0,
-                ExcMessage("Invalid line type, expected LineHomogeneousAveraging<dim>"));
+                dealii::ExcMessage("Invalid line type, expected LineHomogeneousAveraging<dim>"));
     averaging_direction = line_hom->averaging_direction;
 
     AssertThrow(averaging_direction == 0 || averaging_direction == 1 || averaging_direction == 2,
-                ExcMessage("Take the average either in x, y or z-direction"));
+                dealii::ExcMessage("Take the average either in x, y or z-direction"));
 
     unsigned int line_iterator = 0;
     for(typename std::vector<std::shared_ptr<Line<dim>>>::iterator line =
@@ -94,10 +92,10 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
         std::dynamic_pointer_cast<LineHomogeneousAveraging<dim>>(*line);
 
       AssertThrow(line_hom.get() != 0,
-                  ExcMessage("Invalid line type, expected LineHomogeneousAveraging<dim>"));
+                  dealii::ExcMessage("Invalid line type, expected LineHomogeneousAveraging<dim>"));
 
       AssertThrow(averaging_direction == line_hom->averaging_direction,
-                  ExcMessage("All lines must use the same averaging direction."));
+                  dealii::ExcMessage("All lines must use the same averaging direction."));
 
       // Resize global variables for # of points on line
       velocity_global[line_iterator].resize((*line)->n_points);
@@ -110,8 +108,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
       // initialize global_points: use equidistant points along line
       for(unsigned int i = 0; i < (*line)->n_points; ++i)
       {
-        Point<dim> point = (*line)->begin + double(i) / double((*line)->n_points - 1) *
-                                              ((*line)->end - (*line)->begin);
+        dealii::Point<dim> point = (*line)->begin + double(i) / double((*line)->n_points - 1) *
+                                                      ((*line)->end - (*line)->begin);
         global_points[line_iterator].push_back(point);
       }
     }
@@ -123,7 +121,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
     double const tolerance = 1.e-12;
 
     // For velocity quantities:
-    for(typename DoFHandler<dim>::active_cell_iterator cell = dof_handler_velocity.begin_active();
+    for(typename dealii::DoFHandler<dim>::active_cell_iterator cell =
+          dof_handler_velocity.begin_active();
         cell != dof_handler_velocity.end();
         ++cell)
     {
@@ -136,7 +135,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
             ++line, ++line_iterator)
         {
           AssertThrow((*line)->quantities.size() > 0,
-                      ExcMessage("No quantities specified for line."));
+                      dealii::ExcMessage("No quantities specified for line."));
 
           bool velocity_has_to_be_evaluated = false;
           for(typename std::vector<std::shared_ptr<Quantity>>::iterator quantity =
@@ -159,22 +158,22 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
             {
               // First, we move the line to the position of the current cell (vertex 0) in
               // averaging direction and check whether this new point is inside the current cell
-              Point<dim> translated_point           = global_points[line_iterator][p];
+              dealii::Point<dim> translated_point   = global_points[line_iterator][p];
               translated_point[averaging_direction] = cell->vertex(0)[averaging_direction];
 
               // If the new point lies in the current cell, we have to take the current cell into
               // account
-              Point<dim> const p_unit =
+              dealii::Point<dim> const p_unit =
                 cell->real_to_unit_cell_affine_approximation(translated_point);
 
-              if(GeometryInfo<dim>::is_inside_unit_cell(p_unit, tolerance))
+              if(dealii::GeometryInfo<dim>::is_inside_unit_cell(p_unit, tolerance))
               {
                 cells_and_ref_points_velocity[line_iterator][p].push_back(
-                  std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>(cell,
-                                                                                        p_unit));
+                  std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator,
+                            dealii::Point<dim>>(cell, p_unit));
               }
 
-              //              Point<dim> p_unit = Point<dim>();
+              //              dealii::Point<dim> p_unit = Point<dim>();
               //              try
               //              {
               //                p_unit = mapping.transform_real_to_unit_cell(cell,
@@ -185,11 +184,12 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
               //                // A point that does not lie on the reference cell.
               //                p_unit[0] = 2.0;
               //              }
-              //              if(GeometryInfo<dim>::is_inside_unit_cell(p_unit,1.e-12))
+              //              if(dealii::GeometryInfo<dim>::is_inside_unit_cell(p_unit,1.e-12))
               //              {
               //                cells_and_ref_points_velocity[line_iterator][p].push_back(
-              //                    std::pair<typename DoFHandler<dim>::active_cell_iterator,
-              //                    Point<dim> >(cell,p_unit));
+              //                    std::pair<typename
+              //                    dealii::DoFHandler<dim>::active_cell_iterator,
+              //                    dealii::Point<dim> >(cell,p_unit));
               //              }
             }
           }
@@ -198,9 +198,10 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
     }
 
     // Save all cells and corresponding points on unit cell that are relevant for a given point
-    // along the line. We have to do the same for the pressure because the DoFHandlers for velocity
-    // and pressure are different.
-    for(typename DoFHandler<dim>::active_cell_iterator cell = dof_handler_pressure.begin_active();
+    // along the line. We have to do the same for the pressure because the dealii::DoFHandlers for
+    // velocity and pressure are different.
+    for(typename dealii::DoFHandler<dim>::active_cell_iterator cell =
+          dof_handler_pressure.begin_active();
         cell != dof_handler_pressure.end();
         ++cell)
     {
@@ -218,7 +219,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
               ++quantity)
           {
             AssertThrow((*line)->quantities.size() > 0,
-                        ExcMessage("No quantities specified for line."));
+                        dealii::ExcMessage("No quantities specified for line."));
 
             // evaluate quantities that involve pressure
             if((*quantity)->type == QuantityType::Pressure)
@@ -228,21 +229,21 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
               {
                 // First, we move the line to the position of the current cell (vertex 0) in
                 // averaging direction and check whether this new point is inside the current cell
-                Point<dim> translated_point           = global_points[line_iterator][p];
+                dealii::Point<dim> translated_point   = global_points[line_iterator][p];
                 translated_point[averaging_direction] = cell->vertex(0)[averaging_direction];
 
                 // If the new point lies in the current cell, we have to take the current cell into
                 // account
-                Point<dim> const p_unit =
+                dealii::Point<dim> const p_unit =
                   cell->real_to_unit_cell_affine_approximation(translated_point);
-                if(GeometryInfo<dim>::is_inside_unit_cell(p_unit, tolerance))
+                if(dealii::GeometryInfo<dim>::is_inside_unit_cell(p_unit, tolerance))
                 {
                   cells_and_ref_points_pressure[line_iterator][p].push_back(
-                    std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>(cell,
-                                                                                          p_unit));
+                    std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator,
+                              dealii::Point<dim>>(cell, p_unit));
                 }
 
-                //                Point<dim> p_unit = Point<dim>();
+                //                dealii::Point<dim> p_unit = Point<dim>();
                 //                try
                 //                {
                 //                  p_unit = mapping.transform_real_to_unit_cell(cell,
@@ -253,11 +254,12 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
                 //                  // A point that does not lie on the reference cell.
                 //                  p_unit[0] = 2.0;
                 //                }
-                //                if(GeometryInfo<dim>::is_inside_unit_cell(p_unit,1.e-12))
+                //                if(dealii::GeometryInfo<dim>::is_inside_unit_cell(p_unit,1.e-12))
                 //                {
                 //                  cells_and_ref_points_pressure[line_iterator][p].push_back(
-                //                    std::pair<typename DoFHandler<dim>::active_cell_iterator,
-                //                    Point<dim> >(cell,p_unit));
+                //                    std::pair<typename
+                //                    dealii::DoFHandler<dim>::active_cell_iterator,
+                //                    dealii::Point<dim> >(cell,p_unit));
                 //                }
               }
             }
@@ -270,7 +272,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
               ++quantity)
           {
             AssertThrow((*line)->quantities.size() > 0,
-                        ExcMessage("No quantities specified for line."));
+                        dealii::ExcMessage("No quantities specified for line."));
 
             // evaluate quantities that involve pressure
             if((*quantity)->type == QuantityType::PressureCoefficient)
@@ -280,21 +282,21 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
 
               // First, we move the line to the position of the current cell (vertex 0) in
               // averaging direction and check whether this new point is inside the current cell
-              Point<dim> translated_point           = quantity_ref_pressure->reference_point;
+              dealii::Point<dim> translated_point   = quantity_ref_pressure->reference_point;
               translated_point[averaging_direction] = cell->vertex(0)[averaging_direction];
 
               // If the new point lies in the current cell, we have to take the current cell into
               // account
-              Point<dim> const p_unit =
+              dealii::Point<dim> const p_unit =
                 cell->real_to_unit_cell_affine_approximation(translated_point);
-              if(GeometryInfo<dim>::is_inside_unit_cell(p_unit, tolerance))
+              if(dealii::GeometryInfo<dim>::is_inside_unit_cell(p_unit, tolerance))
               {
                 cells_and_ref_points_ref_pressure[line_iterator].push_back(
-                  std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>(cell,
-                                                                                        p_unit));
+                  std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator,
+                            dealii::Point<dim>>(cell, p_unit));
               }
 
-              //              Point<dim> p_unit = Point<dim>();
+              //              dealii::Point<dim> p_unit = Point<dim>();
               //              try
               //              {
               //                p_unit = mapping.transform_real_to_unit_cell(cell,
@@ -305,11 +307,12 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::setup(
               //                // A point that does not lie on the reference cell.
               //                p_unit[0] = 2.0;
               //              }
-              //              if(GeometryInfo<dim>::is_inside_unit_cell(p_unit,1.e-12))
+              //              if(dealii::GeometryInfo<dim>::is_inside_unit_cell(p_unit,1.e-12))
               //              {
               //                ref_pressure_cells_and_ref_points[line_iterator].push_back(
-              //                    std::pair<typename DoFHandler<dim>::active_cell_iterator,
-              //                    Point<dim> >(cell,p_unit));
+              //                    std::pair<typename
+              //                    dealii::DoFHandler<dim>::active_cell_iterator,
+              //                    dealii::Point<dim> >(cell,p_unit));
               //              }
             }
           }
@@ -424,17 +427,18 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
   unsigned int const line_iterator)
 {
   // Local variables for specific line
-  std::vector<double>                 length_local(line.n_points);
-  std::vector<Tensor<1, dim, double>> velocity_local(line.n_points);
-  std::vector<double>                 wall_shear_local(line.n_points);
-  std::vector<Tensor<2, dim, double>> reynolds_local(line.n_points);
+  std::vector<double>                         length_local(line.n_points);
+  std::vector<dealii::Tensor<1, dim, double>> velocity_local(line.n_points);
+  std::vector<double>                         wall_shear_local(line.n_points);
+  std::vector<dealii::Tensor<2, dim, double>> reynolds_local(line.n_points);
 
   unsigned int const scalar_dofs_per_cell =
     dof_handler_velocity.get_fe().base_element(0).dofs_per_cell;
 
-  std::vector<Tensor<1, dim>> velocity_vector(scalar_dofs_per_cell);
+  std::vector<dealii::Tensor<1, dim>> velocity_vector(scalar_dofs_per_cell);
 
-  std::vector<types::global_dof_index> dof_indices(dof_handler_velocity.get_fe().dofs_per_cell);
+  std::vector<dealii::types::global_dof_index> dof_indices(
+    dof_handler_velocity.get_fe().dofs_per_cell);
 
   for(unsigned int p = 0; p < line.n_points; ++p)
   {
@@ -446,24 +450,25 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
       unsigned int const fe_degree_velocity = dof_handler_velocity.get_fe().degree;
 
       // use quadrature for averaging in homogeneous direction
-      QGauss<1>               gauss_1d(fe_degree_velocity + 1);
-      std::vector<Point<dim>> points(gauss_1d.size());  // 1D points
-      std::vector<double>     weights(gauss_1d.size()); // 1D weights
+      dealii::QGauss<1>               gauss_1d(fe_degree_velocity + 1);
+      std::vector<dealii::Point<dim>> points(gauss_1d.size());  // 1D points
+      std::vector<double>             weights(gauss_1d.size()); // 1D weights
 
-      typename DoFHandler<dim>::active_cell_iterator const cell = cell_and_ref_point->first;
+      typename dealii::DoFHandler<dim>::active_cell_iterator const cell = cell_and_ref_point->first;
 
-      Point<dim> const p_unit = cell_and_ref_point->second;
+      dealii::Point<dim> const p_unit = cell_and_ref_point->second;
 
       // Find points and weights for Gauss quadrature
       find_points_and_weights(p_unit, points, weights, averaging_direction, gauss_1d);
 
-      FEValues<dim, dim> fe_values(mapping,
-                                   dof_handler_velocity.get_fe().base_element(0),
-                                   Quadrature<dim>(points, weights),
-                                   update_values | update_jacobians | update_quadrature_points |
-                                     update_gradients);
+      dealii::FEValues<dim, dim> fe_values(mapping,
+                                           dof_handler_velocity.get_fe().base_element(0),
+                                           dealii::Quadrature<dim>(points, weights),
+                                           dealii::update_values | dealii::update_jacobians |
+                                             dealii::update_quadrature_points |
+                                             dealii::update_gradients);
 
-      fe_values.reinit(typename Triangulation<dim>::active_cell_iterator(cell));
+      fe_values.reinit(typename dealii::Triangulation<dim>::active_cell_iterator(cell));
 
       cell->get_dof_indices(dof_indices);
 
@@ -490,7 +495,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
             quantity != line.quantities.end();
             ++quantity)
         {
-          Tensor<1, dim> velocity;
+          dealii::Tensor<1, dim> velocity;
 
           if((*quantity)->type == QuantityType::Velocity ||
              (*quantity)->type == QuantityType::ReynoldsStresses)
@@ -517,15 +522,15 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
           }
           else if((*quantity)->type == QuantityType::SkinFriction)
           {
-            Tensor<2, dim> velocity_gradient;
+            dealii::Tensor<2, dim> velocity_gradient;
             for(unsigned int j = 0; j < velocity_vector.size(); ++j)
               velocity_gradient += outer_product(velocity_vector[j], fe_values.shape_grad(j, q));
 
             std::shared_ptr<QuantitySkinFriction<dim>> quantity_skin_friction =
               std::dynamic_pointer_cast<QuantitySkinFriction<dim>>(*quantity);
 
-            Tensor<1, dim, double> normal  = quantity_skin_friction->normal_vector;
-            Tensor<1, dim, double> tangent = quantity_skin_friction->tangent_vector;
+            dealii::Tensor<1, dim, double> normal  = quantity_skin_friction->normal_vector;
+            dealii::Tensor<1, dim, double> tangent = quantity_skin_friction->tangent_vector;
 
             for(unsigned int i = 0; i < dim; ++i)
               for(unsigned int j = 0; j < dim; ++j)
@@ -536,7 +541,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
     }
   }
 
-  Utilities::MPI::sum(length_local, mpi_comm, length_local);
+  dealii::Utilities::MPI::sum(length_local, mpi_comm, length_local);
 
   for(typename std::vector<std::shared_ptr<Quantity>>::const_iterator quantity =
         line.quantities.begin();
@@ -547,10 +552,10 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
     // to sum the contributions of every single processor.
     if((*quantity)->type == QuantityType::Velocity)
     {
-      Utilities::MPI::sum(ArrayView<double const>(&velocity_local[0][0],
-                                                  dim * velocity_local.size()),
-                          mpi_comm,
-                          ArrayView<double>(&velocity_local[0][0], dim * velocity_local.size()));
+      dealii::Utilities::MPI::sum(
+        dealii::ArrayView<double const>(&velocity_local[0][0], dim * velocity_local.size()),
+        mpi_comm,
+        dealii::ArrayView<double>(&velocity_local[0][0], dim * velocity_local.size()));
 
       for(unsigned int p = 0; p < line.n_points; ++p)
       {
@@ -562,10 +567,11 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
     }
     else if((*quantity)->type == QuantityType::ReynoldsStresses)
     {
-      Utilities::MPI::sum(
-        ArrayView<double const>(&reynolds_local[0][0][0], dim * dim * reynolds_local.size()),
+      dealii::Utilities::MPI::sum(
+        dealii::ArrayView<double const>(&reynolds_local[0][0][0],
+                                        dim * dim * reynolds_local.size()),
         mpi_comm,
-        ArrayView<double>(&reynolds_local[0][0][0], dim * dim * reynolds_local.size()));
+        dealii::ArrayView<double>(&reynolds_local[0][0][0], dim * dim * reynolds_local.size()));
 
       for(unsigned int p = 0; p < line.n_points; ++p)
       {
@@ -580,7 +586,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_velocity(
     }
     else if((*quantity)->type == QuantityType::SkinFriction)
     {
-      Utilities::MPI::sum(wall_shear_local, mpi_comm, wall_shear_local);
+      dealii::Utilities::MPI::sum(wall_shear_local, mpi_comm, wall_shear_local);
 
       for(unsigned int p = 0; p < line.n_points; ++p)
       {
@@ -620,8 +626,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_pressure(
       }
 
       // MPI communication
-      Utilities::MPI::sum(length_local, mpi_comm, length_local);
-      Utilities::MPI::sum(pressure_local, mpi_comm, pressure_local);
+      dealii::Utilities::MPI::sum(length_local, mpi_comm, length_local);
+      dealii::Utilities::MPI::sum(pressure_local, mpi_comm, pressure_local);
 
       // averaging in space (over homogeneous direction)
       for(unsigned int p = 0; p < line.n_points; ++p)
@@ -641,8 +647,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate_pressure(
                                        pressure_local);
 
       // MPI communication
-      length_local   = Utilities::MPI::sum(length_local, mpi_comm);
-      pressure_local = Utilities::MPI::sum(pressure_local, mpi_comm);
+      length_local   = dealii::Utilities::MPI::sum(length_local, mpi_comm);
+      pressure_local = dealii::Utilities::MPI::sum(pressure_local, mpi_comm);
 
       // averaging in space (over homogeneous direction)
       reference_pressure_global[line_iterator] += pressure_local / length_local;
@@ -660,8 +666,9 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::average_pressure_for_given
 {
   unsigned int const scalar_dofs_per_cell =
     dof_handler_pressure.get_fe().base_element(0).dofs_per_cell;
-  std::vector<double>                  pressure_vector(scalar_dofs_per_cell);
-  std::vector<types::global_dof_index> dof_indices(dof_handler_pressure.get_fe().dofs_per_cell);
+  std::vector<double>                          pressure_vector(scalar_dofs_per_cell);
+  std::vector<dealii::types::global_dof_index> dof_indices(
+    dof_handler_pressure.get_fe().dofs_per_cell);
 
   for(typename TYPE::const_iterator cell_and_ref_point = vector_cells_and_ref_points.begin();
       cell_and_ref_point != vector_cells_and_ref_points.end();
@@ -670,23 +677,24 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::average_pressure_for_given
     unsigned int const fe_degree_pressure = dof_handler_pressure.get_fe().degree;
 
     // use quadrature for averaging in homogeneous direction
-    QGauss<1>               gauss_1d(fe_degree_pressure + 1);
-    std::vector<Point<dim>> points(gauss_1d.size());  // 1D points
-    std::vector<double>     weights(gauss_1d.size()); // 1D weights
+    dealii::QGauss<1>               gauss_1d(fe_degree_pressure + 1);
+    std::vector<dealii::Point<dim>> points(gauss_1d.size());  // 1D points
+    std::vector<double>             weights(gauss_1d.size()); // 1D weights
 
-    typename DoFHandler<dim>::active_cell_iterator const cell = cell_and_ref_point->first;
+    typename dealii::DoFHandler<dim>::active_cell_iterator const cell = cell_and_ref_point->first;
 
-    Point<dim> const p_unit = cell_and_ref_point->second;
+    dealii::Point<dim> const p_unit = cell_and_ref_point->second;
 
     // Find points and weights for Gauss quadrature
     find_points_and_weights(p_unit, points, weights, averaging_direction, gauss_1d);
 
-    FEValues<dim, dim> fe_values(mapping,
-                                 dof_handler_pressure.get_fe().base_element(0),
-                                 Quadrature<dim>(points, weights),
-                                 update_values | update_jacobians | update_quadrature_points);
+    dealii::FEValues<dim, dim> fe_values(mapping,
+                                         dof_handler_pressure.get_fe().base_element(0),
+                                         dealii::Quadrature<dim>(points, weights),
+                                         dealii::update_values | dealii::update_jacobians |
+                                           dealii::update_quadrature_points);
 
-    fe_values.reinit(typename Triangulation<dim>::active_cell_iterator(cell));
+    fe_values.reinit(typename dealii::Triangulation<dim>::active_cell_iterator(cell));
 
     cell->get_dof_indices(dof_indices);
 
@@ -712,11 +720,11 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::average_pressure_for_given
 template<int dim, typename Number>
 void
 LinePlotCalculatorStatisticsHomogeneous<dim, Number>::find_points_and_weights(
-  Point<dim> const &        point_in_ref_coord,
-  std::vector<Point<dim>> & points,
-  std::vector<double> &     weights,
-  unsigned int const        averaging_direction,
-  QGauss<1> const &         gauss_1d)
+  dealii::Point<dim> const &        point_in_ref_coord,
+  std::vector<dealii::Point<dim>> & points,
+  std::vector<double> &             weights,
+  unsigned int const                averaging_direction,
+  dealii::QGauss<1> const &         gauss_1d)
 {
   for(unsigned int q = 0; q < gauss_1d.size(); ++q)
   {
@@ -735,7 +743,7 @@ template<int dim, typename Number>
 void
 LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_write_output() const
 {
-  if(Utilities::MPI::this_mpi_process(mpi_comm) == 0 && data.statistics_data.calculate)
+  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0 && data.statistics_data.calculate)
   {
     unsigned int const precision = data.line_data.precision;
 
@@ -769,9 +777,11 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_write_output() const
           print_headline(f, number_of_samples);
 
           for(unsigned int d = 0; d < dim; ++d)
-            f << std::setw(precision + 8) << std::left << "x_" + Utilities::int_to_string(d + 1);
+            f << std::setw(precision + 8) << std::left
+              << "x_" + dealii::Utilities::int_to_string(d + 1);
           for(unsigned int d = 0; d < dim; ++d)
-            f << std::setw(precision + 8) << std::left << "u_" + Utilities::int_to_string(d + 1);
+            f << std::setw(precision + 8) << std::left
+              << "u_" + dealii::Utilities::int_to_string(d + 1);
 
           f << std::endl;
 
@@ -810,14 +820,16 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_write_output() const
           print_headline(f, number_of_samples);
 
           for(unsigned int d = 0; d < dim; ++d)
-            f << std::setw(precision + 8) << std::left << "x_" + Utilities::int_to_string(d + 1);
+            f << std::setw(precision + 8) << std::left
+              << "x_" + dealii::Utilities::int_to_string(d + 1);
 
           for(unsigned int i = 0; i < dim; ++i)
           {
             for(unsigned int j = 0; j < dim; ++j)
             {
               f << std::setw(precision + 8) << std::left
-                << "u_" + Utilities::int_to_string(i + 1) + "u_" + Utilities::int_to_string(j + 1);
+                << "u_" + dealii::Utilities::int_to_string(i + 1) + "u_" +
+                     dealii::Utilities::int_to_string(j + 1);
             }
           }
           f << std::endl;
@@ -866,7 +878,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_write_output() const
           print_headline(f, number_of_samples);
 
           for(unsigned int d = 0; d < dim; ++d)
-            f << std::setw(precision + 8) << std::left << "x_" + Utilities::int_to_string(d + 1);
+            f << std::setw(precision + 8) << std::left
+              << "x_" + dealii::Utilities::int_to_string(d + 1);
 
           f << std::setw(precision + 8) << std::left << "tau_w" << std::endl;
 
@@ -907,7 +920,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_write_output() const
           print_headline(f, number_of_samples);
 
           for(unsigned int d = 0; d < dim; ++d)
-            f << std::setw(precision + 8) << std::left << "x_" + Utilities::int_to_string(d + 1);
+            f << std::setw(precision + 8) << std::left
+              << "x_" + dealii::Utilities::int_to_string(d + 1);
 
           f << std::setw(precision + 8) << std::left << "p";
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.h
@@ -37,8 +37,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  * This function calculates statistics along lines over time
  * and one spatial, homogeneous direction (averaging_direction = {0,1,2}), e.g.,
@@ -54,16 +52,16 @@ template<int dim, typename Number>
 class LinePlotCalculatorStatisticsHomogeneous
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef
-    typename std::vector<std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>>
-      TYPE;
+  typedef typename std::vector<
+    std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator, dealii::Point<dim>>>
+    TYPE;
 
-  LinePlotCalculatorStatisticsHomogeneous(DoFHandler<dim> const & dof_handler_velocity_in,
-                                          DoFHandler<dim> const & dof_handler_pressure_in,
-                                          Mapping<dim> const &    mapping_in,
-                                          MPI_Comm const &        mpi_comm_in);
+  LinePlotCalculatorStatisticsHomogeneous(dealii::DoFHandler<dim> const & dof_handler_velocity_in,
+                                          dealii::DoFHandler<dim> const & dof_handler_pressure_in,
+                                          dealii::Mapping<dim> const &    mapping_in,
+                                          MPI_Comm const &                mpi_comm_in);
 
   void
   setup(LinePlotDataStatistics<dim> const & data_in);
@@ -98,42 +96,43 @@ private:
                                    double &           pressure_local);
 
   void
-  find_points_and_weights(Point<dim> const &        point_in_ref_coord,
-                          std::vector<Point<dim>> & points,
-                          std::vector<double> &     weights,
-                          unsigned int const        averaging_direction,
-                          QGauss<1> const &         gauss_1d);
+  find_points_and_weights(dealii::Point<dim> const &        point_in_ref_coord,
+                          std::vector<dealii::Point<dim>> & points,
+                          std::vector<double> &             weights,
+                          unsigned int const                averaging_direction,
+                          dealii::QGauss<1> const &         gauss_1d);
 
   void
   do_write_output() const;
 
   mutable bool clear_files;
 
-  DoFHandler<dim> const & dof_handler_velocity;
-  DoFHandler<dim> const & dof_handler_pressure;
-  Mapping<dim> const &    mapping;
-  MPI_Comm                mpi_comm;
+  dealii::DoFHandler<dim> const & dof_handler_velocity;
+  dealii::DoFHandler<dim> const & dof_handler_pressure;
+  dealii::Mapping<dim> const &    mapping;
+  MPI_Comm                        mpi_comm;
 
   LinePlotDataStatistics<dim> data;
 
   // Global points
-  std::vector<std::vector<Point<dim>>> global_points;
+  std::vector<std::vector<dealii::Point<dim>>> global_points;
 
   // For all lines: for all points along the line: list of all relevant cells and points in ref
   // coordinates
-  std::vector<
-    std::vector<std::vector<std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>>>>
+  std::vector<std::vector<std::vector<
+    std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator, dealii::Point<dim>>>>>
     cells_and_ref_points_velocity;
 
   // For all lines: for all points along the line: list of all relevant cells and points in ref
   // coordinates
-  std::vector<
-    std::vector<std::vector<std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>>>>
+  std::vector<std::vector<std::vector<
+    std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator, dealii::Point<dim>>>>>
     cells_and_ref_points_pressure;
 
   // For all lines: for pressure reference point: list of all relevant cells and points in ref
   // coordinates
-  std::vector<std::vector<std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>>>>
+  std::vector<std::vector<
+    std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator, dealii::Point<dim>>>>
     cells_and_ref_points_ref_pressure;
 
   // number of samples for averaging in time
@@ -144,7 +143,7 @@ private:
 
   // Velocity quantities
   // For all lines: for all points along the line
-  std::vector<std::vector<Tensor<1, dim, double>>> velocity_global;
+  std::vector<std::vector<dealii::Tensor<1, dim, double>>> velocity_global;
 
   // Skin Friction quantities
   // For all lines: for all points along the line
@@ -152,7 +151,7 @@ private:
 
   // Reynolds Stress quantities
   // For all lines: for all points along the line
-  std::vector<std::vector<Tensor<2, dim, double>>> reynolds_global;
+  std::vector<std::vector<dealii::Tensor<2, dim, double>>> reynolds_global;
 
   // Pressure quantities
   // For all lines: for all points along the line

--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_data.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_data.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 enum class QuantityType
 {
   Undefined,
@@ -64,11 +62,11 @@ struct Quantity
 template<int dim>
 struct QuantityPressureCoefficient : Quantity
 {
-  QuantityPressureCoefficient() : Quantity(), reference_point(Point<dim>())
+  QuantityPressureCoefficient() : Quantity(), reference_point(dealii::Point<dim>())
   {
   }
 
-  Point<dim> reference_point;
+  dealii::Point<dim> reference_point;
 };
 
 template<int dim>
@@ -77,14 +75,14 @@ struct QuantitySkinFriction : Quantity
   QuantitySkinFriction()
     : Quantity(),
       viscosity(1.0),
-      normal_vector(Tensor<1, dim, double>()),
-      tangent_vector(Tensor<1, dim, double>())
+      normal_vector(dealii::Tensor<1, dim, double>()),
+      tangent_vector(dealii::Tensor<1, dim, double>())
   {
   }
 
-  double                 viscosity;
-  Tensor<1, dim, double> normal_vector;
-  Tensor<1, dim, double> tangent_vector;
+  double                         viscosity;
+  dealii::Tensor<1, dim, double> normal_vector;
+  dealii::Tensor<1, dim, double> tangent_vector;
 };
 
 template<int dim>
@@ -101,8 +99,8 @@ struct Line
   /*
    *  begin and end points of line
    */
-  Point<dim> begin;
-  Point<dim> end;
+  dealii::Point<dim> begin;
+  dealii::Point<dim> end;
 
   /*
    *  number of data points written along a line
@@ -134,7 +132,7 @@ struct LineCircumferentialAveraging : Line<dim>
     : Line<dim>(),
       average_circumferential(false),
       n_points_circumferential(4),
-      normal_vector(Tensor<1, dim>())
+      normal_vector(dealii::Tensor<1, dim>())
   {
   }
 
@@ -148,7 +146,7 @@ struct LineCircumferentialAveraging : Line<dim>
   // defines the averaging plane along with the begin and end points
   // of the line. Has to be specified if averaging in circumferential
   // direction is activated.
-  Tensor<1, dim> normal_vector;
+  dealii::Tensor<1, dim> normal_vector;
 };
 
 /*
@@ -182,7 +180,7 @@ struct StatisticsData
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(calculate)
     {
@@ -221,7 +219,7 @@ struct LinePlotData
   }
 
   void
-  print(ConditionalOStream &)
+  print(dealii::ConditionalOStream &)
   {
     // TODO: add output for basic line plot data
   }
@@ -251,7 +249,7 @@ struct LinePlotDataInstantaneous
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     line_data.print(pcout);
   }
@@ -272,7 +270,7 @@ struct LinePlotDataStatistics
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     line_data.print(pcout);
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/mean_velocity_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/mean_velocity_calculator.h
@@ -29,22 +29,20 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct MeanVelocityCalculatorData
 {
   MeanVelocityCalculatorData()
     : calculate(false),
       write_to_file(false),
-      direction(Tensor<1, dim, double>()),
+      direction(dealii::Tensor<1, dim, double>()),
       directory("output/"),
       filename("mean_velocity")
   {
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(calculate == true)
     {
@@ -66,14 +64,14 @@ struct MeanVelocityCalculatorData
   // Set containing boundary ID's of the surface area
   // for which we want to calculate the mean velocity.
   // This parameter is only relevant for area-based computation.
-  std::set<types::boundary_id> boundary_IDs;
+  std::set<dealii::types::boundary_id> boundary_IDs;
 
   // write results to file?
   bool write_to_file;
 
   // Direction in which we want to compute the flow rate
   // This parameter is only relevant for volume-based computation.
-  Tensor<1, dim, double> direction;
+  dealii::Tensor<1, dim, double> direction;
 
   // directory and filename
   std::string directory;
@@ -84,16 +82,16 @@ template<int dim, typename Number>
 class MeanVelocityCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef CellIntegrator<dim, dim, Number> CellIntegratorU;
   typedef FaceIntegrator<dim, dim, Number> FaceIntegratorU;
 
   typedef MeanVelocityCalculator<dim, Number> This;
 
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
-  MeanVelocityCalculator(MatrixFree<dim, Number> const &         matrix_free_in,
+  MeanVelocityCalculator(dealii::MatrixFree<dim, Number> const & matrix_free_in,
                          unsigned int const                      dof_index_in,
                          unsigned int const                      quad_index_in,
                          MeanVelocityCalculatorData<dim> const & data_in,
@@ -142,8 +140,8 @@ private:
   calculate_volume() const;
 
   void
-  local_calculate_volume(MatrixFree<dim, Number> const & data,
-                         std::vector<Number> &           dst,
+  local_calculate_volume(dealii::MatrixFree<dim, Number> const & data,
+                         std::vector<Number> &                   dst,
                          VectorType const &,
                          std::pair<unsigned int, unsigned int> const & cell_range) const;
 
@@ -157,13 +155,13 @@ private:
   do_calculate_flow_rate_volume(VectorType const & velocity) const;
 
   void
-  local_calculate_flow_rate_volume(MatrixFree<dim, Number> const &               data,
+  local_calculate_flow_rate_volume(dealii::MatrixFree<dim, Number> const &       data,
                                    std::vector<Number> &                         dst,
                                    VectorType const &                            src,
                                    std::pair<unsigned int, unsigned int> const & cell_range) const;
 
   MeanVelocityCalculatorData<dim> const & data;
-  MatrixFree<dim, Number> const &         matrix_free;
+  dealii::MatrixFree<dim, Number> const & matrix_free;
   unsigned int                            dof_index, quad_index;
   bool                                    area_has_been_initialized, volume_has_been_initialized;
   double                                  area, volume;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  *  Average velocity field over time for statistically steady, turbulent
  *  flow problems in order to visualize the time-averaged velocity field.
@@ -45,7 +43,7 @@ struct OutputDataMeanVelocity
   }
 
   void
-  print(ConditionalOStream & pcout, bool unsteady)
+  print(dealii::ConditionalOStream & pcout, bool unsteady)
   {
     if(unsteady)
     {
@@ -81,7 +79,7 @@ struct OutputData : public OutputDataBase
   }
 
   void
-  print(ConditionalOStream & pcout, bool unsteady)
+  print(dealii::ConditionalOStream & pcout, bool unsteady)
   {
     OutputDataBase::print(pcout, unsteady);
 
@@ -136,18 +134,18 @@ template<int dim, typename Number>
 class OutputGenerator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef SpatialOperatorBase<dim, Number> NavierStokesOperator;
 
   OutputGenerator(MPI_Comm const & comm);
 
   void
-  setup(NavierStokesOperator const & navier_stokes_operator_in,
-        DoFHandler<dim> const &      dof_handler_velocity_in,
-        DoFHandler<dim> const &      dof_handler_pressure_in,
-        Mapping<dim> const &         mapping_in,
-        OutputData const &           output_data_in);
+  setup(NavierStokesOperator const &    navier_stokes_operator_in,
+        dealii::DoFHandler<dim> const & dof_handler_velocity_in,
+        dealii::DoFHandler<dim> const & dof_handler_pressure_in,
+        dealii::Mapping<dim> const &    mapping_in,
+        OutputData const &              output_data_in);
 
   void
   evaluate(VectorType const & velocity,
@@ -177,10 +175,10 @@ private:
 
   OutputData output_data;
 
-  SmartPointer<DoFHandler<dim> const>      dof_handler_velocity;
-  SmartPointer<DoFHandler<dim> const>      dof_handler_pressure;
-  SmartPointer<Mapping<dim> const>         mapping;
-  SmartPointer<NavierStokesOperator const> navier_stokes_operator;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  dealii::SmartPointer<NavierStokesOperator const>    navier_stokes_operator;
 
   // additional fields
   VectorType   vorticity;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -27,8 +27,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & postprocessor_data,
                                           MPI_Comm const &               comm)

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -36,8 +36,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct PostProcessorData
 {

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor_base.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor_base.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class SpatialOperatorBase;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor_interface.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor_interface.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<typename Number>
 class PostProcessorInterface
 {

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & comm)
   : Base(comm),
@@ -38,15 +36,16 @@ MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & c
 
 template<int dim, typename Number>
 void
-MultigridPreconditioner<dim, Number>::initialize(MultigridData const &               mg_data,
-                                                 Triangulation<dim> const *          tria,
-                                                 FiniteElement<dim> const &          fe,
-                                                 std::shared_ptr<Mapping<dim> const> mapping,
-                                                 PDEOperator const &                 pde_operator,
-                                                 MultigridOperatorType const & mg_operator_type,
-                                                 bool const                    mesh_is_moving,
-                                                 Map const *                   dirichlet_bc,
-                                                 PeriodicFacePairs const *     periodic_face_pairs)
+MultigridPreconditioner<dim, Number>::initialize(
+  MultigridData const &                       mg_data,
+  dealii::Triangulation<dim> const *          tria,
+  dealii::FiniteElement<dim> const &          fe,
+  std::shared_ptr<dealii::Mapping<dim> const> mapping,
+  PDEOperator const &                         pde_operator,
+  MultigridOperatorType const &               mg_operator_type,
+  bool const                                  mesh_is_moving,
+  Map const *                                 dirichlet_bc,
+  PeriodicFacePairs const *                   periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 
@@ -63,7 +62,7 @@ MultigridPreconditioner<dim, Number>::initialize(MultigridData const &          
   // operators should be "active" for the multigrid preconditioner, independently of
   // the actual equation type that is solved.
   AssertThrow(this->mg_operator_type != MultigridOperatorType::Undefined,
-              ExcMessage("Invalid parameter mg_operator_type."));
+              dealii::ExcMessage("Invalid parameter mg_operator_type."));
 
   if(this->mg_operator_type == MultigridOperatorType::ReactionDiffusion)
   {
@@ -72,11 +71,11 @@ MultigridPreconditioner<dim, Number>::initialize(MultigridData const &          
   }
   else if(this->mg_operator_type == MultigridOperatorType::ReactionConvectionDiffusion)
   {
-    AssertThrow(data.convective_problem == true, ExcMessage("Invalid parameter."));
+    AssertThrow(data.convective_problem == true, dealii::ExcMessage("Invalid parameter."));
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   Base::initialize(
@@ -124,14 +123,14 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops && this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> const *>(
+    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
       &this->dof_handlers[level]->get_triangulation());
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, h_level);
   }
 
   matrix_free_data.insert_dof_handler(&(*this->dof_handlers[level]), "std_dof_handler");
   matrix_free_data.insert_constraint(&(*this->constraints[level]), "std_dof_handler");
-  matrix_free_data.insert_quadrature(QGauss<1>(this->level_info[level].degree() + 1),
+  matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
                                      "std_quadrature");
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  * Multigrid preconditioner for momentum operator of the incompressible Navier-Stokes equations.
  */
@@ -59,15 +57,15 @@ public:
   MultigridPreconditioner(MPI_Comm const & comm);
 
   void
-  initialize(MultigridData const &               mg_data,
-             Triangulation<dim> const *          tria,
-             FiniteElement<dim> const &          fe,
-             std::shared_ptr<Mapping<dim> const> mapping,
-             PDEOperator const &                 pde_operator,
-             MultigridOperatorType const &       mg_operator_type,
-             bool const                          mesh_is_moving,
-             Map const *                         dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *           periodic_face_pairs = nullptr);
+  initialize(MultigridData const &                       mg_data,
+             dealii::Triangulation<dim> const *          tria,
+             dealii::FiniteElement<dim> const &          fe,
+             std::shared_ptr<dealii::Mapping<dim> const> mapping,
+             PDEOperator const &                         pde_operator,
+             MultigridOperatorType const &               mg_operator_type,
+             bool const                                  mesh_is_moving,
+             Map const *                                 dirichlet_bc        = nullptr,
+             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 MultigridPreconditionerProjection<dim, Number>::MultigridPreconditionerProjection(
   MPI_Comm const & mpi_comm)
@@ -38,14 +36,14 @@ MultigridPreconditionerProjection<dim, Number>::MultigridPreconditionerProjectio
 template<int dim, typename Number>
 void
 MultigridPreconditionerProjection<dim, Number>::initialize(
-  MultigridData const &               mg_data,
-  Triangulation<dim> const *          tria,
-  FiniteElement<dim> const &          fe,
-  std::shared_ptr<Mapping<dim> const> mapping,
-  PDEOperator const &                 pde_operator,
-  bool const                          mesh_is_moving,
-  Map const *                         dirichlet_bc,
-  PeriodicFacePairs const *           periodic_face_pairs)
+  MultigridData const &                       mg_data,
+  dealii::Triangulation<dim> const *          tria,
+  dealii::FiniteElement<dim> const &          fe,
+  std::shared_ptr<dealii::Mapping<dim> const> mapping,
+  PDEOperator const &                         pde_operator,
+  bool const                                  mesh_is_moving,
+  Map const *                                 dirichlet_bc,
+  PeriodicFacePairs const *                   periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 
@@ -96,14 +94,14 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops && this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> const *>(
+    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
       &this->dof_handlers[level]->get_triangulation());
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, h_level);
   }
 
   matrix_free_data.insert_dof_handler(&(*this->dof_handlers[level]), "std_dof_handler");
   matrix_free_data.insert_constraint(&(*this->constraints[level]), "std_dof_handler");
-  matrix_free_data.insert_quadrature(QGauss<1>(this->level_info[level].degree() + 1),
+  matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
                                      "std_quadrature");
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  * Multigrid preconditioner for projection operator of the incompressible Navier-Stokes equations.
  */
@@ -59,14 +57,14 @@ public:
   MultigridPreconditionerProjection(MPI_Comm const & mpi_comm);
 
   void
-  initialize(MultigridData const &               mg_data,
-             Triangulation<dim> const *          tria,
-             FiniteElement<dim> const &          fe,
-             std::shared_ptr<Mapping<dim> const> mapping,
-             PDEOperator const &                 pde_operator,
-             bool const                          mesh_is_moving,
-             Map const *                         dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *           periodic_face_pairs = nullptr);
+  initialize(MultigridData const &                       mg_data,
+             dealii::Triangulation<dim> const *          tria,
+             dealii::FiniteElement<dim> const &          fe,
+             std::shared_ptr<dealii::Mapping<dim> const> mapping,
+             PDEOperator const &                         pde_operator,
+             bool const                                  mesh_is_moving,
+             Map const *                                 dirichlet_bc        = nullptr,
+             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/solver.h
+++ b/include/exadg/incompressible_navier_stokes/solver.h
@@ -74,7 +74,7 @@ run(std::string const & input_file,
     MPI_Comm const &    mpi_comm,
     bool const          is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<IncNS::ApplicationBase<dim, Number>> application =
@@ -111,8 +111,8 @@ main(int argc, char ** argv)
   // use stride of n cores
   int const n = 48; // 24;
 
-  int const rank     = Utilities::MPI::this_mpi_process(mpi_comm);
-  int const size     = Utilities::MPI::n_mpi_processes(mpi_comm);
+  int const rank     = dealii::Utilities::MPI::this_mpi_process(mpi_comm);
+  int const size     = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
   int const flag     = 1;
   int const new_rank = rank + (rank % n) * size;
 

--- a/include/exadg/incompressible_navier_stokes/solver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/solver_precursor.h
@@ -74,7 +74,7 @@ template<int dim, typename Number>
 void
 run(std::string const & input_file, MPI_Comm const & mpi_comm, bool const is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<IncNS::ApplicationBasePrecursor<dim, Number>> application =

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/divergence_calculator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/divergence_calculator.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DivergenceCalculator<dim, Number>::DivergenceCalculator()
   : matrix_free(nullptr), dof_index_u(0), dof_index_u_scalar(0), quad_index(0)
@@ -35,10 +33,11 @@ DivergenceCalculator<dim, Number>::DivergenceCalculator()
 
 template<int dim, typename Number>
 void
-DivergenceCalculator<dim, Number>::initialize(MatrixFree<dim, Number> const & matrix_free_in,
-                                              unsigned int const              dof_index_u_in,
-                                              unsigned int const              dof_index_u_scalar_in,
-                                              unsigned int const              quad_index_in)
+DivergenceCalculator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_u_in,
+  unsigned int const                      dof_index_u_scalar_in,
+  unsigned int const                      quad_index_in)
 {
   matrix_free        = &matrix_free_in;
   dof_index_u        = dof_index_u_in;
@@ -58,10 +57,10 @@ DivergenceCalculator<dim, Number>::compute_divergence(VectorType &       dst,
 
 template<int dim, typename Number>
 void
-DivergenceCalculator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                             VectorType &                    dst,
-                                             VectorType const &              src,
-                                             Range const &                   cell_range) const
+DivergenceCalculator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                             VectorType &                            dst,
+                                             VectorType const &                      src,
+                                             Range const & cell_range) const
 {
   CellIntegratorVector integrator_vector(matrix_free, dof_index_u, quad_index);
   CellIntegratorScalar integrator_scalar(matrix_free, dof_index_u_scalar, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/divergence_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/divergence_calculator.h
@@ -32,17 +32,15 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class DivergenceCalculator
 {
 private:
   typedef DivergenceCalculator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -53,22 +51,22 @@ public:
   DivergenceCalculator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_u_in,
-             unsigned int const              dof_index_u_scalar_in,
-             unsigned int const              quad_index_in);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_u_in,
+             unsigned int const                      dof_index_u_scalar_in,
+             unsigned int const                      quad_index_in);
 
   void
   compute_divergence(VectorType & dst, VectorType const & src) const;
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index_u;
   unsigned int dof_index_u_scalar;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/q_criterion_calculator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/q_criterion_calculator.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 QCriterionCalculator<dim, Number>::QCriterionCalculator()
   : matrix_free(nullptr), dof_index_u(0), dof_index_u_scalar(0), quad_index(0)
@@ -35,10 +33,11 @@ QCriterionCalculator<dim, Number>::QCriterionCalculator()
 
 template<int dim, typename Number>
 void
-QCriterionCalculator<dim, Number>::initialize(MatrixFree<dim, Number> const & matrix_free_in,
-                                              unsigned int const              dof_index_u_in,
-                                              unsigned int const              dof_index_u_scalar_in,
-                                              unsigned int const              quad_index_in)
+QCriterionCalculator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_u_in,
+  unsigned int const                      dof_index_u_scalar_in,
+  unsigned int const                      quad_index_in)
 {
   matrix_free        = &matrix_free_in;
   dof_index_u        = dof_index_u_in;
@@ -57,10 +56,10 @@ QCriterionCalculator<dim, Number>::compute(VectorType & dst, VectorType const & 
 
 template<int dim, typename Number>
 void
-QCriterionCalculator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                             VectorType &                    dst,
-                                             VectorType const &              src,
-                                             Range const &                   cell_range) const
+QCriterionCalculator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                             VectorType &                            dst,
+                                             VectorType const &                      src,
+                                             Range const & cell_range) const
 {
   CellIntegratorVector integrator_vector(matrix_free, dof_index_u, quad_index);
   CellIntegratorScalar integrator_scalar(matrix_free, dof_index_u_scalar, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/q_criterion_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/q_criterion_calculator.h
@@ -32,18 +32,16 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class QCriterionCalculator
 {
 private:
   typedef QCriterionCalculator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -54,22 +52,22 @@ public:
   QCriterionCalculator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_u_in,
-             unsigned int const              dof_index_u_scalar_in,
-             unsigned int const              quad_index_in);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_u_in,
+             unsigned int const                      dof_index_u_scalar_in,
+             unsigned int const                      quad_index_in);
 
   void
   compute(VectorType & dst, VectorType const & src) const;
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index_u;
   unsigned int dof_index_u_scalar;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/streamfunction_calculator_rhs_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/streamfunction_calculator_rhs_operator.cpp
@@ -25,22 +25,21 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 StreamfunctionCalculatorRHSOperator<dim, Number>::StreamfunctionCalculatorRHSOperator()
   : matrix_free(nullptr), dof_index_u(0), dof_index_u_scalar(0), quad_index(0)
 {
-  AssertThrow(dim == 2, ExcMessage("Calculation of streamfunction can only be used for dim==2."));
+  AssertThrow(dim == 2,
+              dealii::ExcMessage("Calculation of streamfunction can only be used for dim==2."));
 }
 
 template<int dim, typename Number>
 void
 StreamfunctionCalculatorRHSOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const & matrix_free_in,
-  unsigned int const              dof_index_u_in,
-  unsigned int const              dof_index_u_scalar_in,
-  unsigned int const              quad_index_in)
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_u_in,
+  unsigned int const                      dof_index_u_scalar_in,
+  unsigned int const                      quad_index_in)
 {
   matrix_free        = &matrix_free_in;
   dof_index_u        = dof_index_u_in;
@@ -61,10 +60,10 @@ StreamfunctionCalculatorRHSOperator<dim, Number>::apply(VectorType &       dst,
 template<int dim, typename Number>
 void
 StreamfunctionCalculatorRHSOperator<dim, Number>::cell_loop(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   cell_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           cell_range) const
 {
   IntegratorVector integrator_vector(matrix_free, dof_index_u, quad_index);
   IntegratorScalar integrator_scalar(matrix_free, dof_index_u_scalar, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/streamfunction_calculator_rhs_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/streamfunction_calculator_rhs_operator.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  *  This function calculates the right-hand side of the Laplace equation that is solved in order to
  * obtain the streamfunction psi
@@ -46,7 +44,7 @@ template<int dim, typename Number>
 class StreamfunctionCalculatorRHSOperator
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -59,22 +57,22 @@ public:
   StreamfunctionCalculatorRHSOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_u_in,
-             unsigned int const              dof_index_u_scalar_in,
-             unsigned int const              quad_index_in);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_u_in,
+             unsigned int const                      dof_index_u_scalar_in,
+             unsigned int const                      quad_index_in);
 
   void
   apply(VectorType & dst, VectorType const & src) const;
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index_u;
   unsigned int dof_index_u_scalar;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/velocity_magnitude_calculator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/velocity_magnitude_calculator.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 VelocityMagnitudeCalculator<dim, Number>::VelocityMagnitudeCalculator()
   : matrix_free(nullptr), dof_index_u(0), dof_index_u_scalar(0), quad_index(0)
@@ -35,10 +33,11 @@ VelocityMagnitudeCalculator<dim, Number>::VelocityMagnitudeCalculator()
 
 template<int dim, typename Number>
 void
-VelocityMagnitudeCalculator<dim, Number>::initialize(MatrixFree<dim, Number> const & matrix_free_in,
-                                                     unsigned int const              dof_index_u_in,
-                                                     unsigned int const dof_index_u_scalar_in,
-                                                     unsigned int const quad_index_in)
+VelocityMagnitudeCalculator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_u_in,
+  unsigned int const                      dof_index_u_scalar_in,
+  unsigned int const                      quad_index_in)
 {
   matrix_free        = &matrix_free_in;
   dof_index_u        = dof_index_u_in;
@@ -57,10 +56,11 @@ VelocityMagnitudeCalculator<dim, Number>::compute(VectorType & dst, VectorType c
 
 template<int dim, typename Number>
 void
-VelocityMagnitudeCalculator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                                    VectorType &                    dst,
-                                                    VectorType const &              src,
-                                                    Range const & cell_range) const
+VelocityMagnitudeCalculator<dim, Number>::cell_loop(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           cell_range) const
 {
   IntegratorVector integrator_vector(matrix_free, dof_index_u, quad_index);
   IntegratorScalar integrator_scalar(matrix_free, dof_index_u_scalar, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/velocity_magnitude_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/velocity_magnitude_calculator.h
@@ -32,17 +32,15 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class VelocityMagnitudeCalculator
 {
 private:
   typedef VelocityMagnitudeCalculator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -53,22 +51,22 @@ public:
   VelocityMagnitudeCalculator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_u_in,
-             unsigned int const              dof_index_u_scalar_in,
-             unsigned int const              quad_index_in);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_u_in,
+             unsigned int const                      dof_index_u_scalar_in,
+             unsigned int const                      quad_index_in);
 
   void
   compute(VectorType & dst, VectorType const & src) const;
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index_u;
   unsigned int dof_index_u_scalar;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/vorticity_calculator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/vorticity_calculator.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 VorticityCalculator<dim, Number>::VorticityCalculator()
   : matrix_free(nullptr), dof_index(0), quad_index(0)
@@ -35,9 +33,9 @@ VorticityCalculator<dim, Number>::VorticityCalculator()
 
 template<int dim, typename Number>
 void
-VorticityCalculator<dim, Number>::initialize(MatrixFree<dim, Number> const & matrix_free_in,
-                                             unsigned int const              dof_index_in,
-                                             unsigned int const              quad_index_in)
+VorticityCalculator<dim, Number>::initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                                             unsigned int const                      dof_index_in,
+                                             unsigned int const                      quad_index_in)
 {
   matrix_free = &matrix_free_in;
   dof_index   = dof_index_in;
@@ -55,10 +53,10 @@ VorticityCalculator<dim, Number>::compute_vorticity(VectorType & dst, VectorType
 
 template<int dim, typename Number>
 void
-VorticityCalculator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                            VectorType &                    dst,
-                                            VectorType const &              src,
-                                            Range const &                   cell_range) const
+VorticityCalculator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                            VectorType &                            dst,
+                                            VectorType const &                      src,
+                                            Range const & cell_range) const
 {
   Integrator integrator(matrix_free, dof_index, quad_index);
 
@@ -70,7 +68,7 @@ VorticityCalculator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matr
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
       // omega is a scalar quantity in 2D and a vector with dim components in 3D
-      Tensor<1, number_vorticity_components, VectorizedArray<Number>> omega =
+      dealii::Tensor<1, number_vorticity_components, dealii::VectorizedArray<Number>> omega =
         integrator.get_curl(q);
 
       // omega_vector is a vector with dim components

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/vorticity_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/calculators/vorticity_calculator.h
@@ -32,17 +32,15 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class VorticityCalculator
 {
 private:
   typedef VorticityCalculator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -54,21 +52,21 @@ public:
   VorticityCalculator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_in,
-             unsigned int const              quad_index_in);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_in,
+             unsigned int const                      quad_index_in);
 
   void
   compute_vorticity(VectorType & dst, VectorType const & src) const;
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index;
   unsigned int quad_index;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
@@ -65,7 +65,7 @@ create_operator(std::shared_ptr<Grid<dim> const>                  grid,
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   return pde_operator;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/curl_compute.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/curl_compute.h
@@ -29,12 +29,10 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename FEEval>
 struct CurlCompute
 {
-  static Tensor<1, dim, VectorizedArray<typename FEEval::number_type>>
+  static dealii::Tensor<1, dim, dealii::VectorizedArray<typename FEEval::number_type>>
   compute(FEEval & fe_eval, unsigned int const q_point)
   {
     return fe_eval.get_curl(q_point);
@@ -45,15 +43,15 @@ struct CurlCompute
 template<typename FEEval>
 struct CurlCompute<2, FEEval>
 {
-  static Tensor<1, 2, VectorizedArray<typename FEEval::number_type>>
+  static dealii::Tensor<1, 2, dealii::VectorizedArray<typename FEEval::number_type>>
   compute(FEEval & fe_eval, unsigned int const q_point)
   {
-    Tensor<1, 2, VectorizedArray<typename FEEval::number_type>> curl;
+    dealii::Tensor<1, 2, dealii::VectorizedArray<typename FEEval::number_type>> curl;
     /*
      * fe_eval = / phi \   _____\   grad(fe_eval) = / d(phi)/dx1   d(phi)/dx2 \
      *           \  0  /        /                   \     0             0     /
      */
-    Tensor<2, 2, VectorizedArray<typename FEEval::number_type>> temp =
+    dealii::Tensor<2, 2, dealii::VectorizedArray<typename FEEval::number_type>> temp =
       fe_eval.get_gradient(q_point);
     /*
      *         __    /  0  \     /   d(phi)/dx2 \

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // forward declaration
 template<int dim, typename Number>
 class OperatorCoupled;
@@ -40,8 +38,8 @@ template<int dim, typename Number>
 class NonlinearOperatorCoupled
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number>      VectorType;
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number>      VectorType;
+  typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef OperatorCoupled<dim, Number> PDEOperator;
 
@@ -87,7 +85,7 @@ template<int dim, typename Number>
 class LinearOperatorCoupled : public dealii::Subscriptor
 {
 private:
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef OperatorCoupled<dim, Number> PDEOperator;
 
@@ -141,7 +139,7 @@ template<int dim, typename Number>
 class BlockPreconditioner
 {
 private:
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef OperatorCoupled<dim, Number> PDEOperator;
 
@@ -172,7 +170,8 @@ public:
   get_timings() const
   {
     AssertThrow(false,
-                ExcMessage("Function get_timings() is not implemented for BlockPreconditioner."));
+                dealii::ExcMessage(
+                  "Function get_timings() is not implemented for BlockPreconditioner."));
 
     return std::make_shared<TimerTree>();
   }
@@ -211,9 +210,9 @@ public:
   virtual ~OperatorCoupled();
 
   void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data,
-        std::string const &                          dof_index_temperature = "");
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data,
+        std::string const &                              dof_index_temperature = "");
 
   void
   setup_solvers(double const & scaling_factor_time_derivative_term, VectorType const & velocity);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 OperatorDualSplitting<dim, Number>::OperatorDualSplitting(
   std::shared_ptr<Grid<dim> const>                  grid_in,
@@ -131,7 +129,8 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Preconditioner specified for viscous step is not implemented."));
+    AssertThrow(
+      false, dealii::ExcMessage("Preconditioner specified for viscous step is not implemented."));
   }
 }
 
@@ -204,7 +203,7 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_solver()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified viscous solver is not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Specified viscous solver is not implemented."));
   }
 }
 
@@ -244,8 +243,8 @@ OperatorDualSplitting<dim, Number>::rhs_ppe_div_term_body_forces_add(VectorType 
 template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_body_forces_boundary_face(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
   VectorType const &,
   Range const & face_range) const
 {
@@ -266,7 +265,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_body_forces_boundary_
       if(boundary_type == BoundaryTypeU::Dirichlet ||
          boundary_type == BoundaryTypeU::DirichletMortar)
       {
-        Point<dim, scalar> q_points = integrator.quadrature_point(q);
+        dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
         // evaluate right-hand side
         vector rhs =
@@ -285,12 +284,13 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_body_forces_boundary_
         // Remark: On symmetry boundaries it follows from g_u * n = 0 that also g_{u_hat} * n = 0.
         // Hence, a symmetry boundary for u is also a symmetry boundary for u_hat. Hence, there
         // are no inhomogeneous contributions on symmetry boundaries.
-        scalar zero = make_vectorized_array<Number>(0.0);
+        scalar zero = dealii::make_vectorized_array<Number>(0.0);
         integrator.submit_value(zero, q);
       }
       else
       {
-        AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+        AssertThrow(false,
+                    dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
       }
     }
     integrator.integrate(true, false);
@@ -324,10 +324,10 @@ OperatorDualSplitting<dim, Number>::rhs_ppe_div_term_convective_term_add(
 template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_convective_term_boundary_face(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   unsigned int const dof_index_velocity = this->get_dof_index_velocity();
   unsigned int const dof_index_pressure = this->get_dof_index_pressure();
@@ -378,7 +378,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_convective_term_bound
         }
         else
         {
-          AssertThrow(false, ExcMessage("Not implemented."));
+          AssertThrow(false, dealii::ExcMessage("Not implemented."));
         }
 
         if(this->param.ale_formulation && this->param.store_previous_boundary_values)
@@ -396,12 +396,13 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_convective_term_bound
         // Remark: On symmetry boundaries it follows from g_u * n = 0 that also g_{u_hat} * n = 0.
         // Hence, a symmetry boundary for u is also a symmetry boundary for u_hat. Hence, there
         // are no inhomogeneous contributions on symmetry boundaries.
-        scalar zero = make_vectorized_array<Number>(0.0);
+        scalar zero = dealii::make_vectorized_array<Number>(0.0);
         pressure.submit_value(zero, q);
       }
       else
       {
-        AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+        AssertThrow(false,
+                    dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
       }
     }
     pressure.integrate_scatter(true, false, dst);
@@ -428,8 +429,8 @@ OperatorDualSplitting<dim, Number>::rhs_ppe_nbc_analytical_time_derivative_add(V
 template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_analytical_time_derivative_add_boundary_face(
-  MatrixFree<dim, Number> const & data,
-  VectorType &                    dst,
+  dealii::MatrixFree<dim, Number> const & data,
+  VectorType &                            dst,
   VectorType const &,
   Range const & face_range) const
 {
@@ -442,18 +443,19 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_analytical_time_derivative
   {
     integrator.reinit(face);
 
-    types::boundary_id boundary_id = data.get_boundary_id(face);
-    BoundaryTypeP      boundary_type =
+    dealii::types::boundary_id boundary_id = data.get_boundary_id(face);
+    BoundaryTypeP              boundary_type =
       this->boundary_descriptor->pressure->get_boundary_type(boundary_id);
 
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
       if(boundary_type == BoundaryTypeP::Neumann)
       {
-        Point<dim, scalar> q_points = integrator.quadrature_point(q);
+        dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
         // evaluate boundary condition
-        typename std::map<types::boundary_id, std::shared_ptr<Function<dim>>>::iterator it =
+        typename std::map<dealii::types::boundary_id,
+                          std::shared_ptr<dealii::Function<dim>>>::iterator it =
           this->boundary_descriptor->pressure->neumann_bc.find(boundary_id);
         vector dudt =
           FunctionEvaluator<1, dim, Number>::value(it->second, q_points, this->evaluation_time);
@@ -466,12 +468,13 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_analytical_time_derivative
       }
       else if(boundary_type == BoundaryTypeP::Dirichlet)
       {
-        scalar zero = make_vectorized_array<Number>(0.0);
+        scalar zero = dealii::make_vectorized_array<Number>(0.0);
         integrator.submit_value(zero, q);
       }
       else
       {
-        AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+        AssertThrow(false,
+                    dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
       }
     }
     integrator.integrate(true, false);
@@ -496,10 +499,10 @@ OperatorDualSplitting<dim, Number>::rhs_ppe_nbc_numerical_time_derivative_add(
 template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_numerical_time_derivative_add_boundary_face(
-  MatrixFree<dim, Number> const & data,
-  VectorType &                    dst,
-  VectorType const &              acceleration,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & data,
+  VectorType &                            dst,
+  VectorType const &                      acceleration,
+  Range const &                           face_range) const
 {
   unsigned int dof_index_velocity  = this->get_dof_index_velocity();
   unsigned int dof_index_pressure  = this->get_dof_index_pressure();
@@ -515,8 +518,8 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_numerical_time_derivative_
 
     integrator_pressure.reinit(face);
 
-    types::boundary_id boundary_id = data.get_boundary_id(face);
-    BoundaryTypeP      boundary_type =
+    dealii::types::boundary_id boundary_id = data.get_boundary_id(face);
+    BoundaryTypeP              boundary_type =
       this->boundary_descriptor->pressure->get_boundary_type(boundary_id);
 
     for(unsigned int q = 0; q < integrator_pressure.n_q_points; ++q)
@@ -531,12 +534,13 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_numerical_time_derivative_
       }
       else if(boundary_type == BoundaryTypeP::Dirichlet)
       {
-        scalar zero = make_vectorized_array<Number>(0.0);
+        scalar zero = dealii::make_vectorized_array<Number>(0.0);
         integrator_pressure.submit_value(zero, q);
       }
       else
       {
-        AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+        AssertThrow(false,
+                    dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
       }
     }
 
@@ -564,8 +568,8 @@ OperatorDualSplitting<dim, Number>::rhs_ppe_nbc_body_force_term_add(VectorType &
 template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_body_force_term_add_boundary_face(
-  MatrixFree<dim, Number> const & data,
-  VectorType &                    dst,
+  dealii::MatrixFree<dim, Number> const & data,
+  VectorType &                            dst,
   VectorType const &,
   Range const & face_range) const
 {
@@ -578,15 +582,15 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_body_force_term_add_bounda
   {
     integrator.reinit(face);
 
-    types::boundary_id boundary_id = data.get_boundary_id(face);
-    BoundaryTypeP      boundary_type =
+    dealii::types::boundary_id boundary_id = data.get_boundary_id(face);
+    BoundaryTypeP              boundary_type =
       this->boundary_descriptor->pressure->get_boundary_type(boundary_id);
 
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
       if(boundary_type == BoundaryTypeP::Neumann)
       {
-        Point<dim, scalar> q_points = integrator.quadrature_point(q);
+        dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
         // evaluate right-hand side
         vector rhs =
@@ -602,12 +606,13 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_body_force_term_add_bounda
       }
       else if(boundary_type == BoundaryTypeP::Dirichlet)
       {
-        scalar zero = make_vectorized_array<Number>(0.0);
+        scalar zero = dealii::make_vectorized_array<Number>(0.0);
         integrator.submit_value(zero, q);
       }
       else
       {
-        AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+        AssertThrow(false,
+                    dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
       }
     }
     integrator.integrate(true, false);
@@ -631,10 +636,10 @@ OperatorDualSplitting<dim, Number>::rhs_ppe_convective_add(VectorType &       ds
 template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_convective_add_boundary_face(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   unsigned int const dof_index_velocity = this->get_dof_index_velocity();
   unsigned int const dof_index_pressure = this->get_dof_index_pressure();
@@ -683,7 +688,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_convective_add_boundary_fa
         }
         else
         {
-          AssertThrow(false, ExcMessage("Not implemented."));
+          AssertThrow(false, dealii::ExcMessage("Not implemented."));
         }
 
         if(this->param.ale_formulation && this->param.store_previous_boundary_values)
@@ -695,11 +700,12 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_convective_add_boundary_fa
       }
       else if(boundary_type == BoundaryTypeP::Dirichlet)
       {
-        pressure.submit_value(make_vectorized_array<Number>(0.0), q);
+        pressure.submit_value(dealii::make_vectorized_array<Number>(0.0), q);
       }
       else
       {
-        AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+        AssertThrow(false,
+                    dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
       }
     }
 
@@ -723,10 +729,10 @@ OperatorDualSplitting<dim, Number>::rhs_ppe_viscous_add(VectorType &       dst,
 template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_viscous_add_boundary_face(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   unsigned int const dof_index_velocity = this->get_dof_index_velocity();
   unsigned int const dof_index_pressure = this->get_quad_index_pressure();
@@ -752,7 +758,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_viscous_add_boundary_face(
 
       if(boundary_type == BoundaryTypeP::Neumann)
       {
-        scalar h = make_vectorized_array<Number>(0.0);
+        scalar h = dealii::make_vectorized_array<Number>(0.0);
 
         vector normal = pressure.get_normal_vector(q);
 
@@ -764,11 +770,12 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_viscous_add_boundary_face(
       }
       else if(boundary_type == BoundaryTypeP::Dirichlet)
       {
-        pressure.submit_value(make_vectorized_array<Number>(0.0), q);
+        pressure.submit_value(dealii::make_vectorized_array<Number>(0.0), q);
       }
       else
       {
-        AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+        AssertThrow(false,
+                    dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
       }
     }
     pressure.integrate_scatter(true, false, dst);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number = double>
 class OperatorDualSplitting : public OperatorProjectionMethods<dim, Number>
 {
@@ -150,7 +148,7 @@ private:
    */
 
   void
-  cell_loop_empty(MatrixFree<dim, Number> const &,
+  cell_loop_empty(dealii::MatrixFree<dim, Number> const &,
                   VectorType &,
                   VectorType const &,
                   Range const &) const
@@ -158,7 +156,7 @@ private:
   }
 
   void
-  face_loop_empty(MatrixFree<dim, Number> const &,
+  face_loop_empty(dealii::MatrixFree<dim, Number> const &,
                   VectorType &,
                   VectorType const &,
                   Range const &) const
@@ -169,56 +167,60 @@ private:
 
   // convective term
   void
-  local_rhs_ppe_div_term_convective_term_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                                       VectorType &                    dst,
-                                                       VectorType const &              src,
-                                                       Range const & face_range) const;
+  local_rhs_ppe_div_term_convective_term_boundary_face(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   // body force term
   void
-  local_rhs_ppe_div_term_body_forces_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                                   VectorType &                    dst,
-                                                   VectorType const &              src,
-                                                   Range const & face_range) const;
+  local_rhs_ppe_div_term_body_forces_boundary_face(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   // Neumann boundary condition term
 
   // dg_u/dt term with analytical derivative
   void
   local_rhs_ppe_nbc_analytical_time_derivative_add_boundary_face(
-    MatrixFree<dim, Number> const & matrix_free,
-    VectorType &                    dst,
-    VectorType const &              src,
-    Range const &                   face_range) const;
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   // dg_u/dt with numerical time derivative
   void
   local_rhs_ppe_nbc_numerical_time_derivative_add_boundary_face(
-    MatrixFree<dim, Number> const & matrix_free,
-    VectorType &                    dst,
-    VectorType const &              src,
-    Range const &                   face_range) const;
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   // body force term
   void
-  local_rhs_ppe_nbc_body_force_term_add_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                                      VectorType &                    dst,
-                                                      VectorType const &              src,
-                                                      Range const & face_range) const;
+  local_rhs_ppe_nbc_body_force_term_add_boundary_face(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   // convective term
   void
-  local_rhs_ppe_nbc_convective_add_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                                 VectorType &                    dst,
-                                                 VectorType const &              src,
-                                                 Range const &                   face_range) const;
+  local_rhs_ppe_nbc_convective_add_boundary_face(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   // viscous term
   void
-  local_rhs_ppe_nbc_viscous_add_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                              VectorType &                    dst,
-                                              VectorType const &              src,
-                                              Range const &                   face_range) const;
+  local_rhs_ppe_nbc_viscous_add_boundary_face(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                              VectorType &                            dst,
+                                              VectorType const &                      src,
+                                              Range const & face_range) const;
 
 
   /*

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 OperatorPressureCorrection<dim, Number>::OperatorPressureCorrection(
   std::shared_ptr<Grid<dim> const>                  grid_in,
@@ -58,9 +56,9 @@ OperatorPressureCorrection<dim, Number>::~OperatorPressureCorrection()
 template<int dim, typename Number>
 void
 OperatorPressureCorrection<dim, Number>::setup(
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data,
-  std::string const &                          dof_index_temperature)
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data,
+  std::string const &                              dof_index_temperature)
 {
   ProjectionBase::setup(matrix_free, matrix_free_data, dof_index_temperature);
 
@@ -139,7 +137,7 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
   else
   {
     AssertThrow(this->param.preconditioner_momentum == MomentumPreconditioner::None,
-                ExcNotImplemented());
+                dealii::ExcNotImplemented());
   }
 }
 
@@ -195,7 +193,8 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_solver()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified solver for momentum equation is not implemented."));
+    AssertThrow(false,
+                dealii::ExcMessage("Specified solver for momentum equation is not implemented."));
   }
 
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // forward declaration
 template<int dim, typename Number>
 class OperatorPressureCorrection;
@@ -39,7 +37,7 @@ template<int dim, typename Number>
 class NonlinearMomentumOperator
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef OperatorPressureCorrection<dim, Number> PDEOperator;
 
@@ -124,9 +122,9 @@ public:
    * times depending on the specific ALE formulation chosen).
    */
   virtual void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data,
-        std::string const &                          dof_index_temperature = "");
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data,
+        std::string const &                              dof_index_temperature = "");
 
   void
   setup_solvers(double const & scaling_factor_mass, VectorType const & velocity);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 OperatorProjectionMethods<dim, Number>::OperatorProjectionMethods(
   std::shared_ptr<Grid<dim> const>                  grid_in,
@@ -57,9 +55,9 @@ OperatorProjectionMethods<dim, Number>::~OperatorProjectionMethods()
 template<int dim, typename Number>
 void
 OperatorProjectionMethods<dim, Number>::setup(
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data,
-  std::string const &                          dof_index_temperature)
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data,
+  std::string const &                              dof_index_temperature)
 {
   Base::setup(matrix_free, matrix_free_data, dof_index_temperature);
 
@@ -186,8 +184,9 @@ OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poiss
   }
   else
   {
-    AssertThrow(
-      false, ExcMessage("Specified preconditioner for pressure Poisson equation not implemented"));
+    AssertThrow(false,
+                dealii::ExcMessage(
+                  "Specified preconditioner for pressure Poisson equation not implemented"));
   }
 }
 
@@ -241,7 +240,8 @@ OperatorProjectionMethods<dim, Number>::initialize_solver_pressure_poisson()
   else
   {
     AssertThrow(false,
-                ExcMessage("Specified solver for pressure Poisson equation is not implemented."));
+                dealii::ExcMessage(
+                  "Specified solver for pressure Poisson equation is not implemented."));
   }
 }
 
@@ -304,7 +304,7 @@ OperatorProjectionMethods<dim, Number>::apply_projection_operator(VectorType &  
                                                                   VectorType const & src) const
 {
   AssertThrow(this->projection_operator.get() != 0,
-              ExcMessage("Projection operator is not initialized correctly."));
+              dealii::ExcMessage("Projection operator is not initialized correctly."));
 
   this->projection_operator->vmult(dst, src);
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  * Base class for projection-type incompressible Navier-Stokes solvers such as the high-order dual
  * splitting (velocity-correction) scheme or pressure correction schemes.
@@ -65,9 +63,9 @@ public:
    * needed for projection-type methods.
    */
   void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data,
-        std::string const &                          dof_index_temperature = "") override;
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data,
+        std::string const &                              dof_index_temperature = "") override;
 
   void
   update_after_grid_motion() override;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.cpp
@@ -12,8 +12,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 ContinuityPenaltyOperator<dim, Number>::ContinuityPenaltyOperator()
   : matrix_free(nullptr), time(0.0)
@@ -22,9 +20,10 @@ ContinuityPenaltyOperator<dim, Number>::ContinuityPenaltyOperator()
 
 template<int dim, typename Number>
 void
-ContinuityPenaltyOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &    matrix_free,
-                                                   ContinuityPenaltyData<dim> const & data,
-                                                   std::shared_ptr<Kernel> const      kernel)
+ContinuityPenaltyOperator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  ContinuityPenaltyData<dim> const &      data,
+  std::shared_ptr<Kernel> const           kernel)
 {
   this->matrix_free = &matrix_free;
   this->data        = data;
@@ -49,8 +48,8 @@ ContinuityPenaltyOperator<dim, Number>::apply(VectorType & dst, VectorType const
                     dst,
                     src,
                     true,
-                    MatrixFree<dim, Number>::DataAccessOnFaces::values,
-                    MatrixFree<dim, Number>::DataAccessOnFaces::values);
+                    dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
+                    dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
 }
 
 template<int dim, typename Number>
@@ -64,8 +63,8 @@ ContinuityPenaltyOperator<dim, Number>::apply_add(VectorType & dst, VectorType c
                     dst,
                     src,
                     false,
-                    MatrixFree<dim, Number>::DataAccessOnFaces::values,
-                    MatrixFree<dim, Number>::DataAccessOnFaces::values);
+                    dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
+                    dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
 }
 
 template<int dim, typename Number>
@@ -134,10 +133,11 @@ ContinuityPenaltyOperator<dim, Number>::evaluate_add(VectorType &       dst,
 
 template<int dim, typename Number>
 void
-ContinuityPenaltyOperator<dim, Number>::cell_loop_empty(MatrixFree<dim, Number> const & matrix_free,
-                                                        VectorType &                    dst,
-                                                        VectorType const &              src,
-                                                        Range const &                   range) const
+ContinuityPenaltyOperator<dim, Number>::cell_loop_empty(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           range) const
 {
   (void)matrix_free;
   (void)dst;
@@ -147,10 +147,11 @@ ContinuityPenaltyOperator<dim, Number>::cell_loop_empty(MatrixFree<dim, Number> 
 
 template<int dim, typename Number>
 void
-ContinuityPenaltyOperator<dim, Number>::face_loop(MatrixFree<dim, Number> const & matrix_free,
-                                                  VectorType &                    dst,
-                                                  VectorType const &              src,
-                                                  Range const &                   face_range) const
+ContinuityPenaltyOperator<dim, Number>::face_loop(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   IntegratorFace integrator_m(matrix_free, true, data.dof_index, data.quad_index);
   IntegratorFace integrator_p(matrix_free, false, data.dof_index, data.quad_index);
@@ -174,10 +175,11 @@ ContinuityPenaltyOperator<dim, Number>::face_loop(MatrixFree<dim, Number> const 
 
 template<int dim, typename Number>
 void
-ContinuityPenaltyOperator<dim, Number>::face_loop_empty(MatrixFree<dim, Number> const & matrix_free,
-                                                        VectorType &                    dst,
-                                                        VectorType const &              src,
-                                                        Range const & face_range) const
+ContinuityPenaltyOperator<dim, Number>::face_loop_empty(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   (void)matrix_free;
   (void)dst;
@@ -188,10 +190,10 @@ ContinuityPenaltyOperator<dim, Number>::face_loop_empty(MatrixFree<dim, Number> 
 template<int dim, typename Number>
 void
 ContinuityPenaltyOperator<dim, Number>::boundary_face_loop_hom(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   if(data.use_boundary_data)
   {
@@ -217,10 +219,10 @@ ContinuityPenaltyOperator<dim, Number>::boundary_face_loop_hom(
 template<int dim, typename Number>
 void
 ContinuityPenaltyOperator<dim, Number>::boundary_face_loop_full(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   if(data.use_boundary_data)
   {
@@ -244,10 +246,10 @@ ContinuityPenaltyOperator<dim, Number>::boundary_face_loop_full(
 template<int dim, typename Number>
 void
 ContinuityPenaltyOperator<dim, Number>::boundary_face_loop_inhom(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   (void)src;
 
@@ -291,9 +293,9 @@ ContinuityPenaltyOperator<dim, Number>::do_face_integral(IntegratorFace & integr
 template<int dim, typename Number>
 void
 ContinuityPenaltyOperator<dim, Number>::do_boundary_integral(
-  IntegratorFace &           integrator_m,
-  OperatorType const &       operator_type,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator_m,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeU boundary_type = data.bc->get_boundary_type(boundary_id);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -12,8 +12,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::set_velocity_copy(VectorType const & src) const
@@ -29,7 +27,7 @@ ConvectiveOperator<dim, Number>::set_velocity_ptr(VectorType const & src) const
 }
 
 template<int dim, typename Number>
-LinearAlgebra::distributed::Vector<Number> const &
+dealii::LinearAlgebra::distributed::Vector<Number> const &
 ConvectiveOperator<dim, Number>::get_velocity() const
 {
   return kernel->get_velocity();
@@ -38,8 +36,8 @@ ConvectiveOperator<dim, Number>::get_velocity() const
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                           matrix_free,
-  AffineConstraints<Number> const &                         affine_constraints,
+  dealii::MatrixFree<dim, Number> const &                   matrix_free,
+  dealii::AffineConstraints<Number> const &                 affine_constraints,
   ConvectiveOperatorData<dim> const &                       data,
   std::shared_ptr<Operators::ConvectiveKernel<dim, Number>> convective_kernel)
 {
@@ -67,8 +65,8 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator(VectorType &       
                           dst,
                           src,
                           true /*zero_dst_vector = true*/,
-                          MatrixFree<dim, Number>::DataAccessOnFaces::values,
-                          MatrixFree<dim, Number>::DataAccessOnFaces::values);
+                          dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
+                          dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
 }
 
 template<int dim, typename Number>
@@ -86,8 +84,8 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator_add(VectorType &   
                           dst,
                           src,
                           false /*zero_dst_vector = false*/,
-                          MatrixFree<dim, Number>::DataAccessOnFaces::values,
-                          MatrixFree<dim, Number>::DataAccessOnFaces::values);
+                          dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
+                          dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
 }
 
 template<int dim, typename Number>
@@ -109,8 +107,8 @@ ConvectiveOperator<dim, Number>::evaluate_linear_transport(
                           dst,
                           src,
                           true /*zero_dst_vector = true*/,
-                          MatrixFree<dim, Number>::DataAccessOnFaces::values,
-                          MatrixFree<dim, Number>::DataAccessOnFaces::values);
+                          dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
+                          dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
 }
 
 template<int dim, typename Number>
@@ -120,7 +118,8 @@ ConvectiveOperator<dim, Number>::rhs(VectorType & dst) const
   (void)dst;
 
   AssertThrow(false,
-              ExcMessage("The function rhs() does not make sense for the convective operator."));
+              dealii::ExcMessage(
+                "The function rhs() does not make sense for the convective operator."));
 }
 
 template<int dim, typename Number>
@@ -129,8 +128,9 @@ ConvectiveOperator<dim, Number>::rhs_add(VectorType & dst) const
 {
   (void)dst;
 
-  AssertThrow(
-    false, ExcMessage("The function rhs_add() does not make sense for the convective operator."));
+  AssertThrow(false,
+              dealii::ExcMessage(
+                "The function rhs_add() does not make sense for the convective operator."));
 }
 
 template<int dim, typename Number>
@@ -140,8 +140,9 @@ ConvectiveOperator<dim, Number>::evaluate(VectorType & dst, VectorType const & s
   (void)dst;
   (void)src;
 
-  AssertThrow(
-    false, ExcMessage("The function evaluate() does not make sense for the convective operator."));
+  AssertThrow(false,
+              dealii::ExcMessage(
+                "The function evaluate() does not make sense for the convective operator."));
 }
 
 template<int dim, typename Number>
@@ -152,17 +153,17 @@ ConvectiveOperator<dim, Number>::evaluate_add(VectorType & dst, VectorType const
   (void)src;
 
   AssertThrow(false,
-              ExcMessage(
+              dealii::ExcMessage(
                 "The function evaluate_add() does not make sense for the convective operator."));
 }
 
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::cell_loop_nonlinear_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   cell_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           cell_range) const
 {
   IntegratorCell integrator(matrix_free,
                             operator_data.dof_index,
@@ -199,10 +200,10 @@ ConvectiveOperator<dim, Number>::cell_loop_nonlinear_operator(
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::face_loop_nonlinear_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   IntegratorFace integrator_m(matrix_free,
                               true,
@@ -254,10 +255,10 @@ ConvectiveOperator<dim, Number>::face_loop_nonlinear_operator(
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::boundary_face_loop_nonlinear_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   IntegratorFace integrator_m(matrix_free,
                               true,
@@ -328,7 +329,7 @@ ConvectiveOperator<dim, Number>::do_cell_integral_nonlinear_operator(
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -361,9 +362,9 @@ ConvectiveOperator<dim, Number>::do_face_integral_nonlinear_operator(
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::do_boundary_integral_nonlinear_operator(
-  IntegratorFace &           integrator,
-  IntegratorFace &           integrator_grid_velocity,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator,
+  IntegratorFace &                   integrator_grid_velocity,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeU boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -416,7 +417,7 @@ ConvectiveOperator<dim, Number>::get_integrator_flags_linear_transport() const
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   return flags;
@@ -433,10 +434,10 @@ ConvectiveOperator<dim, Number>::set_velocity_linear_transport(VectorType const 
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::cell_loop_linear_transport(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   cell_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           cell_range) const
 {
   IntegratorCell integrator(matrix_free,
                             operator_data.dof_index,
@@ -471,10 +472,10 @@ ConvectiveOperator<dim, Number>::cell_loop_linear_transport(
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::face_loop_linear_transport(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   IntegratorFace integrator_m(matrix_free,
                               true,
@@ -528,10 +529,10 @@ ConvectiveOperator<dim, Number>::face_loop_linear_transport(
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::boundary_face_loop_linear_transport(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   IntegratorFace integrator_m(matrix_free,
                               true,
@@ -591,7 +592,7 @@ ConvectiveOperator<dim, Number>::do_cell_integral_linear_transport(IntegratorCel
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -625,9 +626,9 @@ ConvectiveOperator<dim, Number>::do_face_integral_linear_transport(
 template<int dim, typename Number>
 void
 ConvectiveOperator<dim, Number>::do_boundary_integral_linear_transport(
-  IntegratorFace &           integrator,
-  IntegratorFace &           velocity,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator,
+  IntegratorFace &                   velocity,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeU boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -685,9 +686,10 @@ ConvectiveOperator<dim, Number>::reinit_boundary_face(unsigned int const face) c
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_cell_based(unsigned int const       cell,
-                                                        unsigned int const       face,
-                                                        types::boundary_id const boundary_id) const
+ConvectiveOperator<dim, Number>::reinit_face_cell_based(
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -720,7 +722,7 @@ ConvectiveOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) c
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -827,14 +829,15 @@ ConvectiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::do_boundary_integral(IntegratorFace &           integrator,
-                                                      OperatorType const &       operator_type,
-                                                      types::boundary_id const & boundary_id) const
+ConvectiveOperator<dim, Number>::do_boundary_integral(
+  IntegratorFace &                   integrator,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   // make sure that this function is only accessed for OperatorType::homogeneous
   AssertThrow(
     operator_type == OperatorType::homogeneous,
-    ExcMessage(
+    dealii::ExcMessage(
       "For the linearized convective operator, only OperatorType::homogeneous makes sense."));
 
   BoundaryTypeU boundary_type = operator_data.bc->get_boundary_type(boundary_id);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -17,8 +17,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 namespace Operators
 {
 struct ConvectiveKernelData
@@ -51,22 +49,22 @@ public:
 
 
 private:
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef CellIntegrator<dim, dim, Number> IntegratorCell;
   typedef FaceIntegrator<dim, dim, Number> IntegratorFace;
 
 public:
   void
-  reinit(MatrixFree<dim, Number> const & matrix_free,
-         ConvectiveKernelData const &    data,
-         unsigned int const              dof_index,
-         unsigned int const              quad_index_linearized,
-         bool const                      is_mg)
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free,
+         ConvectiveKernelData const &            data,
+         unsigned int const                      dof_index,
+         unsigned int const                      quad_index_linearized,
+         bool const                              is_mg)
   {
     this->data = data;
 
@@ -98,7 +96,7 @@ public:
       matrix_free.initialize_dof_vector(grid_velocity, dof_index);
 
       AssertThrow(data.formulation == FormulationConvectiveTerm::ConvectiveFormulation,
-                  ExcMessage(
+                  dealii::ExcMessage(
                     "ALE formulation can only be used in combination with ConvectiveFormulation"));
     }
   }
@@ -108,9 +106,9 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells          = update_JxW_values | update_gradients;
-    flags.inner_faces    = update_JxW_values | update_normal_vectors;
-    flags.boundary_faces = update_JxW_values | update_normal_vectors;
+    flags.cells          = dealii::update_JxW_values | dealii::update_gradients;
+    flags.inner_faces    = dealii::update_JxW_values | dealii::update_normal_vectors;
+    flags.boundary_faces = dealii::update_JxW_values | dealii::update_normal_vectors;
 
     return flags;
   }
@@ -142,7 +140,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return flags;
@@ -257,7 +255,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 
@@ -291,9 +289,9 @@ public:
   }
 
   void
-  reinit_face_cell_based(unsigned int const       cell,
-                         unsigned int const       face,
-                         types::boundary_id const boundary_id) const
+  reinit_face_cell_based(unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const
   {
     integrator_velocity_m->reinit(cell, face);
     integrator_velocity_m->gather_evaluate(*velocity, true, false);
@@ -304,7 +302,7 @@ public:
       integrator_grid_velocity_face->gather_evaluate(grid_velocity, true, false);
     }
 
-    if(boundary_id == numbers::internal_face_boundary_id) // internal face
+    if(boundary_id == dealii::numbers::internal_face_boundary_id) // internal face
     {
       // TODO: Matrix-free implementation in deal.II does currently not allow to access data of
       // the neighboring element in case of cell-based face loops.
@@ -389,7 +387,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return std::make_tuple(flux_m, flux_p);
@@ -439,7 +437,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return flux;
@@ -481,7 +479,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return std::make_tuple(fluxM, fluxP);
@@ -525,7 +523,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return flux;
@@ -575,7 +573,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return std::make_tuple(fluxM, fluxP);
@@ -621,7 +619,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return flux;
@@ -675,7 +673,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     return flux;
@@ -706,7 +704,8 @@ public:
     scalar uM_n = uM * normalM;
     scalar uP_n = uP * normalM;
 
-    vector average_normal_flux = make_vectorized_array<Number>(0.5) * (uM * uM_n + uP * uP_n);
+    vector average_normal_flux =
+      dealii::make_vectorized_array<Number>(0.5) * (uM * uM_n + uP * uP_n);
 
     vector jump_value = uM - uP;
 
@@ -729,7 +728,8 @@ public:
     scalar wM_n = wM * normalM;
     scalar wP_n = wP * normalM;
 
-    vector average_normal_flux = make_vectorized_array<Number>(0.5) * (uM * wM_n + uP * wP_n);
+    vector average_normal_flux =
+      dealii::make_vectorized_array<Number>(0.5) * (uM * wM_n + uP * wP_n);
 
     vector jump_value = uM - uP;
 
@@ -756,7 +756,7 @@ public:
     scalar delta_uP_n = delta_uP * normalM;
 
     vector average_normal_flux =
-      make_vectorized_array<Number>(0.5) *
+      dealii::make_vectorized_array<Number>(0.5) *
       (uM * delta_uM_n + delta_uM * uM_n + uP * delta_uP_n + delta_uP * uP_n);
 
     vector jump_value = delta_uM - delta_uP;
@@ -815,9 +815,9 @@ public:
     // on the Neumann part of the boundary.
     // outflow: factor = 1.0 (do nothing, neutral element of multiplication)
     // inflow:  factor = 0.0 (set convective flux to zero)
-    scalar outflow_indicator = make_vectorized_array<Number>(1.0);
+    scalar outflow_indicator = dealii::make_vectorized_array<Number>(1.0);
 
-    for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+    for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
     {
       if(uM_n[v] < 0.0) // backflow at outflow boundary
         outflow_indicator[v] = 0.0;
@@ -864,14 +864,15 @@ public:
    *  symmetry boundary:  delta_u⁺ = delta_u⁻ - 2 (delta_u⁻*n)n
    */
   inline DEAL_II_ALWAYS_INLINE //
-      Tensor<1, dim, VectorizedArray<Number>>
-      calculate_exterior_value_linearized(Tensor<1, dim, VectorizedArray<Number>> & delta_uM,
-                                          unsigned int const                        q,
-                                          FaceIntegrator<dim, dim, Number> &        integrator,
-                                          BoundaryTypeU const & boundary_type) const
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+      calculate_exterior_value_linearized(
+        dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> & delta_uM,
+        unsigned int const                                        q,
+        FaceIntegrator<dim, dim, Number> &                        integrator,
+        BoundaryTypeU const &                                     boundary_type) const
   {
     // element e⁺
-    Tensor<1, dim, VectorizedArray<Number>> delta_uP;
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> delta_uP;
 
     if(boundary_type == BoundaryTypeU::Dirichlet || boundary_type == BoundaryTypeU::DirichletMortar)
     {
@@ -888,7 +889,7 @@ public:
       {
         AssertThrow(
           false,
-          ExcMessage(
+          dealii::ExcMessage(
             "Type of imposition of Dirichlet BC's for convective term is not implemented."));
       }
     }
@@ -898,12 +899,14 @@ public:
     }
     else if(boundary_type == BoundaryTypeU::Symmetry)
     {
-      Tensor<1, dim, VectorizedArray<Number>> normalM = integrator.get_normal_vector(q);
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normalM =
+        integrator.get_normal_vector(q);
       delta_uP = delta_uM - 2. * (delta_uM * normalM) * normalM;
     }
     else
     {
-      AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+      AssertThrow(false,
+                  dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
     }
 
     return delta_uP;
@@ -956,9 +959,9 @@ template<int dim, typename Number>
 class ConvectiveOperator : public OperatorBase<dim, Number, dim>
 {
 public:
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   typedef ConvectiveOperator<dim, Number> This;
 
@@ -979,12 +982,12 @@ public:
   void
   set_velocity_ptr(VectorType const & src) const;
 
-  LinearAlgebra::distributed::Vector<Number> const &
+  dealii::LinearAlgebra::distributed::Vector<Number> const &
   get_velocity() const;
 
   void
-  initialize(MatrixFree<dim, Number> const &                           matrix_free,
-             AffineConstraints<Number> const &                         affine_constraints,
+  initialize(dealii::MatrixFree<dim, Number> const &                   matrix_free,
+             dealii::AffineConstraints<Number> const &                 affine_constraints,
              ConvectiveOperatorData<dim> const &                       data,
              std::shared_ptr<Operators::ConvectiveKernel<dim, Number>> kernel);
 
@@ -1026,22 +1029,22 @@ private:
    *  Evaluation of nonlinear operator.
    */
   void
-  cell_loop_nonlinear_operator(MatrixFree<dim, Number> const & matrix_free,
-                               VectorType &                    dst,
-                               VectorType const &              src,
-                               Range const &                   cell_range) const;
+  cell_loop_nonlinear_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                               VectorType &                            dst,
+                               VectorType const &                      src,
+                               Range const &                           cell_range) const;
 
   void
-  face_loop_nonlinear_operator(MatrixFree<dim, Number> const & matrix_free,
-                               VectorType &                    dst,
-                               VectorType const &              src,
-                               Range const &                   face_range) const;
+  face_loop_nonlinear_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                               VectorType &                            dst,
+                               VectorType const &                      src,
+                               Range const &                           face_range) const;
 
   void
-  boundary_face_loop_nonlinear_operator(MatrixFree<dim, Number> const & matrix_free,
-                                        VectorType &                    dst,
-                                        VectorType const &              src,
-                                        Range const &                   face_range) const;
+  boundary_face_loop_nonlinear_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                        VectorType &                            dst,
+                                        VectorType const &                      src,
+                                        Range const &                           face_range) const;
 
   void
   do_cell_integral_nonlinear_operator(IntegratorCell & integrator,
@@ -1053,9 +1056,9 @@ private:
                                       IntegratorFace & integrator_grid_velocity) const;
 
   void
-  do_boundary_integral_nonlinear_operator(IntegratorFace &           integrator,
-                                          IntegratorFace &           integrator_grid_velocity,
-                                          types::boundary_id const & boundary_id) const;
+  do_boundary_integral_nonlinear_operator(IntegratorFace & integrator,
+                                          IntegratorFace & integrator_grid_velocity,
+                                          dealii::types::boundary_id const & boundary_id) const;
 
   /*
    *  OIF splitting: evaluation of convective operator (linear transport).
@@ -1067,22 +1070,22 @@ private:
   set_velocity_linear_transport(VectorType const & src) const;
 
   void
-  cell_loop_linear_transport(MatrixFree<dim, Number> const & matrix_free,
-                             VectorType &                    dst,
-                             VectorType const &              src,
-                             Range const &                   cell_range) const;
+  cell_loop_linear_transport(dealii::MatrixFree<dim, Number> const & matrix_free,
+                             VectorType &                            dst,
+                             VectorType const &                      src,
+                             Range const &                           cell_range) const;
 
   void
-  face_loop_linear_transport(MatrixFree<dim, Number> const & matrix_free,
-                             VectorType &                    dst,
-                             VectorType const &              src,
-                             Range const &                   face_range) const;
+  face_loop_linear_transport(dealii::MatrixFree<dim, Number> const & matrix_free,
+                             VectorType &                            dst,
+                             VectorType const &                      src,
+                             Range const &                           face_range) const;
 
   void
-  boundary_face_loop_linear_transport(MatrixFree<dim, Number> const & matrix_free,
-                                      VectorType &                    dst,
-                                      VectorType const &              src,
-                                      Range const &                   face_range) const;
+  boundary_face_loop_linear_transport(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                      VectorType &                            dst,
+                                      VectorType const &                      src,
+                                      Range const &                           face_range) const;
 
   void
   do_cell_integral_linear_transport(IntegratorCell & integrator, IntegratorCell & velocity) const;
@@ -1094,9 +1097,9 @@ private:
                                     IntegratorFace & velocity_p) const;
 
   void
-  do_boundary_integral_linear_transport(IntegratorFace &           integrator,
-                                        IntegratorFace &           velocity,
-                                        types::boundary_id const & boundary_id) const;
+  do_boundary_integral_linear_transport(IntegratorFace &                   integrator,
+                                        IntegratorFace &                   velocity,
+                                        dealii::types::boundary_id const & boundary_id) const;
 
 
   /*
@@ -1117,9 +1120,9 @@ private:
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_face_cell_based(unsigned int const       cell,
-                         unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+  reinit_face_cell_based(unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const;
 
   // linearized operator
   void
@@ -1149,9 +1152,9 @@ private:
 
   // linearized operator
   void
-  do_boundary_integral(IntegratorFace &           integrator,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(IntegratorFace &                   integrator,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   ConvectiveOperatorData<dim> operator_data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_operator.cpp
@@ -11,8 +11,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DivergenceOperator<dim, Number>::DivergenceOperator()
   : matrix_free(nullptr), time(0.0), velocity_bc(nullptr)
@@ -21,8 +19,8 @@ DivergenceOperator<dim, Number>::DivergenceOperator()
 
 template<int dim, typename Number>
 void
-DivergenceOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &     matrix_free_in,
-                                            DivergenceOperatorData<dim> const & data_in)
+DivergenceOperator<dim, Number>::initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                                            DivergenceOperatorData<dim> const &     data_in)
 {
   this->matrix_free = &matrix_free_in;
   this->data        = data_in;
@@ -204,17 +202,18 @@ DivergenceOperator<dim, Number>::do_face_integral(FaceIntegratorU & velocity_m,
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
 
 template<int dim, typename Number>
 void
-DivergenceOperator<dim, Number>::do_boundary_integral(FaceIntegratorU &          velocity,
-                                                      FaceIntegratorP &          pressure,
-                                                      OperatorType const &       operator_type,
-                                                      types::boundary_id const & boundary_id) const
+DivergenceOperator<dim, Number>::do_boundary_integral(
+  FaceIntegratorU &                  velocity,
+  FaceIntegratorP &                  pressure,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeU boundary_type = data.bc->get_boundary_type(boundary_id);
 
@@ -244,7 +243,7 @@ DivergenceOperator<dim, Number>::do_boundary_integral(FaceIntegratorU &         
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -252,11 +251,11 @@ DivergenceOperator<dim, Number>::do_boundary_integral(FaceIntegratorU &         
 template<int dim, typename Number>
 void
 DivergenceOperator<dim, Number>::do_boundary_integral_from_dof_vector(
-  FaceIntegratorU &          velocity,
-  FaceIntegratorU &          velocity_bc,
-  FaceIntegratorP &          pressure,
-  OperatorType const &       operator_type,
-  types::boundary_id const & boundary_id) const
+  FaceIntegratorU &                  velocity,
+  FaceIntegratorU &                  velocity_bc,
+  FaceIntegratorP &                  pressure,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeU boundary_type = data.bc->get_boundary_type(boundary_id);
 
@@ -286,17 +285,17 @@ DivergenceOperator<dim, Number>::do_boundary_integral_from_dof_vector(
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
 
 template<int dim, typename Number>
 void
-DivergenceOperator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                           VectorType &                    dst,
-                                           VectorType const &              src,
-                                           Range const &                   cell_range) const
+DivergenceOperator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                           VectorType &                            dst,
+                                           VectorType const &                      src,
+                                           Range const &                           cell_range) const
 {
   CellIntegratorU velocity(matrix_free, data.dof_index_velocity, data.quad_index);
   CellIntegratorP pressure(matrix_free, data.dof_index_pressure, data.quad_index);
@@ -329,10 +328,10 @@ DivergenceOperator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matri
 
 template<int dim, typename Number>
 void
-DivergenceOperator<dim, Number>::face_loop(MatrixFree<dim, Number> const & matrix_free,
-                                           VectorType &                    dst,
-                                           VectorType const &              src,
-                                           Range const &                   face_range) const
+DivergenceOperator<dim, Number>::face_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                           VectorType &                            dst,
+                                           VectorType const &                      src,
+                                           Range const &                           face_range) const
 {
   if(data.integration_by_parts == true)
   {
@@ -364,10 +363,10 @@ DivergenceOperator<dim, Number>::face_loop(MatrixFree<dim, Number> const & matri
 template<int dim, typename Number>
 void
 DivergenceOperator<dim, Number>::boundary_face_loop_hom_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   if(data.integration_by_parts == true)
   {
@@ -395,10 +394,10 @@ DivergenceOperator<dim, Number>::boundary_face_loop_hom_operator(
 template<int dim, typename Number>
 void
 DivergenceOperator<dim, Number>::boundary_face_loop_full_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   if(data.integration_by_parts == true)
   {
@@ -425,7 +424,7 @@ DivergenceOperator<dim, Number>::boundary_face_loop_full_operator(
 
 template<int dim, typename Number>
 void
-DivergenceOperator<dim, Number>::cell_loop_inhom_operator(MatrixFree<dim, Number> const &,
+DivergenceOperator<dim, Number>::cell_loop_inhom_operator(dealii::MatrixFree<dim, Number> const &,
                                                           VectorType &,
                                                           VectorType const &,
                                                           Range const &) const
@@ -434,7 +433,7 @@ DivergenceOperator<dim, Number>::cell_loop_inhom_operator(MatrixFree<dim, Number
 
 template<int dim, typename Number>
 void
-DivergenceOperator<dim, Number>::face_loop_inhom_operator(MatrixFree<dim, Number> const &,
+DivergenceOperator<dim, Number>::face_loop_inhom_operator(dealii::MatrixFree<dim, Number> const &,
                                                           VectorType &,
                                                           VectorType const &,
                                                           Range const &) const
@@ -444,8 +443,8 @@ DivergenceOperator<dim, Number>::face_loop_inhom_operator(MatrixFree<dim, Number
 template<int dim, typename Number>
 void
 DivergenceOperator<dim, Number>::boundary_face_loop_inhom_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
   VectorType const &,
   std::pair<unsigned int, unsigned int> const & face_range) const
 {
@@ -473,8 +472,8 @@ DivergenceOperator<dim, Number>::boundary_face_loop_inhom_operator(
 template<int dim, typename Number>
 void
 DivergenceOperator<dim, Number>::boundary_face_loop_inhom_operator_bc_from_dof_vector(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
   VectorType const &,
   Range const & face_range) const
 {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_operator.h
@@ -18,8 +18,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 namespace Operators
 {
 template<int dim, typename Number>
@@ -28,8 +26,8 @@ class DivergenceKernel
 private:
   typedef CellIntegrator<dim, dim, Number> CellIntegratorU;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
 public:
   static MappingFlags
@@ -37,9 +35,10 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells          = update_JxW_values | update_gradients;
-    flags.inner_faces    = update_JxW_values | update_normal_vectors;
-    flags.boundary_faces = update_JxW_values | update_quadrature_points | update_normal_vectors;
+    flags.cells       = dealii::update_JxW_values | dealii::update_gradients;
+    flags.inner_faces = dealii::update_JxW_values | dealii::update_normal_vectors;
+    flags.boundary_faces =
+      dealii::update_JxW_values | dealii::update_quadrature_points | dealii::update_normal_vectors;
 
     return flags;
   }
@@ -111,10 +110,10 @@ class DivergenceOperator
 public:
   typedef DivergenceOperator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -127,7 +126,8 @@ public:
   DivergenceOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free, DivergenceOperatorData<dim> const & data);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             DivergenceOperatorData<dim> const &     data);
 
   DivergenceOperatorData<dim> const &
   get_operator_data() const;
@@ -170,67 +170,68 @@ private:
                    FaceIntegratorP & pressure_p) const;
 
   void
-  do_boundary_integral(FaceIntegratorU &          velocity,
-                       FaceIntegratorP &          pressure,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(FaceIntegratorU &                  velocity,
+                       FaceIntegratorP &                  pressure,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   void
-  do_boundary_integral_from_dof_vector(FaceIntegratorU &          velocity,
-                                       FaceIntegratorU &          velocity_exterior,
-                                       FaceIntegratorP &          pressure,
-                                       OperatorType const &       operator_type,
-                                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral_from_dof_vector(FaceIntegratorU &                  velocity,
+                                       FaceIntegratorU &                  velocity_exterior,
+                                       FaceIntegratorP &                  pressure,
+                                       OperatorType const &               operator_type,
+                                       dealii::types::boundary_id const & boundary_id) const;
 
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
   void
-  face_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   face_range) const;
+  face_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           face_range) const;
 
   void
-  boundary_face_loop_hom_operator(MatrixFree<dim, Number> const & matrix_free,
-                                  VectorType &                    dst,
-                                  VectorType const &              src,
-                                  Range const &                   face_range) const;
+  boundary_face_loop_hom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                  VectorType &                            dst,
+                                  VectorType const &                      src,
+                                  Range const &                           face_range) const;
 
   void
-  boundary_face_loop_full_operator(MatrixFree<dim, Number> const & matrix_free,
-                                   VectorType &                    dst,
-                                   VectorType const &              src,
-                                   Range const &                   face_range) const;
+  boundary_face_loop_full_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                   VectorType &                            dst,
+                                   VectorType const &                      src,
+                                   Range const &                           face_range) const;
 
   void
-  cell_loop_inhom_operator(MatrixFree<dim, Number> const & matrix_free,
-                           VectorType &                    dst,
-                           VectorType const &              src,
-                           Range const &                   cell_range) const;
+  cell_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           VectorType &                            dst,
+                           VectorType const &                      src,
+                           Range const &                           cell_range) const;
 
   void
-  face_loop_inhom_operator(MatrixFree<dim, Number> const & matrix_free,
-                           VectorType &                    dst,
-                           VectorType const &              src,
-                           Range const &                   face_range) const;
+  face_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           VectorType &                            dst,
+                           VectorType const &                      src,
+                           Range const &                           face_range) const;
 
   void
-  boundary_face_loop_inhom_operator(MatrixFree<dim, Number> const &               matrix_free,
+  boundary_face_loop_inhom_operator(dealii::MatrixFree<dim, Number> const &       matrix_free,
                                     VectorType &                                  dst,
                                     VectorType const &                            src,
                                     std::pair<unsigned int, unsigned int> const & face_range) const;
 
   void
-  boundary_face_loop_inhom_operator_bc_from_dof_vector(MatrixFree<dim, Number> const & matrix_free,
-                                                       VectorType &                    dst,
-                                                       VectorType const &              src,
-                                                       Range const & face_range) const;
+  boundary_face_loop_inhom_operator_bc_from_dof_vector(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   DivergenceOperatorData<dim> data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.cpp
@@ -11,8 +11,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DivergencePenaltyOperator<dim, Number>::DivergencePenaltyOperator() : matrix_free(nullptr)
 {
@@ -20,9 +18,10 @@ DivergencePenaltyOperator<dim, Number>::DivergencePenaltyOperator() : matrix_fre
 
 template<int dim, typename Number>
 void
-DivergencePenaltyOperator<dim, Number>::initialize(MatrixFree<dim, Number> const & matrix_free,
-                                                   DivergencePenaltyData const &   data,
-                                                   std::shared_ptr<Kernel> const   kernel)
+DivergencePenaltyOperator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  DivergencePenaltyData const &           data,
+  std::shared_ptr<Kernel> const           kernel)
 {
   this->matrix_free = &matrix_free;
   this->data        = data;
@@ -52,10 +51,11 @@ DivergencePenaltyOperator<dim, Number>::apply_add(VectorType & dst, VectorType c
 
 template<int dim, typename Number>
 void
-DivergencePenaltyOperator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                                  VectorType &                    dst,
-                                                  VectorType const &              src,
-                                                  Range const &                   range) const
+DivergencePenaltyOperator<dim, Number>::cell_loop(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           range) const
 {
   IntegratorCell integrator(matrix_free, data.dof_index, data.quad_index);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -17,8 +17,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  *  Divergence penalty operator:
  *
@@ -72,9 +70,9 @@ class DivergencePenaltyKernel
 private:
   typedef CellIntegrator<dim, dim, Number> IntegratorCell;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
 public:
   DivergencePenaltyKernel()
@@ -83,10 +81,10 @@ public:
   }
 
   void
-  reinit(MatrixFree<dim, Number> const &     matrix_free,
-         unsigned int const                  dof_index,
-         unsigned int const                  quad_index,
-         DivergencePenaltyKernelData const & data)
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free,
+         unsigned int const                      dof_index,
+         unsigned int const                      quad_index,
+         DivergencePenaltyKernelData const &     data)
   {
     this->matrix_free = &matrix_free;
 
@@ -123,7 +121,7 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells = update_JxW_values | update_gradients;
+    flags.cells = dealii::update_JxW_values | dealii::update_gradients;
 
     // no face integrals
 
@@ -137,13 +135,13 @@ public:
 
     IntegratorCell integrator(*matrix_free, dof_index, quad_index);
 
-    AlignedVector<scalar> JxW_values(integrator.n_q_points);
+    dealii::AlignedVector<scalar> JxW_values(integrator.n_q_points);
 
     unsigned int n_cells = matrix_free->n_cell_batches() + matrix_free->n_ghost_cell_batches();
     for(unsigned int cell = 0; cell < n_cells; ++cell)
     {
-      scalar tau_convective = make_vectorized_array<Number>(0.0);
-      scalar tau_viscous    = make_vectorized_array<Number>(data.viscosity);
+      scalar tau_convective = dealii::make_vectorized_array<Number>(0.0);
+      scalar tau_viscous    = dealii::make_vectorized_array<Number>(data.viscosity);
 
       if(data.type_penalty_parameter == TypePenaltyParameter::ConvectiveTerm ||
          data.type_penalty_parameter == TypePenaltyParameter::ViscousAndConvectiveTerms)
@@ -152,8 +150,8 @@ public:
         integrator.read_dof_values(velocity);
         integrator.evaluate(true, false);
 
-        scalar volume      = make_vectorized_array<Number>(0.0);
-        scalar norm_U_mean = make_vectorized_array<Number>(0.0);
+        scalar volume      = dealii::make_vectorized_array<Number>(0.0);
+        scalar norm_U_mean = dealii::make_vectorized_array<Number>(0.0);
         for(unsigned int q = 0; q < integrator.n_q_points; ++q)
         {
           volume += integrator.JxW(q);
@@ -197,14 +195,14 @@ public:
   }
 
 private:
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index;
   unsigned int quad_index;
 
   DivergencePenaltyKernelData data;
 
-  AlignedVector<scalar> array_penalty_parameter;
+  dealii::AlignedVector<scalar> array_penalty_parameter;
 
   mutable scalar tau;
 };
@@ -227,7 +225,7 @@ class DivergencePenaltyOperator
 private:
   typedef DivergencePenaltyOperator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -239,9 +237,9 @@ public:
   DivergencePenaltyOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free,
-             DivergencePenaltyData const &   data,
-             std::shared_ptr<Kernel> const   kernel);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             DivergencePenaltyData const &           data,
+             std::shared_ptr<Kernel> const           kernel);
 
   void
   update(VectorType const & velocity);
@@ -254,15 +252,15 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           range) const;
 
   void
   do_cell_integral(IntegratorCell & integrator) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   DivergencePenaltyData data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/gradient_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/gradient_operator.cpp
@@ -11,8 +11,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 GradientOperator<dim, Number>::GradientOperator()
   : matrix_free(nullptr), time(0.0), inverse_scaling_factor_pressure(1.0), pressure_bc(nullptr)
@@ -21,8 +19,8 @@ GradientOperator<dim, Number>::GradientOperator()
 
 template<int dim, typename Number>
 void
-GradientOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &   matrix_free_in,
-                                          GradientOperatorData<dim> const & data_in)
+GradientOperator<dim, Number>::initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                                          GradientOperatorData<dim> const &       data_in)
 {
   matrix_free = &matrix_free_in;
   data        = data_in;
@@ -230,17 +228,18 @@ GradientOperator<dim, Number>::do_face_integral(FaceIntegratorP & pressure_m,
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
 
 template<int dim, typename Number>
 void
-GradientOperator<dim, Number>::do_boundary_integral(FaceIntegratorP &          pressure,
-                                                    FaceIntegratorU &          velocity,
-                                                    OperatorType const &       operator_type,
-                                                    types::boundary_id const & boundary_id) const
+GradientOperator<dim, Number>::do_boundary_integral(
+  FaceIntegratorP &                  pressure,
+  FaceIntegratorU &                  velocity,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeP boundary_type = data.bc->get_boundary_type(boundary_id);
 
@@ -248,7 +247,7 @@ GradientOperator<dim, Number>::do_boundary_integral(FaceIntegratorP &          p
   {
     scalar value_m = calculate_interior_value(q, pressure, operator_type);
 
-    scalar value_p = make_vectorized_array<Number>(0.0);
+    scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     if(data.use_boundary_data == true)
     {
       value_p = calculate_exterior_value(value_m,
@@ -278,7 +277,7 @@ GradientOperator<dim, Number>::do_boundary_integral(FaceIntegratorP &          p
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
@@ -286,11 +285,11 @@ GradientOperator<dim, Number>::do_boundary_integral(FaceIntegratorP &          p
 template<int dim, typename Number>
 void
 GradientOperator<dim, Number>::do_boundary_integral_from_dof_vector(
-  FaceIntegratorP &          pressure,
-  FaceIntegratorP &          pressure_bc,
-  FaceIntegratorU &          velocity,
-  OperatorType const &       operator_type,
-  types::boundary_id const & boundary_id) const
+  FaceIntegratorP &                  pressure,
+  FaceIntegratorP &                  pressure_bc,
+  FaceIntegratorU &                  velocity,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeP boundary_type = data.bc->get_boundary_type(boundary_id);
 
@@ -298,7 +297,7 @@ GradientOperator<dim, Number>::do_boundary_integral_from_dof_vector(
   {
     scalar value_m = calculate_interior_value(q, pressure, operator_type);
 
-    scalar value_p = make_vectorized_array<Number>(0.0);
+    scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     if(data.use_boundary_data == true)
     {
       value_p = calculate_exterior_value_from_dof_vector(
@@ -321,17 +320,17 @@ GradientOperator<dim, Number>::do_boundary_integral_from_dof_vector(
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 }
 
 template<int dim, typename Number>
 void
-GradientOperator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                         VectorType &                    dst,
-                                         VectorType const &              src,
-                                         Range const &                   cell_range) const
+GradientOperator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                         VectorType &                            dst,
+                                         VectorType const &                      src,
+                                         Range const &                           cell_range) const
 {
   CellIntegratorU velocity(matrix_free, data.dof_index_velocity, data.quad_index);
   CellIntegratorP pressure(matrix_free, data.dof_index_pressure, data.quad_index);
@@ -363,10 +362,10 @@ GradientOperator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_
 
 template<int dim, typename Number>
 void
-GradientOperator<dim, Number>::face_loop(MatrixFree<dim, Number> const & matrix_free,
-                                         VectorType &                    dst,
-                                         VectorType const &              src,
-                                         Range const &                   face_range) const
+GradientOperator<dim, Number>::face_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                         VectorType &                            dst,
+                                         VectorType const &                      src,
+                                         Range const &                           face_range) const
 {
   if(data.integration_by_parts == true)
   {
@@ -398,10 +397,10 @@ GradientOperator<dim, Number>::face_loop(MatrixFree<dim, Number> const & matrix_
 template<int dim, typename Number>
 void
 GradientOperator<dim, Number>::boundary_face_loop_hom_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   if(data.integration_by_parts == true)
   {
@@ -428,10 +427,10 @@ GradientOperator<dim, Number>::boundary_face_loop_hom_operator(
 template<int dim, typename Number>
 void
 GradientOperator<dim, Number>::boundary_face_loop_full_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   if(data.integration_by_parts == true)
   {
@@ -457,7 +456,7 @@ GradientOperator<dim, Number>::boundary_face_loop_full_operator(
 
 template<int dim, typename Number>
 void
-GradientOperator<dim, Number>::cell_loop_inhom_operator(MatrixFree<dim, Number> const &,
+GradientOperator<dim, Number>::cell_loop_inhom_operator(dealii::MatrixFree<dim, Number> const &,
                                                         VectorType &,
                                                         VectorType const &,
                                                         Range const &) const
@@ -466,7 +465,7 @@ GradientOperator<dim, Number>::cell_loop_inhom_operator(MatrixFree<dim, Number> 
 
 template<int dim, typename Number>
 void
-GradientOperator<dim, Number>::face_loop_inhom_operator(MatrixFree<dim, Number> const &,
+GradientOperator<dim, Number>::face_loop_inhom_operator(dealii::MatrixFree<dim, Number> const &,
                                                         VectorType &,
                                                         VectorType const &,
                                                         Range const &) const
@@ -476,10 +475,10 @@ GradientOperator<dim, Number>::face_loop_inhom_operator(MatrixFree<dim, Number> 
 template<int dim, typename Number>
 void
 GradientOperator<dim, Number>::boundary_face_loop_inhom_operator(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   (void)src;
 
@@ -506,8 +505,8 @@ GradientOperator<dim, Number>::boundary_face_loop_inhom_operator(
 template<int dim, typename Number>
 void
 GradientOperator<dim, Number>::boundary_face_loop_inhom_operator_bc_from_dof_vector(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
   VectorType const &,
   Range const & face_range) const
 {
@@ -540,10 +539,10 @@ GradientOperator<dim, Number>::boundary_face_loop_inhom_operator_bc_from_dof_vec
 template<int dim, typename Number>
 void
 GradientOperator<dim, Number>::boundary_face_loop_full_operator_bc_from_dof_vector(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   face_range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           face_range) const
 {
   if(data.integration_by_parts == true)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/gradient_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/gradient_operator.h
@@ -17,8 +17,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 namespace Operators
 {
 template<int dim, typename Number>
@@ -27,8 +25,8 @@ class GradientKernel
 private:
   typedef CellIntegrator<dim, 1, Number> CellIntegratorP;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
 public:
   static MappingFlags
@@ -36,9 +34,10 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells          = update_JxW_values | update_gradients;
-    flags.inner_faces    = update_JxW_values | update_normal_vectors;
-    flags.boundary_faces = update_JxW_values | update_quadrature_points | update_normal_vectors;
+    flags.cells       = dealii::update_JxW_values | dealii::update_gradients;
+    flags.inner_faces = dealii::update_JxW_values | dealii::update_normal_vectors;
+    flags.boundary_faces =
+      dealii::update_JxW_values | dealii::update_quadrature_points | dealii::update_normal_vectors;
 
     return flags;
   }
@@ -110,10 +109,10 @@ class GradientOperator
 public:
   typedef GradientOperator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -126,8 +125,8 @@ public:
   GradientOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const &   matrix_free_in,
-             GradientOperatorData<dim> const & data_in);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             GradientOperatorData<dim> const &       data_in);
 
   void
   set_scaling_factor_pressure(double const & scaling_factor);
@@ -178,73 +177,75 @@ private:
                    FaceIntegratorU & velocity_p) const;
 
   void
-  do_boundary_integral(FaceIntegratorP &          pressure,
-                       FaceIntegratorU &          velocity,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(FaceIntegratorP &                  pressure,
+                       FaceIntegratorU &                  velocity,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   void
-  do_boundary_integral_from_dof_vector(FaceIntegratorP &          pressure,
-                                       FaceIntegratorP &          pressure_exterior,
-                                       FaceIntegratorU &          velocity,
-                                       OperatorType const &       operator_type,
-                                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral_from_dof_vector(FaceIntegratorP &                  pressure,
+                                       FaceIntegratorP &                  pressure_exterior,
+                                       FaceIntegratorU &                  velocity,
+                                       OperatorType const &               operator_type,
+                                       dealii::types::boundary_id const & boundary_id) const;
 
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
   void
-  face_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   face_range) const;
+  face_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           face_range) const;
 
   void
-  boundary_face_loop_hom_operator(MatrixFree<dim, Number> const & matrix_free,
-                                  VectorType &                    dst,
-                                  VectorType const &              src,
-                                  Range const &                   face_range) const;
+  boundary_face_loop_hom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                  VectorType &                            dst,
+                                  VectorType const &                      src,
+                                  Range const &                           face_range) const;
 
   void
-  boundary_face_loop_full_operator(MatrixFree<dim, Number> const & matrix_free,
-                                   VectorType &                    dst,
-                                   VectorType const &              src,
-                                   Range const &                   face_range) const;
+  boundary_face_loop_full_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                   VectorType &                            dst,
+                                   VectorType const &                      src,
+                                   Range const &                           face_range) const;
 
   void
-  cell_loop_inhom_operator(MatrixFree<dim, Number> const & matrix_free,
-                           VectorType &                    dst,
-                           VectorType const &              src,
-                           Range const &                   cell_range) const;
+  cell_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           VectorType &                            dst,
+                           VectorType const &                      src,
+                           Range const &                           cell_range) const;
 
   void
-  face_loop_inhom_operator(MatrixFree<dim, Number> const & matrix_free,
-                           VectorType &                    dst,
-                           VectorType const &              src,
-                           Range const &                   face_range) const;
+  face_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           VectorType &                            dst,
+                           VectorType const &                      src,
+                           Range const &                           face_range) const;
 
   void
-  boundary_face_loop_inhom_operator(MatrixFree<dim, Number> const & matrix_free,
-                                    VectorType &                    dst,
-                                    VectorType const &              src,
-                                    Range const &                   face_range) const;
+  boundary_face_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                    VectorType &                            dst,
+                                    VectorType const &                      src,
+                                    Range const &                           face_range) const;
 
   void
-  boundary_face_loop_inhom_operator_bc_from_dof_vector(MatrixFree<dim, Number> const & matrix_free,
-                                                       VectorType &                    dst,
-                                                       VectorType const &              src,
-                                                       Range const & face_range) const;
+  boundary_face_loop_inhom_operator_bc_from_dof_vector(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   void
-  boundary_face_loop_full_operator_bc_from_dof_vector(MatrixFree<dim, Number> const & matrix_free,
-                                                      VectorType &                    dst,
-                                                      VectorType const &              src,
-                                                      Range const & face_range) const;
+  boundary_face_loop_full_operator_bc_from_dof_vector(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   GradientOperatorData<dim> data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -4,8 +4,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 MomentumOperator<dim, Number>::MomentumOperator() : scaling_factor_mass(1.0)
 {
@@ -13,9 +11,10 @@ MomentumOperator<dim, Number>::MomentumOperator() : scaling_factor_mass(1.0)
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &   matrix_free,
-                                          AffineConstraints<Number> const & affine_constraints,
-                                          MomentumOperatorData<dim> const & data)
+MomentumOperator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const &   matrix_free,
+  dealii::AffineConstraints<Number> const & affine_constraints,
+  MomentumOperatorData<dim> const &         data)
 {
   operator_data = data;
 
@@ -64,8 +63,8 @@ MomentumOperator<dim, Number>::get_data() const
 template<int dim, typename Number>
 void
 MomentumOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                           matrix_free,
-  AffineConstraints<Number> const &                         affine_constraints,
+  dealii::MatrixFree<dim, Number> const &                   matrix_free,
+  dealii::AffineConstraints<Number> const &                 affine_constraints,
   MomentumOperatorData<dim> const &                         data,
   std::shared_ptr<Operators::ViscousKernel<dim, Number>>    viscous_kernel,
   std::shared_ptr<Operators::ConvectiveKernel<dim, Number>> convective_kernel)
@@ -114,7 +113,7 @@ MomentumOperator<dim, Number>::get_viscous_kernel_data() const
 }
 
 template<int dim, typename Number>
-LinearAlgebra::distributed::Vector<Number> const &
+dealii::LinearAlgebra::distributed::Vector<Number> const &
 MomentumOperator<dim, Number>::get_velocity() const
 {
   return convective_kernel->get_velocity();
@@ -172,8 +171,8 @@ MomentumOperator<dim, Number>::rhs(VectorType & dst) const
 {
   (void)dst;
 
-  AssertThrow(false,
-              ExcMessage("The function rhs() does not make sense for the momentum operator."));
+  AssertThrow(
+    false, dealii::ExcMessage("The function rhs() does not make sense for the momentum operator."));
 }
 
 template<int dim, typename Number>
@@ -183,7 +182,8 @@ MomentumOperator<dim, Number>::rhs_add(VectorType & dst) const
   (void)dst;
 
   AssertThrow(false,
-              ExcMessage("The function rhs_add() does not make sense for the momentum operator."));
+              dealii::ExcMessage(
+                "The function rhs_add() does not make sense for the momentum operator."));
 }
 
 template<int dim, typename Number>
@@ -194,7 +194,8 @@ MomentumOperator<dim, Number>::evaluate(VectorType & dst, VectorType const & src
   (void)src;
 
   AssertThrow(false,
-              ExcMessage("The function evaluate() does not make sense for the momentum operator."));
+              dealii::ExcMessage(
+                "The function evaluate() does not make sense for the momentum operator."));
 }
 
 template<int dim, typename Number>
@@ -205,7 +206,7 @@ MomentumOperator<dim, Number>::evaluate_add(VectorType & dst, VectorType const &
   (void)src;
 
   AssertThrow(false,
-              ExcMessage(
+              dealii::ExcMessage(
                 "The function evaluate_add() does not make sense for the momentum operator."));
 }
 
@@ -247,9 +248,10 @@ MomentumOperator<dim, Number>::reinit_boundary_face(unsigned int const face) con
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_face_cell_based(unsigned int const       cell,
-                                                      unsigned int const       face,
-                                                      types::boundary_id const boundary_id) const
+MomentumOperator<dim, Number>::reinit_face_cell_based(
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -298,7 +300,7 @@ MomentumOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) con
       }
       else
       {
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
       }
     }
 
@@ -534,14 +536,15 @@ MomentumOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::do_boundary_integral(IntegratorFace &           integrator,
-                                                    OperatorType const &       operator_type,
-                                                    types::boundary_id const & boundary_id) const
+MomentumOperator<dim, Number>::do_boundary_integral(
+  IntegratorFace &                   integrator,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   // make sure that this function is only accessed for OperatorType::homogeneous
   AssertThrow(
     operator_type == OperatorType::homogeneous,
-    ExcMessage(
+    dealii::ExcMessage(
       "For the linearized momentum operator, only OperatorType::homogeneous makes sense."));
 
   BoundaryTypeU boundary_type = operator_data.bc->get_boundary_type(boundary_id);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
@@ -17,8 +17,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct MomentumOperatorData : public OperatorBaseData
 {
@@ -41,9 +39,9 @@ template<int dim, typename Number>
 class MomentumOperator : public OperatorBase<dim, Number, dim>
 {
 private:
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   typedef OperatorBase<dim, Number, dim> Base;
 
@@ -58,13 +56,13 @@ public:
   MomentumOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const &   matrix_free,
-             AffineConstraints<Number> const & affine_constraints,
-             MomentumOperatorData<dim> const & data);
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
+             dealii::AffineConstraints<Number> const & affine_constraints,
+             MomentumOperatorData<dim> const &         data);
 
   void
-  initialize(MatrixFree<dim, Number> const &                           matrix_free,
-             AffineConstraints<Number> const &                         affine_constraints,
+  initialize(dealii::MatrixFree<dim, Number> const &                   matrix_free,
+             dealii::AffineConstraints<Number> const &                 affine_constraints,
              MomentumOperatorData<dim> const &                         data,
              std::shared_ptr<Operators::ViscousKernel<dim, Number>>    viscous_kernel,
              std::shared_ptr<Operators::ConvectiveKernel<dim, Number>> convective_kernel);
@@ -78,7 +76,7 @@ public:
   Operators::ViscousKernelData
   get_viscous_kernel_data() const;
 
-  LinearAlgebra::distributed::Vector<Number> const &
+  dealii::LinearAlgebra::distributed::Vector<Number> const &
   get_velocity() const;
 
   /*
@@ -131,9 +129,9 @@ private:
   reinit_boundary_face(unsigned int const face) const;
 
   void
-  reinit_face_cell_based(unsigned int const       cell,
-                         unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+  reinit_face_cell_based(unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const;
 
   // linearized operator
   void
@@ -163,9 +161,9 @@ private:
 
   // linearized operator
   void
-  do_boundary_integral(IntegratorFace &           integrator,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(IntegratorFace &                   integrator,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   MomentumOperatorData<dim> operator_data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
@@ -12,13 +12,11 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
 ProjectionOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                matrix_free,
-  AffineConstraints<Number> const &              affine_constraints,
+  dealii::MatrixFree<dim, Number> const &        matrix_free,
+  dealii::AffineConstraints<Number> const &      affine_constraints,
   ProjectionOperatorData<dim> const &            data,
   Operators::DivergencePenaltyKernelData const & div_kernel_data,
   Operators::ContinuityPenaltyKernelData const & conti_kernel_data)
@@ -60,11 +58,12 @@ ProjectionOperator<dim, Number>::initialize(
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &     matrix_free,
-                                            AffineConstraints<Number> const &   affine_constraints,
-                                            ProjectionOperatorData<dim> const & data,
-                                            std::shared_ptr<DivKernel>          div_penalty_kernel,
-                                            std::shared_ptr<ContiKernel> conti_penalty_kernel)
+ProjectionOperator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const &   matrix_free,
+  dealii::AffineConstraints<Number> const & affine_constraints,
+  ProjectionOperatorData<dim> const &       data,
+  std::shared_ptr<DivKernel>                div_penalty_kernel,
+  std::shared_ptr<ContiKernel>              conti_penalty_kernel)
 {
   operator_data = data;
 
@@ -121,11 +120,11 @@ ProjectionOperator<dim, Number>::get_time_step_size() const
 }
 
 template<int dim, typename Number>
-LinearAlgebra::distributed::Vector<Number> const &
+dealii::LinearAlgebra::distributed::Vector<Number> const &
 ProjectionOperator<dim, Number>::get_velocity() const
 {
   AssertThrow(velocity != nullptr,
-              ExcMessage("Velocity ptr is not initialized in ProjectionOperator."));
+              dealii::ExcMessage("Velocity ptr is not initialized in ProjectionOperator."));
 
   return *velocity;
 }
@@ -175,9 +174,10 @@ ProjectionOperator<dim, Number>::reinit_boundary_face(unsigned int const face) c
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_face_cell_based(unsigned int const       cell,
-                                                        unsigned int const       face,
-                                                        types::boundary_id const boundary_id) const
+ProjectionOperator<dim, Number>::reinit_face_cell_based(
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -256,9 +256,10 @@ ProjectionOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::do_boundary_integral(IntegratorFace &           integrator_m,
-                                                      OperatorType const &       operator_type,
-                                                      types::boundary_id const & boundary_id) const
+ProjectionOperator<dim, Number>::do_boundary_integral(
+  IntegratorFace &                   integrator_m,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   if(operator_data.use_boundary_data == true)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
@@ -16,8 +16,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  *  Combined divergence and continuity penalty operator: applies the operation
  *
@@ -67,7 +65,7 @@ class ProjectionOperator : public OperatorBase<dim, Number, dim>
 private:
   typedef OperatorBase<dim, Number, dim> Base;
 
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   typedef typename Base::VectorType     VectorType;
   typedef typename Base::IntegratorCell IntegratorCell;
@@ -84,18 +82,18 @@ public:
   }
 
   void
-  initialize(MatrixFree<dim, Number> const &                matrix_free,
-             AffineConstraints<Number> const &              affine_constraints,
+  initialize(dealii::MatrixFree<dim, Number> const &        matrix_free,
+             dealii::AffineConstraints<Number> const &      affine_constraints,
              ProjectionOperatorData<dim> const &            data,
              Operators::DivergencePenaltyKernelData const & div_kernel_data,
              Operators::ContinuityPenaltyKernelData const & conti_kernel_data);
 
   void
-  initialize(MatrixFree<dim, Number> const &     matrix_free,
-             AffineConstraints<Number> const &   affine_constraints,
-             ProjectionOperatorData<dim> const & data,
-             std::shared_ptr<DivKernel>          div_penalty_kernel,
-             std::shared_ptr<ContiKernel>        conti_penalty_kernel);
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
+             dealii::AffineConstraints<Number> const & affine_constraints,
+             ProjectionOperatorData<dim> const &       data,
+             std::shared_ptr<DivKernel>                div_penalty_kernel,
+             std::shared_ptr<ContiKernel>              conti_penalty_kernel);
 
   ProjectionOperatorData<dim>
   get_data() const;
@@ -109,7 +107,7 @@ public:
   double
   get_time_step_size() const;
 
-  LinearAlgebra::distributed::Vector<Number> const &
+  dealii::LinearAlgebra::distributed::Vector<Number> const &
   get_velocity() const;
 
   void
@@ -126,9 +124,9 @@ private:
   reinit_boundary_face(unsigned int const face) const;
 
   void
-  reinit_face_cell_based(unsigned int const       cell,
-                         unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+  reinit_face_cell_based(unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const;
 
   void
   do_cell_integral(IntegratorCell & integrator) const;
@@ -143,9 +141,9 @@ private:
   do_face_ext_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
 
   void
-  do_boundary_integral(IntegratorFace &           integrator_m,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(IntegratorFace &                   integrator_m,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   ProjectionOperatorData<dim> operator_data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/rhs_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/rhs_operator.cpp
@@ -11,8 +11,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 RHSOperator<dim, Number>::RHSOperator() : matrix_free(nullptr), time(0.0), temperature(nullptr)
 {
@@ -20,8 +18,8 @@ RHSOperator<dim, Number>::RHSOperator() : matrix_free(nullptr), time(0.0), tempe
 
 template<int dim, typename Number>
 void
-RHSOperator<dim, Number>::initialize(MatrixFree<dim, Number> const & matrix_free_in,
-                                     RHSOperatorData<dim> const &    data_in)
+RHSOperator<dim, Number>::initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                                     RHSOperatorData<dim> const &            data_in)
 {
   this->matrix_free = &matrix_free_in;
   this->data        = data_in;
@@ -69,10 +67,10 @@ RHSOperator<dim, Number>::do_cell_integral(Integrator &       integrator,
 
 template<int dim, typename Number>
 void
-RHSOperator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                    VectorType &                    dst,
-                                    VectorType const &              src,
-                                    Range const &                   cell_range) const
+RHSOperator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                    VectorType &                            dst,
+                                    VectorType const &                      src,
+                                    Range const &                           cell_range) const
 {
   (void)src;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/rhs_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/rhs_operator.h
@@ -16,8 +16,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 namespace Operators
 {
 template<int dim>
@@ -31,22 +29,22 @@ struct RHSKernelData
   {
   }
 
-  std::shared_ptr<Function<dim>> f;
+  std::shared_ptr<dealii::Function<dim>> f;
 
   // Boussinesq term
-  bool                           boussinesq_term;
-  bool                           boussinesq_dynamic_part_only;
-  double                         thermal_expansion_coefficient;
-  double                         reference_temperature;
-  std::shared_ptr<Function<dim>> gravitational_force;
+  bool                                   boussinesq_term;
+  bool                                   boussinesq_dynamic_part_only;
+  double                                 thermal_expansion_coefficient;
+  double                                 reference_temperature;
+  std::shared_ptr<dealii::Function<dim>> gravitational_force;
 };
 
 template<int dim, typename Number>
 class RHSKernel
 {
 private:
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
 
   typedef CellIntegrator<dim, dim, Number> Integrator;
   typedef CellIntegrator<dim, 1, Number>   IntegratorScalar;
@@ -63,7 +61,8 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells = update_JxW_values | update_quadrature_points; // q-points due to rhs function f
+    flags.cells = dealii::update_JxW_values |
+                  dealii::update_quadrature_points; // q-points due to rhs function f
 
     // no face integrals
 
@@ -80,7 +79,7 @@ public:
                     unsigned int const       q,
                     Number const &           time) const
   {
-    Point<dim, scalar> q_points = integrator.quadrature_point(q);
+    dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
     vector f = FunctionEvaluator<1, dim, Number>::value(data.f, q_points, time);
 
@@ -127,7 +126,7 @@ class RHSOperator
 public:
   typedef RHSOperator<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -138,7 +137,8 @@ public:
   RHSOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free, RHSOperatorData<dim> const & data);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             RHSOperatorData<dim> const &            data);
 
   void
   evaluate(VectorType & dst, Number const evaluation_time) const;
@@ -154,12 +154,12 @@ private:
   do_cell_integral(Integrator & integrator, IntegratorScalar & integrator_temperature) const;
 
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   RHSOperatorData<dim> data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
@@ -12,13 +12,11 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
 ViscousOperator<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                        matrix_free,
-  AffineConstraints<Number> const &                      affine_constraints,
+  dealii::MatrixFree<dim, Number> const &                matrix_free,
+  dealii::AffineConstraints<Number> const &              affine_constraints,
   ViscousOperatorData<dim> const &                       data,
   std::shared_ptr<Operators::ViscousKernel<dim, Number>> viscous_kernel)
 {
@@ -58,9 +56,10 @@ ViscousOperator<dim, Number>::reinit_boundary_face(unsigned int const face) cons
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::reinit_face_cell_based(unsigned int const       cell,
-                                                     unsigned int const       face,
-                                                     types::boundary_id const boundary_id) const
+ViscousOperator<dim, Number>::reinit_face_cell_based(
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -171,9 +170,10 @@ ViscousOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_m
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::do_boundary_integral(IntegratorFace &           integrator,
-                                                   OperatorType const &       operator_type,
-                                                   types::boundary_id const & boundary_id) const
+ViscousOperator<dim, Number>::do_boundary_integral(
+  IntegratorFace &                   integrator,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryTypeU boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
@@ -18,8 +18,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // clang-format off
 /*
  * Velocity:
@@ -41,13 +39,13 @@ using namespace dealii;
 // clang-format on
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<1, dim, VectorizedArray<Number>>
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
   calculate_interior_value(unsigned int const                       q,
                            FaceIntegrator<dim, dim, Number> const & integrator,
                            OperatorType const &                     operator_type)
 {
   // element e⁻
-  Tensor<1, dim, VectorizedArray<Number>> value_m;
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value_m;
 
   if(operator_type == OperatorType::full || operator_type == OperatorType::homogeneous)
   {
@@ -59,7 +57,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+    AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
   }
 
   return value_m;
@@ -67,24 +65,25 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
-    calculate_exterior_value(Tensor<1, dim, VectorizedArray<Number>> const & value_m,
-                             unsigned int const                              q,
-                             FaceIntegrator<dim, dim, Number> const &        integrator,
-                             OperatorType const &                            operator_type,
-                             BoundaryTypeU const &                           boundary_type,
-                             types::boundary_id const                        boundary_id,
-                             std::shared_ptr<BoundaryDescriptorU<dim> const> boundary_descriptor,
-                             double const &                                  time)
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+    calculate_exterior_value(
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & value_m,
+      unsigned int const                                              q,
+      FaceIntegrator<dim, dim, Number> const &                        integrator,
+      OperatorType const &                                            operator_type,
+      BoundaryTypeU const &                                           boundary_type,
+      dealii::types::boundary_id const                                boundary_id,
+      std::shared_ptr<BoundaryDescriptorU<dim> const>                 boundary_descriptor,
+      double const &                                                  time)
 {
   // element e⁺
-  Tensor<1, dim, VectorizedArray<Number>> value_p;
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value_p;
 
   if(boundary_type == BoundaryTypeU::Dirichlet || boundary_type == BoundaryTypeU::DirichletMortar)
   {
     if(operator_type == OperatorType::full || operator_type == OperatorType::inhomogeneous)
     {
-      Tensor<1, dim, VectorizedArray<Number>> g;
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> g;
 
       if(boundary_type == BoundaryTypeU::Dirichlet)
       {
@@ -103,10 +102,10 @@ inline DEAL_II_ALWAYS_INLINE //
       }
       else
       {
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
       }
 
-      value_p = -value_m + Tensor<1, dim, VectorizedArray<Number>>(2.0 * g);
+      value_p = -value_m + dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>(2.0 * g);
     }
     else if(operator_type == OperatorType::homogeneous)
     {
@@ -114,7 +113,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else if(boundary_type == BoundaryTypeU::Neumann)
@@ -123,13 +122,14 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(boundary_type == BoundaryTypeU::Symmetry)
   {
-    Tensor<1, dim, VectorizedArray<Number>> normal_m = integrator.get_normal_vector(q);
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m =
+      integrator.get_normal_vector(q);
 
     value_p = value_m - 2.0 * (value_m * normal_m) * normal_m;
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return value_p;
@@ -148,22 +148,22 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
     calculate_exterior_value_nonlinear(
-      Tensor<1, dim, VectorizedArray<Number>> const & u_m,
-      unsigned int const                              q,
-      FaceIntegrator<dim, dim, Number> &              integrator,
-      BoundaryTypeU const &                           boundary_type,
-      TypeDirichletBCs const &                        type_dirichlet_bc,
-      types::boundary_id const                        boundary_id,
-      std::shared_ptr<BoundaryDescriptorU<dim> const> boundary_descriptor,
-      double const &                                  time)
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & u_m,
+      unsigned int const                                              q,
+      FaceIntegrator<dim, dim, Number> &                              integrator,
+      BoundaryTypeU const &                                           boundary_type,
+      TypeDirichletBCs const &                                        type_dirichlet_bc,
+      dealii::types::boundary_id const                                boundary_id,
+      std::shared_ptr<BoundaryDescriptorU<dim> const>                 boundary_descriptor,
+      double const &                                                  time)
 {
-  Tensor<1, dim, VectorizedArray<Number>> u_p;
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> u_p;
 
   if(boundary_type == BoundaryTypeU::Dirichlet || boundary_type == BoundaryTypeU::DirichletMortar)
   {
-    Tensor<1, dim, VectorizedArray<Number>> g;
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> g;
 
     if(boundary_type == BoundaryTypeU::Dirichlet)
     {
@@ -182,12 +182,12 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     if(type_dirichlet_bc == TypeDirichletBCs::Mirror)
     {
-      u_p = -u_m + make_vectorized_array<Number>(2.0) * g;
+      u_p = -u_m + dealii::make_vectorized_array<Number>(2.0) * g;
     }
     else if(type_dirichlet_bc == TypeDirichletBCs::Direct)
     {
@@ -195,7 +195,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("TypeDirichletBCs is not implemented."));
+      AssertThrow(false, dealii::ExcMessage("TypeDirichletBCs is not implemented."));
     }
   }
   else if(boundary_type == BoundaryTypeU::Neumann)
@@ -204,13 +204,14 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(boundary_type == BoundaryTypeU::Symmetry)
   {
-    Tensor<1, dim, VectorizedArray<Number>> normal_m = integrator.get_normal_vector(q);
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m =
+      integrator.get_normal_vector(q);
 
     u_p = u_m - 2. * (u_m * normal_m) * normal_m;
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return u_p;
@@ -218,24 +219,24 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
     calculate_exterior_value_from_dof_vector(
-      Tensor<1, dim, VectorizedArray<Number>> const & value_m,
-      unsigned int const                              q,
-      FaceIntegrator<dim, dim, Number> const &        integrator_bc,
-      OperatorType const &                            operator_type,
-      BoundaryTypeU const &                           boundary_type)
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & value_m,
+      unsigned int const                                              q,
+      FaceIntegrator<dim, dim, Number> const &                        integrator_bc,
+      OperatorType const &                                            operator_type,
+      BoundaryTypeU const &                                           boundary_type)
 {
   // element e⁺
-  Tensor<1, dim, VectorizedArray<Number>> value_p;
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value_p;
 
   if(boundary_type == BoundaryTypeU::Dirichlet || boundary_type == BoundaryTypeU::DirichletMortar)
   {
     if(operator_type == OperatorType::full || operator_type == OperatorType::inhomogeneous)
     {
-      Tensor<1, dim, VectorizedArray<Number>> g = integrator_bc.get_value(q);
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> g = integrator_bc.get_value(q);
 
-      value_p = -value_m + make_vectorized_array<Number>(2.0) * g;
+      value_p = -value_m + dealii::make_vectorized_array<Number>(2.0) * g;
     }
     else if(operator_type == OperatorType::homogeneous)
     {
@@ -243,7 +244,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else if(boundary_type == BoundaryTypeU::Neumann)
@@ -252,13 +253,14 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(boundary_type == BoundaryTypeU::Symmetry)
   {
-    Tensor<1, dim, VectorizedArray<Number>> normal_m = integrator_bc.get_normal_vector(q);
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m =
+      integrator_bc.get_normal_vector(q);
 
     value_p = value_m - 2.0 * (value_m * normal_m) * normal_m;
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return value_p;
@@ -283,13 +285,13 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
+  dealii::VectorizedArray<Number>
   calculate_interior_value(unsigned int const                     q,
                            FaceIntegrator<dim, 1, Number> const & integrator,
                            OperatorType const &                   operator_type)
 {
   // element e⁻
-  VectorizedArray<Number> value_m = make_vectorized_array<Number>(0.0);
+  dealii::VectorizedArray<Number> value_m = dealii::make_vectorized_array<Number>(0.0);
 
   if(operator_type == OperatorType::full || operator_type == OperatorType::homogeneous)
   {
@@ -301,7 +303,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+    AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
   }
 
   return value_m;
@@ -310,18 +312,18 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
-  calculate_exterior_value(VectorizedArray<Number> const &                 value_m,
+  dealii::VectorizedArray<Number>
+  calculate_exterior_value(dealii::VectorizedArray<Number> const &         value_m,
                            unsigned int const                              q,
                            FaceIntegrator<dim, 1, Number> const &          integrator,
                            OperatorType const &                            operator_type,
                            BoundaryTypeP const &                           boundary_type,
-                           types::boundary_id const                        boundary_id,
+                           dealii::types::boundary_id const                boundary_id,
                            std::shared_ptr<BoundaryDescriptorP<dim> const> boundary_descriptor,
                            double const &                                  time,
                            double const &                                  inverse_scaling_factor)
 {
-  VectorizedArray<Number> value_p = make_vectorized_array<Number>(0.0);
+  dealii::VectorizedArray<Number> value_p = dealii::make_vectorized_array<Number>(0.0);
 
   if(boundary_type == BoundaryTypeP::Dirichlet)
   {
@@ -330,7 +332,8 @@ inline DEAL_II_ALWAYS_INLINE //
       auto bc       = boundary_descriptor->dirichlet_bc.find(boundary_id)->second;
       auto q_points = integrator.quadrature_point(q);
 
-      VectorizedArray<Number> g = FunctionEvaluator<0, dim, Number>::value(bc, q_points, time);
+      dealii::VectorizedArray<Number> g =
+        FunctionEvaluator<0, dim, Number>::value(bc, q_points, time);
 
       value_p = -value_m + 2.0 * inverse_scaling_factor * g;
     }
@@ -340,7 +343,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else if(boundary_type == BoundaryTypeP::Neumann)
@@ -349,7 +352,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return value_p;
@@ -357,21 +360,21 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  VectorizedArray<Number>
-  calculate_exterior_value_from_dof_vector(VectorizedArray<Number> const &        value_m,
-                                           unsigned int const                     q,
-                                           FaceIntegrator<dim, 1, Number> const & integrator_bc,
-                                           OperatorType const &                   operator_type,
-                                           BoundaryTypeP const &                  boundary_type,
+  dealii::VectorizedArray<Number>
+  calculate_exterior_value_from_dof_vector(dealii::VectorizedArray<Number> const & value_m,
+                                           unsigned int const                      q,
+                                           FaceIntegrator<dim, 1, Number> const &  integrator_bc,
+                                           OperatorType const &                    operator_type,
+                                           BoundaryTypeP const &                   boundary_type,
                                            double const & inverse_scaling_factor)
 {
-  VectorizedArray<Number> value_p = make_vectorized_array<Number>(0.0);
+  dealii::VectorizedArray<Number> value_p = dealii::make_vectorized_array<Number>(0.0);
 
   if(boundary_type == BoundaryTypeP::Dirichlet)
   {
     if(operator_type == OperatorType::full || operator_type == OperatorType::inhomogeneous)
     {
-      VectorizedArray<Number> g = integrator_bc.get_value(q);
+      dealii::VectorizedArray<Number> g = integrator_bc.get_value(q);
 
       value_p = -value_m + 2.0 * inverse_scaling_factor * g;
     }
@@ -381,7 +384,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else if(boundary_type == BoundaryTypeP::Neumann)
@@ -390,7 +393,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return value_p;
@@ -429,19 +432,19 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, VectorizedArray<Number>>
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
     calculate_exterior_normal_gradient(
-      Tensor<1, dim, VectorizedArray<Number>> const & normal_gradient_m,
-      unsigned int const                              q,
-      FaceIntegrator<dim, dim, Number> const &        integrator,
-      OperatorType const &                            operator_type,
-      BoundaryTypeU const &                           boundary_type,
-      types::boundary_id const                        boundary_id,
-      std::shared_ptr<BoundaryDescriptorU<dim> const> boundary_descriptor,
-      double const &                                  time,
-      bool const                                      variable_normal_vector)
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normal_gradient_m,
+      unsigned int const                                              q,
+      FaceIntegrator<dim, dim, Number> const &                        integrator,
+      OperatorType const &                                            operator_type,
+      BoundaryTypeU const &                                           boundary_type,
+      dealii::types::boundary_id const                                boundary_id,
+      std::shared_ptr<BoundaryDescriptorU<dim> const>                 boundary_descriptor,
+      double const &                                                  time,
+      bool const                                                      variable_normal_vector)
 {
-  Tensor<1, dim, VectorizedArray<Number>> normal_gradient_p;
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_gradient_p;
 
   if(boundary_type == BoundaryTypeU::Dirichlet || boundary_type == BoundaryTypeU::DirichletMortar)
   {
@@ -454,7 +457,7 @@ inline DEAL_II_ALWAYS_INLINE //
       auto bc       = boundary_descriptor->neumann_bc.find(boundary_id)->second;
       auto q_points = integrator.quadrature_point(q);
 
-      Tensor<1, dim, VectorizedArray<Number>> h;
+      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> h;
       if(variable_normal_vector == false)
       {
         h = FunctionEvaluator<1, dim, Number>::value(bc, q_points, time);
@@ -473,7 +476,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else if(boundary_type == BoundaryTypeU::Symmetry)
@@ -483,7 +486,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return normal_gradient_p;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -60,8 +60,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class SpatialOperatorBase;
 
@@ -72,7 +70,7 @@ template<int dim, typename Number>
 class OperatorOIF
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   OperatorOIF(std::shared_ptr<SpatialOperatorBase<dim, Number>> operator_in)
     : pde_operator(operator_in),
@@ -129,14 +127,14 @@ template<int dim, typename Number>
 class SpatialOperatorBase : public dealii::Subscriptor
 {
 protected:
-  typedef LinearAlgebra::distributed::Vector<Number>      VectorType;
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number>      VectorType;
+  typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef SpatialOperatorBase<dim, Number> This;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -171,9 +169,9 @@ public:
    * of equations.
    */
   virtual void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data,
-        std::string const &                          dof_index_temperature = "");
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data,
+        std::string const &                              dof_index_temperature = "");
 
   /*
    * This function initializes operators, preconditioners, and solvers related to the solution of
@@ -186,7 +184,7 @@ public:
   /*
    * Getters and setters.
    */
-  MatrixFree<dim, Number> const &
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const;
 
   std::string
@@ -219,34 +217,34 @@ public:
   unsigned int
   get_quad_index_velocity_linearized() const;
 
-  std::shared_ptr<Mapping<dim> const>
+  std::shared_ptr<dealii::Mapping<dim> const>
   get_mapping() const;
 
-  FESystem<dim> const &
+  dealii::FESystem<dim> const &
   get_fe_u() const;
 
-  FE_DGQ<dim> const &
+  dealii::FE_DGQ<dim> const &
   get_fe_p() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler_u() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler_u_scalar() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler_p() const;
 
-  AffineConstraints<Number> const &
+  dealii::AffineConstraints<Number> const &
   get_constraint_p() const;
 
-  types::global_dof_index
+  dealii::types::global_dof_index
   get_number_of_dofs() const;
 
   double
   get_viscosity() const;
 
-  VectorizedArray<Number>
+  dealii::VectorizedArray<Number>
   get_viscosity_boundary_face(unsigned int const face, unsigned int const q) const;
 
   void
@@ -278,7 +276,7 @@ public:
   /*
    * Fill a DoF vector with velocity Dirichlet values on Dirichlet boundaries.
    *
-   * Note that this function only works as long as one uses a nodal FE_DGQ element with
+   * Note that this function only works as long as one uses a nodal dealii::FE_DGQ element with
    * Gauss-Lobatto points. Otherwise, the quadrature formula used in this function does not match
    * the nodes of the element, and the values injected by this function into the DoF vector are not
    * the degrees of freedom of the underlying finite element space.
@@ -544,8 +542,8 @@ protected:
   /*
    * Special case: pure Dirichlet boundary conditions.
    */
-  Point<dim>              first_point;
-  types::global_dof_index dof_index_first_point;
+  dealii::Point<dim>              first_point;
+  dealii::types::global_dof_index dof_index_first_point;
 
   /*
    * Element variable used to store the current physical time. This variable is needed for the
@@ -557,15 +555,15 @@ private:
   /*
    * Basic finite element ingredients.
    */
-  std::shared_ptr<FESystem<dim>> fe_u;
-  FE_DGQ<dim>                    fe_p;
-  FE_DGQ<dim>                    fe_u_scalar;
+  std::shared_ptr<dealii::FESystem<dim>> fe_u;
+  dealii::FE_DGQ<dim>                    fe_p;
+  dealii::FE_DGQ<dim>                    fe_u_scalar;
 
-  DoFHandler<dim> dof_handler_u;
-  DoFHandler<dim> dof_handler_p;
-  DoFHandler<dim> dof_handler_u_scalar;
+  dealii::DoFHandler<dim> dof_handler_u;
+  dealii::DoFHandler<dim> dof_handler_p;
+  dealii::DoFHandler<dim> dof_handler_u_scalar;
 
-  AffineConstraints<Number> constraint_u, constraint_p, constraint_u_scalar;
+  dealii::AffineConstraints<Number> constraint_u, constraint_p, constraint_u_scalar;
 
   std::string const dof_index_u        = "velocity";
   std::string const dof_index_p        = "pressure";
@@ -577,8 +575,8 @@ private:
   std::string const quad_index_u_gauss_lobatto = "velocity_gauss_lobatto";
   std::string const quad_index_p_gauss_lobatto = "pressure_gauss_lobatto";
 
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   bool pressure_level_is_undefined;
 
@@ -633,7 +631,8 @@ protected:
   typedef Elementwise::OperatorBase<dim, Number, ProjOperator> ELEMENTWISE_PROJ_OPERATOR;
   std::shared_ptr<ELEMENTWISE_PROJ_OPERATOR>                   elementwise_projection_operator;
 
-  typedef Elementwise::PreconditionerBase<VectorizedArray<Number>> ELEMENTWISE_PRECONDITIONER;
+  typedef Elementwise::PreconditionerBase<dealii::VectorizedArray<Number>>
+                                              ELEMENTWISE_PRECONDITIONER;
   std::shared_ptr<ELEMENTWISE_PRECONDITIONER> elementwise_preconditioner_projection;
 
   // projection solver
@@ -650,7 +649,7 @@ protected:
 
   MPI_Comm const mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
 private:
   // Minimum element length h_min required for global CFL condition.
@@ -679,7 +678,7 @@ private:
   initialization_pure_dirichlet_bc();
 
   void
-  cell_loop_empty(MatrixFree<dim, Number> const &,
+  cell_loop_empty(dealii::MatrixFree<dim, Number> const &,
                   VectorType &,
                   VectorType const &,
                   Range const &) const
@@ -687,7 +686,7 @@ private:
   }
 
   void
-  face_loop_empty(MatrixFree<dim, Number> const &,
+  face_loop_empty(dealii::MatrixFree<dim, Number> const &,
                   VectorType &,
                   VectorType const &,
                   Range const &) const
@@ -695,22 +694,24 @@ private:
   }
 
   void
-  local_interpolate_velocity_dirichlet_bc_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                                        VectorType &                    dst,
-                                                        VectorType const &              src,
-                                                        Range const & face_range) const;
+  local_interpolate_velocity_dirichlet_bc_boundary_face(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   void
-  local_interpolate_pressure_dirichlet_bc_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                                        VectorType &                    dst,
-                                                        VectorType const &              src,
-                                                        Range const & face_range) const;
+  local_interpolate_pressure_dirichlet_bc_boundary_face(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           face_range) const;
 
   void
-  local_interpolate_stress_bc_boundary_face(MatrixFree<dim, Number> const & matrix_free,
-                                            VectorType &                    dst,
-                                            VectorType const &              src,
-                                            Range const &                   face_range) const;
+  local_interpolate_stress_bc_boundary_face(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                            VectorType &                            dst,
+                                            VectorType const &                      src,
+                                            Range const & face_range) const;
 
   // Interpolation of stress requires velocity and pressure, but the MatrixFree interface
   // only provides one argument, so we store pointers to have access to both velocity and

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/turbulence_model.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/turbulence_model.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 TurbulenceModel<dim, Number>::TurbulenceModel() : matrix_free(nullptr)
 {
@@ -35,8 +33,8 @@ TurbulenceModel<dim, Number>::TurbulenceModel() : matrix_free(nullptr)
 template<int dim, typename Number>
 void
 TurbulenceModel<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &                        matrix_free_in,
-  Mapping<dim> const &                                   mapping_in,
+  dealii::MatrixFree<dim, Number> const &                matrix_free_in,
+  dealii::Mapping<dim> const &                           mapping_in,
   std::shared_ptr<Operators::ViscousKernel<dim, Number>> viscous_kernel_in,
   TurbulenceModelData const &                            data_in)
 {
@@ -64,7 +62,7 @@ TurbulenceModel<dim, Number>::calculate_turbulent_viscosity(VectorType const & v
 template<int dim, typename Number>
 void
 TurbulenceModel<dim, Number>::cell_loop_set_coefficients(
-  MatrixFree<dim, Number> const & matrix_free,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
   VectorType &,
   VectorType const & src,
   Range const &      cell_range) const
@@ -86,7 +84,7 @@ TurbulenceModel<dim, Number>::cell_loop_set_coefficients(
     // loop over all quadrature points
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
-      scalar viscosity = make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
+      scalar viscosity = dealii::make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
 
       // calculate velocity gradient
       tensor velocity_gradient = integrator.get_gradient(q);
@@ -102,7 +100,7 @@ TurbulenceModel<dim, Number>::cell_loop_set_coefficients(
 template<int dim, typename Number>
 void
 TurbulenceModel<dim, Number>::face_loop_set_coefficients(
-  MatrixFree<dim, Number> const & matrix_free,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
   VectorType &,
   VectorType const & src,
   Range const &      face_range) const
@@ -136,9 +134,9 @@ TurbulenceModel<dim, Number>::face_loop_set_coefficients(
     // loop over all quadrature points
     for(unsigned int q = 0; q < integrator_m.n_q_points; ++q)
     {
-      scalar viscosity = make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
+      scalar viscosity = dealii::make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
       scalar viscosity_neighbor =
-        make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
+        dealii::make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
 
       // calculate velocity gradient for both elements adjacent to the current face
       tensor velocity_gradient          = integrator_m.get_gradient(q);
@@ -160,7 +158,7 @@ TurbulenceModel<dim, Number>::face_loop_set_coefficients(
 template<int dim, typename Number>
 void
 TurbulenceModel<dim, Number>::boundary_face_loop_set_coefficients(
-  MatrixFree<dim, Number> const & matrix_free,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
   VectorType &,
   VectorType const & src,
   Range const &      face_range) const
@@ -185,7 +183,7 @@ TurbulenceModel<dim, Number>::boundary_face_loop_set_coefficients(
     // loop over all quadrature points
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
-      scalar viscosity = make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
+      scalar viscosity = dealii::make_vectorized_array<Number>(turb_model_data.kinematic_viscosity);
 
       // calculate velocity gradient
       tensor velocity_gradient = integrator.get_gradient(q);
@@ -200,7 +198,7 @@ TurbulenceModel<dim, Number>::boundary_face_loop_set_coefficients(
 
 template<int dim, typename Number>
 void
-TurbulenceModel<dim, Number>::calculate_filter_width(Mapping<dim> const & mapping)
+TurbulenceModel<dim, Number>::calculate_filter_width(dealii::Mapping<dim> const & mapping)
 {
   unsigned int n_cells = matrix_free->n_cell_batches() + matrix_free->n_ghost_cell_batches();
 
@@ -208,19 +206,19 @@ TurbulenceModel<dim, Number>::calculate_filter_width(Mapping<dim> const & mappin
 
   unsigned int const dof_index = turb_model_data.dof_index;
 
-  QGauss<dim> quadrature(turb_model_data.degree + 1);
+  dealii::QGauss<dim> quadrature(turb_model_data.degree + 1);
 
-  FEValues<dim> fe_values(mapping,
-                          matrix_free->get_dof_handler(dof_index).get_fe(),
-                          quadrature,
-                          update_JxW_values);
+  dealii::FEValues<dim> fe_values(mapping,
+                                  matrix_free->get_dof_handler(dof_index).get_fe(),
+                                  quadrature,
+                                  dealii::update_JxW_values);
 
   // loop over all cells
   for(unsigned int i = 0; i < n_cells; ++i)
   {
     for(unsigned int v = 0; v < matrix_free->n_active_entries_per_cell_batch(i); ++v)
     {
-      typename DoFHandler<dim>::cell_iterator cell =
+      typename dealii::DoFHandler<dim>::cell_iterator cell =
         matrix_free->get_cell_iterator(i, v, dof_index);
       fe_values.reinit(cell);
 
@@ -254,7 +252,7 @@ TurbulenceModel<dim, Number>::add_turbulent_viscosity(scalar &       viscosity,
   {
     case TurbulenceEddyViscosityModel::Undefined:
       AssertThrow(turb_model_data.turbulence_model != TurbulenceEddyViscosityModel::Undefined,
-                  ExcMessage("parameter must be defined"));
+                  dealii::ExcMessage("parameter must be defined"));
       break;
     case TurbulenceEddyViscosityModel::Smagorinsky:
       smagorinsky_model(filter_width, velocity_gradient, model_constant, viscosity);
@@ -279,7 +277,7 @@ TurbulenceModel<dim, Number>::smagorinsky_model(scalar const & filter_width,
                                                 scalar &       viscosity) const
 {
   tensor symmetric_gradient =
-    make_vectorized_array<Number>(0.5) * (velocity_gradient + transpose(velocity_gradient));
+    dealii::make_vectorized_array<Number>(0.5) * (velocity_gradient + transpose(velocity_gradient));
 
   scalar rate_of_strain = 2.0 * scalar_product(symmetric_gradient, symmetric_gradient);
   rate_of_strain        = std::exp(0.5 * std::log(rate_of_strain));
@@ -302,7 +300,7 @@ TurbulenceModel<dim, Number>::vreman_model(scalar const & filter_width,
   tensor tensor = velocity_gradient * transpose(velocity_gradient);
 
   AssertThrow(dim == 3,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Number of dimensions has to be dim==3 to evaluate Vreman turbulence model."));
 
   scalar B_gamma = +tensor[0][0] * tensor[1][1] - tensor[0][1] * tensor[0][1] +
@@ -311,7 +309,7 @@ TurbulenceModel<dim, Number>::vreman_model(scalar const & filter_width,
 
   scalar factor = C * filter_width;
 
-  for(unsigned int i = 0; i < VectorizedArray<Number>::size(); i++)
+  for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); i++)
   {
     // If the norm of the velocity gradient tensor is zero, the subgrid-scale
     // viscosity is defined as zero, so we do nothing in that case.
@@ -333,7 +331,7 @@ TurbulenceModel<dim, Number>::wale_model(scalar const & filter_width,
                                          scalar &       viscosity) const
 {
   tensor S =
-    make_vectorized_array<Number>(0.5) * (velocity_gradient + transpose(velocity_gradient));
+    dealii::make_vectorized_array<Number>(0.5) * (velocity_gradient + transpose(velocity_gradient));
   scalar S_norm_square = scalar_product(S, S);
 
   tensor square_gradient       = velocity_gradient * velocity_gradient;
@@ -345,14 +343,15 @@ TurbulenceModel<dim, Number>::wale_model(scalar const & filter_width,
     isotropic_tensor[i][i] = 1.0 / 3.0 * trace_square_gradient;
   }
 
-  tensor S_d = make_vectorized_array<Number>(0.5) * (square_gradient + transpose(square_gradient)) -
-               isotropic_tensor;
+  tensor S_d =
+    dealii::make_vectorized_array<Number>(0.5) * (square_gradient + transpose(square_gradient)) -
+    isotropic_tensor;
 
   scalar S_d_norm_square = scalar_product(S_d, S_d);
 
-  scalar D = make_vectorized_array<Number>(0.0);
+  scalar D = dealii::make_vectorized_array<Number>(0.0);
 
-  for(unsigned int i = 0; i < VectorizedArray<Number>::size(); i++)
+  for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); i++)
   {
     Number const tolerance = 1.e-12;
     if(S_d_norm_square[i] > tolerance)
@@ -375,7 +374,7 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
                                           scalar &       viscosity) const
 {
   AssertThrow(dim == 3,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Number of dimensions has to be dim==3 to evaluate Sigma turbulence model."));
 
   /*
@@ -383,7 +382,7 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
    *  (see appendix in Nicoud et al. (2011)). This approach is more efficient
    *  than calculating eigenvalues or singular values using LAPACK routines.
    */
-  scalar D = make_vectorized_array<Number>(0.0);
+  scalar D = dealii::make_vectorized_array<Number>(0.0);
 
   tensor G = transpose(velocity_gradient) * velocity_gradient;
 
@@ -391,7 +390,7 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
   scalar invariant2 = 0.5 * (invariant1 * invariant1 - trace(G * G));
   scalar invariant3 = determinant(G);
 
-  for(unsigned int n = 0; n < VectorizedArray<Number>::size(); n++)
+  for(unsigned int n = 0; n < dealii::VectorizedArray<Number>::size(); n++)
   {
     // if trace(G) = 0, all eigenvalues (and all singular values) have to be zero
     // and hence G is also zero. Set D[n]=0 in that case.
@@ -402,14 +401,14 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
                       invariant1[n] * invariant2[n] / 6.0 + invariant3[n] / 2.0;
 
       AssertThrow(alpha1 >= std::numeric_limits<double>::denorm_min() /*smallest positive value*/,
-                  ExcMessage("alpha1 has to be larger than zero."));
+                  dealii::ExcMessage("alpha1 has to be larger than zero."));
 
       Number factor = alpha2 / std::pow(alpha1, 1.5);
 
       AssertThrow(std::abs(factor) <=
                     1.0 + 1.0e-12, /* we found that a larger tolerance (1e-8,1e-6,1e-4) might be
                                       necessary in some cases */
-                  ExcMessage("Cannot compute arccos(value) if abs(value)>1.0."));
+                  dealii::ExcMessage("Cannot compute arccos(value) if abs(value)>1.0."));
 
       // Ensure that the argument of arccos() is in the interval [-1,1].
       if(factor > 1.0)
@@ -419,11 +418,13 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
 
       Number alpha3 = 1.0 / 3.0 * std::acos(factor);
 
-      Vector<Number> sv = Vector<Number>(dim);
+      dealii::Vector<Number> sv = dealii::Vector<Number>(dim);
 
       sv[0] = invariant1[n] / 3.0 + 2 * std::sqrt(alpha1) * std::cos(alpha3);
-      sv[1] = invariant1[n] / 3.0 - 2 * std::sqrt(alpha1) * std::cos(numbers::PI / 3.0 + alpha3);
-      sv[2] = invariant1[n] / 3.0 - 2 * std::sqrt(alpha1) * std::cos(numbers::PI / 3.0 - alpha3);
+      sv[1] =
+        invariant1[n] / 3.0 - 2 * std::sqrt(alpha1) * std::cos(dealii::numbers::PI / 3.0 + alpha3);
+      sv[2] =
+        invariant1[n] / 3.0 - 2 * std::sqrt(alpha1) * std::cos(dealii::numbers::PI / 3.0 - alpha3);
 
       // Calculate the square root only if the value is larger than zero.
       // Otherwise set sv to zero (this is reasonable since negative values will
@@ -450,7 +451,7 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
    */
 
   //    scalar D_copy = D; // save a copy in order to verify the correctness of
-  //    the computation for(unsigned int n = 0; n < VectorizedArray<Number>::size();
+  //    the computation for(unsigned int n = 0; n < dealii::VectorizedArray<Number>::size();
   //    n++)
   //    {
   //      LAPACKFullMatrix<Number> G_local = LAPACKFullMatrix<Number>(dim);
@@ -475,7 +476,7 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
   //      // This sorts the list in ascending order, beginning with the smallest eigenvalue.
   //      ev_list.sort();
   //
-  //      Vector<Number> ev = Vector<Number>(dim);
+  //      dealii::Vector<Number> ev = dealii::Vector<Number>(dim);
   //      typename std::list<Number>::reverse_iterator it;
   //      unsigned int k;
   //
@@ -494,10 +495,10 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
   //    }
   //
   //    // make sure that both variants yield the same result
-  //    for(unsigned int n = 0; n < VectorizedArray<Number>::size(); n++)
+  //    for(unsigned int n = 0; n < dealii::VectorizedArray<Number>::size(); n++)
   //    {
-  //      AssertThrow(std::abs(D[n]-D_copy[n])<1.e-5,ExcMessage("Calculation of singular values is
-  //      incorrect."));
+  //      AssertThrow(std::abs(D[n]-D_copy[n])<1.e-5,dealii::ExcMessage("Calculation of singular
+  //      values is incorrect."));
   //    }
 
 
@@ -505,9 +506,9 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
    *  Alternatively, compute singular values directly using SVD.
    */
   //    scalar D_copy2 = D; // save a copy in order to verify the correctness of
-  //    the computation D = make_vectorized_array<Number>(0.0);
+  //    the computation D = dealii::make_vectorized_array<Number>(0.0);
   //
-  //    for(unsigned int n = 0; n < VectorizedArray<Number>::size(); n++)
+  //    for(unsigned int n = 0; n < dealii::VectorizedArray<Number>::size(); n++)
   //    {
   //      LAPACKFullMatrix<Number> gradient = LAPACKFullMatrix<Number>(dim);
   //      for(unsigned int i = 0; i < dim; i++)
@@ -519,7 +520,7 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
   //      }
   //      gradient.compute_svd();
   //
-  //      Vector<Number> sv = Vector<Number>(dim);
+  //      dealii::Vector<Number> sv = dealii::Vector<Number>(dim);
   //      for(unsigned int i=0;i<dim;++i)
   //      {
   //        sv[i] = gradient.singular_value(i);
@@ -533,10 +534,10 @@ TurbulenceModel<dim, Number>::sigma_model(scalar const & filter_width,
   //    }
   //
   //    // make sure that both variants yield the same result
-  //    for(unsigned int n = 0; n < VectorizedArray<Number>::size(); n++)
+  //    for(unsigned int n = 0; n < dealii::VectorizedArray<Number>::size(); n++)
   //    {
-  //      AssertThrow(std::abs(D[n]-D_copy2[n])<1.e-5,ExcMessage("Calculation of singular values
-  //      is incorrect."));
+  //      AssertThrow(std::abs(D[n]-D_copy2[n])<1.e-5,dealii::ExcMessage("Calculation of singular
+  //      values is incorrect."));
   //    }
 
   // add turbulent eddy-viscosity to laminar viscosity

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/turbulence_model.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/turbulence_model.h
@@ -34,8 +34,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /*
  *  Turbulence model data.
  */
@@ -75,10 +73,10 @@ class TurbulenceModel
 private:
   typedef TurbulenceModel<dim, Number> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -95,8 +93,8 @@ public:
    * Initialization function.
    */
   void
-  initialize(MatrixFree<dim, Number> const &                        matrix_free_in,
-             Mapping<dim> const &                                   mapping_in,
+  initialize(dealii::MatrixFree<dim, Number> const &                matrix_free_in,
+             dealii::Mapping<dim> const &                           mapping_in,
              std::shared_ptr<Operators::ViscousKernel<dim, Number>> viscous_kernel_in,
              TurbulenceModelData const &                            data_in);
 
@@ -110,23 +108,23 @@ public:
    *  This function calculates the filter width for each cell.
    */
   void
-  calculate_filter_width(Mapping<dim> const & mapping);
+  calculate_filter_width(dealii::Mapping<dim> const & mapping);
 
 private:
   void
-  cell_loop_set_coefficients(MatrixFree<dim, Number> const & data,
+  cell_loop_set_coefficients(dealii::MatrixFree<dim, Number> const & data,
                              VectorType &,
                              VectorType const & src,
                              Range const &      cell_range) const;
 
   void
-  face_loop_set_coefficients(MatrixFree<dim, Number> const & data,
+  face_loop_set_coefficients(dealii::MatrixFree<dim, Number> const & data,
                              VectorType &,
                              VectorType const & src,
                              Range const &      face_range) const;
 
   void
-  boundary_face_loop_set_coefficients(MatrixFree<dim, Number> const & data,
+  boundary_face_loop_set_coefficients(dealii::MatrixFree<dim, Number> const & data,
                                       VectorType &,
                                       VectorType const & src,
                                       Range const &      face_range) const;
@@ -248,11 +246,11 @@ private:
 
   TurbulenceModelData turb_model_data;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   std::shared_ptr<Operators::ViscousKernel<dim, Number>> viscous_kernel;
 
-  AlignedVector<scalar> filter_width_vector;
+  dealii::AlignedVector<scalar> filter_width_vector;
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/throughput.h
+++ b/include/exadg/incompressible_navier_stokes/throughput.h
@@ -93,7 +93,7 @@ run(ThroughputParameters const & throughput,
 
   driver->setup();
 
-  std::tuple<unsigned int, types::global_dof_index, double> wall_time =
+  std::tuple<unsigned int, dealii::types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,
                            throughput.n_repetitions_inner,
                            throughput.n_repetitions_outer);

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -70,7 +70,7 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   return time_integrator;

--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DriverSteadyProblems<dim, Number>::DriverSteadyProblems(
   std::shared_ptr<Operator>                       operator_,
@@ -47,7 +45,7 @@ DriverSteadyProblems<dim, Number>::DriverSteadyProblems(
     mpi_comm(mpi_comm_),
     is_test(is_test_),
     timer_tree(new TimerTree()),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
     postprocessor(postprocessor_),
     iterations({0, {0, 0}})
 {
@@ -66,7 +64,7 @@ DriverSteadyProblems<dim, Number>::setup()
 }
 
 template<int dim, typename Number>
-LinearAlgebra::distributed::Vector<Number> const &
+dealii::LinearAlgebra::distributed::Vector<Number> const &
 DriverSteadyProblems<dim, Number>::get_velocity() const
 {
   return solution.block(0);
@@ -103,7 +101,7 @@ template<int dim, typename Number>
 void
 DriverSteadyProblems<dim, Number>::solve(double const time, bool unsteady_problem)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessing(time, unsteady_problem);
@@ -122,7 +120,7 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
   if(iterations.first == 0)
     global_timer.restart();
 
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(print_solver_info(time, unsteady_problem))
@@ -134,7 +132,7 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
   if(this->param.use_divergence_penalty == true || this->param.use_continuity_penalty == true)
   {
     AssertThrow(this->param.apply_penalty_terms_in_postprocessing_step == false,
-                ExcMessage(
+                dealii::ExcMessage(
                   "Penalty terms have to be applied in momentum equation for steady problems."));
 
     if(this->param.use_divergence_penalty == true)
@@ -230,7 +228,7 @@ template<int dim, typename Number>
 void
 DriverSteadyProblems<dim, Number>::postprocessing(double const time, bool unsteady_problem) const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(unsteady_problem)

--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.h
@@ -34,8 +34,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // forward declarations
 class Parameters;
 
@@ -49,8 +47,8 @@ template<int dim, typename Number>
 class DriverSteadyProblems
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number>      VectorType;
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number>      VectorType;
+  typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef OperatorCoupled<dim, Number> Operator;
 
@@ -99,10 +97,10 @@ private:
 
   bool is_test;
 
-  Timer                      global_timer;
+  dealii::Timer              global_timer;
   std::shared_ptr<TimerTree> timer_tree;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   BlockVectorType solution;
   BlockVectorType rhs_vector;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 TimeIntBDF<dim, Number>::TimeIntBDF(
   std::shared_ptr<OperatorBase>                   operator_in,
@@ -172,7 +170,7 @@ TimeIntBDF<dim, Number>::advance_one_timestep_partitioned_solve(bool const use_e
                                                                 bool const store_solution)
 {
   if(this->use_extrapolation == false)
-    AssertThrow(this->store_solution == true, ExcMessage("Invalid parameters."));
+    AssertThrow(this->store_solution == true, dealii::ExcMessage("Invalid parameters."));
 
   this->use_extrapolation = use_extrapolation;
   this->store_solution    = store_solution;
@@ -270,11 +268,11 @@ TimeIntBDF<dim, Number>::initialize_oif()
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     AssertThrow(time_integrator_OIF.get() != 0,
-                ExcMessage("OIF time integrator has not been initialized correctly."));
+                dealii::ExcMessage("OIF time integrator has not been initialized correctly."));
   }
 }
 
@@ -417,7 +415,8 @@ TimeIntBDF<dim, Number>::calculate_time_step_size()
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified type of time step calculation is not implemented."));
+    AssertThrow(false,
+                dealii::ExcMessage("Specified type of time step calculation is not implemented."));
   }
 
   if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::ExplicitOIF)
@@ -425,7 +424,7 @@ TimeIntBDF<dim, Number>::calculate_time_step_size()
     // make sure that CFL condition is used for the calculation of the time step size (the aim
     // of the OIF splitting approach is to overcome limitations of the CFL condition)
     AssertThrow(param.calculation_of_time_step_size == TimeStepCalculation::CFL,
-                ExcMessage(
+                dealii::ExcMessage(
                   "Specified type of time step calculation is not compatible with OIF approach!"));
 
     this->pcout << std::endl << "OIF sub-stepping for convective term:" << std::endl << std::endl;
@@ -440,7 +439,7 @@ double
 TimeIntBDF<dim, Number>::recalculate_time_step_size() const
 {
   AssertThrow(param.calculation_of_time_step_size == TimeStepCalculation::CFL,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Adaptive time step is not implemented for this type of time step calculation."));
 
   VectorType u_relative = get_velocity();
@@ -505,7 +504,7 @@ TimeIntBDF<dim, Number>::get_velocities_and_times(std::vector<VectorType const *
   }
 
   AssertThrow(current_order > 0 && current_order <= this->order,
-              ExcMessage("Invalid parameter current_order"));
+              dealii::ExcMessage("Invalid parameter current_order"));
 
   velocities.resize(current_order);
   times.resize(current_order);
@@ -540,7 +539,7 @@ TimeIntBDF<dim, Number>::get_velocities_and_times_np(std::vector<VectorType cons
   }
 
   AssertThrow(current_order > 0 && current_order <= this->order,
-              ExcMessage("Invalid parameter current_order"));
+              dealii::ExcMessage("Invalid parameter current_order"));
 
   velocities.resize(current_order + 1);
   times.resize(current_order + 1);
@@ -604,7 +603,7 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // To allow a computation of errors at start_time (= if time step number is 1 and if the

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 class Parameters;
 
 template<int dim, typename Number>
@@ -50,9 +48,9 @@ template<int dim, typename Number>
 class TimeIntBDF : public TimeIntBDFBase<Number>
 {
 public:
-  typedef TimeIntBDFBase<Number>                          Base;
-  typedef typename Base::VectorType                       VectorType;
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef TimeIntBDFBase<Number>                                  Base;
+  typedef typename Base::VectorType                               VectorType;
+  typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef SpatialOperatorBase<dim, Number> OperatorBase;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 TimeIntBDFCoupled<dim, Number>::TimeIntBDFCoupled(
   std::shared_ptr<Operator>                       operator_in,
@@ -153,7 +151,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // extrapolate old solutions to obtain a good initial guess for the solver, or
@@ -173,7 +171,7 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
   // update of turbulence model
   if(this->param.use_turbulence_model == true)
   {
-    Timer timer_turbulence;
+    dealii::Timer timer_turbulence;
     timer_turbulence.restart();
 
     pde_operator->update_turbulence_model(solution_np.block(0));
@@ -378,7 +376,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFCoupled<dim, Number>::penalty_step()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // right-hand side term: apply mass operator
@@ -438,23 +436,23 @@ void
 TimeIntBDFCoupled<dim, Number>::postprocessing_stability_analysis()
 {
   AssertThrow(this->order == 1,
-              ExcMessage("Order of BDF scheme has to be 1 for this stability analysis"));
+              dealii::ExcMessage("Order of BDF scheme has to be 1 for this stability analysis"));
 
   AssertThrow(this->param.convective_problem() == false,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Stability analysis can not be performed for nonlinear convective problems."));
 
   AssertThrow(solution[0].block(0).l2_norm() < 1.e-15 && solution[0].block(1).l2_norm() < 1.e-15,
-              ExcMessage("Solution vector has to be zero for this stability analysis."));
+              dealii::ExcMessage("Solution vector has to be zero for this stability analysis."));
 
-  AssertThrow(Utilities::MPI::n_mpi_processes(this->mpi_comm) == 1,
-              ExcMessage("Number of MPI processes has to be 1."));
+  AssertThrow(dealii::Utilities::MPI::n_mpi_processes(this->mpi_comm) == 1,
+              dealii::ExcMessage("Number of MPI processes has to be 1."));
 
   std::cout << std::endl << "Analysis of eigenvalue spectrum:" << std::endl;
 
   unsigned int const size = solution[0].block(0).locally_owned_size();
 
-  LAPACKFullMatrix<Number> propagation_matrix(size, size);
+  dealii::LAPACKFullMatrix<Number> propagation_matrix(size, size);
 
   // loop over all columns of propagation matrix
   for(unsigned int j = 0; j < size; ++j)
@@ -592,12 +590,12 @@ TimeIntBDFCoupled<dim, Number>::solve_steady_problem()
   }
   else
   {
-    AssertThrow(false, ExcMessage("not implemented."));
+    AssertThrow(false, dealii::ExcMessage("not implemented."));
   }
 
   AssertThrow(
     converged == true,
-    ExcMessage(
+    dealii::ExcMessage(
       "Maximum number of time steps or end time exceeded! This might be due to the fact that "
       "(i) the maximum number of time steps is simply too small to reach a steady solution, "
       "(ii) the problem is unsteady so that the applied solution approach is inappropriate, "

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // forward declarations
 template<int dim, typename Number>
 class OperatorCoupled;
@@ -46,7 +44,7 @@ private:
 
   typedef typename Base::VectorType VectorType;
 
-  typedef LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
+  typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
 
   typedef OperatorCoupled<dim, Number> Operator;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 TimeIntBDFDualSplitting<dim, Number>::TimeIntBDFDualSplitting(
   std::shared_ptr<Operator>                       operator_in,
@@ -252,23 +250,23 @@ void
 TimeIntBDFDualSplitting<dim, Number>::postprocessing_stability_analysis()
 {
   AssertThrow(this->order == 1,
-              ExcMessage("Order of BDF scheme has to be 1 for this stability analysis."));
+              dealii::ExcMessage("Order of BDF scheme has to be 1 for this stability analysis."));
 
   AssertThrow(this->param.convective_problem() == false,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Stability analysis can not be performed for nonlinear convective problems."));
 
   AssertThrow(velocity[0].l2_norm() < 1.e-15 && pressure[0].l2_norm() < 1.e-15,
-              ExcMessage("Solution vector has to be zero for this stability analysis."));
+              dealii::ExcMessage("Solution vector has to be zero for this stability analysis."));
 
-  AssertThrow(Utilities::MPI::n_mpi_processes(this->mpi_comm) == 1,
-              ExcMessage("Number of MPI processes has to be 1."));
+  AssertThrow(dealii::Utilities::MPI::n_mpi_processes(this->mpi_comm) == 1,
+              dealii::ExcMessage("Number of MPI processes has to be 1."));
 
   std::cout << std::endl << "Analysis of eigenvalue spectrum:" << std::endl;
 
   unsigned int const size = velocity[0].locally_owned_size();
 
-  LAPACKFullMatrix<Number> propagation_matrix(size, size);
+  dealii::LAPACKFullMatrix<Number> propagation_matrix(size, size);
 
   // loop over all columns of propagation matrix
   for(unsigned int j = 0; j < size; ++j)
@@ -346,7 +344,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFDualSplitting<dim, Number>::convective_step()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   velocity_np = 0.0;
@@ -414,7 +412,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFDualSplitting<dim, Number>::evaluate_convective_term()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(this->param.convective_problem() &&
@@ -435,7 +433,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFDualSplitting<dim, Number>::pressure_step()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // compute right-hand-side vector
@@ -610,7 +608,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFDualSplitting<dim, Number>::projection_step()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // compute right-hand-side vector
@@ -697,7 +695,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFDualSplitting<dim, Number>::viscous_step()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(this->param.viscous_problem())
@@ -706,7 +704,7 @@ TimeIntBDFDualSplitting<dim, Number>::viscous_step()
     // update turbulence model before calculating rhs_viscous
     if(this->param.use_turbulence_model == true)
     {
-      Timer timer_turbulence;
+      dealii::Timer timer_turbulence;
       timer_turbulence.restart();
 
       // extrapolate velocity to time t_n+1 and use this velocity field to
@@ -766,7 +764,8 @@ TimeIntBDFDualSplitting<dim, Number>::viscous_step()
   else // inviscid
   {
     // nothing to do
-    AssertThrow(this->param.equation_type == EquationType::Euler, ExcMessage("Logical error."));
+    AssertThrow(this->param.equation_type == EquationType::Euler,
+                dealii::ExcMessage("Logical error."));
   }
 
   this->timer_tree->insert({"Timeloop", "Viscous step"}, timer.wall_time());
@@ -794,7 +793,7 @@ TimeIntBDFDualSplitting<dim, Number>::penalty_step()
 {
   if(this->param.use_divergence_penalty == true || this->param.use_continuity_penalty == true)
   {
-    Timer timer;
+    dealii::Timer timer;
     timer.restart();
 
     // compute right-hand-side vector
@@ -934,18 +933,19 @@ TimeIntBDFDualSplitting<dim, Number>::solve_steady_problem()
   {
     AssertThrow(this->param.convergence_criterion_steady_problem !=
                   ConvergenceCriterionSteadyProblem::ResidualSteadyNavierStokes,
-                ExcMessage("This option is not available for the dual splitting scheme. "
-                           "Due to splitting errors the solution does not fulfill the "
-                           "residual of the steady, incompressible Navier-Stokes equations."));
+                dealii::ExcMessage(
+                  "This option is not available for the dual splitting scheme. "
+                  "Due to splitting errors the solution does not fulfill the "
+                  "residual of the steady, incompressible Navier-Stokes equations."));
   }
   else
   {
-    AssertThrow(false, ExcMessage("not implemented."));
+    AssertThrow(false, dealii::ExcMessage("not implemented."));
   }
 
   AssertThrow(
     converged == true,
-    ExcMessage(
+    dealii::ExcMessage(
       "Maximum number of time steps or end time exceeded! This might be due to the fact that "
       "(i) the maximum number of time steps is simply too small to reach a steady solution, "
       "(ii) the problem is unsteady so that the applied solution approach is inappropriate, "

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // forward declarations
 template<int dim, typename Number>
 class OperatorDualSplitting;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 TimeIntBDFPressureCorrection<dim, Number>::TimeIntBDFPressureCorrection(
   std::shared_ptr<Operator>                       operator_in,
@@ -259,23 +257,23 @@ void
 TimeIntBDFPressureCorrection<dim, Number>::postprocessing_stability_analysis()
 {
   AssertThrow(this->order == 1,
-              ExcMessage("Order of BDF scheme has to be 1 for this stability analysis."));
+              dealii::ExcMessage("Order of BDF scheme has to be 1 for this stability analysis."));
 
   AssertThrow(this->param.convective_problem() == false,
-              ExcMessage(
+              dealii::ExcMessage(
                 "Stability analysis can not be performed for nonlinear convective problems."));
 
   AssertThrow(velocity[0].l2_norm() < 1.e-15 && pressure[0].l2_norm() < 1.e-15,
-              ExcMessage("Solution vector has to be zero for this stability analysis."));
+              dealii::ExcMessage("Solution vector has to be zero for this stability analysis."));
 
-  AssertThrow(Utilities::MPI::n_mpi_processes(this->mpi_comm) == 1,
-              ExcMessage("Number of MPI processes has to be 1."));
+  AssertThrow(dealii::Utilities::MPI::n_mpi_processes(this->mpi_comm) == 1,
+              dealii::ExcMessage("Number of MPI processes has to be 1."));
 
   std::cout << std::endl << "Analysis of eigenvalue spectrum:" << std::endl;
 
   unsigned int const size = velocity[0].locally_owned_size();
 
-  LAPACKFullMatrix<Number> propagation_matrix(size, size);
+  dealii::LAPACKFullMatrix<Number> propagation_matrix(size, size);
 
   // loop over all columns of propagation matrix
   for(unsigned int j = 0; j < size; ++j)
@@ -341,7 +339,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // Extrapolate old solutionsto get a good initial estimate for the solver.
@@ -364,7 +362,7 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
    */
   if(this->param.use_turbulence_model == true)
   {
-    Timer timer_turbulence;
+    dealii::Timer timer_turbulence;
     timer_turbulence.restart();
 
     pde_operator->update_turbulence_model(velocity_np);
@@ -426,7 +424,8 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
   }
   else // nonlinear problem
   {
-    AssertThrow(this->param.nonlinear_problem_has_to_be_solved(), ExcMessage("Logical error."));
+    AssertThrow(this->param.nonlinear_problem_has_to_be_solved(),
+                dealii::ExcMessage("Logical error."));
 
     // solve non-linear system of equations
     auto const iter = pde_operator->solve_nonlinear_momentum_equation(
@@ -560,7 +559,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFPressureCorrection<dim, Number>::pressure_step(VectorType & pressure_increment)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // compute right-hand side vector
@@ -650,7 +649,7 @@ TimeIntBDFPressureCorrection<dim, Number>::calculate_chi(double & chi) const
                     FormulationViscousTerm::LaplaceFormulation &&
                   this->param.formulation_viscous_term ==
                     FormulationViscousTerm::DivergenceFormulation,
-                ExcMessage("Not implemented!"));
+                dealii::ExcMessage("Not implemented!"));
   }
 }
 
@@ -794,7 +793,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFPressureCorrection<dim, Number>::projection_step(VectorType const & pressure_increment)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // compute right-hand-side vector
@@ -870,7 +869,7 @@ template<int dim, typename Number>
 void
 TimeIntBDFPressureCorrection<dim, Number>::evaluate_convective_term()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // evaluate convective term once solution_np is known
@@ -998,12 +997,12 @@ TimeIntBDFPressureCorrection<dim, Number>::solve_steady_problem()
   }
   else
   {
-    AssertThrow(false, ExcMessage("not implemented."));
+    AssertThrow(false, dealii::ExcMessage("not implemented."));
   }
 
   AssertThrow(
     converged == true,
-    ExcMessage(
+    dealii::ExcMessage(
       "Maximum number of time steps or end time exceeded! This might be due to the fact that "
       "(i) the maximum number of time steps is simply too small to reach a steady solution, "
       "(ii) the problem is unsteady so that the applied solution approach is inappropriate, "

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // forward declarations
 template<int dim, typename Number>
 class OperatorPressureCorrection;

--- a/include/exadg/incompressible_navier_stokes/user_interface/analytical_solution.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/analytical_solution.h
@@ -28,20 +28,18 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct AnalyticalSolution
 {
   /*
    *  velocity
    */
-  std::shared_ptr<Function<dim>> velocity;
+  std::shared_ptr<dealii::Function<dim>> velocity;
 
   /*
    *  pressure
    */
-  std::shared_ptr<Function<dim>> pressure;
+  std::shared_ptr<dealii::Function<dim>> pressure;
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -47,14 +47,12 @@ class Mesh;
 
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class ApplicationBase
 {
 public:
   virtual void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     // clang-format off
     prm.enter_subsection("Output");
@@ -67,7 +65,7 @@ public:
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
     : mpi_comm(comm),
-      pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
       parameter_file(parameter_file)
   {
   }
@@ -146,11 +144,11 @@ public:
   }
 
   // Analytical mesh motion
-  virtual std::shared_ptr<Function<dim>>
+  virtual std::shared_ptr<dealii::Function<dim>>
   create_mesh_movement_function()
   {
-    std::shared_ptr<Function<dim>> mesh_motion =
-      std::make_shared<Functions::ZeroFunction<dim>>(dim);
+    std::shared_ptr<dealii::Function<dim>> mesh_motion =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(dim);
 
     return mesh_motion;
   }
@@ -173,8 +171,8 @@ public:
     set_field_functions_poisson();
 
     AssertThrow(poisson_param.right_hand_side == false,
-                ExcMessage("Poisson problem is used for mesh movement. Hence, "
-                           "the right-hand side has to be zero for the Poisson problem."));
+                dealii::ExcMessage("Poisson problem is used for mesh movement. Hence, "
+                                   "the right-hand side has to be zero for the Poisson problem."));
   }
 
   Poisson::Parameters const &
@@ -198,7 +196,7 @@ public:
 protected:
   MPI_Comm const & mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   Parameters param;
 
@@ -235,24 +233,24 @@ private:
   set_parameters_poisson()
   {
     AssertThrow(false,
-                ExcMessage("Has to be overwritten by derived classes in order "
-                           "to use Poisson solver for mesh movement."));
+                dealii::ExcMessage("Has to be overwritten by derived classes in order "
+                                   "to use Poisson solver for mesh movement."));
   }
 
   virtual void
   set_boundary_descriptor_poisson()
   {
     AssertThrow(false,
-                ExcMessage("Has to be overwritten by derived classes in order "
-                           "to use Poisson solver for mesh movement."));
+                dealii::ExcMessage("Has to be overwritten by derived classes in order "
+                                   "to use Poisson solver for mesh movement."));
   }
 
   virtual void
   set_field_functions_poisson()
   {
     AssertThrow(false,
-                ExcMessage("Has to be overwritten by derived classes in order "
-                           "to use Poisson solver for mesh movement."));
+                dealii::ExcMessage("Has to be overwritten by derived classes in order "
+                                   "to use Poisson solver for mesh movement."));
   }
 };
 
@@ -290,19 +288,20 @@ public:
     param_pre.print(this->pcout, "List of parameters for precursor domain:");
 
     // make some additional parameter checks
-    AssertThrow(param_pre.ale_formulation == false, ExcMessage("not implemented."));
-    AssertThrow(this->param.ale_formulation == false, ExcMessage("not implemented."));
+    AssertThrow(param_pre.ale_formulation == false, dealii::ExcMessage("not implemented."));
+    AssertThrow(this->param.ale_formulation == false, dealii::ExcMessage("not implemented."));
 
-    AssertThrow(param_pre.calculation_of_time_step_size ==
-                  this->param.calculation_of_time_step_size,
-                ExcMessage("Type of time step calculation has to be the same for both domains."));
+    AssertThrow(
+      param_pre.calculation_of_time_step_size == this->param.calculation_of_time_step_size,
+      dealii::ExcMessage("Type of time step calculation has to be the same for both domains."));
 
     AssertThrow(param_pre.adaptive_time_stepping == this->param.adaptive_time_stepping,
-                ExcMessage("Type of time step calculation has to be the same for both domains."));
+                dealii::ExcMessage(
+                  "Type of time step calculation has to be the same for both domains."));
 
     AssertThrow(param_pre.solver_type == SolverType::Unsteady &&
                   this->param.solver_type == SolverType::Unsteady,
-                ExcMessage("This is an unsteady solver. Check parameters."));
+                dealii::ExcMessage("This is an unsteady solver. Check parameters."));
 
     // For the two-domain solver the parameter start_with_low_order has to be true.
     // This is due to the fact that the setup function of the time integrator initializes
@@ -312,7 +311,7 @@ public:
     // in order to find the minimum time step size. Hence, the easiest way to avoid these kind of
     // inconsistencies is to preclude the case start_with_low_order == false.
     AssertThrow(param_pre.start_with_low_order == true && this->param.start_with_low_order == true,
-                ExcMessage("start_with_low_order has to be true for two-domain solver."));
+                dealii::ExcMessage("start_with_low_order has to be true for two-domain solver."));
 
     // grid
     grid_pre = std::make_shared<Grid<dim>>(param_pre.grid, this->mpi_comm);

--- a/include/exadg/incompressible_navier_stokes/user_interface/boundary_descriptor.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/boundary_descriptor.h
@@ -37,8 +37,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 //clang-format off
 /*
  *
@@ -82,23 +80,23 @@ template<int dim>
 struct BoundaryDescriptorU
 {
   // Dirichlet: prescribe all components of the velocity
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> dirichlet_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
 
   // another type of Dirichlet boundary condition where the Dirichlet value comes
   // from the solution on another domain that is in contact with the actual domain
   // of interest at the given boundary (this type of Dirichlet boundary condition
   // is required for fluid-structure interaction problems)
-  std::map<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>> dirichlet_mortar_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>> dirichlet_mortar_bc;
 
   // Neumann: prescribe all components of the velocity gradient in normal direction
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> neumann_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> neumann_bc;
 
   // Symmetry: For this boundary condition, the velocity normal to boundary is set to zero
   // (u*n=0) as well as the normal velocity gradient in tangential directions
   // (grad(u)*n - [(grad(u)*n)*n] n = 0). This is done automatically by the code. The user does not
   // have to prescribe a boundary condition, simply use ZeroFunction<dim>, it is not relevant
   // because this function will not be evaluated by the code.
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> symmetry_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> symmetry_bc;
 
   // add more types of boundary conditions
 
@@ -106,7 +104,7 @@ struct BoundaryDescriptorU
   // return the boundary type
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryTypeU
-    get_boundary_type(types::boundary_id const & boundary_id) const
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
   {
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
       return BoundaryTypeU::Dirichlet;
@@ -117,15 +115,16 @@ struct BoundaryDescriptorU
     else if(this->symmetry_bc.find(boundary_id) != this->symmetry_bc.end())
       return BoundaryTypeU::Symmetry;
 
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
 
     return BoundaryTypeU::Undefined;
   }
 
   inline DEAL_II_ALWAYS_INLINE //
     void
-    verify_boundary_conditions(types::boundary_id const             boundary_id,
-                               std::set<types::boundary_id> const & periodic_boundary_ids) const
+    verify_boundary_conditions(
+      dealii::types::boundary_id const             boundary_id,
+      std::set<dealii::types::boundary_id> const & periodic_boundary_ids) const
   {
     unsigned int counter = 0;
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
@@ -143,7 +142,8 @@ struct BoundaryDescriptorU
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())
       counter++;
 
-    AssertThrow(counter == 1, ExcMessage("Boundary face with non-unique boundary type found."));
+    AssertThrow(counter == 1,
+                dealii::ExcMessage("Boundary face with non-unique boundary type found."));
   }
 };
 
@@ -151,7 +151,7 @@ template<int dim>
 struct BoundaryDescriptorP
 {
   // Dirichlet: prescribe pressure value
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> dirichlet_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
 
   // Neumann: It depends on the chosen Navier-Stokes solver how this map has to be filled
   //
@@ -161,12 +161,13 @@ struct BoundaryDescriptorP
   //  - pressure-correction: this solver always prescribes homogeneous Neumann BCs in the
   //                         pressure Poisson equation. Hence, no function has to be specified.
   //
-  //  - dual splitting: Specify a Function<dim> with dim components for the boundary condition
+  //  - dual splitting: Specify a dealii::Function<dim> with dim components for the boundary
+  //  condition
   //                    dg_u/dt that has to be evaluated for the dual splitting scheme. But this
   //                    is only necessary if the parameter store_previous_boundary_values == false.
   //                    Otherwise, the code automatically determines the time derivative dg_u/dt
   //                    numerically and no boundary condition has to be set by the user.
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> neumann_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> neumann_bc;
 
   // add more types of boundary conditions
 
@@ -174,22 +175,23 @@ struct BoundaryDescriptorP
   // return the boundary type
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryTypeP
-    get_boundary_type(types::boundary_id const & boundary_id) const
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
   {
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
       return BoundaryTypeP::Dirichlet;
     else if(this->neumann_bc.find(boundary_id) != this->neumann_bc.end())
       return BoundaryTypeP::Neumann;
 
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
 
     return BoundaryTypeP::Undefined;
   }
 
   inline DEAL_II_ALWAYS_INLINE //
     void
-    verify_boundary_conditions(types::boundary_id const             boundary_id,
-                               std::set<types::boundary_id> const & periodic_boundary_ids) const
+    verify_boundary_conditions(
+      dealii::types::boundary_id const             boundary_id,
+      std::set<dealii::types::boundary_id> const & periodic_boundary_ids) const
   {
     unsigned int counter = 0;
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
@@ -201,7 +203,8 @@ struct BoundaryDescriptorP
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())
       counter++;
 
-    AssertThrow(counter == 1, ExcMessage("Boundary face with non-unique boundary type found."));
+    AssertThrow(counter == 1,
+                dealii::ExcMessage("Boundary face with non-unique boundary type found."));
   }
 };
 

--- a/include/exadg/incompressible_navier_stokes/user_interface/enum_types.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/enum_types.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                                 MATHEMATICAL MODEL                                 */
@@ -54,7 +52,7 @@ enum_to_string(ProblemType const enum_type)
       string_type = "Unsteady";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -81,7 +79,7 @@ enum_to_string(EquationType const enum_type)
       string_type = "NavierStokes";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -105,7 +103,7 @@ enum_to_string(FormulationViscousTerm const enum_type)
       string_type = "LaplaceFormulation";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -129,7 +127,7 @@ enum_to_string(FormulationConvectiveTerm const enum_type)
       string_type = "ConvectiveFormulation";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -153,7 +151,7 @@ enum_to_string(MeshMovementType const enum_type)
       string_type = "Elasticity";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -194,7 +192,7 @@ enum_to_string(TemporalDiscretization const enum_type)
       string_type = "BDF coupled solution";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -221,7 +219,7 @@ enum_to_string(TreatmentOfConvectiveTerm const enum_type)
       string_type = "Implicit";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -269,7 +267,7 @@ enum_to_string(TimeIntegratorOIF const enum_type)
       string_type = "ExplRK5Stage9Reg2S";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -297,7 +295,7 @@ enum_to_string(TimeStepCalculation const enum_type)
       string_type = "MaxEfficiency";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -321,7 +319,7 @@ enum_to_string(ConvergenceCriterionSteadyProblem const enum_type)
       string_type = "SolutionIncrement";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -342,7 +340,7 @@ enum_to_string(DegreePressure const enum_type)
       string_type = "Equal-order";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -369,7 +367,7 @@ enum_to_string(TypeDirichletBCs const enum_type)
       string_type = "Mirror";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -393,7 +391,7 @@ enum_to_string(InteriorPenaltyFormulation const enum_type)
       string_type = "NIPG";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -417,7 +415,7 @@ enum_to_string(PenaltyTermDivergenceFormulation const enum_type)
       string_type = "NotSymmetrized";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -441,7 +439,7 @@ enum_to_string(AdjustPressureLevel const enum_type)
       string_type = "ApplyAnalyticalSolutionInPoint";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -462,7 +460,7 @@ enum_to_string(FormulationVelocityDivergenceTerm const enum_type)
       string_type = "Strong";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -483,7 +481,7 @@ enum_to_string(FormulationPressureGradientTerm const enum_type)
       string_type = "Strong";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -507,7 +505,7 @@ enum_to_string(ContinuityPenaltyComponents const enum_type)
       string_type = "Normal";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -534,7 +532,7 @@ enum_to_string(TypePenaltyParameter const enum_type)
       string_type = "ViscousAndConvectiveTerms";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -564,7 +562,7 @@ enum_to_string(MultigridOperatorType const enum_type)
       string_type = "ReactionConvectionDiffusion";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -585,7 +583,7 @@ enum_to_string(QuadratureRuleLinearization const enum_type)
       string_type = "Over-integration (3/2k)";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -612,7 +610,7 @@ enum_to_string(SolverPressurePoisson const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -636,7 +634,7 @@ enum_to_string(PreconditionerPressurePoisson const enum_type)
       string_type = "Multigrid";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -657,7 +655,7 @@ enum_to_string(SolverProjection const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -687,7 +685,7 @@ enum_to_string(PreconditionerProjection const enum_type)
       string_type = "Multigrid";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -711,7 +709,7 @@ enum_to_string(SolverViscous const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -741,7 +739,7 @@ enum_to_string(PreconditionerViscous const enum_type)
       string_type = "Multigrid";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -765,7 +763,7 @@ enum_to_string(SolverMomentum const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -786,7 +784,7 @@ enum_to_string(SolverCoupled const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -813,7 +811,7 @@ enum_to_string(PreconditionerCoupled const enum_type)
       string_type = "BlockTriangularFactorization";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -843,7 +841,7 @@ enum_to_string(MomentumPreconditioner const enum_type)
       string_type = "Multigrid";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -873,7 +871,7 @@ enum_to_string(SchurComplementPreconditioner const enum_type)
       string_type = "PressureConvectionDiffusion";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -909,7 +907,7 @@ enum_to_string(TurbulenceEddyViscosityModel const enum_type)
       string_type = "Sigma";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/incompressible_navier_stokes/user_interface/field_functions.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/field_functions.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 template<int dim>
 struct FieldFunctions
 {
@@ -35,13 +33,13 @@ struct FieldFunctions
    * The function initial_solution_velocity is used to initialize the velocity field at the
    * beginning of the simulation.
    */
-  std::shared_ptr<Function<dim>> initial_solution_velocity;
+  std::shared_ptr<dealii::Function<dim>> initial_solution_velocity;
 
   /*
    * The function initial_solution_pressure is used to initialize the pressure field at the
    * beginning of the simulation.
    */
-  std::shared_ptr<Function<dim>> initial_solution_pressure;
+  std::shared_ptr<dealii::Function<dim>> initial_solution_pressure;
 
   /*
    * The function analytical_solution_pressure is used to adjust the pressure level in the special
@@ -50,14 +48,14 @@ struct FieldFunctions
    * constant) and
    *   ... if an analytical solution for the pressure is available.
    */
-  std::shared_ptr<Function<dim>> analytical_solution_pressure;
+  std::shared_ptr<dealii::Function<dim>> analytical_solution_pressure;
 
   /*
    * The function right_hand_side is used to evaluate the body force term on the right-hand side of
    * the momentum equation of the incompressible Navier-Stokes equations.
    */
-  std::shared_ptr<Function<dim>> right_hand_side;
-  std::shared_ptr<Function<dim>> gravitational_force; // Boussinesq term
+  std::shared_ptr<dealii::Function<dim>> right_hand_side;
+  std::shared_ptr<dealii::Function<dim>> gravitational_force; // Boussinesq term
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 // standard constructor that initializes parameters
 Parameters::Parameters()
   : // MATHEMATICAL MODEL
@@ -235,88 +233,93 @@ Parameters::Parameters()
 }
 
 void
-Parameters::check(ConditionalOStream const & pcout) const
+Parameters::check(dealii::ConditionalOStream const & pcout) const
 {
   // MATHEMATICAL MODEL
-  AssertThrow(problem_type != ProblemType::Undefined, ExcMessage("parameter must be defined"));
-  AssertThrow(equation_type != EquationType::Undefined, ExcMessage("parameter must be defined"));
+  AssertThrow(problem_type != ProblemType::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
+  AssertThrow(equation_type != EquationType::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
 
   if(equation_type == EquationType::Euler)
   {
     AssertThrow(std::abs(viscosity) < 1.e-15,
-                ExcMessage(
+                dealii::ExcMessage(
                   "Make sure that the viscosity is zero when solving the Euler equations."));
   }
 
   AssertThrow(formulation_viscous_term != FormulationViscousTerm::Undefined,
-              ExcMessage("parameter must be defined"));
+              dealii::ExcMessage("parameter must be defined"));
   AssertThrow(formulation_convective_term != FormulationConvectiveTerm::Undefined,
-              ExcMessage("parameter must be defined"));
+              dealii::ExcMessage("parameter must be defined"));
 
   // ALE
   if(ale_formulation)
   {
     AssertThrow(
       formulation_convective_term == FormulationConvectiveTerm::ConvectiveFormulation,
-      ExcMessage(
+      dealii::ExcMessage(
         "Convective formulation of convective operator has to be used for ALE formulation."));
 
     AssertThrow(
       problem_type == ProblemType::Unsteady && solver_type == SolverType::Unsteady,
-      ExcMessage(
+      dealii::ExcMessage(
         "Both problem type and solver type have to be Unsteady when using ALE formulation."));
 
     AssertThrow(treatment_of_convective_term != TreatmentOfConvectiveTerm::ExplicitOIF,
-                ExcMessage("ALE formulation is not implemented for OIF substepping technique."));
+                dealii::ExcMessage(
+                  "ALE formulation is not implemented for OIF substepping technique."));
 
     AssertThrow(
       convective_problem() == true,
-      ExcMessage(
+      dealii::ExcMessage(
         "ALE formulation only implemented for equations that include the convective operator, "
         "e.g., ALE is currently not available for the Stokes equations."));
   }
 
   // PHYSICAL QUANTITIES
-  AssertThrow(end_time > start_time, ExcMessage("parameter end_time must be defined"));
-  AssertThrow(viscosity >= 0.0, ExcMessage("parameter must be defined"));
+  AssertThrow(end_time > start_time, dealii::ExcMessage("parameter end_time must be defined"));
+  AssertThrow(viscosity >= 0.0, dealii::ExcMessage("parameter must be defined"));
 
   // TEMPORAL DISCRETIZATION
-  AssertThrow(solver_type != SolverType::Undefined, ExcMessage("parameter must be defined"));
+  AssertThrow(solver_type != SolverType::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
   AssertThrow(temporal_discretization != TemporalDiscretization::Undefined,
-              ExcMessage("parameter must be defined"));
+              dealii::ExcMessage("parameter must be defined"));
 
   if(convective_problem())
   {
     AssertThrow(treatment_of_convective_term != TreatmentOfConvectiveTerm::Undefined,
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
   }
 
   AssertThrow(calculation_of_time_step_size != TimeStepCalculation::Undefined,
-              ExcMessage("parameter must be defined"));
+              dealii::ExcMessage("parameter must be defined"));
 
   if(calculation_of_time_step_size == TimeStepCalculation::CFL)
   {
-    AssertThrow(cfl > 0., ExcMessage("parameter must be defined"));
-    AssertThrow(max_velocity > 0., ExcMessage("parameter must be defined"));
+    AssertThrow(cfl > 0., dealii::ExcMessage("parameter must be defined"));
+    AssertThrow(max_velocity > 0., dealii::ExcMessage("parameter must be defined"));
   }
 
   if(calculation_of_time_step_size == TimeStepCalculation::UserSpecified)
-    AssertThrow(time_step_size > 0., ExcMessage("parameter must be defined"));
+    AssertThrow(time_step_size > 0., dealii::ExcMessage("parameter must be defined"));
 
   if(calculation_of_time_step_size == TimeStepCalculation::MaxEfficiency)
-    AssertThrow(c_eff > 0., ExcMessage("parameter must be defined"));
+    AssertThrow(c_eff > 0., dealii::ExcMessage("parameter must be defined"));
 
   if(adaptive_time_stepping)
   {
     AssertThrow(calculation_of_time_step_size == TimeStepCalculation::CFL,
-                ExcMessage(
+                dealii::ExcMessage(
                   "Adaptive time stepping is only implemented for TimeStepCalculation::CFL."));
   }
 
   if(problem_type == ProblemType::Unsteady)
   {
     AssertThrow(solver_type == SolverType::Unsteady,
-                ExcMessage("An unsteady solver has to be used to solve unsteady problems."));
+                dealii::ExcMessage(
+                  "An unsteady solver has to be used to solve unsteady problems."));
   }
 
   if(solver_type == SolverType::Steady)
@@ -324,7 +327,7 @@ Parameters::check(ConditionalOStream const & pcout) const
     if(convective_problem())
     {
       AssertThrow(treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit,
-                  ExcMessage(
+                  dealii::ExcMessage(
                     "Convective term has to be formulated implicitly when using a steady solver."));
     }
   }
@@ -335,7 +338,7 @@ Parameters::check(ConditionalOStream const & pcout) const
     {
       AssertThrow(
         treatment_of_convective_term != TreatmentOfConvectiveTerm::ExplicitOIF,
-        ExcMessage(
+        dealii::ExcMessage(
           "Operator-integration-factor splitting approach introduces a splitting error. "
           "Hence, this approach cannot be used to solve the steady Navier-Stokes equations."));
     }
@@ -351,27 +354,27 @@ Parameters::check(ConditionalOStream const & pcout) const
   if(temporal_discretization != TemporalDiscretization::BDFCoupledSolution)
     AssertThrow(
       get_degree_p(degree_u) > 0,
-      ExcMessage(
+      dealii::ExcMessage(
         "Polynomial degree of pressure has to be larger than zero for projection-type methods."));
 
   AssertThrow(IP_formulation_viscous != InteriorPenaltyFormulation::Undefined,
-              ExcMessage("parameter must be defined"));
+              dealii::ExcMessage("parameter must be defined"));
 
   if(formulation_viscous_term == FormulationViscousTerm::DivergenceFormulation)
   {
     AssertThrow(penalty_term_div_formulation != PenaltyTermDivergenceFormulation::Undefined,
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
   }
 
   if(equation_type == EquationType::NavierStokes)
   {
-    AssertThrow(upwind_factor >= 0.0, ExcMessage("Upwind factor must not be negative."));
+    AssertThrow(upwind_factor >= 0.0, dealii::ExcMessage("Upwind factor must not be negative."));
   }
 
   if(use_continuity_penalty == true)
   {
     AssertThrow(continuity_penalty_components != ContinuityPenaltyComponents::Undefined,
-                ExcMessage("Parameter must be defined"));
+                dealii::ExcMessage("Parameter must be defined"));
 
     if(continuity_penalty_use_boundary_data == true)
     {
@@ -379,7 +382,7 @@ Parameters::check(ConditionalOStream const & pcout) const
       {
         AssertThrow(
           apply_penalty_terms_in_postprocessing_step == true,
-          ExcMessage(
+          dealii::ExcMessage(
             "Penalty terms have to be applied in postprocessing step if boundary data is used. "
             "Otherwise, the boundary condition will be inconsistent and temporal accuracy is limited to low order."));
       }
@@ -389,7 +392,7 @@ Parameters::check(ConditionalOStream const & pcout) const
   if(use_divergence_penalty == true || use_continuity_penalty == true)
   {
     AssertThrow(type_penalty_parameter != TypePenaltyParameter::Undefined,
-                ExcMessage("Parameter must be defined"));
+                dealii::ExcMessage("Parameter must be defined"));
   }
 
   if(solver_type == SolverType::Steady)
@@ -397,8 +400,9 @@ Parameters::check(ConditionalOStream const & pcout) const
     if(use_divergence_penalty == true || use_continuity_penalty == true)
     {
       AssertThrow(apply_penalty_terms_in_postprocessing_step == false,
-                  ExcMessage("Use apply_penalty_terms_in_postprocessing_step = false, "
-                             "otherwise the penalty terms will be ignored by the steady solver."));
+                  dealii::ExcMessage(
+                    "Use apply_penalty_terms_in_postprocessing_step = false, "
+                    "otherwise the penalty terms will be ignored by the steady solver."));
     }
   }
 
@@ -406,7 +410,7 @@ Parameters::check(ConditionalOStream const & pcout) const
   if(temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
   {
     AssertThrow(order_extrapolation_pressure_nbc <= order_time_integrator,
-                ExcMessage("Invalid parameter order_extrapolation_pressure_nbc!"));
+                dealii::ExcMessage("Invalid parameter order_extrapolation_pressure_nbc!"));
 
     if(order_extrapolation_pressure_nbc > 2)
     {
@@ -422,29 +426,29 @@ Parameters::check(ConditionalOStream const & pcout) const
                     FormulationConvectiveTerm::DivergenceFormulation ||
                   formulation_convective_term_bc ==
                     FormulationConvectiveTerm::ConvectiveFormulation,
-                ExcMessage("Not implemented."));
+                dealii::ExcMessage("Not implemented."));
 
     AssertThrow(treatment_of_convective_term != TreatmentOfConvectiveTerm::Implicit,
-                ExcMessage("An implicit treatment of the convective term is not possible "
-                           "in combination with the dual splitting scheme."));
+                dealii::ExcMessage("An implicit treatment of the convective term is not possible "
+                                   "in combination with the dual splitting scheme."));
   }
 
   // PRESSURE-CORRECTION SCHEME
   if(temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
   {
     AssertThrow(order_pressure_extrapolation <= order_time_integrator,
-                ExcMessage("Invalid parameter order_pressure_extrapolation!"));
+                dealii::ExcMessage("Invalid parameter order_pressure_extrapolation!"));
 
     if(preconditioner_momentum == MomentumPreconditioner::Multigrid)
     {
       AssertThrow(multigrid_operator_type_momentum != MultigridOperatorType::Undefined,
-                  ExcMessage("Parameter must be defined"));
+                  dealii::ExcMessage("Parameter must be defined"));
 
       if(treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
       {
-        AssertThrow(multigrid_operator_type_momentum !=
-                      MultigridOperatorType::ReactionConvectionDiffusion,
-                    ExcMessage("Invalid parameter. Convective term is treated explicitly."));
+        AssertThrow(
+          multigrid_operator_type_momentum != MultigridOperatorType::ReactionConvectionDiffusion,
+          dealii::ExcMessage("Invalid parameter. Convective term is treated explicitly."));
       }
     }
   }
@@ -453,25 +457,27 @@ Parameters::check(ConditionalOStream const & pcout) const
   if(temporal_discretization == TemporalDiscretization::BDFCoupledSolution)
   {
     if(use_scaling_continuity == true)
-      AssertThrow(scaling_factor_continuity > 0.0, ExcMessage("Invalid parameter"));
+      AssertThrow(scaling_factor_continuity > 0.0, dealii::ExcMessage("Invalid parameter"));
 
     if(preconditioner_velocity_block == MomentumPreconditioner::Multigrid)
     {
       AssertThrow(multigrid_operator_type_velocity_block != MultigridOperatorType::Undefined,
-                  ExcMessage("Parameter must be defined"));
+                  dealii::ExcMessage("Parameter must be defined"));
 
       if(equation_type == EquationType::Stokes)
       {
         AssertThrow(multigrid_operator_type_velocity_block !=
                       MultigridOperatorType::ReactionConvectionDiffusion,
-                    ExcMessage("Invalid parameter (the specified equation type is Stokes)."));
+                    dealii::ExcMessage(
+                      "Invalid parameter (the specified equation type is Stokes)."));
       }
 
       if(treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
       {
         AssertThrow(multigrid_operator_type_velocity_block !=
                       MultigridOperatorType::ReactionConvectionDiffusion,
-                    ExcMessage("Invalid parameter. Convective term is treated explicitly."));
+                    dealii::ExcMessage(
+                      "Invalid parameter. Convective term is treated explicitly."));
       }
     }
   }
@@ -480,13 +486,14 @@ Parameters::check(ConditionalOStream const & pcout) const
   if(treatment_of_convective_term == TreatmentOfConvectiveTerm::ExplicitOIF)
   {
     AssertThrow(time_integrator_oif != TimeIntegratorOIF::Undefined,
-                ExcMessage("parameter must be defined"));
+                dealii::ExcMessage("parameter must be defined"));
 
-    AssertThrow(cfl > 0., ExcMessage("parameter must be defined"));
-    AssertThrow(cfl_oif > 0., ExcMessage("parameter must be defined"));
+    AssertThrow(cfl > 0., dealii::ExcMessage("parameter must be defined"));
+    AssertThrow(cfl_oif > 0., dealii::ExcMessage("parameter must be defined"));
 
     AssertThrow(ale_formulation == false,
-                ExcMessage("ALE formulation is not implemented for OIF substepping technique."));
+                dealii::ExcMessage(
+                  "ALE formulation is not implemented for OIF substepping technique."));
   }
 
   // NUMERICAL PARAMETERS
@@ -494,7 +501,7 @@ Parameters::check(ConditionalOStream const & pcout) const
   {
     AssertThrow(
       use_cell_based_face_loops == true,
-      ExcMessage(
+      dealii::ExcMessage(
         "Cell based face loops have to be used for matrix-free implementation of block diagonal preconditioner."));
   }
 
@@ -503,8 +510,9 @@ Parameters::check(ConditionalOStream const & pcout) const
   if(use_turbulence_model)
   {
     AssertThrow(turbulence_model != TurbulenceEddyViscosityModel::Undefined,
-                ExcMessage("parameter must be defined"));
-    AssertThrow(turbulence_model_constant > 0, ExcMessage("parameter must be greater than zero"));
+                dealii::ExcMessage("parameter must be defined"));
+    AssertThrow(turbulence_model_constant > 0,
+                dealii::ExcMessage("parameter must be greater than zero"));
   }
 }
 
@@ -546,8 +554,8 @@ Parameters::get_degree_p(unsigned int const degree_u) const
   if(degree_p == DegreePressure::MixedOrder)
   {
     AssertThrow(degree_u > 0,
-                ExcMessage("The polynomial degree of the velocity shape functions"
-                           " has to be larger than zero for a mixed-order formulation."));
+                dealii::ExcMessage("The polynomial degree of the velocity shape functions"
+                                   " has to be larger than zero for a mixed-order formulation."));
 
     k = degree_u - 1;
   }
@@ -557,14 +565,14 @@ Parameters::get_degree_p(unsigned int const degree_u) const
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   return k;
 }
 
 void
-Parameters::print(ConditionalOStream const & pcout, std::string const & name) const
+Parameters::print(dealii::ConditionalOStream const & pcout, std::string const & name) const
 {
   pcout << std::endl << name << std::endl;
 
@@ -603,7 +611,7 @@ Parameters::print(ConditionalOStream const & pcout, std::string const & name) co
 }
 
 void
-Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout) const
+Parameters::print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Mathematical model:" << std::endl;
 
@@ -637,7 +645,7 @@ Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout
 
 
 void
-Parameters::print_parameters_physical_quantities(ConditionalOStream const & pcout) const
+Parameters::print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Physical quantities:" << std::endl;
 
@@ -662,7 +670,7 @@ Parameters::print_parameters_physical_quantities(ConditionalOStream const & pcou
 }
 
 void
-Parameters::print_parameters_temporal_discretization(ConditionalOStream const & pcout) const
+Parameters::print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Temporal discretization:" << std::endl;
 
@@ -726,7 +734,7 @@ Parameters::print_parameters_temporal_discretization(ConditionalOStream const & 
 }
 
 void
-Parameters::print_parameters_spatial_discretization(ConditionalOStream const & pcout) const
+Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Spatial discretization:" << std::endl;
 
@@ -813,7 +821,7 @@ Parameters::print_parameters_spatial_discretization(ConditionalOStream const & p
 }
 
 void
-Parameters::print_parameters_turbulence(ConditionalOStream const & pcout) const
+Parameters::print_parameters_turbulence(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Turbulence:" << std::endl;
 
@@ -827,7 +835,7 @@ Parameters::print_parameters_turbulence(ConditionalOStream const & pcout) const
 }
 
 void
-Parameters::print_parameters_numerical_parameters(ConditionalOStream const & pcout) const
+Parameters::print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Numerical parameters:" << std::endl;
 
@@ -846,7 +854,7 @@ Parameters::print_parameters_numerical_parameters(ConditionalOStream const & pco
 }
 
 void
-Parameters::print_parameters_pressure_poisson(ConditionalOStream const & pcout) const
+Parameters::print_parameters_pressure_poisson(dealii::ConditionalOStream const & pcout) const
 {
   // pressure Poisson equation
   pcout << std::endl << "  Pressure Poisson equation (PPE):" << std::endl;
@@ -877,7 +885,7 @@ Parameters::print_parameters_pressure_poisson(ConditionalOStream const & pcout) 
 }
 
 void
-Parameters::print_parameters_projection_step(ConditionalOStream const & pcout) const
+Parameters::print_parameters_projection_step(dealii::ConditionalOStream const & pcout) const
 {
   if(use_divergence_penalty == true)
   {
@@ -921,7 +929,7 @@ Parameters::print_parameters_projection_step(ConditionalOStream const & pcout) c
 }
 
 void
-Parameters::print_parameters_dual_splitting(ConditionalOStream const & pcout) const
+Parameters::print_parameters_dual_splitting(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "High-order dual splitting scheme:" << std::endl;
 
@@ -972,7 +980,7 @@ Parameters::print_parameters_dual_splitting(ConditionalOStream const & pcout) co
 }
 
 void
-Parameters::print_parameters_pressure_correction(ConditionalOStream const & pcout) const
+Parameters::print_parameters_pressure_correction(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Pressure-correction scheme:" << std::endl;
 
@@ -1043,7 +1051,7 @@ Parameters::print_parameters_pressure_correction(ConditionalOStream const & pcou
 
 
 void
-Parameters::print_parameters_coupled_solver(ConditionalOStream const & pcout) const
+Parameters::print_parameters_coupled_solver(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Coupled Navier-Stokes solver:" << std::endl;
 

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -41,8 +41,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-using namespace dealii;
-
 class Parameters
 {
 public:
@@ -50,7 +48,7 @@ public:
   Parameters();
 
   void
-  check(ConditionalOStream const & pcout) const;
+  check(dealii::ConditionalOStream const & pcout) const;
 
   bool
   convective_problem() const;
@@ -68,41 +66,41 @@ public:
   get_degree_p(unsigned int const degree_u) const;
 
   void
-  print(ConditionalOStream const & pcout, std::string const & name) const;
+  print(dealii::ConditionalOStream const & pcout, std::string const & name) const;
 
 private:
   void
-  print_parameters_mathematical_model(ConditionalOStream const & pcout) const;
+  print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_physical_quantities(ConditionalOStream const & pcout) const;
+  print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_temporal_discretization(ConditionalOStream const & pcout) const;
+  print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_spatial_discretization(ConditionalOStream const & pcout) const;
+  print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_turbulence(ConditionalOStream const & pcout) const;
+  print_parameters_turbulence(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_numerical_parameters(ConditionalOStream const & pcout) const;
+  print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_pressure_poisson(ConditionalOStream const & pcout) const;
+  print_parameters_pressure_poisson(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_projection_step(ConditionalOStream const & pcout) const;
+  print_parameters_projection_step(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_dual_splitting(ConditionalOStream const & pcout) const;
+  print_parameters_dual_splitting(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_pressure_correction(ConditionalOStream const & pcout) const;
+  print_parameters_pressure_correction(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_coupled_solver(ConditionalOStream const & pcout) const;
+  print_parameters_coupled_solver(dealii::ConditionalOStream const & pcout) const;
 
 public:
   /**************************************************************************************/
@@ -452,7 +450,7 @@ public:
   // parameter.
   // Choosing false means that the user has to make sure that the boundary conditions
   // at previous times are accessible and evaluated correctly by just setting the parameter
-  // time of the Function<dim>. Furthermore, the user has to provide the time derivative
+  // time of the dealii::Function<dim>. Furthermore, the user has to provide the time derivative
   // of the velocity (acceleration) analytically in case of the dual splitting scheme.
   bool store_previous_boundary_values;
 

--- a/include/exadg/matrix_free/categorization.h
+++ b/include/exadg/matrix_free/categorization.h
@@ -22,26 +22,27 @@
 #ifndef OPERATOR_BASE_CATEGORIZATION_H
 #define OPERATOR_BASE_CATEGORIZATION_H
 
+// deal.II
+#include <deal.II/grid/tria.h>
+
 namespace ExaDG
 {
 namespace Categorization
 {
-using namespace dealii;
-
 /*
  * Adjust MatrixFree::AdditionalData such that
  *   1) cells which have the same boundary IDs for all faces are put into the
  *      same category
- *   2) cell based loops are enabled (incl. FEEvaluationBase::read_cell_data()
+ *   2) cell based loops are enabled (incl. dealii::FEEvaluationBase::read_cell_data()
  *      for all neighboring cells)
  */
 template<int dim, typename AdditionalData>
 void
-do_cell_based_loops(Triangulation<dim> const & tria,
-                    AdditionalData &           data,
-                    unsigned int const         level = numbers::invalid_unsigned_int)
+do_cell_based_loops(dealii::Triangulation<dim> const & tria,
+                    AdditionalData &                   data,
+                    unsigned int const level = dealii::numbers::invalid_unsigned_int)
 {
-  bool is_mg = (level != numbers::invalid_unsigned_int);
+  bool is_mg = (level != dealii::numbers::invalid_unsigned_int);
 
   // ... create list for the category of each cell
   if(is_mg)

--- a/include/exadg/matrix_free/integrators.h
+++ b/include/exadg/matrix_free/integrators.h
@@ -26,20 +26,17 @@
 #include <deal.II/base/config.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
 
-DEAL_II_NAMESPACE_OPEN
+template<int dim,
+         int n_components,
+         typename Number,
+         typename VectorizedArrayType = dealii::VectorizedArray<Number>>
+using CellIntegrator = dealii::FEEvaluation<dim, -1, 0, n_components, Number, VectorizedArrayType>;
 
 template<int dim,
          int n_components,
          typename Number,
-         typename VectorizedArrayType = VectorizedArray<Number>>
-using CellIntegrator = FEEvaluation<dim, -1, 0, n_components, Number, VectorizedArrayType>;
-
-template<int dim,
-         int n_components,
-         typename Number,
-         typename VectorizedArrayType = VectorizedArray<Number>>
-using FaceIntegrator = FEFaceEvaluation<dim, -1, 0, n_components, Number, VectorizedArrayType>;
-
-DEAL_II_NAMESPACE_CLOSE
+         typename VectorizedArrayType = dealii::VectorizedArray<Number>>
+using FaceIntegrator =
+  dealii::FEFaceEvaluation<dim, -1, 0, n_components, Number, VectorizedArrayType>;
 
 #endif

--- a/include/exadg/matrix_free/matrix_free_data.h
+++ b/include/exadg/matrix_free/matrix_free_data.h
@@ -23,7 +23,10 @@
 #define INCLUDE_FUNCTIONALITIES_MATRIX_FREE_DATA_H_
 
 // deal.II
+#include <deal.II/base/quadrature.h>
 #include <deal.II/distributed/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/matrix_free/matrix_free.h>
 
 // ExaDG
@@ -32,8 +35,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 struct MatrixFreeData
 {
@@ -43,7 +44,7 @@ public:
    */
   MatrixFreeData()
   {
-    data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;
+    data.tasks_parallel_scheme = dealii::MatrixFree<dim, Number>::AdditionalData::none;
   }
 
   /**
@@ -57,25 +58,25 @@ public:
     pde_operator->fill_matrix_free_data(*this);
   }
 
-  std::vector<DoFHandler<dim> const *> &
+  std::vector<dealii::DoFHandler<dim> const *> &
   get_dof_handler_vector()
   {
     return dof_handler_vec;
   }
 
-  std::vector<AffineConstraints<Number> const *> &
+  std::vector<dealii::AffineConstraints<Number> const *> &
   get_constraint_vector()
   {
     return constraint_vec;
   }
 
-  std::vector<Quadrature<dim>> &
+  std::vector<dealii::Quadrature<dim>> &
   get_quadrature_vector()
   {
     return quadrature_vec;
   }
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler(std::string const & name)
   {
     return *dof_handler_vec.at(get_dof_index(name));
@@ -99,22 +100,22 @@ public:
   }
 
   void
-  insert_dof_handler(DoFHandler<dim> const * dof_handler, std::string const & name)
+  insert_dof_handler(dealii::DoFHandler<dim> const * dof_handler, std::string const & name)
   {
     insert_element(dof_handler_vec, dof_index_map, dof_handler, name);
   }
 
   void
-  insert_constraint(AffineConstraints<Number> const * constraint, std::string const & name)
+  insert_constraint(dealii::AffineConstraints<Number> const * constraint, std::string const & name)
   {
     insert_element(constraint_vec, constraint_index_map, constraint, name);
   }
 
   template<int dim_quad>
   void
-  insert_quadrature(Quadrature<dim_quad> const & quadrature, std::string const & name)
+  insert_quadrature(dealii::Quadrature<dim_quad> const & quadrature, std::string const & name)
   {
-    insert_element(quadrature_vec, quad_index_map, Quadrature<dim>(quadrature), name);
+    insert_element(quadrature_vec, quad_index_map, dealii::Quadrature<dim>(quadrature), name);
   }
 
   unsigned int
@@ -136,7 +137,7 @@ public:
   }
 
   // additional data
-  typename MatrixFree<dim, Number>::AdditionalData data;
+  typename dealii::MatrixFree<dim, Number>::AdditionalData data;
 
 private:
   template<typename T>
@@ -157,7 +158,7 @@ private:
     }
     else
     {
-      AssertThrow(it == map.end(), ExcMessage("Element already exists. Aborting."));
+      AssertThrow(it == map.end(), dealii::ExcMessage("Element already exists. Aborting."));
     }
 
     vector.resize(index + 1);
@@ -169,7 +170,7 @@ private:
   {
     auto it = map.find(name);
 
-    unsigned int index = numbers::invalid_unsigned_int;
+    unsigned int index = dealii::numbers::invalid_unsigned_int;
 
     if(it != map.end())
     {
@@ -177,21 +178,21 @@ private:
     }
     else
     {
-      AssertThrow(it != map.end(), ExcMessage("Could not find element. Aborting."));
+      AssertThrow(it != map.end(), dealii::ExcMessage("Could not find element. Aborting."));
     }
 
     return index;
   }
 
-  // maps between names and indices for DoFHandler, Constraint, Quadrature
+  // maps between names and indices for dealii::DoFHandler, Constraint, dealii::Quadrature
   std::map<std::string, unsigned int> dof_index_map;
   std::map<std::string, unsigned int> constraint_index_map;
   std::map<std::string, unsigned int> quad_index_map;
 
   // collection of data structures required for initialization and update of matrix_free
-  std::vector<DoFHandler<dim> const *>           dof_handler_vec;
-  std::vector<AffineConstraints<Number> const *> constraint_vec;
-  std::vector<Quadrature<dim>>                   quadrature_vec;
+  std::vector<dealii::DoFHandler<dim> const *>           dof_handler_vec;
+  std::vector<dealii::AffineConstraints<Number> const *> constraint_vec;
+  std::vector<dealii::Quadrature<dim>>                   quadrature_vec;
 };
 } // namespace ExaDG
 

--- a/include/exadg/operators/elementwise_operator.h
+++ b/include/exadg/operators/elementwise_operator.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace Elementwise
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename Operator>
 class OperatorBase
 {
@@ -38,7 +36,7 @@ public:
   {
   }
 
-  MatrixFree<dim, Number> const &
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const
   {
     return op.get_matrix_free();
@@ -71,7 +69,7 @@ public:
   }
 
   void
-  vmult(VectorizedArray<Number> * dst, VectorizedArray<Number> * src) const
+  vmult(dealii::VectorizedArray<Number> * dst, dealii::VectorizedArray<Number> * src) const
   {
     // set dst vector to zero
     Elementwise::vector_init(dst, problem_size);

--- a/include/exadg/operators/integrator_flags.h
+++ b/include/exadg/operators/integrator_flags.h
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct CellFlags
 {
   CellFlags(bool const value = false, const bool gradient = false, const bool hessian = false)

--- a/include/exadg/operators/interior_penalty_parameter.h
+++ b/include/exadg/operators/interior_penalty_parameter.h
@@ -32,36 +32,36 @@ namespace ExaDG
 {
 namespace IP // IP = interior penalty
 {
-using namespace dealii;
-
 /*
  *  This function calculates the penalty parameter of the interior
  *  penalty method for each cell.
  */
 template<int dim, typename Number>
 void
-calculate_penalty_parameter(AlignedVector<VectorizedArray<Number>> & array_penalty_parameter,
-                            MatrixFree<dim, Number> const &          matrix_free,
-                            unsigned int const                       dof_index = 0)
+calculate_penalty_parameter(
+  dealii::AlignedVector<dealii::VectorizedArray<Number>> & array_penalty_parameter,
+  dealii::MatrixFree<dim, Number> const &                  matrix_free,
+  unsigned int const                                       dof_index = 0)
 {
   unsigned int n_cells = matrix_free.n_cell_batches() + matrix_free.n_ghost_cell_batches();
   array_penalty_parameter.resize(n_cells);
 
-  Mapping<dim> const &       mapping = *matrix_free.get_mapping_info().mapping;
-  FiniteElement<dim> const & fe      = matrix_free.get_dof_handler(dof_index).get_fe();
-  unsigned int const         degree  = fe.degree;
+  dealii::Mapping<dim> const &       mapping = *matrix_free.get_mapping_info().mapping;
+  dealii::FiniteElement<dim> const & fe      = matrix_free.get_dof_handler(dof_index).get_fe();
+  unsigned int const                 degree  = fe.degree;
 
-  QGauss<dim>   quadrature(degree + 1);
-  FEValues<dim> fe_values(mapping, fe, quadrature, update_JxW_values);
+  dealii::QGauss<dim>   quadrature(degree + 1);
+  dealii::FEValues<dim> fe_values(mapping, fe, quadrature, dealii::update_JxW_values);
 
-  QGauss<dim - 1>   face_quadrature(degree + 1);
-  FEFaceValues<dim> fe_face_values(mapping, fe, face_quadrature, update_JxW_values);
+  dealii::QGauss<dim - 1>   face_quadrature(degree + 1);
+  dealii::FEFaceValues<dim> fe_face_values(mapping, fe, face_quadrature, dealii::update_JxW_values);
 
   for(unsigned int i = 0; i < n_cells; ++i)
   {
     for(unsigned int v = 0; v < matrix_free.n_active_entries_per_cell_batch(i); ++v)
     {
-      typename DoFHandler<dim>::cell_iterator cell = matrix_free.get_cell_iterator(i, v, dof_index);
+      typename dealii::DoFHandler<dim>::cell_iterator cell =
+        matrix_free.get_cell_iterator(i, v, dof_index);
       fe_values.reinit(cell);
 
       // calculate cell volume

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -31,20 +31,18 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, int n_components, typename Number>
 class InverseMassOperator
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef InverseMassOperator<dim, n_components, Number> This;
 
   typedef CellIntegrator<dim, n_components, Number> Integrator;
 
   // use a template parameter of -1 to select the precompiled version of this operator
-  typedef MatrixFreeOperators::CellwiseInverseMassMatrix<dim, -1, n_components, Number>
+  typedef dealii::MatrixFreeOperators::CellwiseInverseMassMatrix<dim, -1, n_components, Number>
     CellwiseInverseMass;
 
   typedef std::pair<unsigned int, unsigned int> Range;
@@ -55,9 +53,9 @@ public:
   }
 
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const              dof_index_in,
-             unsigned int const              quad_index_in)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_in,
+             unsigned int const                      quad_index_in)
   {
     this->matrix_free = &matrix_free_in;
     dof_index         = dof_index_in;
@@ -74,7 +72,7 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const &,
+  cell_loop(dealii::MatrixFree<dim, Number> const &,
             VectorType &       dst,
             VectorType const & src,
             Range const &      cell_range) const
@@ -93,7 +91,7 @@ private:
     }
   }
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index, quad_index;
 };

--- a/include/exadg/operators/lazy_ptr.h
+++ b/include/exadg/operators/lazy_ptr.h
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename T>
 class lazy_ptr
 {

--- a/include/exadg/operators/mapping_flags.h
+++ b/include/exadg/operators/mapping_flags.h
@@ -22,16 +22,17 @@
 #ifndef INCLUDE_EXADG_OPERATORS_MAPPING_FLAGS_H_
 #define INCLUDE_EXADG_OPERATORS_MAPPING_FLAGS_H_
 
+// deal.II
 #include <deal.II/fe/fe_update_flags.h>
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct MappingFlags
 {
   MappingFlags()
-    : cells(update_default), inner_faces(update_default), boundary_faces(update_default)
+    : cells(dealii::update_default),
+      inner_faces(dealii::update_default),
+      boundary_faces(dealii::update_default)
   {
   }
 
@@ -47,9 +48,9 @@ struct MappingFlags
     return flags_combined;
   }
 
-  UpdateFlags cells;
-  UpdateFlags inner_faces;
-  UpdateFlags boundary_faces;
+  dealii::UpdateFlags cells;
+  dealii::UpdateFlags inner_faces;
+  dealii::UpdateFlags boundary_faces;
 };
 
 } // namespace ExaDG

--- a/include/exadg/operators/mass_kernel.h
+++ b/include/exadg/operators/mass_kernel.h
@@ -28,8 +28,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class MassKernel
 {
@@ -54,7 +52,7 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells = update_JxW_values;
+    flags.cells = dealii::update_JxW_values;
 
     // no face integrals
 

--- a/include/exadg/operators/mass_operator.cpp
+++ b/include/exadg/operators/mass_operator.cpp
@@ -23,8 +23,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, int n_components, typename Number>
 MassOperator<dim, n_components, Number>::MassOperator() : scaling_factor(1.0)
 {
@@ -33,9 +31,9 @@ MassOperator<dim, n_components, Number>::MassOperator() : scaling_factor(1.0)
 template<int dim, int n_components, typename Number>
 void
 MassOperator<dim, n_components, Number>::initialize(
-  MatrixFree<dim, Number> const &   matrix_free,
-  AffineConstraints<Number> const & affine_constraints,
-  MassOperatorData<dim> const &     data)
+  dealii::MatrixFree<dim, Number> const &   matrix_free,
+  dealii::AffineConstraints<Number> const & affine_constraints,
+  MassOperatorData<dim> const &             data)
 {
   Base::reinit(matrix_free, affine_constraints, data);
 

--- a/include/exadg/operators/mass_operator.h
+++ b/include/exadg/operators/mass_operator.h
@@ -28,8 +28,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
 struct MassOperatorData : public OperatorBaseData
 {
@@ -52,9 +50,9 @@ public:
   MassOperator();
 
   void
-  initialize(MatrixFree<dim, Number> const &   matrix_free,
-             AffineConstraints<Number> const & affine_constraints,
-             MassOperatorData<dim> const &     data);
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
+             dealii::AffineConstraints<Number> const & affine_constraints,
+             MassOperatorData<dim> const &             data);
 
   void
   set_scaling_factor(Number const & number);

--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -26,8 +26,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename Operator>
 class MultigridOperator : public MultigridOperatorBase<dim, Number>
 {
@@ -47,18 +45,18 @@ public:
   std::shared_ptr<Operator>
   get_pde_operator() const
   {
-    AssertThrow(pde_operator.get() != 0, ExcMessage("Invalid pointer"));
+    AssertThrow(pde_operator.get() != 0, dealii::ExcMessage("Invalid pointer"));
 
     return pde_operator;
   }
 
-  virtual AffineConstraints<typename Operator::value_type> const &
+  virtual dealii::AffineConstraints<typename Operator::value_type> const &
   get_affine_constraints() const
   {
     return pde_operator->get_affine_constraints();
   }
 
-  virtual MatrixFree<dim, Number> const &
+  virtual dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const
   {
     return pde_operator->get_matrix_free();
@@ -70,13 +68,13 @@ public:
     return pde_operator->get_dof_index();
   }
 
-  virtual types::global_dof_index
+  virtual dealii::types::global_dof_index
   m() const
   {
     return pde_operator->m();
   }
 
-  virtual types::global_dof_index
+  virtual dealii::types::global_dof_index
   n() const
   {
     return pde_operator->n();
@@ -138,14 +136,14 @@ public:
 
 #ifdef DEAL_II_WITH_TRILINOS
   virtual void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
-                     MPI_Comm const &                 mpi_comm) const
+  init_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                         mpi_comm) const
   {
     pde_operator->init_system_matrix(system_matrix, mpi_comm);
   }
 
   virtual void
-  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const
+  calculate_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix) const
   {
     pde_operator->calculate_system_matrix(system_matrix);
   }
@@ -153,14 +151,14 @@ public:
 
 #ifdef DEAL_II_WITH_PETSC
   virtual void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
-                     MPI_Comm const &                   mpi_comm) const
+  init_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                           mpi_comm) const
   {
     pde_operator->init_system_matrix(system_matrix, mpi_comm);
   }
 
   virtual void
-  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const
+  calculate_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix) const
   {
     pde_operator->calculate_system_matrix(system_matrix);
   }

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -22,20 +22,20 @@
 #ifndef OPERATOR_PRECONDITIONABLE_H
 #define OPERATOR_PRECONDITIONABLE_H
 
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/matrix_free/matrix_free.h>
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class MultigridOperatorBase : public dealii::Subscriptor
 {
 public:
-  typedef Number                                     value_type;
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef Number                                             value_type;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   MultigridOperatorBase() : dealii::Subscriptor()
   {
@@ -45,19 +45,19 @@ public:
   {
   }
 
-  virtual AffineConstraints<Number> const &
+  virtual dealii::AffineConstraints<Number> const &
   get_affine_constraints() const = 0;
 
-  virtual MatrixFree<dim, Number> const &
+  virtual dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const = 0;
 
   virtual unsigned int
   get_dof_index() const = 0;
 
-  virtual types::global_dof_index
+  virtual dealii::types::global_dof_index
   m() const = 0;
 
-  virtual types::global_dof_index
+  virtual dealii::types::global_dof_index
   n() const = 0;
 
   virtual Number
@@ -89,20 +89,20 @@ public:
 
 #ifdef DEAL_II_WITH_TRILINOS
   virtual void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
-                     MPI_Comm const &                 mpi_comm) const = 0;
+  init_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                         mpi_comm) const = 0;
 
   virtual void
-  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const = 0;
+  calculate_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix) const = 0;
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
   virtual void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
-                     MPI_Comm const &                   mpi_comm) const = 0;
+  init_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                           mpi_comm) const = 0;
 
   virtual void
-  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const = 0;
+  calculate_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix) const = 0;
 #endif
 };
 

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -54,8 +54,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct OperatorBaseData
 {
   OperatorBaseData()
@@ -93,16 +91,16 @@ class OperatorBase : public dealii::Subscriptor
 public:
   typedef OperatorBase<dim, Number, n_components> This;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
-  typedef std::pair<unsigned int, unsigned int>      Range;
-  typedef CellIntegrator<dim, n_components, Number>  IntegratorCell;
-  typedef FaceIntegrator<dim, n_components, Number>  IntegratorFace;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef std::pair<unsigned int, unsigned int>              Range;
+  typedef CellIntegrator<dim, n_components, Number>          IntegratorCell;
+  typedef FaceIntegrator<dim, n_components, Number>          IntegratorFace;
 
-  static unsigned int const vectorization_length = VectorizedArray<Number>::size();
+  static unsigned int const vectorization_length = dealii::VectorizedArray<Number>::size();
 
-  typedef std::vector<LAPACKFullMatrix<Number>> BlockMatrix;
+  typedef std::vector<dealii::LAPACKFullMatrix<Number>> BlockMatrix;
 
-  typedef FullMatrix<TrilinosScalar> FullMatrix_;
+  typedef dealii::FullMatrix<dealii::TrilinosScalar> FullMatrix_;
 
   OperatorBase();
 
@@ -122,10 +120,10 @@ public:
   unsigned int
   get_level() const;
 
-  AffineConstraints<Number> const &
+  dealii::AffineConstraints<Number> const &
   get_affine_constraints() const;
 
-  MatrixFree<dim, Number> const &
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const;
 
   unsigned int
@@ -153,10 +151,10 @@ public:
   void
   vmult_add_interface_up(VectorType & dst, VectorType const & src) const;
 
-  types::global_dof_index
+  dealii::types::global_dof_index
   m() const;
 
-  types::global_dof_index
+  dealii::types::global_dof_index
   n() const;
 
   Number
@@ -193,11 +191,11 @@ public:
    */
 #ifdef DEAL_II_WITH_TRILINOS
   void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
-                     MPI_Comm const &                 mpi_comm) const;
+  init_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                         mpi_comm) const;
 
   void
-  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
+  calculate_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix) const;
 #endif
 
   /*
@@ -205,11 +203,11 @@ public:
    */
 #ifdef DEAL_II_WITH_PETSC
   void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
-                     MPI_Comm const &                   mpi_comm) const;
+  init_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                           mpi_comm) const;
 
   void
-  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
+  calculate_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix) const;
 #endif
 
   /*
@@ -287,16 +285,16 @@ public:
   initialize_block_diagonal_preconditioner_matrix_free() const;
 
   void
-  apply_add_block_diagonal_elementwise(unsigned int const                    cell,
-                                       VectorizedArray<Number> * const       dst,
-                                       VectorizedArray<Number> const * const src,
-                                       unsigned int const                    problem_size) const;
+  apply_add_block_diagonal_elementwise(unsigned int const                            cell,
+                                       dealii::VectorizedArray<Number> * const       dst,
+                                       dealii::VectorizedArray<Number> const * const src,
+                                       unsigned int const problem_size) const;
 
 protected:
   void
-  reinit(MatrixFree<dim, Number> const &   matrix_free,
-         AffineConstraints<Number> const & constraints,
-         OperatorBaseData const &          data);
+  reinit(dealii::MatrixFree<dim, Number> const &   matrix_free,
+         dealii::AffineConstraints<Number> const & constraints,
+         OperatorBaseData const &                  data);
 
   /*
    * These methods have to be overwritten by derived classes because these functions are
@@ -319,13 +317,13 @@ protected:
   do_face_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
 
   virtual void
-  do_boundary_integral(IntegratorFace &           integrator,
-                       OperatorType const &       operator_type,
-                       types::boundary_id const & boundary_id) const;
+  do_boundary_integral(IntegratorFace &                   integrator,
+                       OperatorType const &               operator_type,
+                       dealii::types::boundary_id const & boundary_id) const;
 
   virtual void
-  do_boundary_integral_continuous(IntegratorFace &           integrator,
-                                  types::boundary_id const & boundary_id) const;
+  do_boundary_integral_continuous(IntegratorFace &                   integrator,
+                                  dealii::types::boundary_id const & boundary_id) const;
 
   // The computation of the diagonal and block-diagonal requires face integrals of type
   // interior (int) and exterior (ext)
@@ -337,9 +335,9 @@ protected:
 
   // cell-based computation of both cell and face integrals
   virtual void
-  reinit_face_cell_based(unsigned int const       cell,
-                         unsigned int const       face,
-                         types::boundary_id const boundary_id) const;
+  reinit_face_cell_based(unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const;
 
   // This function is currently only needed due to limitations of deal.II which do
   // currently not allow to access neighboring data in case of cell-based face loops.
@@ -355,7 +353,7 @@ protected:
   /*
    * Matrix-free object.
    */
-  mutable lazy_ptr<MatrixFree<dim, Number>> matrix_free;
+  mutable lazy_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   /*
    * Physical time (required for time-dependent problems).
@@ -365,9 +363,9 @@ protected:
   /*
    * Constraint matrix.
    */
-  mutable lazy_ptr<AffineConstraints<Number>> constraint;
+  mutable lazy_ptr<dealii::AffineConstraints<Number>> constraint;
 
-  mutable AffineConstraints<double> constraint_double;
+  mutable dealii::AffineConstraints<double> constraint_double;
 
   /*
    * Cell and face integrator flags.
@@ -391,8 +389,9 @@ protected:
   /*
    * Block Jacobi preconditioner/smoother: matrix-free version with elementwise iterative solver
    */
-  typedef Elementwise::OperatorBase<dim, Number, This>             ELEMENTWISE_OPERATOR;
-  typedef Elementwise::PreconditionerBase<VectorizedArray<Number>> ELEMENTWISE_PRECONDITIONER;
+  typedef Elementwise::OperatorBase<dim, Number, This> ELEMENTWISE_OPERATOR;
+  typedef Elementwise::PreconditionerBase<dealii::VectorizedArray<Number>>
+    ELEMENTWISE_PRECONDITIONER;
   typedef Elementwise::
     IterativeSolver<dim, n_components, Number, ELEMENTWISE_OPERATOR, ELEMENTWISE_PRECONDITIONER>
       ELEMENTWISE_SOLVER;
@@ -424,28 +423,28 @@ private:
    * This function applies Dirichlet BCs for continuous Galerkin discretizations.
    */
   void
-  cell_loop_dbc(MatrixFree<dim, Number> const & matrix_free,
-                VectorType &                    dst,
-                VectorType const &              src,
-                Range const &                   range) const;
+  cell_loop_dbc(dealii::MatrixFree<dim, Number> const & matrix_free,
+                VectorType &                            dst,
+                VectorType const &                      src,
+                Range const &                           range) const;
 
   /*
    * This function loops over all cells and calculates cell integrals.
    */
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           range) const;
 
   /*
    * This function loops over all interior faces and calculates face integrals.
    */
   void
-  face_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   range) const;
+  face_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           range) const;
 
   /*
    * The following functions loop over all boundary faces and calculate boundary face integrals.
@@ -455,24 +454,24 @@ private:
 
   // homogeneous operator
   void
-  boundary_face_loop_hom_operator(MatrixFree<dim, Number> const & matrix_free,
-                                  VectorType &                    dst,
-                                  VectorType const &              src,
-                                  Range const &                   range) const;
+  boundary_face_loop_hom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                  VectorType &                            dst,
+                                  VectorType const &                      src,
+                                  Range const &                           range) const;
 
   // inhomogeneous operator
   void
-  boundary_face_loop_inhom_operator(MatrixFree<dim, Number> const & matrix_free,
-                                    VectorType &                    dst,
-                                    VectorType const &              src,
-                                    Range const &                   range) const;
+  boundary_face_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                    VectorType &                            dst,
+                                    VectorType const &                      src,
+                                    Range const &                           range) const;
 
   // full operator
   void
-  boundary_face_loop_full_operator(MatrixFree<dim, Number> const & matrix_free,
-                                   VectorType &                    dst,
-                                   VectorType const &              src,
-                                   Range const &                   range) const;
+  boundary_face_loop_full_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                   VectorType &                            dst,
+                                   VectorType const &                      src,
+                                   Range const &                           range) const;
 
   /*
    * inhomogeneous operator: For the inhomogeneous operator, we only have to calculate boundary face
@@ -480,80 +479,80 @@ private:
    * integrals only. Hence we have to provide empty functions for cell and interior face integrals.
    */
   void
-  cell_loop_empty(MatrixFree<dim, Number> const & matrix_free,
-                  VectorType &                    dst,
-                  VectorType const &              src,
-                  Range const &                   range) const;
+  cell_loop_empty(dealii::MatrixFree<dim, Number> const & matrix_free,
+                  VectorType &                            dst,
+                  VectorType const &                      src,
+                  Range const &                           range) const;
 
   void
-  face_loop_empty(MatrixFree<dim, Number> const & matrix_free,
-                  VectorType &                    dst,
-                  VectorType const &              src,
-                  Range const &                   range) const;
+  face_loop_empty(dealii::MatrixFree<dim, Number> const & matrix_free,
+                  VectorType &                            dst,
+                  VectorType const &                      src,
+                  Range const &                           range) const;
 
   /*
    * Calculate diagonal.
    */
   void
-  cell_loop_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                     VectorType &                    dst,
-                     VectorType const &              src,
-                     Range const &                   range) const;
+  cell_loop_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                     VectorType &                            dst,
+                     VectorType const &                      src,
+                     Range const &                           range) const;
 
   void
-  face_loop_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                     VectorType &                    dst,
-                     VectorType const &              src,
-                     Range const &                   range) const;
+  face_loop_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                     VectorType &                            dst,
+                     VectorType const &                      src,
+                     Range const &                           range) const;
 
   void
-  boundary_face_loop_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                              VectorType &                    dst,
-                              VectorType const &              src,
-                              Range const &                   range) const;
+  boundary_face_loop_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                              VectorType &                            dst,
+                              VectorType const &                      src,
+                              Range const &                           range) const;
 
   void
-  cell_based_loop_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                           VectorType &                    dst,
-                           VectorType const &              src,
-                           Range const &                   range) const;
+  cell_based_loop_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           VectorType &                            dst,
+                           VectorType const &                      src,
+                           Range const &                           range) const;
 
   /*
    * Calculate (assemble) block diagonal.
    */
   void
-  cell_loop_block_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                           BlockMatrix &                   matrices,
-                           BlockMatrix const &             src,
-                           Range const &                   range) const;
+  cell_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           BlockMatrix &                           matrices,
+                           BlockMatrix const &                     src,
+                           Range const &                           range) const;
 
   void
-  face_loop_block_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                           BlockMatrix &                   matrices,
-                           BlockMatrix const &             src,
-                           Range const &                   range) const;
+  face_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           BlockMatrix &                           matrices,
+                           BlockMatrix const &                     src,
+                           Range const &                           range) const;
 
   void
-  boundary_face_loop_block_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                                    BlockMatrix &                   matrices,
-                                    BlockMatrix const &             src,
-                                    Range const &                   range) const;
+  boundary_face_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                    BlockMatrix &                           matrices,
+                                    BlockMatrix const &                     src,
+                                    Range const &                           range) const;
 
   // cell-based variant for computation of both cell and face integrals
   void
-  cell_based_loop_block_diagonal(MatrixFree<dim, Number> const & matrix_free,
-                                 BlockMatrix &                   matrices,
-                                 BlockMatrix const &             src,
-                                 Range const &                   range) const;
+  cell_based_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                 BlockMatrix &                           matrices,
+                                 BlockMatrix const &                     src,
+                                 Range const &                           range) const;
 
   /*
    * Apply block diagonal.
    */
   void
-  cell_loop_apply_block_diagonal_matrix_based(MatrixFree<dim, Number> const & matrix_free,
-                                              VectorType &                    dst,
-                                              VectorType const &              src,
-                                              Range const &                   range) const;
+  cell_loop_apply_block_diagonal_matrix_based(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                              VectorType &                            dst,
+                                              VectorType const &                      src,
+                                              Range const &                           range) const;
 
   /*
    * Apply inverse block diagonal:
@@ -562,10 +561,11 @@ private:
    * should have already been performed with the method update_inverse_block_diagonal())
    */
   void
-  cell_loop_apply_inverse_block_diagonal_matrix_based(MatrixFree<dim, Number> const & matrix_free,
-                                                      VectorType &                    dst,
-                                                      VectorType const &              src,
-                                                      Range const &                   range) const;
+  cell_loop_apply_inverse_block_diagonal_matrix_based(
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           range) const;
 
   /*
    * Set up sparse matrix internally for templated matrix type (Trilinos or
@@ -584,24 +584,24 @@ private:
    */
   template<typename SparseMatrix>
   void
-  cell_loop_calculate_system_matrix(MatrixFree<dim, Number> const & matrix_free,
-                                    SparseMatrix &                  dst,
-                                    SparseMatrix const &            src,
-                                    Range const &                   range) const;
+  cell_loop_calculate_system_matrix(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                    SparseMatrix &                          dst,
+                                    SparseMatrix const &                    src,
+                                    Range const &                           range) const;
 
   template<typename SparseMatrix>
   void
-  face_loop_calculate_system_matrix(MatrixFree<dim, Number> const & matrix_free,
-                                    SparseMatrix &                  dst,
-                                    SparseMatrix const &            src,
-                                    Range const &                   range) const;
+  face_loop_calculate_system_matrix(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                    SparseMatrix &                          dst,
+                                    SparseMatrix const &                    src,
+                                    Range const &                           range) const;
 
   template<typename SparseMatrix>
   void
-  boundary_face_loop_calculate_system_matrix(MatrixFree<dim, Number> const & matrix_free,
-                                             SparseMatrix &                  dst,
-                                             SparseMatrix const &            src,
-                                             Range const &                   range) const;
+  boundary_face_loop_calculate_system_matrix(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                             SparseMatrix &                          dst,
+                                             SparseMatrix const &                    src,
+                                             Range const &                           range) const;
 
   /*
    * This function sets entries in the diagonal corresponding to constraint DoFs to one.
@@ -623,14 +623,14 @@ private:
 
   /*
    * Multigrid level: 0 <= level <= max_level. If the operator is not used as a multigrid
-   * level operator, this variable takes a value of numbers::invalid_unsigned_int.
+   * level operator, this variable takes a value of dealii::numbers::invalid_unsigned_int.
    */
   unsigned int level;
 
   /*
    * Vector of matrices for block-diagonal preconditioners.
    */
-  mutable std::vector<LAPACKFullMatrix<Number>> matrices;
+  mutable std::vector<dealii::LAPACKFullMatrix<Number>> matrices;
 
   /*
    * We want to initialize the block diagonal preconditioner (block diagonal matrices or elementwise

--- a/include/exadg/operators/rhs_operator.cpp
+++ b/include/exadg/operators/rhs_operator.cpp
@@ -23,8 +23,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, int n_components>
 RHSOperator<dim, Number, n_components>::RHSOperator() : matrix_free(nullptr), time(0.0)
 {
@@ -32,8 +30,9 @@ RHSOperator<dim, Number, n_components>::RHSOperator() : matrix_free(nullptr), ti
 
 template<int dim, typename Number, int n_components>
 void
-RHSOperator<dim, Number, n_components>::initialize(MatrixFree<dim, Number> const & matrix_free_in,
-                                                   RHSOperatorData<dim> const &    data_in)
+RHSOperator<dim, Number, n_components>::initialize(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  RHSOperatorData<dim> const &            data_in)
 {
   this->matrix_free = &matrix_free_in;
   this->data        = data_in;
@@ -75,10 +74,11 @@ RHSOperator<dim, Number, n_components>::do_cell_integral(IntegratorCell & integr
 
 template<int dim, typename Number, int n_components>
 void
-RHSOperator<dim, Number, n_components>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                                  VectorType &                    dst,
-                                                  VectorType const &              src,
-                                                  Range const &                   cell_range) const
+RHSOperator<dim, Number, n_components>::cell_loop(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           cell_range) const
 {
   (void)src;
 

--- a/include/exadg/operators/rhs_operator.h
+++ b/include/exadg/operators/rhs_operator.h
@@ -28,14 +28,12 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 namespace Operators
 {
 template<int dim>
 struct RHSKernelData
 {
-  std::shared_ptr<Function<dim>> f;
+  std::shared_ptr<dealii::Function<dim>> f;
 };
 
 template<int dim, typename Number, int n_components = 1>
@@ -45,10 +43,10 @@ private:
   typedef CellIntegrator<dim, n_components, Number> IntegratorCell;
 
   static unsigned int const rank =
-    (n_components == 1) ? 0 : ((n_components == dim) ? 1 : numbers::invalid_unsigned_int);
+    (n_components == 1) ? 0 : ((n_components == dim) ? 1 : dealii::numbers::invalid_unsigned_int);
 
-  typedef VectorizedArray<Number>   scalar;
-  typedef Tensor<rank, dim, scalar> value;
+  typedef dealii::VectorizedArray<Number>   scalar;
+  typedef dealii::Tensor<rank, dim, scalar> value;
 
 public:
   void
@@ -62,7 +60,8 @@ public:
   {
     MappingFlags flags;
 
-    flags.cells = update_JxW_values | update_quadrature_points; // q-points due to rhs function f
+    flags.cells = dealii::update_JxW_values |
+                  dealii::update_quadrature_points; // q-points due to rhs function f
 
     // no face integrals
 
@@ -78,7 +77,7 @@ public:
                     unsigned int const     q,
                     Number const &         time) const
   {
-    Point<dim, scalar> q_points = integrator.quadrature_point(q);
+    dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
     return FunctionEvaluator<rank, dim, Number>::value(data.f, q_points, time);
   }
@@ -107,7 +106,7 @@ template<int dim, typename Number, int n_components = 1>
 class RHSOperator
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef RHSOperator<dim, Number, n_components> This;
 
@@ -125,7 +124,8 @@ public:
    * Initialization.
    */
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free, RHSOperatorData<dim> const & data);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             RHSOperatorData<dim> const &            data);
 
   /*
    * Evaluate operator and overwrite dst-vector.
@@ -148,12 +148,12 @@ private:
    * over all cells and computing the cell integrals.
    */
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   RHSOperatorData<dim> data;
 

--- a/include/exadg/operators/variable_coefficients.h
+++ b/include/exadg/operators/variable_coefficients.h
@@ -23,24 +23,22 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class VariableCoefficientsCells
 {
 private:
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
 public:
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free,
-             unsigned int const              degree,
-             Number const &                  constant_coefficient)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             unsigned int const                      degree,
+             Number const &                          constant_coefficient)
   {
-    unsigned int const points_per_cell = Utilities::pow(degree + 1, dim);
+    unsigned int const points_per_cell = dealii::Utilities::pow(degree + 1, dim);
 
     coefficients_cell.reinit(matrix_free.n_cell_batches(), points_per_cell);
-    coefficients_cell.fill(make_vectorized_array<Number>(constant_coefficient));
+    coefficients_cell.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
   }
 
   scalar
@@ -57,45 +55,45 @@ public:
 
 private:
   // variable coefficients
-  Table<2, scalar> coefficients_cell;
+  dealii::Table<2, scalar> coefficients_cell;
 };
 
 template<int dim, typename Number>
 class VariableCoefficients
 {
 private:
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
 public:
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free,
-             unsigned int const              degree,
-             Number const &                  constant_coefficient)
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             unsigned int const                      degree,
+             Number const &                          constant_coefficient)
   {
-    unsigned int const points_per_cell = Utilities::pow(degree + 1, dim);
-    unsigned int const points_per_face = Utilities::pow(degree + 1, dim - 1);
+    unsigned int const points_per_cell = dealii::Utilities::pow(degree + 1, dim);
+    unsigned int const points_per_face = dealii::Utilities::pow(degree + 1, dim - 1);
 
     // cells
     coefficients_cell.reinit(matrix_free.n_cell_batches(), points_per_cell);
 
-    coefficients_cell.fill(make_vectorized_array<Number>(constant_coefficient));
+    coefficients_cell.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
 
     // face-based loops
     coefficients_face.reinit(matrix_free.n_inner_face_batches() +
                                matrix_free.n_boundary_face_batches(),
                              points_per_face);
 
-    coefficients_face.fill(make_vectorized_array<Number>(constant_coefficient));
+    coefficients_face.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
 
     coefficients_face_neighbor.reinit(matrix_free.n_inner_face_batches(), points_per_face);
 
-    coefficients_face_neighbor.fill(make_vectorized_array<Number>(constant_coefficient));
+    coefficients_face_neighbor.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
 
     // TODO cell-based face loops
     //    coefficients_face_cell_based.reinit(matrix_free.n_cell_batches()*2*dim,
     //        points_per_face);
     //
-    //    coefficients_face_cell_based.fill(make_vectorized_array<Number>(constant_coefficient));
+    //    coefficients_face_cell_based.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
   }
 
   scalar
@@ -154,15 +152,15 @@ private:
   // variable coefficients
 
   // cell
-  Table<2, scalar> coefficients_cell;
+  dealii::Table<2, scalar> coefficients_cell;
 
   // face-based loops
-  Table<2, scalar> coefficients_face;
-  Table<2, scalar> coefficients_face_neighbor;
+  dealii::Table<2, scalar> coefficients_face;
+  dealii::Table<2, scalar> coefficients_face_neighbor;
 
   // TODO
   //  // cell-based face loops
-  //  Table<2, scalar> coefficients_face_cell_based;
+  //  dealii::Table<2, scalar> coefficients_face_cell_based;
 };
 
 } // namespace ExaDG

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -42,8 +42,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 enum class OperatorType
 {
   MatrixFree,
@@ -60,7 +58,7 @@ enum_to_string(OperatorType const enum_type)
     // clang-format off
     case OperatorType::MatrixFree:  string_type = "MatrixFree";  break;
     case OperatorType::MatrixBased: string_type = "MatrixBased"; break;
-    default: AssertThrow(false, ExcMessage("Not implemented.")); break;
+    default: AssertThrow(false, dealii::ExcMessage("Not implemented.")); break;
       // clang-format on
   }
 
@@ -73,7 +71,7 @@ string_to_enum(OperatorType & enum_type, std::string const string_type)
   // clang-format off
   if     (string_type == "MatrixFree")  enum_type = OperatorType::MatrixFree;
   else if(string_type == "MatrixBased") enum_type = OperatorType::MatrixBased;
-  else AssertThrow(false, ExcMessage("Unknown operator type. Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Unknown operator type. Not implemented."));
   // clang-format on
 }
 
@@ -84,12 +82,12 @@ get_dofs_per_element(std::string const & input_file,
 {
   std::string spatial_discretization = "DG";
 
-  ParameterHandler prm;
+  dealii::ParameterHandler prm;
   prm.enter_subsection("Discretization");
   prm.add_parameter("SpatialDiscretization",
                     spatial_discretization,
                     "Spatial discretization (CG vs. DG).",
-                    Patterns::Selection("CG|DG"),
+                    dealii::Patterns::Selection("CG|DG"),
                     true);
   prm.leave_subsection();
 
@@ -98,11 +96,11 @@ get_dofs_per_element(std::string const & input_file,
   unsigned int dofs_per_element = 1;
 
   if(spatial_discretization == "CG")
-    dofs_per_element = Utilities::pow(degree, dim);
+    dofs_per_element = dealii::Utilities::pow(degree, dim);
   else if(spatial_discretization == "DG")
-    dofs_per_element = Utilities::pow(degree + 1, dim);
+    dofs_per_element = dealii::Utilities::pow(degree + 1, dim);
   else
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
 
   return dofs_per_element;
 }
@@ -128,7 +126,7 @@ public:
   /*
    * Throughput study
    */
-  std::tuple<unsigned int, types::global_dof_index, double>
+  std::tuple<unsigned int, dealii::types::global_dof_index, double>
   apply_operator(std::string const & operator_type_string,
                  unsigned int const  n_repetitions_inner,
                  unsigned int const  n_repetitions_outer) const;
@@ -138,7 +136,7 @@ private:
   MPI_Comm const mpi_comm;
 
   // output to std::cout
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -149,8 +147,8 @@ private:
   // application
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
 
   std::shared_ptr<Operator<dim, Number>> pde_operator;
 

--- a/include/exadg/poisson/postprocessor/postprocessor.cpp
+++ b/include/exadg/poisson/postprocessor/postprocessor.cpp
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data_in,
                                           MPI_Comm const &               mpi_comm_in)
@@ -40,8 +38,8 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data
 
 template<int dim, typename Number>
 void
-PostProcessor<dim, Number>::setup(DoFHandler<dim, dim> const & dof_handler,
-                                  Mapping<dim> const &         mapping)
+PostProcessor<dim, Number>::setup(dealii::DoFHandler<dim, dim> const & dof_handler,
+                                  dealii::Mapping<dim> const &         mapping)
 {
   error_calculator.setup(dof_handler, mapping, pp_data.error_data);
 

--- a/include/exadg/poisson/postprocessor/postprocessor.h
+++ b/include/exadg/poisson/postprocessor/postprocessor.h
@@ -35,8 +35,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim>
 struct PostProcessorData
 {
@@ -60,7 +58,8 @@ public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
   void
-  setup(DoFHandler<dim, dim> const & dof_handler, Mapping<dim> const & mapping) override;
+  setup(dealii::DoFHandler<dim, dim> const & dof_handler,
+        dealii::Mapping<dim> const &         mapping) override;
 
   void
   do_postprocessing(VectorType const & solution,

--- a/include/exadg/poisson/postprocessor/postprocessor_base.h
+++ b/include/exadg/poisson/postprocessor/postprocessor_base.h
@@ -32,13 +32,11 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<typename Number>
 class PostProcessorInterface
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   virtual ~PostProcessorInterface()
   {
@@ -62,7 +60,7 @@ public:
   }
 
   virtual void
-  setup(DoFHandler<dim, dim> const & dof_handler, Mapping<dim> const & mapping) = 0;
+  setup(dealii::DoFHandler<dim, dim> const & dof_handler, dealii::Mapping<dim> const & mapping) = 0;
 };
 
 } // namespace Poisson

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim, typename Number, int n_components>
 MultigridPreconditioner<dim, Number, n_components>::MultigridPreconditioner(
   MPI_Comm const & mpi_comm)
@@ -37,14 +35,14 @@ MultigridPreconditioner<dim, Number, n_components>::MultigridPreconditioner(
 template<int dim, typename Number, int n_components>
 void
 MultigridPreconditioner<dim, Number, n_components>::initialize(
-  MultigridData const &                  mg_data,
-  Triangulation<dim> const *             tria,
-  FiniteElement<dim> const &             fe,
-  std::shared_ptr<Mapping<dim> const>    mapping,
-  LaplaceOperatorData<rank, dim> const & data_in,
-  bool const                             mesh_is_moving,
-  Map const *                            dirichlet_bc,
-  PeriodicFacePairs const *              periodic_face_pairs)
+  MultigridData const &                       mg_data,
+  dealii::Triangulation<dim> const *          tria,
+  dealii::FiniteElement<dim> const &          fe,
+  std::shared_ptr<dealii::Mapping<dim> const> mapping,
+  LaplaceOperatorData<rank, dim> const &      data_in,
+  bool const                                  mesh_is_moving,
+  Map const *                                 dirichlet_bc,
+  PeriodicFacePairs const *                   periodic_face_pairs)
 {
   data = data_in;
 
@@ -93,29 +91,29 @@ MultigridPreconditioner<dim, Number, n_components>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops && this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> const *>(
+    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
       &this->dof_handlers[level]->get_triangulation());
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, h_level);
   }
 
   matrix_free_data.insert_dof_handler(&(*this->dof_handlers[level]), "laplace_dof_handler");
   matrix_free_data.insert_constraint(&(*this->constraints[level]), "laplace_dof_handler");
-  matrix_free_data.insert_quadrature(QGauss<1>(this->level_info[level].degree() + 1),
+  matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
                                      "laplace_quadrature");
 }
 
 template<int dim, typename Number, int n_components>
 void
 MultigridPreconditioner<dim, Number, n_components>::initialize_constrained_dofs(
-  DoFHandler<dim> const & dof_handler,
-  MGConstrainedDoFs &     constrained_dofs,
-  Map const &             dirichlet_bc)
+  dealii::DoFHandler<dim> const & dof_handler,
+  dealii::MGConstrainedDoFs &     constrained_dofs,
+  Map const &                     dirichlet_bc)
 {
   // TODO: use the same code as for CG case below (which currently segfaults
   // if used for DG case as well)
   if(is_dg)
   {
-    std::set<types::boundary_id> dirichlet_boundary;
+    std::set<dealii::types::boundary_id> dirichlet_boundary;
     for(auto & it : dirichlet_bc)
       dirichlet_boundary.insert(it.first);
     constrained_dofs.initialize(dof_handler);
@@ -129,11 +127,11 @@ MultigridPreconditioner<dim, Number, n_components>::initialize_constrained_dofs(
     constrained_dofs.initialize(dof_handler);
     for(auto it : data.bc->dirichlet_bc)
     {
-      std::set<types::boundary_id> dirichlet_boundary;
+      std::set<dealii::types::boundary_id> dirichlet_boundary;
       dirichlet_boundary.insert(it.first);
 
-      ComponentMask mask    = ComponentMask();
-      auto          it_mask = data.bc->dirichlet_bc_component_mask.find(it.first);
+      dealii::ComponentMask mask    = dealii::ComponentMask();
+      auto                  it_mask = data.bc->dirichlet_bc_component_mask.find(it.first);
       if(it_mask != data.bc->dirichlet_bc_component_mask.end())
         mask = it_mask->second;
 

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 /*
  *  Multigrid preconditioner for Laplace operator.
  */
@@ -46,7 +44,7 @@ public:
 
 private:
   static unsigned int const rank =
-    (n_components == 1) ? 0 : ((n_components == dim) ? 1 : numbers::invalid_unsigned_int);
+    (n_components == 1) ? 0 : ((n_components == dim) ? 1 : dealii::numbers::invalid_unsigned_int);
 
   typedef typename Base::Map               Map;
   typedef typename Base::PeriodicFacePairs PeriodicFacePairs;
@@ -60,14 +58,14 @@ public:
   MultigridPreconditioner(MPI_Comm const & mpi_comm);
 
   void
-  initialize(MultigridData const &                  mg_data,
-             Triangulation<dim> const *             tria,
-             FiniteElement<dim> const &             fe,
-             std::shared_ptr<Mapping<dim> const>    mapping,
-             LaplaceOperatorData<rank, dim> const & data_in,
-             bool const                             mesh_is_moving,
-             Map const *                            dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *              periodic_face_pairs = nullptr);
+  initialize(MultigridData const &                       mg_data,
+             dealii::Triangulation<dim> const *          tria,
+             dealii::FiniteElement<dim> const &          fe,
+             std::shared_ptr<dealii::Mapping<dim> const> mapping,
+             LaplaceOperatorData<rank, dim> const &      data_in,
+             bool const                                  mesh_is_moving,
+             Map const *                                 dirichlet_bc        = nullptr,
+             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
 
   void
   update() override;
@@ -79,12 +77,12 @@ private:
                         unsigned int const                     h_level) override;
 
   /*
-   * Has to be overwritten since we want to use ComponentMask here
+   * Has to be overwritten since we want to use dealii::ComponentMask here
    */
   void
-  initialize_constrained_dofs(DoFHandler<dim> const & dof_handler,
-                              MGConstrainedDoFs &     constrained_dofs,
-                              Map const &             dirichlet_bc) override;
+  initialize_constrained_dofs(dealii::DoFHandler<dim> const & dof_handler,
+                              dealii::MGConstrainedDoFs &     constrained_dofs,
+                              Map const &                     dirichlet_bc) override;
 
 
   std::shared_ptr<MGOperatorBase>

--- a/include/exadg/poisson/solver.h
+++ b/include/exadg/poisson/solver.h
@@ -74,7 +74,7 @@ run(std::vector<SolverResult> & results,
     MPI_Comm const &            mpi_comm,
     bool const                  is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<Poisson::ApplicationBase<dim, Number>> application =

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -30,14 +30,12 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::initialize(
-  MatrixFree<dim, Number> const &        matrix_free,
-  AffineConstraints<Number> const &      affine_constraints,
-  LaplaceOperatorData<rank, dim> const & data)
+  dealii::MatrixFree<dim, Number> const &   matrix_free,
+  dealii::AffineConstraints<Number> const & affine_constraints,
+  LaplaceOperatorData<rank, dim> const &    data)
 {
   operator_data = data;
 
@@ -51,8 +49,8 @@ LaplaceOperator<dim, Number, n_components>::initialize(
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::calculate_penalty_parameter(
-  MatrixFree<dim, Number> const & matrix_free,
-  unsigned int const              dof_index)
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  unsigned int const                      dof_index)
 {
   kernel.calculate_penalty_parameter(matrix_free, dof_index);
 }
@@ -106,9 +104,9 @@ LaplaceOperator<dim, Number, n_components>::reinit_boundary_face(unsigned int co
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::reinit_face_cell_based(
-  unsigned int const       cell,
-  unsigned int const       face,
-  types::boundary_id const boundary_id) const
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
 {
   Base::reinit_face_cell_based(cell, face, boundary_id);
 
@@ -210,9 +208,9 @@ LaplaceOperator<dim, Number, n_components>::do_face_ext_integral(
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::do_boundary_integral(
-  IntegratorFace &           integrator_m,
-  OperatorType const &       operator_type,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator_m,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -256,10 +254,10 @@ LaplaceOperator<dim, Number, n_components>::do_boundary_integral(
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::cell_loop_empty(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           range) const
 {
   (void)matrix_free;
   (void)dst;
@@ -272,10 +270,10 @@ LaplaceOperator<dim, Number, n_components>::cell_loop_empty(
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::face_loop_empty(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           range) const
 {
   (void)matrix_free;
   (void)dst;
@@ -289,10 +287,10 @@ template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::
   boundary_face_loop_inhom_operator_dirichlet_bc_from_dof_vector(
-    MatrixFree<dim, Number> const & matrix_free,
-    VectorType &                    dst,
-    VectorType const &              src,
-    Range const &                   range) const
+    dealii::MatrixFree<dim, Number> const & matrix_free,
+    VectorType &                            dst,
+    VectorType const &                      src,
+    Range const &                           range) const
 {
   for(unsigned int face = range.first; face < range.second; face++)
   {
@@ -317,9 +315,9 @@ LaplaceOperator<dim, Number, n_components>::
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::do_boundary_integral_dirichlet_bc_from_dof_vector(
-  IntegratorFace &           integrator_m,
-  OperatorType const &       operator_type,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator_m,
+  OperatorType const &               operator_type,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -331,7 +329,8 @@ LaplaceOperator<dim, Number, n_components>::do_boundary_integral_dirichlet_bc_fr
     // deviating from the standard boundary_face_loop_inhom_operator() function,
     // because the boundary condition comes from the vector src
     Assert(operator_type == OperatorType::inhomogeneous,
-           ExcMessage("This function is only implemented for OperatorType::inhomogeneous."));
+           dealii::ExcMessage(
+             "This function is only implemented for OperatorType::inhomogeneous."));
 
     value value_p = value();
     if(boundary_type == BoundaryType::Dirichlet)
@@ -344,7 +343,8 @@ LaplaceOperator<dim, Number, n_components>::do_boundary_integral_dirichlet_bc_fr
     }
     else
     {
-      AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+      AssertThrow(false,
+                  dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
     }
 
     value gradient_flux = kernel.calculate_gradient_flux(value_m, value_p);
@@ -374,8 +374,8 @@ LaplaceOperator<dim, Number, n_components>::do_boundary_integral_dirichlet_bc_fr
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::do_boundary_integral_continuous(
-  IntegratorFace &           integrator_m,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator_m,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -394,23 +394,23 @@ LaplaceOperator<dim, Number, n_components>::set_constrained_values(VectorType & 
                                                                    double const time) const
 {
   // standard Dirichlet boundary conditions
-  std::map<types::global_dof_index, double> boundary_values;
+  std::map<dealii::types::global_dof_index, double> boundary_values;
   for(auto dbc : operator_data.bc->dirichlet_bc)
   {
     dbc.second->set_time(time);
 
-    ComponentMask mask     = ComponentMask();
-    auto          dbc_mask = operator_data.bc->dirichlet_bc_component_mask.find(dbc.first);
+    dealii::ComponentMask mask     = dealii::ComponentMask();
+    auto                  dbc_mask = operator_data.bc->dirichlet_bc_component_mask.find(dbc.first);
     if(dbc_mask != operator_data.bc->dirichlet_bc_component_mask.end())
       mask = dbc_mask->second;
 
-    VectorTools::interpolate_boundary_values(*this->matrix_free->get_mapping_info().mapping,
-                                             this->matrix_free->get_dof_handler(
-                                               operator_data.dof_index),
-                                             dbc.first,
-                                             *dbc.second,
-                                             boundary_values,
-                                             mask);
+    dealii::VectorTools::interpolate_boundary_values(*this->matrix_free->get_mapping_info().mapping,
+                                                     this->matrix_free->get_dof_handler(
+                                                       operator_data.dof_index),
+                                                     dbc.first,
+                                                     *dbc.second,
+                                                     boundary_values,
+                                                     mask);
   }
 
   // set Dirichlet values in solution vector
@@ -433,7 +433,7 @@ LaplaceOperator<dim, Number, n_components>::set_constrained_values(VectorType & 
         this->matrix_free->n_inner_face_batches() + this->matrix_free->n_boundary_face_batches();
         ++face)
     {
-      types::boundary_id const boundary_id = this->matrix_free->get_boundary_id(face);
+      dealii::types::boundary_id const boundary_id = this->matrix_free->get_boundary_id(face);
 
       BoundaryType const boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -450,7 +450,7 @@ LaplaceOperator<dim, Number, n_components>::set_constrained_values(VectorType & 
           unsigned int const index = this->matrix_free->get_shape_info(dof_index, quad_index)
                                        .face_to_cell_index_nodal[local_face_number][q];
 
-          Tensor<rank, dim, VectorizedArray<Number>> g;
+          dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> g;
 
           if(boundary_type == BoundaryType::DirichletMortar)
           {
@@ -460,7 +460,7 @@ LaplaceOperator<dim, Number, n_components>::set_constrained_values(VectorType & 
           }
           else
           {
-            AssertThrow(false, ExcMessage("Not implemented."));
+            AssertThrow(false, dealii::ExcMessage("Not implemented."));
           }
 
           integrator.submit_dof_value(g, index);
@@ -472,7 +472,7 @@ LaplaceOperator<dim, Number, n_components>::set_constrained_values(VectorType & 
       {
         AssertThrow(boundary_type == BoundaryType::Dirichlet ||
                       boundary_type == BoundaryType::Neumann,
-                    ExcMessage("BoundaryType not implemented."));
+                    dealii::ExcMessage("BoundaryType not implemented."));
       }
     }
   }

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -37,19 +37,17 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim, typename Number, int n_components = 1>
 class Operator : public dealii::Subscriptor
 {
 private:
   static unsigned int const rank =
-    (n_components == 1) ? 0 : ((n_components == dim) ? 1 : numbers::invalid_unsigned_int);
+    (n_components == 1) ? 0 : ((n_components == dim) ? 1 : dealii::numbers::invalid_unsigned_int);
 
   typedef LaplaceOperator<dim, Number, n_components> Laplace;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
-  typedef LinearAlgebra::distributed::Vector<double> VectorTypeDouble;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<double> VectorTypeDouble;
 
 public:
   Operator(std::shared_ptr<Grid<dim> const>                     grid,
@@ -63,8 +61,8 @@ public:
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
 
   void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data);
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data);
 
   void
   setup_solver();
@@ -87,10 +85,10 @@ public:
   unsigned int
   solve(VectorType & sol, VectorType const & rhs, double const time) const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler() const;
 
-  types::global_dof_index
+  dealii::types::global_dof_index
   get_number_of_dofs() const;
 
   double
@@ -113,30 +111,30 @@ public:
 
 #ifdef DEAL_II_WITH_TRILINOS
   void
-  init_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix,
-                     MPI_Comm const &                 mpi_comm) const;
+  init_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix,
+                     MPI_Comm const &                         mpi_comm) const;
 
   void
-  calculate_system_matrix(TrilinosWrappers::SparseMatrix & system_matrix) const;
+  calculate_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix) const;
 
   void
-  vmult_matrix_based(VectorTypeDouble &                     dst,
-                     TrilinosWrappers::SparseMatrix const & system_matrix,
-                     VectorTypeDouble const &               src) const;
+  vmult_matrix_based(VectorTypeDouble &                             dst,
+                     dealii::TrilinosWrappers::SparseMatrix const & system_matrix,
+                     VectorTypeDouble const &                       src) const;
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
   void
-  init_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix,
-                     MPI_Comm const &                   mpi_comm) const;
+  init_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix,
+                     MPI_Comm const &                           mpi_comm) const;
 
   void
-  calculate_system_matrix(PETScWrappers::MPI::SparseMatrix & system_matrix) const;
+  calculate_system_matrix(dealii::PETScWrappers::MPI::SparseMatrix & system_matrix) const;
 
   void
-  vmult_matrix_based(VectorTypeDouble &                       dst,
-                     PETScWrappers::MPI::SparseMatrix const & system_matrix,
-                     VectorTypeDouble const &                 src) const;
+  vmult_matrix_based(VectorTypeDouble &                               dst,
+                     dealii::PETScWrappers::MPI::SparseMatrix const & system_matrix,
+                     VectorTypeDouble const &                         src) const;
 #endif
 
 private:
@@ -176,18 +174,18 @@ private:
   /*
    * Basic finite element ingredients.
    */
-  std::shared_ptr<FiniteElement<dim>> fe;
+  std::shared_ptr<dealii::FiniteElement<dim>> fe;
 
-  DoFHandler<dim> dof_handler;
+  dealii::DoFHandler<dim> dof_handler;
 
-  mutable AffineConstraints<Number> affine_constraints;
+  mutable dealii::AffineConstraints<Number> affine_constraints;
 
   std::string const dof_index                = "laplace";
   std::string const quad_index               = "laplace";
   std::string const quad_index_gauss_lobatto = "laplace_gauss_lobatto";
 
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
 
   RHSOperator<dim, Number, n_components> rhs_operator;
 
@@ -204,7 +202,7 @@ private:
   /*
    * Output to screen.
    */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 };
 } // namespace Poisson
 } // namespace ExaDG

--- a/include/exadg/poisson/spatial_discretization/weak_boundary_conditions.h
+++ b/include/exadg/poisson/spatial_discretization/weak_boundary_conditions.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 /*
  *  The following two functions calculate the interior_value/exterior_value
  *  depending on the operator type, the type of the boundary face
@@ -49,7 +47,7 @@ using namespace dealii;
  */
 template<int dim, typename Number, int n_components, int rank>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<rank, dim, VectorizedArray<Number>>
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
   calculate_interior_value(unsigned int const                                q,
                            FaceIntegrator<dim, n_components, Number> const & integrator,
                            OperatorType const &                              operator_type)
@@ -60,35 +58,36 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(operator_type == OperatorType::inhomogeneous)
   {
-    return Tensor<rank, dim, VectorizedArray<Number>>();
+    return dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>();
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+    AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
   }
 
-  return Tensor<rank, dim, VectorizedArray<Number>>();
+  return dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>();
 }
 
 template<int dim, typename Number, int n_components, int rank>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<rank, dim, VectorizedArray<Number>>
-  calculate_exterior_value(Tensor<rank, dim, VectorizedArray<Number>> const &   value_m,
-                           unsigned int const                                   q,
-                           FaceIntegrator<dim, n_components, Number> const &    integrator,
-                           OperatorType const &                                 operator_type,
-                           BoundaryType const &                                 boundary_type,
-                           types::boundary_id const                             boundary_id,
-                           std::shared_ptr<BoundaryDescriptor<rank, dim> const> boundary_descriptor,
-                           double const &                                       time)
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
+  calculate_exterior_value(
+    dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> const & value_m,
+    unsigned int const                                                 q,
+    FaceIntegrator<dim, n_components, Number> const &                  integrator,
+    OperatorType const &                                               operator_type,
+    BoundaryType const &                                               boundary_type,
+    dealii::types::boundary_id const                                   boundary_id,
+    std::shared_ptr<BoundaryDescriptor<rank, dim> const>               boundary_descriptor,
+    double const &                                                     time)
 {
-  Tensor<rank, dim, VectorizedArray<Number>> value_p;
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> value_p;
 
   if(boundary_type == BoundaryType::Dirichlet || boundary_type == BoundaryType::DirichletMortar)
   {
     if(operator_type == OperatorType::full || operator_type == OperatorType::inhomogeneous)
     {
-      Tensor<rank, dim, VectorizedArray<Number>> g;
+      dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> g;
 
       if(boundary_type == BoundaryType::Dirichlet)
       {
@@ -107,10 +106,10 @@ inline DEAL_II_ALWAYS_INLINE //
       }
       else
       {
-        AssertThrow(false, ExcMessage("Not implemented."));
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
       }
 
-      value_p = -value_m + Tensor<rank, dim, VectorizedArray<Number>>(2.0 * g);
+      value_p = -value_m + dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>(2.0 * g);
     }
     else if(operator_type == OperatorType::homogeneous)
     {
@@ -118,7 +117,7 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else if(boundary_type == BoundaryType::Neumann)
@@ -127,7 +126,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return value_p;
@@ -162,12 +161,12 @@ inline DEAL_II_ALWAYS_INLINE //
 // clang-format on
 template<int dim, typename Number, int n_components, int rank>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<rank, dim, VectorizedArray<Number>>
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
   calculate_interior_normal_gradient(unsigned int const                                q,
                                      FaceIntegrator<dim, n_components, Number> const & integrator,
                                      OperatorType const & operator_type)
 {
-  Tensor<rank, dim, VectorizedArray<Number>> normal_gradient_m;
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> normal_gradient_m;
 
   if(operator_type == OperatorType::full || operator_type == OperatorType::homogeneous)
   {
@@ -179,7 +178,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else
   {
-    AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+    AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
   }
 
   return normal_gradient_m;
@@ -187,18 +186,18 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number, int n_components, int rank>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<rank, dim, VectorizedArray<Number>>
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
   calculate_exterior_normal_gradient(
-    Tensor<rank, dim, VectorizedArray<Number>> const &   normal_gradient_m,
-    unsigned int const                                   q,
-    FaceIntegrator<dim, n_components, Number> const &    integrator,
-    OperatorType const &                                 operator_type,
-    BoundaryType const &                                 boundary_type,
-    types::boundary_id const                             boundary_id,
-    std::shared_ptr<BoundaryDescriptor<rank, dim> const> boundary_descriptor,
-    double const &                                       time)
+    dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> const & normal_gradient_m,
+    unsigned int const                                                 q,
+    FaceIntegrator<dim, n_components, Number> const &                  integrator,
+    OperatorType const &                                               operator_type,
+    BoundaryType const &                                               boundary_type,
+    dealii::types::boundary_id const                                   boundary_id,
+    std::shared_ptr<BoundaryDescriptor<rank, dim> const>               boundary_descriptor,
+    double const &                                                     time)
 {
-  Tensor<rank, dim, VectorizedArray<Number>> normal_gradient_p;
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> normal_gradient_p;
 
   if(boundary_type == BoundaryType::Dirichlet || boundary_type == BoundaryType::DirichletMortar)
   {
@@ -213,7 +212,8 @@ inline DEAL_II_ALWAYS_INLINE //
 
       auto h = FunctionEvaluator<rank, dim, Number>::value(bc, q_points, time);
 
-      normal_gradient_p = -normal_gradient_m + Tensor<rank, dim, VectorizedArray<Number>>(2.0 * h);
+      normal_gradient_p =
+        -normal_gradient_m + dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>(2.0 * h);
     }
     else if(operator_type == OperatorType::homogeneous)
     {
@@ -221,12 +221,12 @@ inline DEAL_II_ALWAYS_INLINE //
     }
     else
     {
-      AssertThrow(false, ExcMessage("Specified OperatorType is not implemented!"));
+      AssertThrow(false, dealii::ExcMessage("Specified OperatorType is not implemented!"));
     }
   }
   else
   {
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return normal_gradient_p;
@@ -238,15 +238,15 @@ inline DEAL_II_ALWAYS_INLINE //
  */
 template<int dim, typename Number, int n_components, int rank>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<rank, dim, VectorizedArray<Number>>
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
   calculate_neumann_value(unsigned int const                                   q,
                           FaceIntegrator<dim, n_components, Number> const &    integrator,
                           BoundaryType const &                                 boundary_type,
-                          types::boundary_id const                             boundary_id,
+                          dealii::types::boundary_id const                     boundary_id,
                           std::shared_ptr<BoundaryDescriptor<rank, dim> const> boundary_descriptor,
                           double const &                                       time)
 {
-  Tensor<rank, dim, VectorizedArray<Number>> normal_gradient;
+  dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>> normal_gradient;
 
   if(boundary_type == BoundaryType::Neumann)
   {
@@ -261,7 +261,7 @@ inline DEAL_II_ALWAYS_INLINE //
 
     Assert(boundary_type == BoundaryType::Dirichlet ||
              boundary_type == BoundaryType::DirichletMortar,
-           ExcMessage("Boundary type of face is invalid or not implemented."));
+           dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return normal_gradient;

--- a/include/exadg/poisson/throughput.h
+++ b/include/exadg/poisson/throughput.h
@@ -97,7 +97,7 @@ run(ThroughputParameters const & throughput,
 
   driver->setup();
 
-  std::tuple<unsigned int, types::global_dof_index, double> wall_time =
+  std::tuple<unsigned int, dealii::types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,
                            throughput.n_repetitions_inner,
                            throughput.n_repetitions_outer);

--- a/include/exadg/poisson/user_interface/analytical_solution.h
+++ b/include/exadg/poisson/user_interface/analytical_solution.h
@@ -28,12 +28,10 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim>
 struct AnalyticalSolution
 {
-  std::shared_ptr<Function<dim>> solution;
+  std::shared_ptr<dealii::Function<dim>> solution;
 };
 
 } // namespace Poisson

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -41,18 +41,16 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class ApplicationBase
 {
 public:
-  typedef
-    typename std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
-      PeriodicFaces;
+  typedef typename std::vector<
+    dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
+    PeriodicFaces;
 
   virtual void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     // clang-format off
     prm.enter_subsection("Output");
@@ -65,7 +63,7 @@ public:
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
     : mpi_comm(comm),
-      pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
       parameter_file(parameter_file)
   {
   }
@@ -104,8 +102,9 @@ public:
       double AR = calculate_aspect_ratio_vertex_distance(*grid->triangulation, mpi_comm);
       pcout << std::endl << "Maximum aspect ratio (vertex distance) = " << AR << std::endl;
 
-      QGauss<dim> quad(param.degree + 1);
-      AR = GridTools::compute_maximum_aspect_ratio(*grid->mapping, *grid->triangulation, quad);
+      dealii::QGauss<dim> quad(param.degree + 1);
+      AR =
+        dealii::GridTools::compute_maximum_aspect_ratio(*grid->mapping, *grid->triangulation, quad);
       pcout << std::endl << "Maximum aspect ratio (Jacobian) = " << AR << std::endl;
     }
 
@@ -149,7 +148,7 @@ public:
 protected:
   MPI_Comm const & mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   Parameters param;
 

--- a/include/exadg/poisson/user_interface/boundary_descriptor.h
+++ b/include/exadg/poisson/user_interface/boundary_descriptor.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 enum class BoundaryType
 {
   Undefined,
@@ -46,19 +44,20 @@ enum class BoundaryType
 template<int rank, int dim>
 struct BoundaryDescriptor
 {
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> dirichlet_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
 
-  // ComponentMask is only used for continuous elements, and is ignored for DG
-  std::map<types::boundary_id, ComponentMask> dirichlet_bc_component_mask;
+  // dealii::ComponentMask is only used for continuous elements, and is ignored for DG
+  std::map<dealii::types::boundary_id, dealii::ComponentMask> dirichlet_bc_component_mask;
 
-  std::map<types::boundary_id, std::shared_ptr<FunctionCached<rank, dim>>> dirichlet_mortar_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<FunctionCached<rank, dim>>>
+    dirichlet_mortar_bc;
 
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> neumann_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> neumann_bc;
 
   // returns the boundary type
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryType
-    get_boundary_type(types::boundary_id const & boundary_id) const
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
   {
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
       return BoundaryType::Dirichlet;
@@ -67,15 +66,16 @@ struct BoundaryDescriptor
     else if(this->neumann_bc.find(boundary_id) != this->neumann_bc.end())
       return BoundaryType::Neumann;
 
-    AssertThrow(false, ExcMessage("Boundary type of face is invalid or not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
 
     return BoundaryType::Undefined;
   }
 
   inline DEAL_II_ALWAYS_INLINE //
     void
-    verify_boundary_conditions(types::boundary_id const             boundary_id,
-                               std::set<types::boundary_id> const & periodic_boundary_ids) const
+    verify_boundary_conditions(
+      dealii::types::boundary_id const             boundary_id,
+      std::set<dealii::types::boundary_id> const & periodic_boundary_ids) const
   {
     unsigned int counter = 0;
     if(dirichlet_bc.find(boundary_id) != dirichlet_bc.end())
@@ -90,7 +90,8 @@ struct BoundaryDescriptor
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())
       counter++;
 
-    AssertThrow(counter == 1, ExcMessage("Boundary face with non-unique boundary type found."));
+    AssertThrow(counter == 1,
+                dealii::ExcMessage("Boundary face with non-unique boundary type found."));
   }
 };
 

--- a/include/exadg/poisson/user_interface/enum_types.cpp
+++ b/include/exadg/poisson/user_interface/enum_types.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                              SPATIAL DISCRETIZATION                                */
@@ -54,7 +52,7 @@ enum_to_string(SpatialDiscretization const enum_type)
       string_type = "DG";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -84,7 +82,7 @@ enum_to_string(Solver const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -114,7 +112,7 @@ enum_to_string(Preconditioner const enum_type)
       string_type = "Multigrid";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/poisson/user_interface/enum_types.h
+++ b/include/exadg/poisson/user_interface/enum_types.h
@@ -26,8 +26,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                              SPATIAL DISCRETIZATION                                */

--- a/include/exadg/poisson/user_interface/field_functions.h
+++ b/include/exadg/poisson/user_interface/field_functions.h
@@ -25,13 +25,11 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 template<int dim>
 struct FieldFunctions
 {
-  std::shared_ptr<Function<dim>> initial_solution;
-  std::shared_ptr<Function<dim>> right_hand_side;
+  std::shared_ptr<dealii::Function<dim>> initial_solution;
+  std::shared_ptr<dealii::Function<dim>> right_hand_side;
 };
 
 } // namespace Poisson

--- a/include/exadg/poisson/user_interface/parameters.cpp
+++ b/include/exadg/poisson/user_interface/parameters.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 Parameters::Parameters()
   : // MATHEMATICAL MODEL
     right_hand_side(false),
@@ -60,18 +58,18 @@ Parameters::check() const
   grid.check();
 
   AssertThrow(spatial_discretization != SpatialDiscretization::Undefined,
-              ExcMessage("parameter must be defined."));
+              dealii::ExcMessage("parameter must be defined."));
 
-  AssertThrow(degree > 0, ExcMessage("Polynomial degree must be larger than zero."));
+  AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
 
   // SOLVER
-  AssertThrow(solver != Solver::Undefined, ExcMessage("parameter must be defined."));
+  AssertThrow(solver != Solver::Undefined, dealii::ExcMessage("parameter must be defined."));
   AssertThrow(preconditioner != Preconditioner::Undefined,
-              ExcMessage("parameter must be defined."));
+              dealii::ExcMessage("parameter must be defined."));
 }
 
 void
-Parameters::print(ConditionalOStream const & pcout, std::string const & name) const
+Parameters::print(dealii::ConditionalOStream const & pcout, std::string const & name) const
 {
   pcout << std::endl << name << std::endl;
 
@@ -89,7 +87,7 @@ Parameters::print(ConditionalOStream const & pcout, std::string const & name) co
 }
 
 void
-Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout) const
+Parameters::print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Mathematical model:" << std::endl;
 
@@ -97,7 +95,7 @@ Parameters::print_parameters_mathematical_model(ConditionalOStream const & pcout
 }
 
 void
-Parameters::print_parameters_spatial_discretization(ConditionalOStream const & pcout) const
+Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Spatial Discretization:" << std::endl;
 
@@ -112,7 +110,7 @@ Parameters::print_parameters_spatial_discretization(ConditionalOStream const & p
 }
 
 void
-Parameters::print_parameters_solver(ConditionalOStream const & pcout) const
+Parameters::print_parameters_solver(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Solver:" << std::endl;
 
@@ -128,7 +126,7 @@ Parameters::print_parameters_solver(ConditionalOStream const & pcout) const
 
 
 void
-Parameters::print_parameters_numerical_parameters(ConditionalOStream const & pcout) const
+Parameters::print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Numerical parameters:" << std::endl;
 

--- a/include/exadg/poisson/user_interface/parameters.h
+++ b/include/exadg/poisson/user_interface/parameters.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Poisson
 {
-using namespace dealii;
-
 class Parameters
 {
 public:
@@ -45,20 +43,20 @@ public:
   check() const;
 
   void
-  print(ConditionalOStream const & pcout, std::string const & name) const;
+  print(dealii::ConditionalOStream const & pcout, std::string const & name) const;
 
 private:
   void
-  print_parameters_mathematical_model(ConditionalOStream const & pcout) const;
+  print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_spatial_discretization(ConditionalOStream const & pcout) const;
+  print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_solver(ConditionalOStream const & pcout) const;
+  print_parameters_solver(dealii::ConditionalOStream const & pcout) const;
 
   void
-  print_parameters_numerical_parameters(ConditionalOStream const & pcout) const;
+  print_parameters_numerical_parameters(dealii::ConditionalOStream const & pcout) const;
 
 public:
   /**************************************************************************************/

--- a/include/exadg/postprocessor/error_calculation.h
+++ b/include/exadg/postprocessor/error_calculation.h
@@ -33,8 +33,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
 struct ErrorCalculationData
 {
@@ -52,7 +50,7 @@ struct ErrorCalculationData
   }
 
   void
-  print(ConditionalOStream & pcout, bool unsteady)
+  print(dealii::ConditionalOStream & pcout, bool unsteady)
   {
     print_parameter(pcout, "Calculate error", analytical_solution_available);
     if(analytical_solution_available == true && unsteady == true)
@@ -72,7 +70,7 @@ struct ErrorCalculationData
   // to calculate the error an analytical solution to the problem has to be available
   bool analytical_solution_available;
 
-  std::shared_ptr<Function<dim>> analytical_solution;
+  std::shared_ptr<dealii::Function<dim>> analytical_solution;
 
   // relative or absolute errors?
   // If calculate_relative_errors == false, this implies that absolute errors are calculated
@@ -103,13 +101,13 @@ template<int dim, typename Number>
 class ErrorCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   ErrorCalculator(MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const &           dof_handler,
-        Mapping<dim> const &              mapping,
+  setup(dealii::DoFHandler<dim> const &   dof_handler,
+        dealii::Mapping<dim> const &      mapping,
         ErrorCalculationData<dim> const & error_data);
 
   void
@@ -126,8 +124,8 @@ private:
 
   bool clear_files_L2, clear_files_H1_seminorm;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler;
-  SmartPointer<Mapping<dim> const>    mapping;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
 
   ErrorCalculationData<dim> error_data;
 };

--- a/include/exadg/postprocessor/kinetic_energy_calculation.h
+++ b/include/exadg/postprocessor/kinetic_energy_calculation.h
@@ -32,8 +32,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct KineticEnergyData
 {
   KineticEnergyData()
@@ -48,7 +46,7 @@ struct KineticEnergyData
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(calculate == true)
     {
@@ -88,19 +86,19 @@ class KineticEnergyCalculator
 public:
   static unsigned int const number_vorticity_components = (dim == 2) ? 1 : dim;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   KineticEnergyCalculator(MPI_Comm const & comm);
 
   void
-  setup(MatrixFree<dim, Number> const & matrix_free_in,
-        unsigned int const              dof_index_in,
-        unsigned int const              quad_index_in,
-        KineticEnergyData const &       kinetic_energy_data_in);
+  setup(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+        unsigned int const                      dof_index_in,
+        unsigned int const                      quad_index_in,
+        KineticEnergyData const &               kinetic_energy_data_in);
 
   void
   evaluate(VectorType const & velocity, double const & time, int const & time_step_number);
@@ -127,15 +125,15 @@ protected:
    *  for incompressible flows (div(u)=0) and periodic boundary conditions.
    */
   Number
-  integrate(MatrixFree<dim, Number> const & matrix_free_data,
-            VectorType const &              velocity,
-            Number &                        energy,
-            Number &                        enstrophy,
-            Number &                        dissipation,
-            Number &                        max_vorticity);
+  integrate(dealii::MatrixFree<dim, Number> const & matrix_free_data,
+            VectorType const &                      velocity,
+            Number &                                energy,
+            Number &                                enstrophy,
+            Number &                                dissipation,
+            Number &                                max_vorticity);
 
   void
-  cell_loop(MatrixFree<dim, Number> const &               data,
+  cell_loop(dealii::MatrixFree<dim, Number> const &       data,
             std::vector<Number> &                         dst,
             VectorType const &                            src,
             std::pair<unsigned int, unsigned int> const & cell_range);
@@ -144,9 +142,9 @@ protected:
 
   bool clear_files;
 
-  MatrixFree<dim, Number> const * matrix_free;
-  unsigned int                    dof_index, quad_index;
-  KineticEnergyData               data;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
+  unsigned int                            dof_index, quad_index;
+  KineticEnergyData                       data;
 };
 
 } // namespace ExaDG

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
@@ -286,7 +286,7 @@ private:
   // ... for spectral analysis
   SpectralAnalysis fftw;
 
-  // dealii::Timer
+  // Timer
   DealSpectrumTimer timer;
 
   std::shared_ptr<dealii::Utilities::MPI::NoncontiguousPartitioner> nonconti;

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.h
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.h
@@ -32,8 +32,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 // forward declaration
 class DealSpectrumWrapper;
 
@@ -54,12 +52,12 @@ struct KineticEnergySpectrumData
       exploit_symmetry(false),
       n_cells_1d_coarse_grid(1),
       refine_level(0),
-      length_symmetric_domain(numbers::PI)
+      length_symmetric_domain(dealii::numbers::PI)
   {
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(calculate == true)
     {
@@ -114,14 +112,14 @@ template<int dim, typename Number>
 class KineticEnergySpectrumCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   KineticEnergySpectrumCalculator(MPI_Comm const & mpi_comm);
 
   void
-  setup(MatrixFree<dim, Number> const &   matrix_free_data_in,
-        DoFHandler<dim> const &           dof_handler_in,
-        KineticEnergySpectrumData const & data_in);
+  setup(dealii::MatrixFree<dim, Number> const & matrix_free_data_in,
+        dealii::DoFHandler<dim> const &         dof_handler_in,
+        KineticEnergySpectrumData const &       data_in);
 
   void
   evaluate(VectorType const & velocity, double const & time, int const & time_step_number);
@@ -143,12 +141,12 @@ private:
 
   std::shared_ptr<DealSpectrumWrapper> deal_spectrum_wrapper;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
 
-  std::shared_ptr<VectorType>         velocity_full;
-  std::shared_ptr<Triangulation<dim>> tria_full;
-  std::shared_ptr<FESystem<dim>>      fe_full;
-  std::shared_ptr<DoFHandler<dim>>    dof_handler_full;
+  std::shared_ptr<VectorType>                 velocity_full;
+  std::shared_ptr<dealii::Triangulation<dim>> tria_full;
+  std::shared_ptr<dealii::FESystem<dim>>      fe_full;
+  std::shared_ptr<dealii::DoFHandler<dim>>    dof_handler_full;
 };
 } // namespace ExaDG
 

--- a/include/exadg/postprocessor/lift_and_drag_calculation.h
+++ b/include/exadg/postprocessor/lift_and_drag_calculation.h
@@ -26,8 +26,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct LiftAndDragData
 {
   LiftAndDragData()
@@ -59,7 +57,7 @@ struct LiftAndDragData
    *  set containing boundary ID's of the surface area used
    *  to calculate lift and drag coefficients
    */
-  std::set<types::boundary_id> boundary_IDs;
+  std::set<dealii::types::boundary_id> boundary_IDs;
 
   /*
    *  filenames
@@ -74,17 +72,17 @@ template<int dim, typename Number>
 class LiftAndDragCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   LiftAndDragCalculator(MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const &         dof_handler_velocity_in,
-        MatrixFree<dim, Number> const & matrix_free_in,
-        unsigned int const              dof_index_velocity_in,
-        unsigned int const              dof_index_pressure_in,
-        unsigned int const              quad_index_in,
-        LiftAndDragData const &         lift_and_drag_data_in);
+  setup(dealii::DoFHandler<dim> const &         dof_handler_velocity_in,
+        dealii::MatrixFree<dim, Number> const & matrix_free_in,
+        unsigned int const                      dof_index_velocity_in,
+        unsigned int const                      dof_index_pressure_in,
+        unsigned int const                      quad_index_in,
+        LiftAndDragData const &                 lift_and_drag_data_in);
 
   void
   evaluate(VectorType const & velocity, VectorType const & pressure, Number const & time) const;
@@ -94,9 +92,9 @@ private:
 
   mutable bool clear_files;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler_velocity;
-  MatrixFree<dim, Number> const *     matrix_free;
-  unsigned int                        dof_index_velocity, dof_index_pressure, quad_index;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::MatrixFree<dim, Number> const *             matrix_free;
+  unsigned int dof_index_velocity, dof_index_pressure, quad_index;
 
   mutable double c_L_min, c_L_max, c_D_min, c_D_max;
 

--- a/include/exadg/postprocessor/mean_scalar_calculation.h
+++ b/include/exadg/postprocessor/mean_scalar_calculation.h
@@ -25,30 +25,28 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class MeanScalarCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef FaceIntegrator<dim, 1, Number> FaceIntegratorScalar;
 
-  typedef VectorizedArray<Number> scalar;
+  typedef dealii::VectorizedArray<Number> scalar;
 
-  MeanScalarCalculator(MatrixFree<dim, Number> const & matrix_free_in,
-                       unsigned int                    dof_index_in,
-                       unsigned int                    quad_index_in,
-                       MPI_Comm const &                mpi_comm_in);
+  MeanScalarCalculator(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                       unsigned int                            dof_index_in,
+                       unsigned int                            quad_index_in,
+                       MPI_Comm const &                        mpi_comm_in);
 
   Number
-  calculate_mean_scalar(VectorType const &                     solution,
-                        std::map<types::boundary_id, Number> & mean_scalar);
+  calculate_mean_scalar(VectorType const &                             solution,
+                        std::map<dealii::types::boundary_id, Number> & mean_scalar);
 
 private:
-  MatrixFree<dim, Number> const & matrix_free;
-  unsigned int                    dof_index, quad_index;
+  dealii::MatrixFree<dim, Number> const & matrix_free;
+  unsigned int                            dof_index, quad_index;
 
   MPI_Comm const mpi_comm;
 };

--- a/include/exadg/postprocessor/output_data_base.h
+++ b/include/exadg/postprocessor/output_data_base.h
@@ -26,8 +26,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct OutputDataBase
 {
   OutputDataBase()
@@ -47,7 +45,7 @@ struct OutputDataBase
   }
 
   void
-  print(ConditionalOStream & pcout, bool unsteady)
+  print(dealii::ConditionalOStream & pcout, bool unsteady)
   {
     // output for visualization of results
     print_parameter(pcout, "Write output", write_output);

--- a/include/exadg/postprocessor/output_generator_scalar.cpp
+++ b/include/exadg/postprocessor/output_generator_scalar.cpp
@@ -32,23 +32,21 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename VectorType>
 void
-write_output(OutputDataBase const &  output_data,
-             DoFHandler<dim> const & dof_handler,
-             Mapping<dim> const &    mapping,
-             VectorType const &      solution_vector,
-             unsigned int const      output_counter,
-             MPI_Comm const &        mpi_comm)
+write_output(OutputDataBase const &          output_data,
+             dealii::DoFHandler<dim> const & dof_handler,
+             dealii::Mapping<dim> const &    mapping,
+             VectorType const &              solution_vector,
+             unsigned int const              output_counter,
+             MPI_Comm const &                mpi_comm)
 {
   std::string folder = output_data.directory, file = output_data.filename;
 
-  DataOutBase::VtkFlags flags;
+  dealii::DataOutBase::VtkFlags flags;
   flags.write_higher_order_cells = output_data.write_higher_order;
 
-  DataOut<dim> data_out;
+  dealii::DataOut<dim> data_out;
   data_out.set_flags(flags);
 
   data_out.attach_dof_handler(dof_handler);
@@ -58,7 +56,7 @@ write_output(OutputDataBase const &  output_data,
 #endif
 
   data_out.add_data_vector(solution_vector, "solution");
-  data_out.build_patches(mapping, output_data.degree, DataOut<dim>::curved_inner_cells);
+  data_out.build_patches(mapping, output_data.degree, dealii::DataOut<dim>::curved_inner_cells);
 
   data_out.write_vtu_with_pvtu_record(folder, file, output_counter, mpi_comm, 4);
 }
@@ -71,9 +69,9 @@ OutputGenerator<dim, Number>::OutputGenerator(MPI_Comm const & comm)
 
 template<int dim, typename Number>
 void
-OutputGenerator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_in,
-                                    Mapping<dim> const &    mapping_in,
-                                    OutputDataBase const &  output_data_in)
+OutputGenerator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_in,
+                                    dealii::Mapping<dim> const &    mapping_in,
+                                    OutputDataBase const &          output_data_in)
 {
   dof_handler = &dof_handler_in;
   mapping     = &mapping_in;
@@ -112,7 +110,7 @@ OutputGenerator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_in,
     // processor_id
     if(output_data.write_processor_id)
     {
-      GridOut grid_out;
+      dealii::GridOut grid_out;
 
       grid_out.write_mesh_per_processor_as_vtu(dof_handler->get_triangulation(),
                                                output_data.directory + output_data.filename +
@@ -127,7 +125,8 @@ OutputGenerator<dim, Number>::evaluate(VectorType const & solution,
                                        double const &     time,
                                        int const &        time_step_number)
 {
-  ConditionalOStream pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0);
+  dealii::ConditionalOStream pcout(std::cout,
+                                   dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0);
 
   if(output_data.write_output == true)
   {

--- a/include/exadg/postprocessor/output_generator_scalar.h
+++ b/include/exadg/postprocessor/output_generator_scalar.h
@@ -32,20 +32,18 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class OutputGenerator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   OutputGenerator(MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const & dof_handler_in,
-        Mapping<dim> const &    mapping_in,
-        OutputDataBase const &  output_data_in);
+  setup(dealii::DoFHandler<dim> const & dof_handler_in,
+        dealii::Mapping<dim> const &    mapping_in,
+        OutputDataBase const &          output_data_in);
 
   void
   evaluate(VectorType const & solution, double const & time, int const & time_step_number);
@@ -56,9 +54,9 @@ private:
   unsigned int output_counter;
   bool         reset_counter;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler;
-  SmartPointer<Mapping<dim> const>    mapping;
-  OutputDataBase                      output_data;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  OutputDataBase                                      output_data;
 };
 
 } // namespace ExaDG

--- a/include/exadg/postprocessor/pressure_difference_calculation.cpp
+++ b/include/exadg/postprocessor/pressure_difference_calculation.cpp
@@ -29,8 +29,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 PressureDifferenceCalculator<dim, Number>::PressureDifferenceCalculator(MPI_Comm const & comm)
   : mpi_comm(comm), clear_files(true)
@@ -39,9 +37,10 @@ PressureDifferenceCalculator<dim, Number>::PressureDifferenceCalculator(MPI_Comm
 
 template<int dim, typename Number>
 void
-PressureDifferenceCalculator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_pressure_in,
-                                                 Mapping<dim> const &    mapping_in,
-                                                 PressureDifferenceData<dim> const & data_in)
+PressureDifferenceCalculator<dim, Number>::setup(
+  dealii::DoFHandler<dim> const &     dof_handler_pressure_in,
+  dealii::Mapping<dim> const &        mapping_in,
+  PressureDifferenceData<dim> const & data_in)
 {
   dof_handler_pressure = &dof_handler_pressure_in;
   mapping              = &mapping_in;
@@ -60,7 +59,7 @@ PressureDifferenceCalculator<dim, Number>::evaluate(VectorType const & pressure,
   {
     Number pressure_1 = 0.0, pressure_2 = 0.0;
 
-    Point<dim> point_1, point_2;
+    dealii::Point<dim> point_1, point_2;
     point_1 = data.point_1;
     point_2 = data.point_2;
 
@@ -71,7 +70,7 @@ PressureDifferenceCalculator<dim, Number>::evaluate(VectorType const & pressure,
 
     Number const pressure_difference = pressure_1 - pressure_2;
 
-    if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+    if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
     {
       std::string filename = data.directory + data.filename;
 

--- a/include/exadg/postprocessor/pressure_difference_calculation.h
+++ b/include/exadg/postprocessor/pressure_difference_calculation.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
 struct PressureDifferenceData
 {
@@ -48,8 +46,8 @@ struct PressureDifferenceData
    *  Points:
    *  calculation of pressure difference: p(point_1) - p(point_2)
    */
-  Point<dim> point_1;
-  Point<dim> point_2;
+  dealii::Point<dim> point_1;
+  dealii::Point<dim> point_2;
 
   /*
    *  directory and filename
@@ -62,13 +60,13 @@ template<int dim, typename Number>
 class PressureDifferenceCalculator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   PressureDifferenceCalculator(MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const &             dof_handler_pressure_in,
-        Mapping<dim> const &                mapping_in,
+  setup(dealii::DoFHandler<dim> const &     dof_handler_pressure_in,
+        dealii::Mapping<dim> const &        mapping_in,
         PressureDifferenceData<dim> const & pressure_difference_data_in);
 
   void
@@ -79,8 +77,8 @@ private:
 
   mutable bool clear_files;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler_pressure;
-  SmartPointer<Mapping<dim> const>    mapping;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
 
   PressureDifferenceData<dim> data;
 };

--- a/include/exadg/postprocessor/solution_field.h
+++ b/include/exadg/postprocessor/solution_field.h
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 enum class SolutionFieldType
 {
   scalar,
@@ -49,9 +47,9 @@ public:
 
   std::string name;
 
-  DoFHandler<dim> const * dof_handler;
+  dealii::DoFHandler<dim> const * dof_handler;
 
-  LinearAlgebra::distributed::Vector<Number> const * vector;
+  dealii::LinearAlgebra::distributed::Vector<Number> const * vector;
 };
 
 } // namespace ExaDG

--- a/include/exadg/postprocessor/spectral_analysis/interpolation.h
+++ b/include/exadg/postprocessor/spectral_analysis/interpolation.h
@@ -38,7 +38,7 @@
 // ExaDG
 #include <exadg/postprocessor/spectral_analysis/setup.h>
 
-using namespace dealii;
+
 
 namespace dealspectrum
 {
@@ -59,7 +59,7 @@ public:
   // destination vector (interpolated values)
   double * dst = NULL;
   // shape function (gauss lobatto to equidistant)
-  AlignedVector<double> shape_values;
+  dealii::AlignedVector<double> shape_values;
   // number of cells in each direction
   int cells;
   // dimensions
@@ -161,12 +161,12 @@ public:
    * @params shape_values     data structure to be filled
    */
   void
-  fill_shape_values(AlignedVector<double> & shape_values)
+  fill_shape_values(dealii::AlignedVector<double> & shape_values)
   {
     // determine coefficients with deal.II functions
-    FE_DGQ<1>          fe(points_source - 1);
-    FullMatrix<double> matrix(points_target, points_source);
-    FE_DGQArbitraryNodes<1>(Quadrature<1>(get_equidistant_inner(points_target)))
+    dealii::FE_DGQ<1>          fe(points_source - 1);
+    dealii::FullMatrix<double> matrix(points_target, points_source);
+    dealii::FE_DGQArbitraryNodes<1>(dealii::Quadrature<1>(get_equidistant_inner(points_target)))
       .get_interpolation_matrix(fe, matrix);
 
     // ... and convert to linearized format
@@ -198,8 +198,8 @@ public:
   interpolate(double const *& src)
   {
     // allocate dst- and src-vector
-    AlignedVector<double> temp1(MAX(dofs_source, dofs_target));
-    AlignedVector<double> temp2(MAX(dofs_source, dofs_target));
+    dealii::AlignedVector<double> temp1(MAX(dofs_source, dofs_target));
+    dealii::AlignedVector<double> temp2(MAX(dofs_source, dofs_target));
 
     // get start point of arrays
     double const * src_ = src;

--- a/include/exadg/postprocessor/spectral_analysis/spectrum.h
+++ b/include/exadg/postprocessor/spectral_analysis/spectrum.h
@@ -269,7 +269,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     // scale: due to FFT...

--- a/include/exadg/postprocessor/statistics_manager.h
+++ b/include/exadg/postprocessor/statistics_manager.h
@@ -31,8 +31,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 // turbulent channel data
 
 struct TurbulentChannelData
@@ -51,7 +49,7 @@ struct TurbulentChannelData
   }
 
   void
-  print(ConditionalOStream & pcout)
+  print(dealii::ConditionalOStream & pcout)
   {
     if(calculate)
     {
@@ -98,9 +96,10 @@ template<int dim, typename Number>
 class StatisticsManager
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  StatisticsManager(DoFHandler<dim> const & dof_handler_velocity, Mapping<dim> const & mapping);
+  StatisticsManager(dealii::DoFHandler<dim> const & dof_handler_velocity,
+                    dealii::Mapping<dim> const &    mapping);
 
   // The argument grid_transform indicates how the y-direction that is initially distributed from
   // [0,1] is mapped to the actual grid. This must match the transformation applied to the
@@ -131,9 +130,9 @@ private:
   void
   do_evaluate(const std::vector<VectorType const *> & velocity);
 
-  DoFHandler<dim> const & dof_handler;
-  Mapping<dim> const &    mapping;
-  MPI_Comm                mpi_comm;
+  dealii::DoFHandler<dim> const & dof_handler;
+  dealii::Mapping<dim> const &    mapping;
+  MPI_Comm                        mpi_comm;
 
   // vector of y-coordinates at which statistical quantities are computed
   std::vector<double> y_glob;

--- a/include/exadg/postprocessor/write_output.h
+++ b/include/exadg/postprocessor/write_output.h
@@ -32,20 +32,18 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim>
 void
-write_surface_mesh(Triangulation<dim> const & triangulation,
-                   Mapping<dim> const &       mapping,
-                   unsigned int               n_subdivisions,
-                   std::string const &        folder,
-                   std::string const &        file,
-                   unsigned int const         counter,
-                   MPI_Comm const &           mpi_comm)
+write_surface_mesh(dealii::Triangulation<dim> const & triangulation,
+                   dealii::Mapping<dim> const &       mapping,
+                   unsigned int                       n_subdivisions,
+                   std::string const &                folder,
+                   std::string const &                file,
+                   unsigned int const                 counter,
+                   MPI_Comm const &                   mpi_comm)
 {
   // write surface mesh only
-  DataOutFaces<dim> data_out_surface(true /*surface only*/);
+  dealii::DataOutFaces<dim> data_out_surface(true /*surface only*/);
   data_out_surface.attach_triangulation(triangulation);
   data_out_surface.build_patches(mapping, n_subdivisions);
   data_out_surface.write_vtu_with_pvtu_record(folder, file + "_surface", counter, mpi_comm, 4);
@@ -53,22 +51,22 @@ write_surface_mesh(Triangulation<dim> const & triangulation,
 
 template<int dim>
 void
-write_boundary_IDs(Triangulation<dim> const & triangulation,
-                   std::string const &        folder,
-                   std::string const &        file,
-                   MPI_Comm const &           mpi_communicator)
+write_boundary_IDs(dealii::Triangulation<dim> const & triangulation,
+                   std::string const &                folder,
+                   std::string const &                file,
+                   MPI_Comm const &                   mpi_communicator)
 {
-  unsigned int const rank    = Utilities::MPI::this_mpi_process(mpi_communicator);
-  unsigned int const n_ranks = Utilities::MPI::n_mpi_processes(mpi_communicator);
+  unsigned int const rank    = dealii::Utilities::MPI::this_mpi_process(mpi_communicator);
+  unsigned int const n_ranks = dealii::Utilities::MPI::n_mpi_processes(mpi_communicator);
 
   unsigned int const n_digits = static_cast<int>(std::ceil(std::log10(std::fabs(n_ranks))));
 
-  std::string filename =
-    folder + file + "_boundary_IDs" + "." + Utilities::int_to_string(rank, n_digits) + ".vtk";
+  std::string filename = folder + file + "_boundary_IDs" + "." +
+                         dealii::Utilities::int_to_string(rank, n_digits) + ".vtk";
   std::ofstream output(filename);
 
-  GridOut           grid_out;
-  GridOutFlags::Vtk flags;
+  dealii::GridOut           grid_out;
+  dealii::GridOutFlags::Vtk flags;
   flags.output_cells         = false;
   flags.output_faces         = true;
   flags.output_edges         = false;
@@ -79,13 +77,13 @@ write_boundary_IDs(Triangulation<dim> const & triangulation,
 
 template<int dim>
 void
-write_grid(Triangulation<dim> const & triangulation,
-           std::string const &        folder,
-           std::string const &        file)
+write_grid(dealii::Triangulation<dim> const & triangulation,
+           std::string const &                folder,
+           std::string const &                file)
 {
   std::string filename = folder + file + "_grid";
 
-  GridOut grid_out;
+  dealii::GridOut grid_out;
   grid_out.write_mesh_per_processor_as_vtu(triangulation, filename);
 }
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
@@ -30,23 +30,21 @@ namespace ConstraintUtil
 {
 namespace // anonymous namespace
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
-add_periodicity_constraints(unsigned int const                            level,
-                            unsigned int const                            target_level,
-                            typename DoFHandler<dim>::face_iterator const face1,
-                            typename DoFHandler<dim>::face_iterator const face2,
-                            AffineConstraints<Number> &                   constraints)
+add_periodicity_constraints(unsigned int const                                    level,
+                            unsigned int const                                    target_level,
+                            typename dealii::DoFHandler<dim>::face_iterator const face1,
+                            typename dealii::DoFHandler<dim>::face_iterator const face2,
+                            dealii::AffineConstraints<Number> &                   constraints)
 {
   if(level == 0)
   {
     // level of interest has been reached
     unsigned int const dofs_per_face = face1->get_fe(0).dofs_per_face;
 
-    std::vector<types::global_dof_index> dofs_1(dofs_per_face);
-    std::vector<types::global_dof_index> dofs_2(dofs_per_face);
+    std::vector<dealii::types::global_dof_index> dofs_1(dofs_per_face);
+    std::vector<dealii::types::global_dof_index> dofs_2(dofs_per_face);
 
     face1->get_mg_dof_indices(target_level, dofs_1, 0);
     face2->get_mg_dof_indices(target_level, dofs_2, 0);
@@ -78,25 +76,24 @@ add_periodicity_constraints(unsigned int const                            level,
 template<int dim, typename Number>
 void
 add_periodicity_constraints(
-  DoFHandler<dim> const & dof_handler,
-  unsigned int const      level,
-  std::vector<
-    typename GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const &
-                              periodic_face_pairs_level0,
-  AffineConstraints<Number> & affine_constraints_own)
+  dealii::DoFHandler<dim> const &                                dof_handler,
+  unsigned int const                                             level,
+  std::vector<typename dealii::GridTools::PeriodicFacePair<
+    typename dealii::Triangulation<dim>::cell_iterator>> const & periodic_face_pairs_level0,
+  dealii::AffineConstraints<Number> &                            affine_constraints_own)
 {
   // loop over all periodic face pairs of level 0
   for(auto & it : periodic_face_pairs_level0)
   {
     // get reference to the cells on level 0 sharing the periodic face
-    typename DoFHandler<dim>::cell_iterator cell1(&dof_handler.get_triangulation(),
-                                                  0,
-                                                  it.cell[1]->index(),
-                                                  &dof_handler);
-    typename DoFHandler<dim>::cell_iterator cell0(&dof_handler.get_triangulation(),
-                                                  0,
-                                                  it.cell[0]->index(),
-                                                  &dof_handler);
+    typename dealii::DoFHandler<dim>::cell_iterator cell1(&dof_handler.get_triangulation(),
+                                                          0,
+                                                          it.cell[1]->index(),
+                                                          &dof_handler);
+    typename dealii::DoFHandler<dim>::cell_iterator cell0(&dof_handler.get_triangulation(),
+                                                          0,
+                                                          it.cell[0]->index(),
+                                                          &dof_handler);
 
     // get reference to periodic faces on level and add recursively their
     // subfaces on the given level
@@ -110,15 +107,14 @@ add_periodicity_constraints(
 
 template<int dim, typename Number>
 void
-add_constraints(
-  bool                        is_dg,
-  bool                        operator_is_singular,
-  DoFHandler<dim> const &     dof_handler,
-  AffineConstraints<Number> & affine_constraints_own,
-  MGConstrainedDoFs const &   mg_constrained_dofs,
-  std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>> const &
-                     periodic_face_pairs,
-  unsigned int const level)
+add_constraints(bool                                is_dg,
+                bool                                operator_is_singular,
+                dealii::DoFHandler<dim> const &     dof_handler,
+                dealii::AffineConstraints<Number> & affine_constraints_own,
+                dealii::MGConstrainedDoFs const &   mg_constrained_dofs,
+                std::vector<dealii::GridTools::PeriodicFacePair<
+                  typename dealii::Triangulation<dim>::cell_iterator>> const & periodic_face_pairs,
+                unsigned int const                                             level)
 {
   if(is_dg)
   {
@@ -130,11 +126,11 @@ add_constraints(
   affine_constraints_own.clear();
 
   // ... and set local dofs
-  IndexSet relevant_dofs;
-  if(level != numbers::invalid_unsigned_int)
-    DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, relevant_dofs);
+  dealii::IndexSet relevant_dofs;
+  if(level != dealii::numbers::invalid_unsigned_int)
+    dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, relevant_dofs);
   else
-    DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
   affine_constraints_own.reinit(relevant_dofs);
 
   // 1) add periodic BCs
@@ -154,7 +150,7 @@ add_constraints(
   {
     // if dof 0 is constrained, it must be a periodic dof, so we take the
     // value on the other side
-    types::global_dof_index line_index = 0;
+    dealii::types::global_dof_index line_index = 0;
     while(true)
     {
       auto const * lines = affine_constraints_own.get_constraint_entries(line_index);
@@ -162,14 +158,14 @@ add_constraints(
       if(lines == 0)
       {
         affine_constraints_own.add_line(line_index);
-        // add the constraint back to the MGConstrainedDoFs field. This
+        // add the constraint back to the dealii::MGConstrainedDoFs field. This
         // is potentially dangerous but we know what we are doing... ;-)
-        if(level != numbers::invalid_unsigned_int)
+        if(level != dealii::numbers::invalid_unsigned_int)
         {
           if(mg_constrained_dofs.get_boundary_indices(level).size() != dof_handler.n_dofs(level))
-            const_cast<IndexSet &>(mg_constrained_dofs.get_boundary_indices(level))
+            const_cast<dealii::IndexSet &>(mg_constrained_dofs.get_boundary_indices(level))
               .set_size(dof_handler.n_dofs(level));
-          const_cast<IndexSet &>(mg_constrained_dofs.get_boundary_indices(level))
+          const_cast<dealii::IndexSet &>(mg_constrained_dofs.get_boundary_indices(level))
             .add_index(line_index);
         }
 
@@ -178,7 +174,7 @@ add_constraints(
       else
       {
         Assert(lines->size() == 1 && std::abs((*lines)[0].second - 1.) < 1e-15,
-               ExcMessage("Periodic index expected, bailing out"));
+               dealii::ExcMessage("Periodic index expected, bailing out"));
 
         line_index = (*lines)[0].first;
       }

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h
@@ -46,8 +46,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  * Re-implementation of multigrid preconditioner (V-cycle) in order to have more direct control over
  * its individual components and avoid inner products and other expensive stuff.
@@ -56,12 +54,12 @@ template<typename VectorType, typename MatrixType, typename SmootherType>
 class MultigridAlgorithm
 {
 public:
-  MultigridAlgorithm(MGLevelObject<std::shared_ptr<MatrixType>> const &   matrix,
-                     MGCoarseGridBase<VectorType> const &                 coarse,
-                     MGTransfer<VectorType> const &                       transfer,
-                     MGLevelObject<std::shared_ptr<SmootherType>> const & smoother,
-                     MPI_Comm const &                                     comm,
-                     unsigned int const                                   n_cycles = 1)
+  MultigridAlgorithm(dealii::MGLevelObject<std::shared_ptr<MatrixType>> const &   matrix,
+                     dealii::MGCoarseGridBase<VectorType> const &                 coarse,
+                     MGTransfer<VectorType> const &                               transfer,
+                     dealii::MGLevelObject<std::shared_ptr<SmootherType>> const & smoother,
+                     MPI_Comm const &                                             comm,
+                     unsigned int const                                           n_cycles = 1)
     : minlevel(matrix.min_level()),
       maxlevel(matrix.max_level()),
       defect(minlevel, maxlevel),
@@ -74,7 +72,7 @@ public:
       mpi_comm(comm),
       n_cycles(n_cycles)
   {
-    AssertThrow(n_cycles == 1, ExcNotImplemented());
+    AssertThrow(n_cycles == 1, dealii::ExcNotImplemented());
 
     for(unsigned int level = minlevel; level <= maxlevel; ++level)
     {
@@ -91,7 +89,7 @@ public:
   vmult(OtherVectorType & dst, OtherVectorType const & src) const
   {
 #if ENABLE_TIMING
-    Timer timer;
+    dealii::Timer timer;
 #endif
 
     for(unsigned int i = minlevel; i < maxlevel; i++)
@@ -175,7 +173,7 @@ private:
   v_cycle(unsigned int const level, bool const multigrid_is_a_solver) const
   {
 #if ENABLE_TIMING
-    Timer timer;
+    dealii::Timer timer;
 #endif
 
     // call coarse grid solver
@@ -255,27 +253,27 @@ private:
    * Input vector for the cycle. Contains the defect of the outer method
    * projected to the multilevel vectors.
    */
-  mutable MGLevelObject<VectorType> defect;
+  mutable dealii::MGLevelObject<VectorType> defect;
 
   /**
    * The solution update after the multigrid step.
    */
-  mutable MGLevelObject<VectorType> solution;
+  mutable dealii::MGLevelObject<VectorType> solution;
 
   /**
    * Auxiliary vector.
    */
-  mutable MGLevelObject<VectorType> t;
+  mutable dealii::MGLevelObject<VectorType> t;
 
   /**
    * The matrix for each level.
    */
-  SmartPointer<MGLevelObject<std::shared_ptr<MatrixType>> const> matrix;
+  dealii::SmartPointer<dealii::MGLevelObject<std::shared_ptr<MatrixType>> const> matrix;
 
   /**
    * The matrix for each level.
    */
-  SmartPointer<MGCoarseGridBase<VectorType> const> coarse;
+  dealii::SmartPointer<dealii::MGCoarseGridBase<VectorType> const> coarse;
 
   /**
    * Object for grid transfer.
@@ -285,7 +283,7 @@ private:
   /**
    * The smoothing object.
    */
-  SmartPointer<MGLevelObject<std::shared_ptr<SmootherType>> const> smoother;
+  dealii::SmartPointer<dealii::MGLevelObject<std::shared_ptr<SmootherType>> const> smoother;
 
   MPI_Comm const mpi_comm;
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.cpp
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 std::string
 enum_to_string(MultigridType const enum_type)
 {
@@ -82,7 +80,7 @@ enum_to_string(MultigridType const enum_type)
       string_type = "phc-MG";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -109,7 +107,7 @@ enum_to_string(PSequenceType const enum_type)
       string_type = "Manual";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -136,7 +134,7 @@ enum_to_string(MultigridSmoother const enum_type)
       string_type = "Jacobi";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -157,7 +155,7 @@ enum_to_string(AMGType const enum_type)
       string_type = "BoomerAMG";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -184,7 +182,7 @@ enum_to_string(MultigridCoarseGridSolver const enum_type)
       string_type = "AMG";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -212,7 +210,7 @@ enum_to_string(MultigridCoarseGridPreconditioner const enum_type)
       string_type = "AMG";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -236,7 +234,7 @@ enum_to_string(PreconditionerSmoother const enum_type)
       string_type = "BlockJacobi";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
@@ -129,16 +129,16 @@ struct AMGData
     boomer_data.n_sweeps_coarse = 1;
     boomer_data.max_iter        = 1;
     boomer_data.relaxation_type_down =
-      PETScWrappers::PreconditionBoomerAMG::AdditionalData::RelaxationType::Chebyshev;
+      dealii::PETScWrappers::PreconditionBoomerAMG::AdditionalData::RelaxationType::Chebyshev;
     boomer_data.relaxation_type_up =
-      PETScWrappers::PreconditionBoomerAMG::AdditionalData::RelaxationType::Chebyshev;
+      dealii::PETScWrappers::PreconditionBoomerAMG::AdditionalData::RelaxationType::Chebyshev;
     boomer_data.relaxation_type_coarse =
-      PETScWrappers::PreconditionBoomerAMG::AdditionalData::RelaxationType::Chebyshev;
+      dealii::PETScWrappers::PreconditionBoomerAMG::AdditionalData::RelaxationType::Chebyshev;
 #endif
   };
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "    AMG type", enum_to_string(amg_type));
 
@@ -163,18 +163,18 @@ struct AMGData
     }
     else
     {
-      AssertThrow(false, ExcNotImplemented());
+      AssertThrow(false, dealii::ExcNotImplemented());
     }
   }
 
   AMGType amg_type;
 
 #ifdef DEAL_II_WITH_TRILINOS
-  TrilinosWrappers::PreconditionAMG::AdditionalData ml_data;
+  dealii::TrilinosWrappers::PreconditionAMG::AdditionalData ml_data;
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
-  PETScWrappers::PreconditionBoomerAMG::AdditionalData boomer_data;
+  dealii::PETScWrappers::PreconditionBoomerAMG::AdditionalData boomer_data;
 #endif
 };
 
@@ -201,7 +201,7 @@ struct SmootherData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "Smoother", enum_to_string(smoother));
     print_parameter(pcout, "Preconditioner smoother", enum_to_string(preconditioner));
@@ -249,7 +249,7 @@ struct CoarseGridData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "Coarse grid solver", enum_to_string(solver));
     print_parameter(pcout, "Coarse grid preconditioner", enum_to_string(preconditioner));
@@ -289,7 +289,7 @@ struct MultigridData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "Multigrid type", enum_to_string(type));
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -517,8 +517,8 @@ create_geometric_coarsening_sequence(
     {
       // extract relevant information from distributed triangulation
       auto const construction_data =
-        dealii::TriangulationDescriptionUtilities::create_description_from_triangulation(tria_copy,
-                                                                                         mpi_comm);
+        dealii::TriangulationDescription::Utilities::create_description_from_triangulation(
+          tria_copy, mpi_comm);
 
       // create fully distributed triangulation
       auto level_tria =
@@ -565,7 +565,7 @@ create_geometric_coarsening_sequence(
                  std::max<unsigned int>(1U, serial_tria.n_active_cells() / n_cells_per_process)));
 
       // extract relevant information from distributed triangulation
-      auto const construction_data = dealii::TriangulationDescriptionUtilities::
+      auto const construction_data = dealii::TriangulationDescription::Utilities::
         create_description_from_triangulation_in_groups<dim, dim>(
           [&](auto & tria) { tria.copy_triangulation(serial_tria); },
           [&](auto & tria, auto const &, auto const) {

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -803,7 +803,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
 
     unsigned int const n_components = fe.n_components();
 
-    // temporal storage for new dealii::DoFHandlers and constraints on each p-level
+    // temporal storage for new DoFHandlers and constraints on each p-level
     std::map<MGDoFHandlerIdentifier, std::shared_ptr<dealii::DoFHandler<dim> const>>
       map_dofhandlers;
     std::map<MGDoFHandlerIdentifier, std::shared_ptr<dealii::MGConstrainedDoFs>>

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -380,7 +380,7 @@ gather_distributed_triangulation_by_node(
     auto [points, cell_data, sub_cell_data] =
       dealii::GridTools::get_coarse_mesh_description(distributed_tria);
 
-    std::vector<std::pair<unsigned int, CellData<dim>>> cell_data_sorted;
+    std::vector<std::pair<unsigned int, dealii::CellData<dim>>> cell_data_sorted;
 
     unsigned int counter = 0;
 
@@ -405,11 +405,11 @@ gather_distributed_triangulation_by_node(
   {
     // collect refinement flags from the complete distributed triangulation on
     // global rank 0 by an MPI_Gather step
-    std::vector<std::vector<std::vector<CellId>>> refinement_flags(n_levels - 1);
+    std::vector<std::vector<std::vector<dealii::CellId>>> refinement_flags(n_levels - 1);
     {
       for(unsigned int l = 0; l < n_levels - 1; ++l)
       {
-        std::vector<CellId> local_refinement_flags;
+        std::vector<dealii::CellId> local_refinement_flags;
 
         for(auto const & cell : distributed_tria.cell_iterators_on_level(l))
           if(cell->has_children())
@@ -517,8 +517,8 @@ create_geometric_coarsening_sequence(
     {
       // extract relevant information from distributed triangulation
       auto const construction_data =
-        TriangulationDescriptionUtilities::create_description_from_triangulation(tria_copy,
-                                                                                 mpi_comm);
+        dealii::TriangulationDescriptionUtilities::create_description_from_triangulation(tria_copy,
+                                                                                         mpi_comm);
 
       // create fully distributed triangulation
       auto level_tria =
@@ -565,9 +565,8 @@ create_geometric_coarsening_sequence(
                  std::max<unsigned int>(1U, serial_tria.n_active_cells() / n_cells_per_process)));
 
       // extract relevant information from distributed triangulation
-      auto const construction_data =
-        TriangulationDescriptionUtilities::create_description_from_triangulation_in_groups<dim,
-                                                                                           dim>(
+      auto const construction_data = dealii::TriangulationDescriptionUtilities::
+        create_description_from_triangulation_in_groups<dim, dim>(
           [&](auto & tria) { tria.copy_triangulation(serial_tria); },
           [&](auto & tria, auto const &, auto const) {
 #  ifdef DEAL_II_WITH_METIS

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -54,8 +54,6 @@ class MGCoarseGridBase;
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class MultigridPreconditionerBase : public PreconditionerBase<Number>
 {
@@ -63,12 +61,13 @@ public:
   typedef float MultigridNumber;
 
 protected:
-  typedef std::map<types::boundary_id, std::shared_ptr<Function<dim>>> Map;
-  typedef std::vector<GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
+  typedef std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> Map;
+  typedef std::vector<
+    dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
     PeriodicFacePairs;
 
-  typedef LinearAlgebra::distributed::Vector<Number>          VectorType;
-  typedef LinearAlgebra::distributed::Vector<MultigridNumber> VectorTypeMG;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number>          VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<MultigridNumber> VectorTypeMG;
 
 private:
   typedef MultigridOperatorBase<dim, MultigridNumber> Operator;
@@ -94,13 +93,13 @@ public:
    * Initialization function.
    */
   void
-  initialize(MultigridData const &               data,
-             Triangulation<dim> const *          tria,
-             FiniteElement<dim> const &          fe,
-             std::shared_ptr<Mapping<dim> const> mapping,
-             bool const                          operator_is_singular = false,
-             Map const *                         dirichlet_bc         = nullptr,
-             PeriodicFacePairs const *           periodic_face_pairs  = nullptr);
+  initialize(MultigridData const &                       data,
+             dealii::Triangulation<dim> const *          tria,
+             dealii::FiniteElement<dim> const &          fe,
+             std::shared_ptr<dealii::Mapping<dim> const> mapping,
+             bool const                                  operator_is_singular = false,
+             Map const *                                 dirichlet_bc         = nullptr,
+             PeriodicFacePairs const *                   periodic_face_pairs  = nullptr);
 
   /*
    * This function applies the multigrid preconditioner dst = P^{-1} src.
@@ -172,24 +171,25 @@ protected:
    * Dof-handlers and constraints.
    */
   virtual void
-  initialize_dof_handler_and_constraints(bool                       is_singular,
-                                         PeriodicFacePairs const *  periodic_face_pairs,
-                                         FiniteElement<dim> const & fe,
-                                         Triangulation<dim> const * tria,
-                                         Map const *                dirichlet_bc);
+  initialize_dof_handler_and_constraints(bool                               is_singular,
+                                         PeriodicFacePairs const *          periodic_face_pairs,
+                                         dealii::FiniteElement<dim> const & fe,
+                                         dealii::Triangulation<dim> const * tria,
+                                         Map const *                        dirichlet_bc);
 
   void
   do_initialize_dof_handler_and_constraints(
-    bool                                                                 is_singular,
-    PeriodicFacePairs const &                                            periodic_face_pairs,
-    FiniteElement<dim> const &                                           fe,
-    Triangulation<dim> const *                                           tria,
-    Map const &                                                          dirichlet_bc,
-    std::vector<MGLevelInfo> &                                           level_info,
-    std::vector<MGDoFHandlerIdentifier> &                                p_levels,
-    MGLevelObject<std::shared_ptr<DoFHandler<dim> const>> &              dofhandlers,
-    MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &                  constrained_dofs,
-    MGLevelObject<std::shared_ptr<AffineConstraints<MultigridNumber>>> & constraints);
+    bool                                                                    is_singular,
+    PeriodicFacePairs const &                                               periodic_face_pairs,
+    dealii::FiniteElement<dim> const &                                      fe,
+    dealii::Triangulation<dim> const *                                      tria,
+    Map const &                                                             dirichlet_bc,
+    std::vector<MGLevelInfo> &                                              level_info,
+    std::vector<MGDoFHandlerIdentifier> &                                   p_levels,
+    dealii::MGLevelObject<std::shared_ptr<dealii::DoFHandler<dim> const>> & dofhandlers,
+    dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>> &     constrained_dofs,
+    dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>> &
+      constraints);
 
   /*
    * Transfer operators.
@@ -199,18 +199,21 @@ protected:
 
   void
   do_initialize_transfer_operators(
-    std::shared_ptr<MGTransfer<VectorTypeMG>> &                          transfers,
-    MGLevelObject<std::shared_ptr<AffineConstraints<MultigridNumber>>> & constraints,
-    MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &                  constrained_dofs,
-    unsigned int const                                                   dof_index);
+    std::shared_ptr<MGTransfer<VectorTypeMG>> & transfers,
+    dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>> &
+                                                                        constraints,
+    dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>> & constrained_dofs,
+    unsigned int const                                                  dof_index);
 
-  MGLevelObject<std::shared_ptr<DoFHandler<dim> const>>                dof_handlers;
-  MGLevelObject<std::shared_ptr<MGConstrainedDoFs>>                    constrained_dofs;
-  MGLevelObject<std::shared_ptr<AffineConstraints<MultigridNumber>>>   constraints;
-  MGLevelObject<std::shared_ptr<MatrixFreeData<dim, MultigridNumber>>> matrix_free_data_objects;
-  MGLevelObject<std::shared_ptr<MatrixFree<dim, MultigridNumber>>>     matrix_free_objects;
-  MGLevelObject<std::shared_ptr<Operator>>                             operators;
-  std::shared_ptr<MGTransfer<VectorTypeMG>>                            transfers;
+  dealii::MGLevelObject<std::shared_ptr<dealii::DoFHandler<dim> const>> dof_handlers;
+  dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>>     constrained_dofs;
+  dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>> constraints;
+  dealii::MGLevelObject<std::shared_ptr<MatrixFreeData<dim, MultigridNumber>>>
+    matrix_free_data_objects;
+  dealii::MGLevelObject<std::shared_ptr<dealii::MatrixFree<dim, MultigridNumber>>>
+                                                   matrix_free_objects;
+  dealii::MGLevelObject<std::shared_ptr<Operator>> operators;
+  std::shared_ptr<MGTransfer<VectorTypeMG>>        transfers;
 
   std::vector<MGDoFHandlerIdentifier> p_levels;
   std::vector<MGLevelInfo>            level_info;
@@ -223,7 +226,9 @@ private:
    * Multigrid levels (i.e. coarsening strategy, h-/p-/hp-/ph-MG).
    */
   void
-  initialize_levels(Triangulation<dim> const * tria, unsigned int const degree, bool const is_dg);
+  initialize_levels(dealii::Triangulation<dim> const * tria,
+                    unsigned int const                 degree,
+                    bool const                         is_dg);
 
   void
   check_levels(std::vector<MGLevelInfo> const & level_info);
@@ -232,29 +237,29 @@ private:
    * Coarse grid triangulations in case of global coarsening transfer type.
    */
   void
-  initialize_coarse_grid_triangulations(Triangulation<dim> const * tria);
+  initialize_coarse_grid_triangulations(dealii::Triangulation<dim> const * tria);
 
   /*
    * Returns the correct mapping depending on the multigrid transfer type and the current h-level.
    */
-  Mapping<dim> const &
+  dealii::Mapping<dim> const &
   get_mapping(unsigned int const h_level) const;
 
   /*
-   * Constrained dofs. This function is required for MGTransfer_MGLevelObject.
+   * Constrained dofs. This function is required for MGTransfer_dealii::MGLevelObject.
    */
   virtual void
-  initialize_constrained_dofs(DoFHandler<dim> const & dof_handler,
-                              MGConstrainedDoFs &     constrained_dofs,
-                              Map const &             dirichlet_bc);
+  initialize_constrained_dofs(dealii::DoFHandler<dim> const & dof_handler,
+                              dealii::MGConstrainedDoFs &     constrained_dofs,
+                              Map const &                     dirichlet_bc);
 
   /*
    * Constrained dofs. This function is required for MGTransferGlobalCoarsening.
    */
   void
-  initialize_affine_constraints(DoFHandler<dim> const &              dof_handler,
-                                AffineConstraints<MultigridNumber> & affine_contraints,
-                                Map const &                          dirichlet_bc);
+  initialize_affine_constraints(dealii::DoFHandler<dim> const &              dof_handler,
+                                dealii::AffineConstraints<MultigridNumber> & affine_contraints,
+                                Map const &                                  dirichlet_bc);
 
   /*
    * Data structures needed for matrix-free operator evaluation.
@@ -310,14 +315,14 @@ private:
 
   MultigridData data;
 
-  Triangulation<dim> const * triangulation;
+  dealii::Triangulation<dim> const * triangulation;
 
   // Only relevant for global coarsening, where this vector contains coarse level triangulations,
   // and the fine level triangulation as the last element of the vector.
-  std::vector<std::shared_ptr<Triangulation<dim> const>> coarse_grid_triangulations;
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> coarse_grid_triangulations;
 
   // In case of global coarsening, this is the mapping associated to the fine level triangulation.
-  std::shared_ptr<Mapping<dim> const> mapping;
+  std::shared_ptr<dealii::Mapping<dim> const> mapping;
 
   // Only relevant for global coarsening,where this vector contains coarse level mappings,
   // and the fine level mapping as the last element of the vector.
@@ -327,9 +332,9 @@ private:
   // used.
   std::shared_ptr<MappingDoFVector<dim, Number>> mapping_global_refinement;
 
-  MGLevelObject<std::shared_ptr<Smoother>> smoothers;
+  dealii::MGLevelObject<std::shared_ptr<Smoother>> smoothers;
 
-  std::shared_ptr<MGCoarseGridBase<VectorTypeMG>> coarse_grid_solver;
+  std::shared_ptr<dealii::MGCoarseGridBase<VectorTypeMG>> coarse_grid_solver;
 
   std::shared_ptr<MultigridAlgorithm<VectorTypeMG, Operator, Smoother>> multigrid_algorithm;
 };

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
@@ -85,7 +85,7 @@ public:
     else
     {
       AssertThrow(data.preconditioner == PreconditionerSmoother::None,
-                  ExcMessage("Specified preconditioner not implemented for CG smoother"));
+                  dealii::ExcMessage("Specified preconditioner not implemented for CG smoother"));
     }
   }
 
@@ -107,14 +107,14 @@ public:
   void
   step(VectorType & dst, VectorType const & src) const
   {
-    IterationNumberControl control(data.number_of_iterations, 1.e-20);
+    dealii::IterationNumberControl control(data.number_of_iterations, 1.e-20);
 
-    SolverCG<VectorType> solver(control);
+    dealii::SolverCG<VectorType> solver(control);
 
     if(preconditioner != nullptr)
       solver.solve(*underlying_operator, dst, src, *preconditioner);
     else
-      solver.solve(*underlying_operator, dst, src, PreconditionIdentity());
+      solver.solve(*underlying_operator, dst, src, dealii::PreconditionIdentity());
   }
 
 private:

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
@@ -30,13 +30,12 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Operator, typename VectorType>
 class ChebyshevSmoother : public SmootherBase<VectorType>
 {
 public:
-  typedef typename PreconditionChebyshev<Operator, VectorType>::AdditionalData AdditionalData;
+  typedef
+    typename dealii::PreconditionChebyshev<Operator, VectorType>::AdditionalData AdditionalData;
 
   ChebyshevSmoother()
   {
@@ -61,7 +60,7 @@ public:
   }
 
 private:
-  PreconditionChebyshev<Operator, VectorType> smoother_object;
+  dealii::PreconditionChebyshev<Operator, VectorType> smoother_object;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
@@ -86,7 +86,8 @@ public:
     else
     {
       AssertThrow(data.preconditioner == PreconditionerSmoother::None,
-                  ExcMessage("Specified preconditioner not implemented for GMRES smoother"));
+                  dealii::ExcMessage(
+                    "Specified preconditioner not implemented for GMRES smoother"));
     }
   }
 
@@ -108,16 +109,16 @@ public:
   void
   step(VectorType & dst, VectorType const & src) const
   {
-    IterationNumberControl control(data.number_of_iterations, 1.e-20);
+    dealii::IterationNumberControl control(data.number_of_iterations, 1.e-20);
 
-    typename SolverGMRES<VectorType>::AdditionalData additional_data;
+    typename dealii::SolverGMRES<VectorType>::AdditionalData additional_data;
     additional_data.right_preconditioning = true;
-    SolverGMRES<VectorType> solver(control, additional_data);
+    dealii::SolverGMRES<VectorType> solver(control, additional_data);
 
     if(preconditioner != nullptr)
       solver.solve(*underlying_operator, dst, src, *preconditioner);
     else
-      solver.solve(*underlying_operator, dst, src, PreconditionIdentity());
+      solver.solve(*underlying_operator, dst, src, dealii::PreconditionIdentity());
   }
 
 private:

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
@@ -89,7 +89,7 @@ public:
     {
       AssertThrow(data.preconditioner == PreconditionerSmoother::PointJacobi ||
                     data.preconditioner == PreconditionerSmoother::BlockJacobi,
-                  ExcMessage(
+                  dealii::ExcMessage(
                     "Specified type of preconditioner for Jacobi smoother not implemented."));
     }
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.cpp
@@ -28,29 +28,27 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename VectorType, int components>
 MGTransferC<dim, Number, VectorType, components>::MGTransferC(
-  Mapping<dim> const &              mapping,
-  MatrixFree<dim, Number> const &   matrixfree_dg,
-  MatrixFree<dim, Number> const &   matrixfree_cg,
-  AffineConstraints<Number> const & constraints_dg,
-  AffineConstraints<Number> const & constraints_cg,
-  unsigned int const                level,
-  unsigned int const                fe_degree,
-  unsigned int const                dof_handler_index)
+  dealii::Mapping<dim> const &              mapping,
+  dealii::MatrixFree<dim, Number> const &   matrixfree_dg,
+  dealii::MatrixFree<dim, Number> const &   matrixfree_cg,
+  dealii::AffineConstraints<Number> const & constraints_dg,
+  dealii::AffineConstraints<Number> const & constraints_cg,
+  unsigned int const                        level,
+  unsigned int const                        fe_degree,
+  unsigned int const                        dof_handler_index)
   : fe_degree(fe_degree)
 {
-  std::vector<DoFHandler<dim> const *> dofhandlers = {
+  std::vector<dealii::DoFHandler<dim> const *> dofhandlers = {
     &matrixfree_cg.get_dof_handler(dof_handler_index),
     &matrixfree_dg.get_dof_handler(dof_handler_index)};
 
-  std::vector<AffineConstraints<Number> const *> constraint_matrices = {&constraints_cg,
-                                                                        &constraints_dg};
-  QGauss<1>                                      quadrature(1);
+  std::vector<dealii::AffineConstraints<Number> const *> constraint_matrices = {&constraints_cg,
+                                                                                &constraints_dg};
+  dealii::QGauss<1>                                      quadrature(1);
 
-  typename MatrixFree<dim, Number>::AdditionalData additional_data;
+  typename dealii::MatrixFree<dim, Number>::AdditionalData additional_data;
   additional_data.mg_level = level;
   data_composite.reinit(mapping, dofhandlers, constraint_matrices, quadrature, additional_data);
 }
@@ -66,8 +64,8 @@ void
 MGTransferC<dim, Number, VectorType, components>::do_interpolate(VectorType &       dst,
                                                                  VectorType const & src) const
 {
-  FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
-  FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
+  dealii::FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
+  dealii::FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
 
   VectorType vec_dg;
   data_composite.initialize_dof_vector(vec_dg, 1);
@@ -93,8 +91,8 @@ void
 MGTransferC<dim, Number, VectorType, components>::do_restrict_and_add(VectorType &       dst,
                                                                       VectorType const & src) const
 {
-  FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
-  FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
+  dealii::FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
+  dealii::FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
 
   VectorType src_temp;
   data_composite.initialize_dof_vector(src_temp, 1);
@@ -113,7 +111,7 @@ MGTransferC<dim, Number, VectorType, components>::do_restrict_and_add(VectorType
     fe_eval_cg.distribute_local_to_global(dst);
   }
 
-  dst.compress(VectorOperation::add);
+  dst.compress(dealii::VectorOperation::add);
 }
 
 template<int dim, typename Number, typename VectorType, int components>
@@ -124,8 +122,8 @@ MGTransferC<dim, Number, VectorType, components>::do_prolongate(VectorType &    
 {
   src.update_ghost_values();
 
-  FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
-  FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
+  dealii::FEEvaluation<dim, degree, 1, components, Number> fe_eval_cg(data_composite, 0);
+  dealii::FEEvaluation<dim, degree, 1, components, Number> fe_eval_dg(data_composite, 1);
 
   VectorType dst_temp;
   data_composite.initialize_dof_vector(dst_temp, 1);
@@ -174,7 +172,7 @@ MGTransferC<dim, Number, VectorType, components>::interpolate(unsigned int const
     case 14: do_interpolate<14>(dst, src); break;
     case 15: do_interpolate<15>(dst, src); break;
     default:
-      AssertThrow(false, ExcMessage("MGTransferC::interpolate() not implemented for this degree!"));
+      AssertThrow(false, dealii::ExcMessage("MGTransferC::interpolate() not implemented for this degree!"));
       // clang-format on
   }
 }
@@ -204,7 +202,7 @@ MGTransferC<dim, Number, VectorType, components>::restrict_and_add(unsigned int 
     case 14: do_restrict_and_add<14>(dst, src); break;
     case 15: do_restrict_and_add<15>(dst, src); break;
     default:
-      AssertThrow(false, ExcMessage("MGTransferC::restrict_and_add() not implemented for this degree!"));
+      AssertThrow(false, dealii::ExcMessage("MGTransferC::restrict_and_add() not implemented for this degree!"));
       // clang-format on
   }
 }
@@ -234,7 +232,7 @@ MGTransferC<dim, Number, VectorType, components>::prolongate_and_add(unsigned in
     case 14: do_prolongate<14>(dst, src); break;
     case 15: do_prolongate<15>(dst, src); break;
     default:
-      AssertThrow(false, ExcMessage("MGTransferC::prolongate() not implemented for this degree!"));
+      AssertThrow(false, dealii::ExcMessage("MGTransferC::prolongate() not implemented for this degree!"));
       // clang-format on
   }
 }

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_c.h
@@ -30,23 +30,21 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim,
          typename Number,
-         typename VectorType = LinearAlgebra::distributed::Vector<Number>,
+         typename VectorType = dealii::LinearAlgebra::distributed::Vector<Number>,
          int components      = 1>
 class MGTransferC : virtual public MGTransfer<VectorType>
 {
 public:
-  MGTransferC(Mapping<dim> const &              mapping,
-              MatrixFree<dim, Number> const &   matrixfree_dg,
-              MatrixFree<dim, Number> const &   matrixfree_cg,
-              AffineConstraints<Number> const & constraints_dg,
-              AffineConstraints<Number> const & constraints_cg,
-              unsigned int const                level,
-              unsigned int const                fe_degree,
-              unsigned int const                dof_handler_index = 0);
+  MGTransferC(dealii::Mapping<dim> const &              mapping,
+              dealii::MatrixFree<dim, Number> const &   matrixfree_dg,
+              dealii::MatrixFree<dim, Number> const &   matrixfree_cg,
+              dealii::AffineConstraints<Number> const & constraints_dg,
+              dealii::AffineConstraints<Number> const & constraints_cg,
+              unsigned int const                        level,
+              unsigned int const                        fe_degree,
+              unsigned int const                        dof_handler_index = 0);
 
   virtual ~MGTransferC();
 
@@ -72,8 +70,8 @@ private:
   void
   do_prolongate(VectorType & dst, VectorType const & src) const;
 
-  unsigned int const      fe_degree;
-  MatrixFree<dim, Number> data_composite;
+  unsigned int const              fe_degree;
+  dealii::MatrixFree<dim, Number> data_composite;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.cpp
@@ -25,8 +25,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename VectorType>
 void
 MGTransferGlobalCoarsening<dim, Number, VectorType>::restrict_and_add(unsigned int const level,
@@ -49,15 +47,15 @@ MGTransferGlobalCoarsening<dim, Number, VectorType>::prolongate_and_add(
 template<int dim, typename Number, typename VectorType>
 void
 MGTransferGlobalCoarsening<dim, Number, VectorType>::reinit(
-  MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
-  MGLevelObject<std::shared_ptr<AffineConstraints<Number>>> & mg_constraints,
-  unsigned int const                                          dof_handler_index)
+  dealii::MGLevelObject<std::shared_ptr<dealii::MatrixFree<dim, Number>>> &   mg_matrixfree,
+  dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<Number>>> & mg_constraints,
+  unsigned int const                                                          dof_handler_index)
 {
   std::vector<MGLevelInfo>            global_levels;
   std::vector<MGDoFHandlerIdentifier> p_levels;
 
   unsigned int const min_level = mg_matrixfree.min_level();
-  AssertThrow(min_level == 0, ExcMessage("Currently, we expect min_level==0!"));
+  AssertThrow(min_level == 0, dealii::ExcMessage("Currently, we expect min_level==0!"));
 
   unsigned int const max_level = mg_matrixfree.max_level();
 
@@ -110,7 +108,7 @@ MGTransferGlobalCoarsening<dim, Number, VectorType>::reinit(
     }
     else
     {
-      AssertThrow(false, ExcMessage("Cannot create MGTransfer!"));
+      AssertThrow(false, dealii::ExcMessage("Cannot create MGTransfer!"));
     }
   }
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_coarsening.h
@@ -34,8 +34,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename VectorType>
 class MGTransferGlobalCoarsening : virtual public MGTransfer<VectorType>
 {
@@ -45,9 +43,9 @@ public:
   }
 
   void
-  reinit(MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
-         MGLevelObject<std::shared_ptr<AffineConstraints<Number>>> & mg_constraints,
-         unsigned int const                                          dof_handler_index = 0);
+  reinit(dealii::MGLevelObject<std::shared_ptr<dealii::MatrixFree<dim, Number>>> &   mg_matrixfree,
+         dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<Number>>> & mg_constraints,
+         unsigned int const dof_handler_index = 0);
 
   void
   interpolate(unsigned int const level, VectorType & dst, VectorType const & src) const;
@@ -59,7 +57,7 @@ public:
   prolongate_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const;
 
 private:
-  MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> transfers;
+  dealii::MGLevelObject<dealii::MGTwoLevelTransfer<dim, VectorType>> transfers;
 
   std::unique_ptr<dealii::MGTransferGlobalCoarsening<dim, VectorType>>
     mg_transfer_global_coarsening;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.cpp
@@ -27,22 +27,20 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename VectorType>
 void
 MGTransferGlobalRefinement<dim, Number, VectorType>::reinit(
-  Mapping<dim> const &                                        mapping,
-  MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
-  MGLevelObject<std::shared_ptr<AffineConstraints<Number>>> & mg_constraints,
-  MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &         mg_constrained_dofs,
-  unsigned int const                                          dof_handler_index)
+  dealii::Mapping<dim> const &                                                mapping,
+  dealii::MGLevelObject<std::shared_ptr<dealii::MatrixFree<dim, Number>>> &   mg_matrixfree,
+  dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<Number>>> & mg_constraints,
+  dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>> &         mg_constrained_dofs,
+  unsigned int const                                                          dof_handler_index)
 {
   std::vector<MGLevelInfo>            global_levels;
   std::vector<MGDoFHandlerIdentifier> p_levels;
 
   unsigned int const min_level = mg_matrixfree.min_level();
-  AssertThrow(min_level == 0, ExcMessage("Currently, we expect min_level==0!"));
+  AssertThrow(min_level == 0, dealii::ExcMessage("Currently, we expect min_level==0!"));
 
   unsigned int const max_level = mg_matrixfree.max_level();
   int const          n_components =
@@ -141,7 +139,7 @@ MGTransferGlobalRefinement<dim, Number, VectorType>::reinit(
       }
       else
       {
-        AssertThrow(false, ExcMessage("Cannot create MGTransferP!"));
+        AssertThrow(false, dealii::ExcMessage("Cannot create MGTransferP!"));
       }
     }
     else if(coarse_level.is_dg() != fine_level.is_dg()) // c-transfer
@@ -170,7 +168,7 @@ MGTransferGlobalRefinement<dim, Number, VectorType>::reinit(
       }
       else
       {
-        AssertThrow(false, ExcMessage("Cannot create MGTransferP!"));
+        AssertThrow(false, dealii::ExcMessage("Cannot create MGTransferP!"));
       }
     }
     mg_level_object[i] = temp;

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_global_refinement.h
@@ -33,9 +33,9 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
-template<int dim, typename Number, typename VectorType = LinearAlgebra::distributed::Vector<Number>>
+template<int dim,
+         typename Number,
+         typename VectorType = dealii::LinearAlgebra::distributed::Vector<Number>>
 class MGTransferGlobalRefinement : virtual public MGTransfer<VectorType>
 {
 public:
@@ -44,11 +44,11 @@ public:
   }
 
   void
-  reinit(Mapping<dim> const &                                        mapping,
-         MGLevelObject<std::shared_ptr<MatrixFree<dim, Number>>> &   mg_matrixfree,
-         MGLevelObject<std::shared_ptr<AffineConstraints<Number>>> & mg_constraints,
-         MGLevelObject<std::shared_ptr<MGConstrainedDoFs>> &         mg_constrained_dofs,
-         unsigned int const                                          dof_handler_index = 0);
+  reinit(dealii::Mapping<dim> const &                                                mapping,
+         dealii::MGLevelObject<std::shared_ptr<dealii::MatrixFree<dim, Number>>> &   mg_matrixfree,
+         dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<Number>>> & mg_constraints,
+         dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>> & mg_constrained_dofs,
+         unsigned int const                                                  dof_handler_index = 0);
 
   virtual void
   interpolate(unsigned int const level, VectorType & dst, VectorType const & src) const;
@@ -60,7 +60,7 @@ public:
   prolongate_and_add(unsigned int const level, VectorType & dst, VectorType const & src) const;
 
 private:
-  MGLevelObject<std::shared_ptr<MGTransfer<VectorType>>> mg_level_object;
+  dealii::MGLevelObject<std::shared_ptr<MGTransfer<VectorType>>> mg_level_object;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_h.h
@@ -31,21 +31,19 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /**
  * Specialized matrix-free implementation that overloads the copy_to_mg function for proper
  * initialization of the vectors in matrix-vector products.
  */
 template<int dim, typename Number>
-class MGTransferH : public MGTransferMatrixFree<dim, Number>,
-                    public MGTransfer<LinearAlgebra::distributed::Vector<Number>>
+class MGTransferH : public dealii::MGTransferMatrixFree<dim, Number>,
+                    public MGTransfer<dealii::LinearAlgebra::distributed::Vector<Number>>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   MGTransferH(std::map<unsigned int, unsigned int> level_to_triangulation_level_map,
-              DoFHandler<dim> const &              dof_handler);
+              dealii::DoFHandler<dim> const &      dof_handler);
 
   virtual ~MGTransferH()
   {
@@ -53,7 +51,7 @@ public:
 
   void
   set_operator(
-    MGLevelObject<std::shared_ptr<MultigridOperatorBase<dim, Number>>> const & operator_in);
+    dealii::MGLevelObject<std::shared_ptr<MultigridOperatorBase<dim, Number>>> const & operator_in);
 
   virtual void
   prolongate_and_add(unsigned int const to_level, VectorType & dst, VectorType const & src) const;
@@ -68,12 +66,13 @@ public:
    * Overload copy_to_mg from MGTransferMatrixFree
    */
   void
-  copy_to_mg(DoFHandler<dim, dim> const & mg_dof,
-             MGLevelObject<VectorType> &  dst,
-             VectorType const &           src) const;
+  copy_to_mg(dealii::DoFHandler<dim, dim> const & mg_dof,
+             dealii::MGLevelObject<VectorType> &  dst,
+             VectorType const &                   src) const;
 
 private:
-  MGLevelObject<std::shared_ptr<MultigridOperatorBase<dim, Number>>> const * underlying_operator;
+  dealii::MGLevelObject<std::shared_ptr<MultigridOperatorBase<dim, Number>>> const *
+    underlying_operator;
 
   /*
    * This map converts the multigrid level as used in the V-cycle to an actual level in the
@@ -82,7 +81,7 @@ private:
    */
   mutable std::map<unsigned int, unsigned int> level_to_triangulation_level_map;
 
-  DoFHandler<dim> const & dof_handler;
+  dealii::DoFHandler<dim> const & dof_handler;
 };
 } // namespace ExaDG
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/transfers/mg_transfer_p.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename VectorType, int components = 1>
 class MGTransferP : virtual public MGTransfer<VectorType>
 {
@@ -40,18 +38,18 @@ public:
 
   MGTransferP();
 
-  MGTransferP(MatrixFree<dim, value_type> const * matrixfree_1,
-              MatrixFree<dim, value_type> const * matrixfree_2,
-              int                                 degree_1,
-              int                                 degree_2,
-              int                                 dof_handler_index = 0);
+  MGTransferP(dealii::MatrixFree<dim, value_type> const * matrixfree_1,
+              dealii::MatrixFree<dim, value_type> const * matrixfree_2,
+              int                                         degree_1,
+              int                                         degree_2,
+              int                                         dof_handler_index = 0);
 
   void
-  reinit(MatrixFree<dim, value_type> const * matrixfree_1,
-         MatrixFree<dim, value_type> const * matrixfree_2,
-         int                                 degree_1,
-         int                                 degree_2,
-         int                                 dof_handler_index = 0);
+  reinit(dealii::MatrixFree<dim, value_type> const * matrixfree_1,
+         dealii::MatrixFree<dim, value_type> const * matrixfree_2,
+         int                                         degree_1,
+         int                                         degree_2,
+         int                                         dof_handler_index = 0);
 
   virtual ~MGTransferP();
 
@@ -77,17 +75,17 @@ private:
   void
   do_prolongate(VectorType & dst, VectorType const & src) const;
 
-  MatrixFree<dim, value_type> const *    matrixfree_1;
-  MatrixFree<dim, value_type> const *    matrixfree_2;
-  AlignedVector<VectorizedArray<Number>> prolongation_matrix_1d;
-  AlignedVector<VectorizedArray<Number>> interpolation_matrix_1d;
+  dealii::MatrixFree<dim, value_type> const *            matrixfree_1;
+  dealii::MatrixFree<dim, value_type> const *            matrixfree_2;
+  dealii::AlignedVector<dealii::VectorizedArray<Number>> prolongation_matrix_1d;
+  dealii::AlignedVector<dealii::VectorizedArray<Number>> interpolation_matrix_1d;
 
   unsigned int degree_1;
   unsigned int degree_2;
   unsigned int dof_handler_index;
   unsigned int quad_index;
 
-  AlignedVector<VectorizedArray<Number>> weights;
+  dealii::AlignedVector<dealii::VectorizedArray<Number>> weights;
 
   bool is_dg;
 };

--- a/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
+++ b/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace Newton
 {
-using namespace dealii;
-
 template<typename VectorType,
          typename NonlinearOperator,
          typename LinearOperator,
@@ -115,8 +113,8 @@ public:
       } while(norm_r_damp >= (1.0 - tau * omega) * norm_r && n_iter_damp < max_iter_damp);
 
       AssertThrow(norm_r_damp < (1.0 - tau * omega) * norm_r,
-                  ExcMessage("Damped Newton iteration did not converge. "
-                             "Maximum number of iterations exceeded!"));
+                  dealii::ExcMessage("Damped Newton iteration did not converge. "
+                                     "Maximum number of iterations exceeded!"));
 
       // update solution and residual
       solution = temporary;
@@ -128,8 +126,9 @@ public:
     }
 
     AssertThrow(norm_r <= this->solver_data.abs_tol || norm_r / norm_r_0 <= solver_data.rel_tol,
-                ExcMessage("Newton solver failed to solve nonlinear problem to given tolerance. "
-                           "Maximum number of iterations exceeded!"));
+                dealii::ExcMessage(
+                  "Newton solver failed to solve nonlinear problem to given tolerance. "
+                  "Maximum number of iterations exceeded!"));
 
     return std::tuple<unsigned int, unsigned int>(newton_iterations, linear_iterations);
   }

--- a/include/exadg/solvers_and_preconditioners/newton/newton_solver_data.h
+++ b/include/exadg/solvers_and_preconditioners/newton/newton_solver_data.h
@@ -32,8 +32,6 @@ namespace ExaDG
 {
 namespace Newton
 {
-using namespace dealii;
-
 struct SolverData
 {
   SolverData() : max_iter(100), abs_tol(1.e-12), rel_tol(1.e-12)
@@ -46,7 +44,7 @@ struct SolverData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "Maximum number of iterations", max_iter);
     print_parameter(pcout, "Absolute solver tolerance", abs_tol);

--- a/include/exadg/solvers_and_preconditioners/preconditioners/elementwise_preconditioners.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/elementwise_preconditioners.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Elementwise
 {
-using namespace dealii;
-
 /*
  * Preconditioners
  */
@@ -90,18 +88,19 @@ private:
 };
 
 template<int dim, int n_components, typename Number>
-class InverseMassPreconditioner : public Elementwise::PreconditionerBase<VectorizedArray<Number>>
+class InverseMassPreconditioner
+  : public Elementwise::PreconditionerBase<dealii::VectorizedArray<Number>>
 {
 public:
   typedef CellIntegrator<dim, n_components, Number> Integrator;
 
   // use a template parameter of -1 to select the precompiled version of this operator
-  typedef MatrixFreeOperators::CellwiseInverseMassMatrix<dim, -1, n_components, Number>
+  typedef dealii::MatrixFreeOperators::CellwiseInverseMassMatrix<dim, -1, n_components, Number>
     CellwiseInverseMass;
 
-  InverseMassPreconditioner(MatrixFree<dim, Number> const & matrix_free,
-                            unsigned int const              dof_index,
-                            unsigned int const              quad_index)
+  InverseMassPreconditioner(dealii::MatrixFree<dim, Number> const & matrix_free,
+                            unsigned int const                      dof_index,
+                            unsigned int const                      quad_index)
   {
     integrator = std::make_shared<Integrator>(matrix_free, dof_index, quad_index);
     inverse    = std::make_shared<CellwiseInverseMass>(*integrator);
@@ -114,7 +113,7 @@ public:
   }
 
   void
-  vmult(VectorizedArray<Number> * dst, VectorizedArray<Number> const * src) const
+  vmult(dealii::VectorizedArray<Number> * dst, dealii::VectorizedArray<Number> const * src) const
   {
     inverse->apply(src, dst);
   }

--- a/include/exadg/solvers_and_preconditioners/preconditioners/enum_types.cpp
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/enum_types.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Elementwise
 {
-using namespace dealii;
-
 std::string
 enum_to_string(Preconditioner const enum_type)
 {
@@ -48,7 +46,7 @@ enum_to_string(Preconditioner const enum_type)
       string_type = "InverseMassMatrix";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
@@ -27,17 +27,15 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, int n_components, typename Number>
 class InverseMassPreconditioner : public PreconditionerBase<Number>
 {
 public:
   typedef typename PreconditionerBase<Number>::VectorType VectorType;
 
-  InverseMassPreconditioner(MatrixFree<dim, Number> const & matrix_free,
-                            unsigned int const              dof_index,
-                            unsigned int const              quad_index)
+  InverseMassPreconditioner(dealii::MatrixFree<dim, Number> const & matrix_free,
+                            unsigned int const                      dof_index,
+                            unsigned int const                      quad_index)
   {
     inverse_mass_operator.initialize(matrix_free, dof_index, quad_index);
   }

--- a/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
@@ -47,7 +47,7 @@ public:
   void
   vmult(VectorType & dst, VectorType const & src) const
   {
-    if(!PointerComparison::equal(&dst, &src))
+    if(!dealii::PointerComparison::equal(&dst, &src))
       dst = src;
     dst.scale(inverse_diagonal);
   }

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
@@ -30,13 +30,11 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename value_type>
 class PreconditionerBase
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<value_type> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<value_type> VectorType;
 
   virtual ~PreconditionerBase()
   {

--- a/include/exadg/solvers_and_preconditioners/solvers/elementwise_krylov_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/elementwise_krylov_solvers.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Elementwise
 {
-using namespace dealii;
-
 template<typename Number, typename Number2>
 bool
 all_smaller(Number const a, const Number2 b)
@@ -44,9 +42,9 @@ all_smaller(Number const a, const Number2 b)
 
 template<typename Number, typename Number2>
 bool
-all_smaller(VectorizedArray<Number> const a, Number2 const b)
+all_smaller(dealii::VectorizedArray<Number> const a, Number2 const b)
 {
-  for(unsigned int i = 0; i < VectorizedArray<Number>::size(); ++i)
+  for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); ++i)
     if(a[i] >= b)
       return false;
   return true;
@@ -61,9 +59,9 @@ all_true(Number const a)
 
 template<typename Number>
 bool
-all_true(VectorizedArray<Number> const a)
+all_true(dealii::VectorizedArray<Number> const a)
 {
-  for(unsigned int i = 0; i < VectorizedArray<Number>::size(); ++i)
+  for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); ++i)
     if(a[i] < 0)
       return false;
   return true;
@@ -96,15 +94,15 @@ converged(Number &     is_converged,
 
 template<typename Number, typename Number2>
 bool
-converged(VectorizedArray<Number> & is_converged,
-          VectorizedArray<Number>   norm_r_abs,
-          Number2                   ABS_TOL,
-          VectorizedArray<Number>   norm_r_rel,
-          Number2                   REL_TOL,
-          unsigned int              k,
-          unsigned int              MAX_ITER)
+converged(dealii::VectorizedArray<Number> & is_converged,
+          dealii::VectorizedArray<Number>   norm_r_abs,
+          Number2                           ABS_TOL,
+          dealii::VectorizedArray<Number>   norm_r_rel,
+          Number2                           REL_TOL,
+          unsigned int                      k,
+          unsigned int                      MAX_ITER)
 {
-  for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+  for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
   {
     if((norm_r_abs[v] < ABS_TOL || norm_r_rel[v] < REL_TOL || k >= MAX_ITER))
       is_converged[v] = 1.0;
@@ -123,9 +121,9 @@ adjust_division_by_zero(Number &)
 
 template<typename Number>
 void
-adjust_division_by_zero(VectorizedArray<Number> & x)
+adjust_division_by_zero(dealii::VectorizedArray<Number> & x)
 {
-  for(unsigned int i = 0; i < VectorizedArray<Number>::size(); ++i)
+  for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); ++i)
     if(x[i] < 1e-30)
       x[i] = 1;
 }
@@ -241,12 +239,12 @@ public:
         Preconditioner const * preconditioner);
 
 private:
-  unsigned int const        M;
-  double const              ABS_TOL;
-  double const              REL_TOL;
-  unsigned int const        MAX_ITER;
-  AlignedVector<value_type> storage;
-  value_type *              p, *r, *v;
+  unsigned int const                M;
+  double const                      ABS_TOL;
+  double const                      REL_TOL;
+  unsigned int const                MAX_ITER;
+  dealii::AlignedVector<value_type> storage;
+  value_type *                      p, *r, *v;
 };
 
 /*
@@ -382,9 +380,9 @@ private:
   value_type norm_r_rel;
 
   // store convergence status which is necessary
-  // for the VectorizedArray data type where the
+  // for the dealii::VectorizedArray data type where the
   // convergence status of the different elements
-  // of VectorizedArray has to be tracked seperately
+  // of dealii::VectorizedArray has to be tracked seperately
   value_type convergence_status;
 
   // accumulated iterations
@@ -394,16 +392,16 @@ private:
   unsigned int k;
 
   // matrices of variable size
-  AlignedVector<AlignedVector<value_type>> V;
-  AlignedVector<AlignedVector<value_type>> H;
+  dealii::AlignedVector<dealii::AlignedVector<value_type>> V;
+  dealii::AlignedVector<dealii::AlignedVector<value_type>> H;
 
   // temporary vector
-  AlignedVector<value_type> temp;
+  dealii::AlignedVector<value_type> temp;
 
   // vectors of variable size
-  AlignedVector<value_type> res;
-  AlignedVector<value_type> s;
-  AlignedVector<value_type> c;
+  dealii::AlignedVector<value_type> res;
+  dealii::AlignedVector<value_type> s;
+  dealii::AlignedVector<value_type> c;
 
   // neutral element of multiplication
   // for data of type value_type
@@ -416,23 +414,23 @@ private:
   do_solve(Matrix const * A, value_type * x, value_type const * b, Preconditioner const * P);
 
   void
-  modified_gram_schmidt(AlignedVector<value_type> &                      w,
-                        AlignedVector<AlignedVector<value_type>> &       H,
-                        AlignedVector<AlignedVector<value_type>> const & V,
-                        unsigned int const                               dim);
+  modified_gram_schmidt(dealii::AlignedVector<value_type> &                              w,
+                        dealii::AlignedVector<dealii::AlignedVector<value_type>> &       H,
+                        dealii::AlignedVector<dealii::AlignedVector<value_type>> const & V,
+                        unsigned int const                                               dim);
 
   template<typename Number>
   void perform_givens_rotation_and_calculate_residual(Number);
 
   template<typename Number>
-  void perform_givens_rotation_and_calculate_residual(VectorizedArray<Number>);
+  void perform_givens_rotation_and_calculate_residual(dealii::VectorizedArray<Number>);
 
   template<typename Number>
   void print(Number, std::string);
 
   template<typename Number>
   void
-  print(VectorizedArray<Number> y, std::string name);
+  print(dealii::VectorizedArray<Number> y, std::string name);
 };
 
 /*
@@ -456,7 +454,7 @@ SolverGMRES<value_type, Matrix, Preconditioner>::SolverGMRES(unsigned int const 
   // negative values = false (not converged)
   convergence_status = -1.0;
 
-  temp = AlignedVector<value_type>(M);
+  temp = dealii::AlignedVector<value_type>(M);
 
   one = 1.0;
 }
@@ -480,14 +478,15 @@ void SolverGMRES<value_type, Matrix, Preconditioner>::print(Number, std::string)
 }
 
 /*
- *  Print function for data of type VectorizedArray
+ *  Print function for data of type dealii::VectorizedArray
  */
 template<typename value_type, typename Matrix, typename Preconditioner>
 template<typename Number>
 void
-SolverGMRES<value_type, Matrix, Preconditioner>::print(VectorizedArray<Number> y, std::string name)
+SolverGMRES<value_type, Matrix, Preconditioner>::print(dealii::VectorizedArray<Number> y,
+                                                       std::string                     name)
 {
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
   {
     std::cout << name << "[" << v << "] = " << y[v] << std::endl;
   }
@@ -505,7 +504,7 @@ SolverGMRES<value_type, Matrix, Preconditioner>::print(VectorizedArray<Number> y
  *
  *  The operations performed here are "unproblematic"
  *  and can be performed also in the case of the
- *  VectorizedArray data type, i.e., the values written
+ *  dealii::VectorizedArray data type, i.e., the values written
  *  to the Hessenberg matrix in this function are
  *  ignored in case that the solver has already converged
  *  for a specific component of the vectorized array
@@ -515,10 +514,10 @@ SolverGMRES<value_type, Matrix, Preconditioner>::print(VectorizedArray<Number> y
 template<typename value_type, typename Matrix, typename Preconditioner>
 void
 SolverGMRES<value_type, Matrix, Preconditioner>::modified_gram_schmidt(
-  AlignedVector<value_type> &                      w,
-  AlignedVector<AlignedVector<value_type>> &       H,
-  AlignedVector<AlignedVector<value_type>> const & V,
-  unsigned int const                               dim)
+  dealii::AlignedVector<value_type> &                              w,
+  dealii::AlignedVector<dealii::AlignedVector<value_type>> &       H,
+  dealii::AlignedVector<dealii::AlignedVector<value_type>> const & V,
+  unsigned int const                                               dim)
 {
   for(unsigned int i = 0; i < dim; ++i)
   {
@@ -562,12 +561,12 @@ template<typename value_type, typename Matrix, typename Preconditioner>
 template<typename Number>
 void
   SolverGMRES<value_type, Matrix, Preconditioner>::perform_givens_rotation_and_calculate_residual(
-    VectorizedArray<Number>)
+    dealii::VectorizedArray<Number>)
 {
-  VectorizedArray<Number> H_i_k   = VectorizedArray<Number>();
-  VectorizedArray<Number> H_ip1_k = VectorizedArray<Number>();
+  dealii::VectorizedArray<Number> H_i_k   = dealii::VectorizedArray<Number>();
+  dealii::VectorizedArray<Number> H_ip1_k = dealii::VectorizedArray<Number>();
 
-  for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+  for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
   {
     if(convergence_status[v] > 0.0)
     {
@@ -595,15 +594,15 @@ void
     }
   }
 
-  VectorizedArray<Number> beta        = VectorizedArray<Number>();
-  VectorizedArray<Number> sin         = VectorizedArray<Number>();
-  VectorizedArray<Number> cos         = VectorizedArray<Number>();
-  VectorizedArray<Number> res_k_store = VectorizedArray<Number>();
-  res_k_store                         = res[k];
-  VectorizedArray<Number> res_k       = VectorizedArray<Number>();
-  VectorizedArray<Number> res_kp1     = VectorizedArray<Number>();
+  dealii::VectorizedArray<Number> beta        = dealii::VectorizedArray<Number>();
+  dealii::VectorizedArray<Number> sin         = dealii::VectorizedArray<Number>();
+  dealii::VectorizedArray<Number> cos         = dealii::VectorizedArray<Number>();
+  dealii::VectorizedArray<Number> res_k_store = dealii::VectorizedArray<Number>();
+  res_k_store                                 = res[k];
+  dealii::VectorizedArray<Number> res_k       = dealii::VectorizedArray<Number>();
+  dealii::VectorizedArray<Number> res_kp1     = dealii::VectorizedArray<Number>();
 
-  for(unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+  for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
   {
     if(convergence_status[v] > 0.0)
     {
@@ -678,7 +677,7 @@ SolverGMRES<value_type, Matrix, Preconditioner>::solve(Matrix const *         A,
   //    // the solution x: r = b - A*x
   //
   //    //temp2 = A*x
-  //    AlignedVector<value_type> temp2 = AlignedVector<value_type>(M);
+  //    dealii::AlignedVector<value_type> temp2 = AlignedVector<value_type>(M);
   //    A->vmult(temp2.begin(),x);
   //    // temp = b - temp2 = b - A*x = r
   //    equ(temp.begin(),one,b,-one,temp2.begin());
@@ -693,7 +692,7 @@ SolverGMRES<value_type, Matrix, Preconditioner>::do_solve(Matrix const *        
                                                           Preconditioner const * P)
 {
   // apply matrix vector product: r = A*x
-  V.push_back(AlignedVector<value_type>(M));
+  V.push_back(dealii::AlignedVector<value_type>(M));
   A->vmult(V[0].begin(), x);
 
   // compute residual r = b - A*x and its norm
@@ -732,7 +731,7 @@ SolverGMRES<value_type, Matrix, Preconditioner>::do_solve(Matrix const *        
 
     // calculate new search direction by performing
     // matrix-vector product: V[k+1] = A*V[k]
-    V.push_back(AlignedVector<value_type>(M));
+    V.push_back(dealii::AlignedVector<value_type>(M));
 
     // apply preconditioner
     P->vmult(temp.begin(), V[k].begin());
@@ -740,7 +739,7 @@ SolverGMRES<value_type, Matrix, Preconditioner>::do_solve(Matrix const *        
     A->vmult(V[k + 1].begin(), temp.begin());
 
     // resize H
-    H.push_back(AlignedVector<value_type>(k + 2));
+    H.push_back(dealii::AlignedVector<value_type>(k + 2));
 
     // perform modified Gram-Schmidt orthogonalization
     modified_gram_schmidt(V[k + 1], H, V, k + 1);
@@ -757,8 +756,8 @@ SolverGMRES<value_type, Matrix, Preconditioner>::do_solve(Matrix const *        
   }
 
   // calculate solution
-  AlignedVector<value_type> y(k);
-  AlignedVector<value_type> delta = AlignedVector<value_type>(M);
+  dealii::AlignedVector<value_type> y(k);
+  dealii::AlignedVector<value_type> delta = dealii::AlignedVector<value_type>(M);
 
   /*
    *  calculate solution as linear combination of
@@ -780,8 +779,8 @@ SolverGMRES<value_type, Matrix, Preconditioner>::do_solve(Matrix const *        
    *  |   0    0    0  H_33  | |  y_3  |   |  res_3    | -> y_3 = res_3/H_33
    *  |_  0    0    0    0  _| |_  *  _|   |_ res_k+1 _|
    *
-   *  VectorizedArray: assume that the solver converged after 2 iterations
-   *                   for some components of the VectorizedArray
+   *  dealii::VectorizedArray: assume that the solver converged after 2 iterations
+   *                   for some components of the dealii::VectorizedArray
    *                   but after 4 iterations for the other components
    *   _                    _   _     _     _         _
    *  | H_00 H_01   0    0   | |  y_0  |   |  res_0    | -> y_0 = (res_0-H_01*y_0)/H_00

--- a/include/exadg/solvers_and_preconditioners/solvers/elementwise_krylov_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/elementwise_krylov_solvers.h
@@ -677,7 +677,7 @@ SolverGMRES<value_type, Matrix, Preconditioner>::solve(Matrix const *         A,
   //    // the solution x: r = b - A*x
   //
   //    //temp2 = A*x
-  //    dealii::AlignedVector<value_type> temp2 = AlignedVector<value_type>(M);
+  //    dealii::AlignedVector<value_type> temp2 = dealii::AlignedVector<value_type>(M);
   //    A->vmult(temp2.begin(),x);
   //    // temp = b - temp2 = b - A*x = r
   //    equ(temp.begin(),one,b,-one,temp2.begin());

--- a/include/exadg/solvers_and_preconditioners/solvers/enum_types.cpp
+++ b/include/exadg/solvers_and_preconditioners/solvers/enum_types.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Elementwise
 {
-using namespace dealii;
-
 std::string
 enum_to_string(Solver const enum_type)
 {
@@ -48,7 +46,7 @@ enum_to_string(Solver const enum_type)
       string_type = "GMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -119,7 +119,7 @@ public:
   unsigned int
   solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
-    Timer timer;
+    dealii::Timer timer;
 
     dealii::ReductionControl solver_control(solver_data.max_iter,
                                             solver_data.solver_tolerance_abs,
@@ -227,7 +227,7 @@ public:
   unsigned int
   solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
-    Timer timer;
+    dealii::Timer timer;
 
     dealii::ReductionControl solver_control(solver_data.max_iter,
                                             solver_data.solver_tolerance_abs,
@@ -249,7 +249,7 @@ public:
 
     if(solver_data.use_preconditioner == false)
     {
-      solver.solve(underlying_operator, dst, rhs, PreconditionIdentity());
+      solver.solve(underlying_operator, dst, rhs, dealii::PreconditionIdentity());
     }
     else
     {
@@ -328,7 +328,7 @@ public:
   unsigned int
   solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
-    Timer timer;
+    dealii::Timer timer;
 
     dealii::ReductionControl solver_control(solver_data.max_iter,
                                             solver_data.solver_tolerance_abs,
@@ -342,7 +342,7 @@ public:
 
     if(solver_data.use_preconditioner == false)
     {
-      solver.solve(underlying_operator, dst, rhs, PreconditionIdentity());
+      solver.solve(underlying_operator, dst, rhs, dealii::PreconditionIdentity());
     }
     else
     {

--- a/include/exadg/solvers_and_preconditioners/solvers/solver_data.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/solver_data.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct SolverData
 {
   SolverData() : max_iter(1e3), abs_tol(1e-20), rel_tol(1e-6), max_krylov_size(30)
@@ -47,7 +45,7 @@ struct SolverData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "Maximum number of iterations", max_iter);
     print_parameter(pcout, "Absolute solver tolerance", abs_tol);

--- a/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
@@ -37,7 +37,6 @@ namespace ExaDG
 {
 namespace Elementwise
 {
-using namespace dealii;
 /*
  * Solver data
  */
@@ -57,10 +56,11 @@ template<int dim,
          typename Number,
          typename Operator,
          typename Preconditioner>
-class IterativeSolver : public Krylov::SolverBase<LinearAlgebra::distributed::Vector<Number>>
+class IterativeSolver
+  : public Krylov::SolverBase<dealii::LinearAlgebra::distributed::Vector<Number>>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef IterativeSolver<dim, number_of_equations, Number, Operator, Preconditioner> THIS;
 
@@ -87,7 +87,7 @@ public:
 
 private:
   void
-  solve_elementwise(MatrixFree<dim, Number> const &               matrix_free,
+  solve_elementwise(dealii::MatrixFree<dim, Number> const &       matrix_free,
                     VectorType &                                  dst,
                     VectorType const &                            src,
                     std::pair<unsigned int, unsigned int> const & cell_range) const
@@ -98,24 +98,24 @@ private:
 
     unsigned int const dofs_per_cell = integrator.dofs_per_cell;
 
-    AlignedVector<VectorizedArray<Number>> solution(dofs_per_cell);
+    dealii::AlignedVector<dealii::VectorizedArray<Number>> solution(dofs_per_cell);
 
     // setup elementwise solver
     if(iterative_solver_data.solver_type == Solver::CG)
     {
-      solver =
-        std::make_shared<Elementwise::SolverCG<VectorizedArray<Number>, Operator, Preconditioner>>(
-          dofs_per_cell, iterative_solver_data.solver_data);
+      solver = std::make_shared<
+        Elementwise::SolverCG<dealii::VectorizedArray<Number>, Operator, Preconditioner>>(
+        dofs_per_cell, iterative_solver_data.solver_data);
     }
     else if(iterative_solver_data.solver_type == Solver::GMRES)
     {
       solver = std::make_shared<
-        Elementwise::SolverGMRES<VectorizedArray<Number>, Operator, Preconditioner>>(
+        Elementwise::SolverGMRES<dealii::VectorizedArray<Number>, Operator, Preconditioner>>(
         dofs_per_cell, iterative_solver_data.solver_data);
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     // loop over all cells and solve local problem iteratively on each cell
@@ -139,7 +139,7 @@ private:
   }
 
   mutable std::shared_ptr<
-    Elementwise::SolverBase<VectorizedArray<Number>, Operator, Preconditioner>>
+    Elementwise::SolverBase<dealii::VectorizedArray<Number>, Operator, Preconditioner>>
     solver;
 
   Operator & op;

--- a/include/exadg/solvers_and_preconditioners/utilities/block_jacobi_matrices.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/block_jacobi_matrices.h
@@ -24,17 +24,15 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  *  Initialize block Jacobi matrices with zeros.
  */
 template<typename Number>
 void
-initialize_block_jacobi_matrices_with_zero(std::vector<LAPACKFullMatrix<Number>> & matrices)
+initialize_block_jacobi_matrices_with_zero(std::vector<dealii::LAPACKFullMatrix<Number>> & matrices)
 {
   // initialize matrices
-  for(typename std::vector<LAPACKFullMatrix<Number>>::iterator it = matrices.begin();
+  for(typename std::vector<dealii::LAPACKFullMatrix<Number>>::iterator it = matrices.begin();
       it != matrices.end();
       ++it)
   {
@@ -49,13 +47,13 @@ initialize_block_jacobi_matrices_with_zero(std::vector<LAPACKFullMatrix<Number>>
  */
 template<typename Number>
 void
-calculate_lu_factorization_block_jacobi(std::vector<LAPACKFullMatrix<Number>> & matrices)
+calculate_lu_factorization_block_jacobi(std::vector<dealii::LAPACKFullMatrix<Number>> & matrices)
 {
-  for(typename std::vector<LAPACKFullMatrix<Number>>::iterator it = matrices.begin();
+  for(typename std::vector<dealii::LAPACKFullMatrix<Number>>::iterator it = matrices.begin();
       it != matrices.end();
       ++it)
   {
-    LAPACKFullMatrix<Number> copy(*it);
+    dealii::LAPACKFullMatrix<Number> copy(*it);
     try // the matrix might be singular
     {
       (*it).compute_lu_factorization();

--- a/include/exadg/solvers_and_preconditioners/utilities/check_multigrid.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/check_multigrid.h
@@ -31,15 +31,14 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<int dim, typename Number, typename Operator, typename Preconditioner>
 class CheckMultigrid
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
-  typedef LinearAlgebra::distributed::Vector<typename Preconditioner::MultigridNumber> VectorTypeMG;
+  typedef dealii::LinearAlgebra::distributed::Vector<typename Preconditioner::MultigridNumber>
+    VectorTypeMG;
 
   CheckMultigrid(Operator const &                underlying_operator_in,
                  std::shared_ptr<Preconditioner> preconditioner_in,
@@ -114,8 +113,8 @@ public:
                VectorType const &   solution_after_mg_cylce,
                VectorTypeMG const & solution_after_smoothing) const
   {
-    DataOut<dim>          data_out;
-    DataOutBase::VtkFlags flags;
+    dealii::DataOut<dim>          data_out;
+    dealii::DataOutBase::VtkFlags flags;
     flags.write_higher_order_cells = true;
     data_out.set_flags(flags);
 
@@ -141,9 +140,9 @@ public:
     {
       // velocity
       std::vector<std::string> initial(dim, "initial");
-      std::vector<DataComponentInterpretation::DataComponentInterpretation>
-        initial_component_interpretation(dim,
-                                         DataComponentInterpretation::component_is_part_of_vector);
+      std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+        initial_component_interpretation(
+          dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
 
       data_out.add_data_vector(underlying_operator.get_matrix_free().get_dof_handler(dof_index),
                                initial_solution,
@@ -151,9 +150,9 @@ public:
                                initial_component_interpretation);
 
       std::vector<std::string> mg_cycle(dim, "mg_cycle");
-      std::vector<DataComponentInterpretation::DataComponentInterpretation>
-        mg_cylce_component_interpretation(dim,
-                                          DataComponentInterpretation::component_is_part_of_vector);
+      std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+        mg_cylce_component_interpretation(
+          dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
 
       data_out.add_data_vector(underlying_operator.get_matrix_free().get_dof_handler(dof_index),
                                solution_after_mg_cylce,
@@ -161,9 +160,9 @@ public:
                                mg_cylce_component_interpretation);
 
       std::vector<std::string> smoother(dim, "smoother");
-      std::vector<DataComponentInterpretation::DataComponentInterpretation>
-        smoother_component_interpretation(dim,
-                                          DataComponentInterpretation::component_is_part_of_vector);
+      std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+        smoother_component_interpretation(
+          dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
 
       data_out.add_data_vector(underlying_operator.get_matrix_free().get_dof_handler(dof_index),
                                solution_after_smoothing,
@@ -176,15 +175,15 @@ public:
 
     std::ostringstream filename;
     std::string        name = "smoothing";
-    filename << name << "_Proc" << Utilities::MPI::this_mpi_process(mpi_comm) << ".vtu";
+    filename << name << "_Proc" << dealii::Utilities::MPI::this_mpi_process(mpi_comm) << ".vtu";
 
     std::ofstream output(filename.str().c_str());
     data_out.write_vtu(output);
 
-    if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+    if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
     {
       std::vector<std::string> filenames;
-      for(unsigned int i = 0; i < Utilities::MPI::n_mpi_processes(mpi_comm); ++i)
+      for(unsigned int i = 0; i < dealii::Utilities::MPI::n_mpi_processes(mpi_comm); ++i)
       {
         std::ostringstream filename;
         filename << name << "_Proc" << i << ".vtu";

--- a/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 // manually compute eigenvalues for the coarsest level for proper setup of the
 // Chebyshev iteration
 template<typename Operator, typename VectorType>
@@ -45,13 +43,13 @@ compute_eigenvalues(Operator const &   op,
   if(operator_is_singular)
     set_zero_mean_value(rhs);
 
-  SolverControl control(eig_n_iter, rhs.l2_norm() * 1e-5);
-  internal::PreconditionChebyshevImplementation::EigenvalueTracker eigenvalue_tracker;
+  dealii::SolverControl control(eig_n_iter, rhs.l2_norm() * 1e-5);
+  dealii::internal::PreconditionChebyshevImplementation::EigenvalueTracker eigenvalue_tracker;
 
-  SolverCG<VectorType> solver(control);
+  dealii::SolverCG<VectorType> solver(control);
 
   solver.connect_eigenvalues_slot(
-    std::bind(&internal::PreconditionChebyshevImplementation::EigenvalueTracker::slot,
+    std::bind(&dealii::internal::PreconditionChebyshevImplementation::EigenvalueTracker::slot,
               &eigenvalue_tracker,
               std::placeholders::_1));
 
@@ -61,7 +59,7 @@ compute_eigenvalues(Operator const &   op,
   {
     solver.solve(op, solution, rhs, preconditioner);
   }
-  catch(SolverControl::NoConvergence &)
+  catch(dealii::SolverControl::NoConvergence &)
   {
   }
 

--- a/include/exadg/solvers_and_preconditioners/utilities/invert_diagonal.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/invert_diagonal.h
@@ -26,8 +26,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  *  This function inverts the diagonal (element by element).
  *  If diagonal values are very small, the inverse of this
@@ -35,7 +33,7 @@ using namespace dealii;
  */
 template<typename Number>
 void
-invert_diagonal(LinearAlgebra::distributed::Vector<Number> & diagonal)
+invert_diagonal(dealii::LinearAlgebra::distributed::Vector<Number> & diagonal)
 {
   for(unsigned int i = 0; i < diagonal.locally_owned_size(); ++i)
   {

--- a/include/exadg/solvers_and_preconditioners/utilities/verify_calculation_of_diagonal.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/verify_calculation_of_diagonal.h
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  *  To check the correctness of the efficient computation of the diagonal
  *  the result is compared to a naive calculation that simply applies the
@@ -38,17 +36,18 @@ using namespace dealii;
  */
 template<typename Operator, typename value_type>
 void
-verify_calculation_of_diagonal(Operator &                                       op,
-                               LinearAlgebra::distributed::Vector<value_type> & diagonal,
-                               MPI_Comm const &                                 mpi_comm)
+verify_calculation_of_diagonal(Operator &                                               op,
+                               dealii::LinearAlgebra::distributed::Vector<value_type> & diagonal,
+                               MPI_Comm const &                                         mpi_comm)
 {
-  AssertThrow(Utilities::MPI::n_mpi_processes(mpi_comm) == 1,
-              ExcMessage("Number of MPI processes has to be 1."));
+  AssertThrow(dealii::Utilities::MPI::n_mpi_processes(mpi_comm) == 1,
+              dealii::ExcMessage("Number of MPI processes has to be 1."));
 
-  ConditionalOStream pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0);
+  dealii::ConditionalOStream pcout(std::cout,
+                                   dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0);
   pcout << "Verify calculation of diagonal:" << std::endl;
 
-  typedef LinearAlgebra::distributed::Vector<value_type> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<value_type> VectorType;
 
   VectorType diagonal_check(diagonal);
   VectorType src(diagonal);

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -34,15 +34,13 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 Driver<dim, Number>::Driver(MPI_Comm const &                              comm,
                             std::shared_ptr<ApplicationBase<dim, Number>> app,
                             bool const                                    is_test,
                             bool const                                    is_throughput_study)
   : mpi_comm(comm),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(comm) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(comm) == 0),
     is_test(is_test),
     is_throughput_study(is_throughput_study),
     application(app)
@@ -54,7 +52,7 @@ template<int dim, typename Number>
 void
 Driver<dim, Number>::setup()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   pcout << std::endl << "Setting up elasticity solver:" << std::endl;
@@ -74,7 +72,7 @@ Driver<dim, Number>::setup()
   matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
   matrix_free_data->append(pde_operator);
 
-  matrix_free = std::make_shared<MatrixFree<dim, Number>>();
+  matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
   matrix_free->reinit(*application->get_grid()->mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),
@@ -110,7 +108,7 @@ Driver<dim, Number>::setup()
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     pde_operator->setup_solver();
@@ -137,7 +135,7 @@ Driver<dim, Number>::solve() const
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 }
 
@@ -180,7 +178,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
   }
   else
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   pcout << std::endl << "Timings for level 1:" << std::endl;
@@ -190,11 +188,12 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
   timer_tree.print_level(pcout, 2);
 
   // Throughput in DoFs/s per time step per core
-  types::global_dof_index const DoFs            = pde_operator->get_number_of_dofs();
-  unsigned int const            N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
+  dealii::types::global_dof_index const DoFs = pde_operator->get_number_of_dofs();
+  unsigned int const N_mpi_processes         = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
 
-  Utilities::MPI::MinMaxAvg total_time_data = Utilities::MPI::min_max_avg(total_time, mpi_comm);
-  double const              total_time_avg  = total_time_data.avg;
+  dealii::Utilities::MPI::MinMaxAvg total_time_data =
+    dealii::Utilities::MPI::min_max_avg(total_time, mpi_comm);
+  double const total_time_avg = total_time_data.avg;
 
   if(application->get_parameters().problem_type == ProblemType::Unsteady)
   {
@@ -216,7 +215,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
 }
 
 template<int dim, typename Number>
-std::tuple<unsigned int, types::global_dof_index, double>
+std::tuple<unsigned int, dealii::types::global_dof_index, double>
 Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
                                     unsigned int const  n_repetitions_inner,
                                     unsigned int const  n_repetitions_outer) const
@@ -226,7 +225,7 @@ Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
   OperatorType operator_type;
   string_to_enum(operator_type, operator_type_string);
 
-  LinearAlgebra::distributed::Vector<Number> dst, src, linearization;
+  dealii::LinearAlgebra::distributed::Vector<Number> dst, src, linearization;
   pde_operator->initialize_dof_vector(src);
   pde_operator->initialize_dof_vector(dst);
   src = 1.0;
@@ -264,11 +263,11 @@ Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
                                                             mpi_comm);
 
   // calculate throughput
-  types::global_dof_index const dofs = pde_operator->get_number_of_dofs();
+  dealii::types::global_dof_index const dofs = pde_operator->get_number_of_dofs();
 
   double const throughput = (double)dofs / wall_time;
 
-  unsigned int const N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
+  unsigned int const N_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
 
   if(not(is_test))
   {
@@ -282,7 +281,7 @@ Driver<dim, Number>::apply_operator(std::string const & operator_type_string,
 
   pcout << std::endl << " ... done." << std::endl << std::endl;
 
-  return std::tuple<unsigned int, types::global_dof_index, double>(
+  return std::tuple<unsigned int, dealii::types::global_dof_index, double>(
     application->get_parameters().degree, dofs, throughput);
 }
 

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -41,8 +41,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 enum class OperatorType
 {
   Nonlinear,
@@ -59,7 +57,7 @@ enum_to_string(OperatorType const enum_type)
     // clang-format off
     case OperatorType::Nonlinear:  string_type = "Nonlinear";  break;
     case OperatorType::Linearized: string_type = "Linearized"; break;
-    default: AssertThrow(false, ExcMessage("Not implemented.")); break;
+    default: AssertThrow(false, dealii::ExcMessage("Not implemented.")); break;
       // clang-format on
   }
 
@@ -72,7 +70,7 @@ string_to_enum(OperatorType & enum_type, std::string const string_type)
   // clang-format off
   if     (string_type == "Nonlinear")  enum_type = OperatorType::Nonlinear;
   else if(string_type == "Linearized") enum_type = OperatorType::Linearized;
-  else AssertThrow(false, ExcMessage("Unknown operator type. Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Unknown operator type. Not implemented."));
   // clang-format on
 }
 
@@ -83,7 +81,7 @@ get_dofs_per_element(std::string const & input_file,
 {
   (void)input_file;
 
-  unsigned int const dofs_per_element = Utilities::pow(degree, dim) * dim;
+  unsigned int const dofs_per_element = dealii::Utilities::pow(degree, dim) * dim;
 
   return dofs_per_element;
 }
@@ -109,7 +107,7 @@ public:
   /*
    * Throughput study
    */
-  std::tuple<unsigned int, types::global_dof_index, double>
+  std::tuple<unsigned int, dealii::types::global_dof_index, double>
   apply_operator(std::string const & operator_type_string,
                  unsigned int const  n_repetitions_inner,
                  unsigned int const  n_repetitions_outer) const;
@@ -119,7 +117,7 @@ private:
   MPI_Comm mpi_comm;
 
   // output to std::cout
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // do not print wall times if is_test
   bool const is_test;
@@ -134,8 +132,8 @@ private:
   Parameters param;
 
   // matrix-free
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   // operator
   std::shared_ptr<Operator<dim, Number>> pde_operator;

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -26,23 +26,22 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
-StVenantKirchhoff<dim, Number>::StVenantKirchhoff(MatrixFree<dim, Number> const &    matrix_free,
-                                                  unsigned int const                 n_q_points_1d,
-                                                  unsigned int const                 dof_index,
-                                                  unsigned int const                 quad_index,
-                                                  StVenantKirchhoffData<dim> const & data)
+StVenantKirchhoff<dim, Number>::StVenantKirchhoff(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  unsigned int const                      n_q_points_1d,
+  unsigned int const                      dof_index,
+  unsigned int const                      quad_index,
+  StVenantKirchhoffData<dim> const &      data)
   : dof_index(dof_index),
     quad_index(quad_index),
     data(data),
     E_is_variable(data.E_function != nullptr)
 {
   Number const E = data.E;
-  f0             = make_vectorized_array<Number>(get_f0_factor() * E);
-  f1             = make_vectorized_array<Number>(get_f1_factor() * E);
-  f2             = make_vectorized_array<Number>(get_f2_factor() * E);
+  f0             = dealii::make_vectorized_array<Number>(get_f0_factor() * E);
+  f1             = dealii::make_vectorized_array<Number>(get_f1_factor() * E);
+  f2             = dealii::make_vectorized_array<Number>(get_f2_factor() * E);
 
   if(E_is_variable)
   {
@@ -100,7 +99,7 @@ StVenantKirchhoff<dim, Number>::get_f2_factor() const
 template<int dim, typename Number>
 void
 StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients(
-  MatrixFree<dim, Number> const & matrix_free,
+  dealii::MatrixFree<dim, Number> const & matrix_free,
   VectorType &,
   VectorType const &,
   Range const & cell_range) const
@@ -115,7 +114,7 @@ StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients(
     // loop over all quadrature points
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
-      VectorizedArray<Number> E_vec =
+      dealii::VectorizedArray<Number> E_vec =
         FunctionEvaluator<0, dim, Number>::value(data.E_function,
                                                  integrator.quadrature_point(q),
                                                  0.0 /*time*/);
@@ -129,12 +128,13 @@ StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients(
 }
 
 template<int dim, typename Number>
-Tensor<2, dim, VectorizedArray<Number>>
-  StVenantKirchhoff<dim, Number>::evaluate_stress(Tensor<2, dim, VectorizedArray<Number>> const & E,
-                                                  unsigned int const cell,
-                                                  unsigned int const q) const
+dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+  StVenantKirchhoff<dim, Number>::evaluate_stress(
+    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & E,
+    unsigned int const                                              cell,
+    unsigned int const                                              q) const
 {
-  Tensor<2, dim, VectorizedArray<Number>> S;
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> S;
 
   if(E_is_variable)
   {
@@ -167,10 +167,10 @@ Tensor<2, dim, VectorizedArray<Number>>
 }
 
 template<int dim, typename Number>
-Tensor<2, dim, VectorizedArray<Number>>
-  StVenantKirchhoff<dim, Number>::apply_C(Tensor<2, dim, VectorizedArray<Number>> const & E,
-                                          unsigned int const                              cell,
-                                          unsigned int const                              q) const
+dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> StVenantKirchhoff<dim, Number>::apply_C(
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & E,
+  unsigned int const                                              cell,
+  unsigned int const                                              q) const
 {
   return evaluate_stress(E, cell, q);
 }

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.h
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.h
@@ -36,22 +36,20 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim>
 struct StVenantKirchhoffData : public MaterialData
 {
-  StVenantKirchhoffData(MaterialType const &                 type,
-                        double const &                       E,
-                        double const &                       nu,
-                        Type2D const &                       type_two_dim,
-                        std::shared_ptr<Function<dim>> const E_function = nullptr)
+  StVenantKirchhoffData(MaterialType const &                         type,
+                        double const &                               E,
+                        double const &                               nu,
+                        Type2D const &                               type_two_dim,
+                        std::shared_ptr<dealii::Function<dim>> const E_function = nullptr)
     : MaterialData(type), E(E), E_function(E_function), nu(nu), type_two_dim(type_two_dim)
   {
   }
 
-  double                         E;
-  std::shared_ptr<Function<dim>> E_function;
+  double                                 E;
+  std::shared_ptr<dealii::Function<dim>> E_function;
 
   double nu;
   Type2D type_two_dim;
@@ -61,24 +59,25 @@ template<int dim, typename Number>
 class StVenantKirchhoff : public Material<dim, Number>
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
-  typedef std::pair<unsigned int, unsigned int>      Range;
-  typedef CellIntegrator<dim, dim, Number>           IntegratorCell;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef std::pair<unsigned int, unsigned int>              Range;
+  typedef CellIntegrator<dim, dim, Number>                   IntegratorCell;
 
-  StVenantKirchhoff(MatrixFree<dim, Number> const &    matrix_free,
-                    unsigned int const                 n_q_points_1d,
-                    unsigned int const                 dof_index,
-                    unsigned int const                 quad_index,
-                    StVenantKirchhoffData<dim> const & data);
+  StVenantKirchhoff(dealii::MatrixFree<dim, Number> const & matrix_free,
+                    unsigned int const                      n_q_points_1d,
+                    unsigned int const                      dof_index,
+                    unsigned int const                      quad_index,
+                    StVenantKirchhoffData<dim> const &      data);
 
-  Tensor<2, dim, VectorizedArray<Number>>
-    evaluate_stress(Tensor<2, dim, VectorizedArray<Number>> const & E,
-                    unsigned int const                              cell,
-                    unsigned int const                              q) const;
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+    evaluate_stress(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & E,
+                    unsigned int const                                              cell,
+                    unsigned int const                                              q) const;
 
-  Tensor<2, dim, VectorizedArray<Number>> apply_C(Tensor<2, dim, VectorizedArray<Number>> const & E,
-                                                  unsigned int const cell,
-                                                  unsigned int const q) const;
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+    apply_C(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & E,
+            unsigned int const                                              cell,
+            unsigned int const                                              q) const;
 
 private:
   Number
@@ -91,7 +90,7 @@ private:
   get_f2_factor() const;
 
   void
-  cell_loop_set_coefficients(MatrixFree<dim, Number> const & matrix_free,
+  cell_loop_set_coefficients(dealii::MatrixFree<dim, Number> const & matrix_free,
                              VectorType &,
                              VectorType const & src,
                              Range const &      cell_range) const;
@@ -101,9 +100,9 @@ private:
 
   StVenantKirchhoffData<dim> const & data;
 
-  mutable VectorizedArray<Number> f0;
-  mutable VectorizedArray<Number> f1;
-  mutable VectorizedArray<Number> f2;
+  mutable dealii::VectorizedArray<Number> f0;
+  mutable dealii::VectorizedArray<Number> f1;
+  mutable dealii::VectorizedArray<Number> f2;
 
   // cache coefficients for spatially varying material parameters
   bool                                           E_is_variable;

--- a/include/exadg/structure/material/material.h
+++ b/include/exadg/structure/material/material.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class Material
 {
@@ -43,15 +41,15 @@ public:
   {
   }
 
-  virtual Tensor<2, dim, VectorizedArray<Number>>
-    evaluate_stress(Tensor<2, dim, VectorizedArray<Number>> const & E,
-                    unsigned int const                              cell,
-                    unsigned int const                              q) const = 0;
+  virtual dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+    evaluate_stress(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & E,
+                    unsigned int const                                              cell,
+                    unsigned int const                                              q) const = 0;
 
-  virtual Tensor<2, dim, VectorizedArray<Number>>
-    apply_C(Tensor<2, dim, VectorizedArray<Number>> const & E,
-            unsigned int const                              cell,
-            unsigned int const                              q) const = 0;
+  virtual dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+    apply_C(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & E,
+            unsigned int const                                              cell,
+            unsigned int const                                              q) const = 0;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/material/material_handler.h
+++ b/include/exadg/structure/material/material_handler.h
@@ -34,21 +34,19 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class MaterialHandler
 {
 public:
-  typedef std::pair<types::material_id, std::shared_ptr<Material<dim, Number>>> Pair;
-  typedef std::map<types::material_id, std::shared_ptr<Material<dim, Number>>>  Materials;
+  typedef std::pair<dealii::types::material_id, std::shared_ptr<Material<dim, Number>>> Pair;
+  typedef std::map<dealii::types::material_id, std::shared_ptr<Material<dim, Number>>>  Materials;
 
   MaterialHandler() : dof_index(0)
   {
   }
 
   void
-  initialize(MatrixFree<dim, Number> const &           matrix_free,
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              unsigned int const                        n_q_points_1d,
              unsigned int const                        dof_index,
              unsigned int const                        quad_index,
@@ -59,7 +57,7 @@ public:
 
     for(auto iter = material_descriptor->begin(); iter != material_descriptor->end(); ++iter)
     {
-      types::material_id            id   = iter->first;
+      dealii::types::material_id    id   = iter->first;
       std::shared_ptr<MaterialData> data = iter->second;
       MaterialType                  type = data->type;
 
@@ -67,7 +65,7 @@ public:
       {
         case MaterialType::Undefined:
         {
-          AssertThrow(false, ExcMessage("Material type is undefined."));
+          AssertThrow(false, dealii::ExcMessage("Material type is undefined."));
           break;
         }
         case MaterialType::StVenantKirchhoff:
@@ -82,7 +80,7 @@ public:
         }
         default:
         {
-          AssertThrow(false, ExcMessage("Specified material type is not implemented."));
+          AssertThrow(false, dealii::ExcMessage("Specified material type is not implemented."));
           break;
         }
       }
@@ -90,14 +88,14 @@ public:
   }
 
   void
-  reinit(MatrixFree<dim, Number> const & matrix_free, unsigned int const cell)
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free, unsigned int const cell)
   {
     auto mid = matrix_free.get_cell_iterator(cell, 0, dof_index)->material_id();
 
 #ifdef DEBUG
     for(unsigned int v = 1; v < matrix_free.n_active_entries_per_cell_batch(cell); v++)
       AssertThrow(mid == matrix_free.get_cell_iterator(cell, v)->material_id(),
-                  ExcMessage("You have to categorize cells according to their materials!"));
+                  dealii::ExcMessage("You have to categorize cells according to their materials!"));
 #endif
 
     material = material_map[mid];

--- a/include/exadg/structure/postprocessor/output_generator.cpp
+++ b/include/exadg/structure/postprocessor/output_generator.cpp
@@ -33,26 +33,24 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename VectorType>
 void
-write_output(OutputDataBase const &  output_data,
-             DoFHandler<dim> const & dof_handler,
-             Mapping<dim> const &    mapping,
-             VectorType const &      solution_vector,
-             unsigned int const      output_counter,
-             MPI_Comm const &        mpi_comm)
+write_output(OutputDataBase const &          output_data,
+             dealii::DoFHandler<dim> const & dof_handler,
+             dealii::Mapping<dim> const &    mapping,
+             VectorType const &              solution_vector,
+             unsigned int const              output_counter,
+             MPI_Comm const &                mpi_comm)
 {
-  DataOutBase::VtkFlags flags;
+  dealii::DataOutBase::VtkFlags flags;
   flags.write_higher_order_cells = output_data.write_higher_order;
 
-  DataOut<dim> data_out;
+  dealii::DataOut<dim> data_out;
   data_out.set_flags(flags);
 
-  std::vector<std::string>                                              names(dim, "displacement");
-  std::vector<DataComponentInterpretation::DataComponentInterpretation> component_interpretation(
-    dim, DataComponentInterpretation::component_is_part_of_vector);
+  std::vector<std::string> names(dim, "displacement");
+  std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+    component_interpretation(dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
 
 #if !DEAL_II_VERSION_GTE(10, 0, 0)
   solution_vector.update_ghost_values();
@@ -60,7 +58,7 @@ write_output(OutputDataBase const &  output_data,
 
   data_out.add_data_vector(dof_handler, solution_vector, names, component_interpretation);
 
-  data_out.build_patches(mapping, output_data.degree, DataOut<dim>::curved_inner_cells);
+  data_out.build_patches(mapping, output_data.degree, dealii::DataOut<dim>::curved_inner_cells);
 
   data_out.write_vtu_with_pvtu_record(
     output_data.directory, output_data.filename, output_counter, mpi_comm, 4);
@@ -74,9 +72,9 @@ OutputGenerator<dim, Number>::OutputGenerator(MPI_Comm const & comm)
 
 template<int dim, typename Number>
 void
-OutputGenerator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_in,
-                                    Mapping<dim> const &    mapping_in,
-                                    OutputDataBase const &  output_data_in)
+OutputGenerator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_in,
+                                    dealii::Mapping<dim> const &    mapping_in,
+                                    OutputDataBase const &          output_data_in)
 {
   dof_handler = &dof_handler_in;
   mapping     = &mapping_in;
@@ -115,7 +113,7 @@ OutputGenerator<dim, Number>::setup(DoFHandler<dim> const & dof_handler_in,
     // processor_id
     if(output_data.write_processor_id)
     {
-      GridOut grid_out;
+      dealii::GridOut grid_out;
 
       grid_out.write_mesh_per_processor_as_vtu(dof_handler->get_triangulation(),
                                                output_data.directory + output_data.filename +
@@ -130,7 +128,8 @@ OutputGenerator<dim, Number>::evaluate(VectorType const & solution,
                                        double const &     time,
                                        int const &        time_step_number)
 {
-  ConditionalOStream pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
+  dealii::ConditionalOStream pcout(std::cout,
+                                   dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
 
   if(output_data.write_output == true)
   {

--- a/include/exadg/structure/postprocessor/output_generator.h
+++ b/include/exadg/structure/postprocessor/output_generator.h
@@ -32,20 +32,18 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class OutputGenerator
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   OutputGenerator(MPI_Comm const & comm);
 
   void
-  setup(DoFHandler<dim> const & dof_handler,
-        Mapping<dim> const &    mapping,
-        OutputDataBase const &  output_data);
+  setup(dealii::DoFHandler<dim> const & dof_handler,
+        dealii::Mapping<dim> const &    mapping,
+        OutputDataBase const &          output_data);
 
   void
   evaluate(VectorType const & solution, double const & time, int const & time_step_number);
@@ -56,9 +54,9 @@ private:
   unsigned int output_counter;
   bool         reset_counter;
 
-  SmartPointer<DoFHandler<dim> const> dof_handler;
-  SmartPointer<Mapping<dim> const>    mapping;
-  OutputDataBase                      output_data;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  OutputDataBase                                      output_data;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/postprocessor/postprocessor.cpp
+++ b/include/exadg/structure/postprocessor/postprocessor.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data_in,
                                           MPI_Comm const &               mpi_comm_in)
@@ -39,7 +37,8 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data
 
 template<int dim, typename Number>
 void
-PostProcessor<dim, Number>::setup(DoFHandler<dim> const & dof_handler, Mapping<dim> const & mapping)
+PostProcessor<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler,
+                                  dealii::Mapping<dim> const &    mapping)
 {
   output_generator.setup(dof_handler, mapping, pp_data.output_data);
 

--- a/include/exadg/structure/postprocessor/postprocessor.h
+++ b/include/exadg/structure/postprocessor/postprocessor.h
@@ -35,8 +35,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim>
 struct PostProcessorData
 {
@@ -54,7 +52,7 @@ public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
   void
-  setup(DoFHandler<dim> const & dof_handler, Mapping<dim> const & mapping);
+  setup(dealii::DoFHandler<dim> const & dof_handler, dealii::Mapping<dim> const & mapping);
 
   void
   do_postprocessing(VectorType const & solution,

--- a/include/exadg/structure/postprocessor/postprocessor_base.h
+++ b/include/exadg/structure/postprocessor/postprocessor_base.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<typename Number>
 class PostProcessorBase
 {

--- a/include/exadg/structure/preconditioners/amg_preconditioner.h
+++ b/include/exadg/structure/preconditioners/amg_preconditioner.h
@@ -29,15 +29,13 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<typename Operator, typename Number>
 class PreconditionerAMG : public PreconditionerBase<Number>
 {
 private:
-  typedef double                                          NumberAMG;
-  typedef typename PreconditionerBase<Number>::VectorType VectorType;
-  typedef LinearAlgebra::distributed::Vector<NumberAMG>   VectorTypeAMG;
+  typedef double                                                NumberAMG;
+  typedef typename PreconditionerBase<Number>::VectorType       VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<NumberAMG> VectorTypeAMG;
 
 public:
   PreconditionerAMG(Operator const & pde_operator, AMGData const & data)
@@ -51,7 +49,7 @@ public:
       preconditioner_amg =
         std::make_shared<PreconditionerBoomerAMG<Operator, double>>(pde_operator, data.boomer_data);
 #else
-      AssertThrow(false, ExcMessage("deal.II is not compiled with PETSc!"));
+      AssertThrow(false, dealii::ExcMessage("deal.II is not compiled with PETSc!"));
 #endif
     }
     else if(data.amg_type == AMGType::ML)
@@ -60,12 +58,12 @@ public:
       preconditioner_amg =
         std::make_shared<PreconditionerML<Operator, double>>(pde_operator, data.ml_data);
 #else
-      AssertThrow(false, ExcMessage("deal.II is not compiled with Trilinos!"));
+      AssertThrow(false, dealii::ExcMessage("deal.II is not compiled with Trilinos!"));
 #endif
     }
     else
     {
-      AssertThrow(false, ExcNotImplemented());
+      AssertThrow(false, dealii::ExcNotImplemented());
     }
   }
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -25,8 +25,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & mpi_comm)
   : Base(mpi_comm), pde_operator(nullptr), nonlinear(true)
@@ -37,9 +35,9 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize(
   MultigridData const &                       mg_data,
-  Triangulation<dim> const *                  tria,
-  FiniteElement<dim> const &                  fe,
-  std::shared_ptr<Mapping<dim> const>         mapping,
+  dealii::Triangulation<dim> const *          tria,
+  dealii::FiniteElement<dim> const &          fe,
+  std::shared_ptr<dealii::Mapping<dim> const> mapping,
   ElasticityOperatorBase<dim, Number> const & pde_operator,
   bool const                                  nonlinear_operator,
   Map const *                                 dirichlet_bc,
@@ -71,7 +69,7 @@ MultigridPreconditioner<dim, Number>::update()
   else
   {
     AssertThrow(false,
-                ExcMessage(
+                dealii::ExcMessage(
                   "Update of multigrid preconditioner is not implemented for linear elasticity."));
   }
 }
@@ -92,16 +90,16 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 
   matrix_free_data.insert_dof_handler(&(*this->dof_handlers[level]), "elasticity_dof_handler");
   matrix_free_data.insert_constraint(&(*this->constraints[level]), "elasticity_dof_handler");
-  matrix_free_data.insert_quadrature(QGauss<1>(this->level_info[level].degree() + 1),
+  matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
                                      "elasticity_quadrature");
 }
 
 template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize_constrained_dofs(
-  DoFHandler<dim> const & dof_handler,
-  MGConstrainedDoFs &     constrained_dofs,
-  Map const &             dirichlet_bc)
+  dealii::DoFHandler<dim> const & dof_handler,
+  dealii::MGConstrainedDoFs &     constrained_dofs,
+  Map const &                     dirichlet_bc)
 {
   // We use data.bc->dirichlet_bc since we also need dirichlet_bc_component_mask,
   // but the argument dirichlet_bc could be used as well
@@ -110,11 +108,11 @@ MultigridPreconditioner<dim, Number>::initialize_constrained_dofs(
   constrained_dofs.initialize(dof_handler);
   for(auto it : data.bc->dirichlet_bc)
   {
-    std::set<types::boundary_id> dirichlet_boundary;
+    std::set<dealii::types::boundary_id> dirichlet_boundary;
     dirichlet_boundary.insert(it.first);
 
-    ComponentMask mask    = ComponentMask();
-    auto          it_mask = data.bc->dirichlet_bc_component_mask.find(it.first);
+    dealii::ComponentMask mask    = dealii::ComponentMask();
+    auto                  it_mask = data.bc->dirichlet_bc_component_mask.find(it.first);
     if(it_mask != data.bc->dirichlet_bc_component_mask.end())
       mask = it_mask->second;
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -31,8 +31,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class MultigridPreconditioner : public MultigridPreconditionerBase<dim, Number>
 {
@@ -62,9 +60,9 @@ public:
 
   void
   initialize(MultigridData const &                       mg_data,
-             Triangulation<dim> const *                  tria,
-             FiniteElement<dim> const &                  fe,
-             std::shared_ptr<Mapping<dim> const>         mapping,
+             dealii::Triangulation<dim> const *          tria,
+             dealii::FiniteElement<dim> const &          fe,
+             std::shared_ptr<dealii::Mapping<dim> const> mapping,
              ElasticityOperatorBase<dim, Number> const & pde_operator,
              bool const                                  nonlinear_operator,
              Map const *                                 dirichlet_bc        = nullptr,
@@ -83,12 +81,12 @@ private:
                         unsigned int const                     h_level) override;
 
   /*
-   * Has to be overwritten since we want to use ComponentMask here
+   * Has to be overwritten since we want to use dealii::ComponentMask here
    */
   void
-  initialize_constrained_dofs(DoFHandler<dim> const & dof_handler,
-                              MGConstrainedDoFs &     constrained_dofs,
-                              Map const &             dirichlet_bc) override;
+  initialize_constrained_dofs(dealii::DoFHandler<dim> const & dof_handler,
+                              dealii::MGConstrainedDoFs &     constrained_dofs,
+                              Map const &                     dirichlet_bc) override;
 
   /*
    * This function updates the multigrid operators for all levels

--- a/include/exadg/structure/solver.h
+++ b/include/exadg/structure/solver.h
@@ -79,7 +79,7 @@ run(std::string const & input_file,
     MPI_Comm const &    mpi_comm,
     bool const          is_test)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<Structure::ApplicationBase<dim, Number>> application =

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -44,8 +44,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 // forward declaration
 template<int dim, typename Number>
 class Operator;
@@ -59,7 +57,7 @@ template<int dim, typename Number>
 class ResidualOperator
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef Operator<dim, Number> PDEOperator;
 
@@ -111,7 +109,7 @@ template<int dim, typename Number>
 class LinearizedOperator : public dealii::Subscriptor
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef Operator<dim, Number> PDEOperator;
 
@@ -167,7 +165,7 @@ class Operator : public dealii::Subscriptor, public Interface::Operator<Number>
 private:
   typedef float MultigridNumber;
 
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
   /*
@@ -189,8 +187,8 @@ public:
    * related to the solution of linear systems of equations.
    */
   void
-  setup(std::shared_ptr<MatrixFree<dim, Number>>     matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data);
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free,
+        std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data);
 
   /*
    * This function initializes operators, preconditioners, and solvers related to the solution of
@@ -283,16 +281,16 @@ public:
   /*
    * Setters and getters.
    */
-  MatrixFree<dim, Number> const &
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const;
 
-  Mapping<dim> const &
+  dealii::Mapping<dim> const &
   get_mapping() const;
 
-  DoFHandler<dim> const &
+  dealii::DoFHandler<dim> const &
   get_dof_handler() const;
 
-  types::global_dof_index
+  dealii::types::global_dof_index
   get_number_of_dofs() const;
 
   unsigned int
@@ -306,7 +304,7 @@ public:
 
 private:
   /*
-   * Initializes DoFHandler.
+   * Initializes dealii::DoFHandler.
    */
   void
   distribute_dofs();
@@ -366,11 +364,11 @@ private:
   /*
    * Basic finite element ingredients.
    */
-  FESystem<dim>             fe;
-  DoFHandler<dim>           dof_handler;
-  AffineConstraints<Number> affine_constraints;
+  dealii::FESystem<dim>             fe;
+  dealii::DoFHandler<dim>           dof_handler;
+  dealii::AffineConstraints<Number> affine_constraints;
   // constraints for mass operator (i.e., do not apply any constraints)
-  AffineConstraints<Number> constraints_mass;
+  dealii::AffineConstraints<Number> constraints_mass;
 
   std::string const dof_index                = "dof";
   std::string const dof_index_mass           = "dof_mass";
@@ -380,8 +378,8 @@ private:
   /*
    * Matrix-free operator evaluation.
    */
-  std::shared_ptr<MatrixFreeData<dim, Number>> matrix_free_data;
-  std::shared_ptr<MatrixFree<dim, Number>>     matrix_free;
+  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   /*
    * Basic operators.
@@ -434,7 +432,7 @@ private:
   /*
    * Output to screen.
    */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
@@ -27,8 +27,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 BodyForceOperator<dim, Number>::BodyForceOperator() : matrix_free(nullptr), time(0.0)
 {
@@ -36,8 +34,8 @@ BodyForceOperator<dim, Number>::BodyForceOperator() : matrix_free(nullptr), time
 
 template<int dim, typename Number>
 void
-BodyForceOperator<dim, Number>::initialize(MatrixFree<dim, Number> const & matrix_free,
-                                           BodyForceData<dim> const &      data)
+BodyForceOperator<dim, Number>::initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                           BodyForceData<dim> const &              data)
 {
   this->matrix_free = &matrix_free;
   this->data        = data;
@@ -50,7 +48,8 @@ BodyForceOperator<dim, Number>::get_mapping_flags()
   MappingFlags flags;
 
   // gradients because of potential pull-back of body forces
-  flags.cells = update_gradients | update_JxW_values | update_quadrature_points;
+  flags.cells =
+    dealii::update_gradients | dealii::update_JxW_values | dealii::update_quadrature_points;
 
   return flags;
 }
@@ -68,10 +67,10 @@ BodyForceOperator<dim, Number>::evaluate_add(VectorType &       dst,
 
 template<int dim, typename Number>
 void
-BodyForceOperator<dim, Number>::cell_loop(MatrixFree<dim, Number> const & matrix_free,
-                                          VectorType &                    dst,
-                                          VectorType const &              src,
-                                          Range const &                   cell_range) const
+BodyForceOperator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                          VectorType &                            dst,
+                                          VectorType const &                      src,
+                                          Range const &                           cell_range) const
 {
   IntegratorCell integrator(matrix_free, data.dof_index, data.quad_index);
 

--- a/include/exadg/structure/spatial_discretization/operators/body_force_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/body_force_operator.h
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim>
 struct BodyForceData
 {
@@ -42,7 +40,7 @@ struct BodyForceData
   unsigned int dof_index;
   unsigned int quad_index;
 
-  std::shared_ptr<Function<dim>> function;
+  std::shared_ptr<dealii::Function<dim>> function;
 
   bool pull_back_body_force;
 };
@@ -51,7 +49,7 @@ template<int dim, typename Number>
 class BodyForceOperator
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef BodyForceOperator<dim, Number> This;
 
@@ -69,7 +67,7 @@ public:
    * Initialization.
    */
   void
-  initialize(MatrixFree<dim, Number> const & matrix_free, BodyForceData<dim> const & data);
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free, BodyForceData<dim> const & data);
 
   static MappingFlags
   get_mapping_flags();
@@ -82,12 +80,12 @@ public:
 
 private:
   void
-  cell_loop(MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                    dst,
-            VectorType const &              src,
-            Range const &                   cell_range) const;
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
 
-  MatrixFree<dim, Number> const * matrix_free;
+  dealii::MatrixFree<dim, Number> const * matrix_free;
 
   BodyForceData<dim> data;
 

--- a/include/exadg/structure/spatial_discretization/operators/boundary_conditions.h
+++ b/include/exadg/structure/spatial_discretization/operators/boundary_conditions.h
@@ -29,22 +29,20 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 /*
  * This function calculates the Neumann boundary value.
  */
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<1, dim, VectorizedArray<Number>>
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
   calculate_neumann_value(unsigned int const                             q,
                           FaceIntegrator<dim, dim, Number> const &       integrator,
                           BoundaryType const &                           boundary_type,
-                          types::boundary_id const                       boundary_id,
+                          dealii::types::boundary_id const               boundary_id,
                           std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor,
                           double const &                                 time)
 {
-  Tensor<1, dim, VectorizedArray<Number>> traction;
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> traction;
 
   if(boundary_type == BoundaryType::Neumann)
   {
@@ -68,7 +66,7 @@ inline DEAL_II_ALWAYS_INLINE //
 
     AssertThrow(boundary_type == BoundaryType::Dirichlet ||
                   boundary_type == BoundaryType::DirichletMortar,
-                ExcMessage("Boundary type of face is invalid or not implemented."));
+                dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
   }
 
   return traction;

--- a/include/exadg/structure/spatial_discretization/operators/continuum_mechanics.h
+++ b/include/exadg/structure/spatial_discretization/operators/continuum_mechanics.h
@@ -30,12 +30,10 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number = double>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<2, dim, VectorizedArray<Number>>
-    add_identity(Tensor<2, dim, VectorizedArray<Number>> gradient)
+    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+    add_identity(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> gradient)
 {
   for(unsigned int i = 0; i < dim; i++)
     gradient[i][i] = gradient[i][i] + 1.0;
@@ -44,8 +42,8 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number = double>
 inline DEAL_II_ALWAYS_INLINE //
-    Tensor<2, dim, VectorizedArray<Number>>
-    subtract_identity(Tensor<2, dim, VectorizedArray<Number>> gradient)
+    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+    subtract_identity(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> gradient)
 {
   for(unsigned int i = 0; i < dim; i++)
     gradient[i][i] = gradient[i][i] - 1.0;
@@ -54,16 +52,16 @@ inline DEAL_II_ALWAYS_INLINE //
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<2, dim, VectorizedArray<Number>>
-  get_F(const Tensor<2, dim, VectorizedArray<Number>> & H)
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+  get_F(const dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> & H)
 {
   return add_identity(H);
 }
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  Tensor<2, dim, VectorizedArray<Number>>
-  get_E(const Tensor<2, dim, VectorizedArray<Number>> & F)
+  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+  get_E(const dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> & F)
 {
   return 0.5 * subtract_identity(transpose(F) * F);
 }

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -30,8 +30,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 ElasticityOperatorBase<dim, Number>::ElasticityOperatorBase() : scaling_factor_mass(1.0)
 {
@@ -59,10 +57,11 @@ ElasticityOperatorBase<dim, Number>::get_mapping_flags()
 {
   MappingFlags flags;
 
-  flags.cells = update_gradients | update_JxW_values | update_quadrature_points;
+  flags.cells =
+    dealii::update_gradients | dealii::update_JxW_values | dealii::update_quadrature_points;
 
-  flags.boundary_faces =
-    update_gradients | update_JxW_values | update_normal_vectors | update_quadrature_points;
+  flags.boundary_faces = dealii::update_gradients | dealii::update_JxW_values |
+                         dealii::update_normal_vectors | dealii::update_quadrature_points;
 
   return flags;
 }
@@ -70,9 +69,9 @@ ElasticityOperatorBase<dim, Number>::get_mapping_flags()
 template<int dim, typename Number>
 void
 ElasticityOperatorBase<dim, Number>::initialize(
-  MatrixFree<dim, Number> const &   matrix_free,
-  AffineConstraints<Number> const & affine_constraints,
-  OperatorData<dim> const &         data)
+  dealii::MatrixFree<dim, Number> const &   matrix_free,
+  dealii::AffineConstraints<Number> const & affine_constraints,
+  OperatorData<dim> const &                 data)
 {
   operator_data = data;
 
@@ -105,19 +104,20 @@ ElasticityOperatorBase<dim, Number>::set_constrained_values(VectorType & dst,
                                                             double const time) const
 {
   // standard Dirichlet boundary conditions
-  std::map<types::global_dof_index, double> boundary_values;
+  std::map<dealii::types::global_dof_index, double> boundary_values;
   for(auto dbc : operator_data.bc->dirichlet_bc)
   {
     dbc.second->set_time(time);
-    ComponentMask mask = operator_data.bc->dirichlet_bc_component_mask.find(dbc.first)->second;
+    dealii::ComponentMask mask =
+      operator_data.bc->dirichlet_bc_component_mask.find(dbc.first)->second;
 
-    VectorTools::interpolate_boundary_values(*this->matrix_free->get_mapping_info().mapping,
-                                             this->matrix_free->get_dof_handler(
-                                               operator_data.dof_index),
-                                             dbc.first,
-                                             *dbc.second,
-                                             boundary_values,
-                                             mask);
+    dealii::VectorTools::interpolate_boundary_values(*this->matrix_free->get_mapping_info().mapping,
+                                                     this->matrix_free->get_dof_handler(
+                                                       operator_data.dof_index),
+                                                     dbc.first,
+                                                     *dbc.second,
+                                                     boundary_values,
+                                                     mask);
   }
 
   // set Dirichlet values in solution vector
@@ -140,7 +140,7 @@ ElasticityOperatorBase<dim, Number>::set_constrained_values(VectorType & dst,
         this->matrix_free->n_inner_face_batches() + this->matrix_free->n_boundary_face_batches();
         ++face)
     {
-      types::boundary_id const boundary_id = this->matrix_free->get_boundary_id(face);
+      dealii::types::boundary_id const boundary_id = this->matrix_free->get_boundary_id(face);
 
       BoundaryType const boundary_type = operator_data.bc->get_boundary_type(boundary_id);
 
@@ -157,7 +157,7 @@ ElasticityOperatorBase<dim, Number>::set_constrained_values(VectorType & dst,
           unsigned int const index = this->matrix_free->get_shape_info(dof_index, quad_index)
                                        .face_to_cell_index_nodal[local_face_number][q];
 
-          Tensor<1, dim, VectorizedArray<Number>> g;
+          dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> g;
 
           if(boundary_type == BoundaryType::DirichletMortar)
           {
@@ -167,7 +167,7 @@ ElasticityOperatorBase<dim, Number>::set_constrained_values(VectorType & dst,
           }
           else
           {
-            AssertThrow(false, ExcMessage("Not implemented."));
+            AssertThrow(false, dealii::ExcMessage("Not implemented."));
           }
 
           integrator.submit_dof_value(g, index);
@@ -180,7 +180,7 @@ ElasticityOperatorBase<dim, Number>::set_constrained_values(VectorType & dst,
         AssertThrow(boundary_type == BoundaryType::Dirichlet ||
                       boundary_type == BoundaryType::Neumann ||
                       boundary_type == BoundaryType::NeumannMortar,
-                    ExcMessage("BoundaryType not implemented."));
+                    dealii::ExcMessage("BoundaryType not implemented."));
       }
     }
   }

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -31,8 +31,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim>
 struct OperatorData : public OperatorBaseData
 {
@@ -94,9 +92,9 @@ public:
   get_mapping_flags();
 
   virtual void
-  initialize(MatrixFree<dim, Number> const &   matrix_free,
-             AffineConstraints<Number> const & affine_constraints,
-             OperatorData<dim> const &         data);
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
+             dealii::AffineConstraints<Number> const & affine_constraints,
+             OperatorData<dim> const &                 data);
 
   OperatorData<dim> const &
   get_data() const;

--- a/include/exadg/structure/spatial_discretization/operators/linear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/linear_operator.cpp
@@ -27,8 +27,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
 LinearOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) const
@@ -56,8 +54,8 @@ LinearOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) const
 template<int dim, typename Number>
 void
 LinearOperator<dim, Number>::do_boundary_integral_continuous(
-  IntegratorFace &           integrator_m,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator_m,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = this->operator_data.bc->get_boundary_type(boundary_id);
 

--- a/include/exadg/structure/spatial_discretization/operators/linear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/linear_operator.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class LinearOperator : public ElasticityOperatorBase<dim, Number>
 {
@@ -40,7 +38,7 @@ private:
   typedef typename Base::IntegratorCell IntegratorCell;
   typedef typename Base::IntegratorFace IntegratorFace;
 
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   /*
    * Calculates the integral
@@ -64,8 +62,8 @@ private:
    *  - (v_h, t)_{Gamma_N}
    */
   void
-  do_boundary_integral_continuous(IntegratorFace &           integrator_m,
-                                  types::boundary_id const & boundary_id) const override;
+  do_boundary_integral_continuous(IntegratorFace &                   integrator_m,
+                                  dealii::types::boundary_id const & boundary_id) const override;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -27,13 +27,12 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 void
-NonLinearOperator<dim, Number>::initialize(MatrixFree<dim, Number> const &   matrix_free,
-                                           AffineConstraints<Number> const & affine_constraints,
-                                           OperatorData<dim> const &         data)
+NonLinearOperator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const &   matrix_free,
+  dealii::AffineConstraints<Number> const & affine_constraints,
+  OperatorData<dim> const &                 data)
 {
   Base::initialize(matrix_free, affine_constraints, data);
 
@@ -82,10 +81,11 @@ NonLinearOperator<dim, Number>::reinit_cell_nonlinear(IntegratorCell &   integra
 
 template<int dim, typename Number>
 void
-NonLinearOperator<dim, Number>::cell_loop_nonlinear(MatrixFree<dim, Number> const & matrix_free,
-                                                    VectorType &                    dst,
-                                                    VectorType const &              src,
-                                                    Range const &                   range) const
+NonLinearOperator<dim, Number>::cell_loop_nonlinear(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           range) const
 {
   IntegratorCell integrator(matrix_free,
                             this->operator_data.dof_index,
@@ -106,10 +106,11 @@ NonLinearOperator<dim, Number>::cell_loop_nonlinear(MatrixFree<dim, Number> cons
 
 template<int dim, typename Number>
 void
-NonLinearOperator<dim, Number>::face_loop_nonlinear(MatrixFree<dim, Number> const & matrix_free,
-                                                    VectorType &                    dst,
-                                                    VectorType const &              src,
-                                                    Range const &                   range) const
+NonLinearOperator<dim, Number>::face_loop_nonlinear(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           range) const
 {
   (void)matrix_free;
   (void)dst;
@@ -120,10 +121,10 @@ NonLinearOperator<dim, Number>::face_loop_nonlinear(MatrixFree<dim, Number> cons
 template<int dim, typename Number>
 void
 NonLinearOperator<dim, Number>::boundary_face_loop_nonlinear(
-  MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                    dst,
-  VectorType const &              src,
-  Range const &                   range) const
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  VectorType &                            dst,
+  VectorType const &                      src,
+  Range const &                           range) const
 {
   (void)src;
 
@@ -187,8 +188,8 @@ NonLinearOperator<dim, Number>::do_cell_integral_nonlinear(IntegratorCell & inte
 template<int dim, typename Number>
 void
 NonLinearOperator<dim, Number>::do_boundary_integral_continuous(
-  IntegratorFace &           integrator_m,
-  types::boundary_id const & boundary_id) const
+  IntegratorFace &                   integrator_m,
+  dealii::types::boundary_id const & boundary_id) const
 {
   BoundaryType boundary_type = this->operator_data.bc->get_boundary_type(boundary_id);
 

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -28,8 +28,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class NonLinearOperator : public ElasticityOperatorBase<dim, Number>
 {
@@ -44,15 +42,15 @@ private:
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
-  typedef VectorizedArray<Number>                 scalar;
-  typedef Tensor<1, dim, VectorizedArray<Number>> vector;
-  typedef Tensor<2, dim, VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
 public:
   void
-  initialize(MatrixFree<dim, Number> const &   matrix_free,
-             AffineConstraints<Number> const & affine_constraints,
-             OperatorData<dim> const &         data) override;
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
+             dealii::AffineConstraints<Number> const & affine_constraints,
+             OperatorData<dim> const &                 data) override;
 
   /*
    * Evaluates the non-linear operator.
@@ -77,22 +75,22 @@ private:
   reinit_cell_nonlinear(IntegratorCell & integrator, unsigned int const cell) const;
 
   void
-  cell_loop_nonlinear(MatrixFree<dim, Number> const & matrix_free,
-                      VectorType &                    dst,
-                      VectorType const &              src,
-                      Range const &                   range) const;
+  cell_loop_nonlinear(dealii::MatrixFree<dim, Number> const & matrix_free,
+                      VectorType &                            dst,
+                      VectorType const &                      src,
+                      Range const &                           range) const;
 
   void
-  face_loop_nonlinear(MatrixFree<dim, Number> const & matrix_free,
-                      VectorType &                    dst,
-                      VectorType const &              src,
-                      Range const &                   range) const;
+  face_loop_nonlinear(dealii::MatrixFree<dim, Number> const & matrix_free,
+                      VectorType &                            dst,
+                      VectorType const &                      src,
+                      Range const &                           range) const;
 
   void
-  boundary_face_loop_nonlinear(MatrixFree<dim, Number> const & matrix_free,
-                               VectorType &                    dst,
-                               VectorType const &              src,
-                               Range const &                   range) const;
+  boundary_face_loop_nonlinear(dealii::MatrixFree<dim, Number> const & matrix_free,
+                               VectorType &                            dst,
+                               VectorType const &                      src,
+                               Range const &                           range) const;
 
   /*
    * Calculates the integral
@@ -136,8 +134,8 @@ private:
    * is necessary.
    */
   void
-  do_boundary_integral_continuous(IntegratorFace &           integrator_m,
-                                  types::boundary_id const & boundary_id) const override;
+  do_boundary_integral_continuous(IntegratorFace &                   integrator_m,
+                                  dealii::types::boundary_id const & boundary_id) const override;
 
   /*
    * Linearized operator.

--- a/include/exadg/structure/throughput.h
+++ b/include/exadg/structure/throughput.h
@@ -97,7 +97,7 @@ run(ThroughputParameters const & throughput,
 
   driver->setup();
 
-  std::tuple<unsigned int, types::global_dof_index, double> wall_time =
+  std::tuple<unsigned int, dealii::types::global_dof_index, double> wall_time =
     driver->apply_operator(throughput.operator_type,
                            throughput.n_repetitions_inner,
                            throughput.n_repetitions_outer);

--- a/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
+++ b/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DriverQuasiStatic<dim, Number>::DriverQuasiStatic(
   std::shared_ptr<Interface::Operator<Number>> operator_,
@@ -43,7 +41,7 @@ DriverQuasiStatic<dim, Number>::DriverQuasiStatic(
     param(param_),
     mpi_comm(mpi_comm_),
     is_test(is_test_),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
     step_number(1),
     timer_tree(new TimerTree()),
     iterations({0, {0, 0}})
@@ -54,7 +52,7 @@ template<int dim, typename Number>
 void
 DriverQuasiStatic<dim, Number>::setup()
 {
-  AssertThrow(param.large_deformation, ExcMessage("Not implemented."));
+  AssertThrow(param.large_deformation, dealii::ExcMessage("Not implemented."));
 
   // initialize global solution vectors (allocation)
   initialize_vectors();
@@ -67,7 +65,7 @@ template<int dim, typename Number>
 void
 DriverQuasiStatic<dim, Number>::solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessing();
@@ -104,7 +102,7 @@ DriverQuasiStatic<dim, Number>::print_iterations() const
   }
   else // linear
   {
-    AssertThrow(false, ExcMessage("Not implemented."));
+    AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
   print_list_of_iterations(pcout, names, iterations_avg);
@@ -121,7 +119,7 @@ template<int dim, typename Number>
 void
 DriverQuasiStatic<dim, Number>::do_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   pcout << std::endl << "Solving quasi-static problem ..." << std::endl << std::flush;
@@ -223,7 +221,7 @@ template<int dim, typename Number>
 std::tuple<unsigned int, unsigned int>
 DriverQuasiStatic<dim, Number>::solve_step(double const load_factor)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   output_solver_info_header(load_factor);
@@ -247,7 +245,7 @@ template<int dim, typename Number>
 void
 DriverQuasiStatic<dim, Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessor->do_postprocessing(solution);

--- a/include/exadg/structure/time_integration/driver_quasi_static_problems.h
+++ b/include/exadg/structure/time_integration/driver_quasi_static_problems.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 // forward declarations
 class Parameters;
 
@@ -51,7 +49,7 @@ template<int dim, typename Number>
 class DriverQuasiStatic
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
   DriverQuasiStatic(std::shared_ptr<Interface::Operator<Number>> operator_,
@@ -101,7 +99,7 @@ private:
 
   bool const is_test;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // vectors
   VectorType solution;

--- a/include/exadg/structure/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/structure/time_integration/driver_steady_problems.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 DriverSteady<dim, Number>::DriverSteady(std::shared_ptr<Interface::Operator<Number>> operator_,
                                         std::shared_ptr<PostProcessorBase<Number>>   postprocessor_,
@@ -42,7 +40,7 @@ DriverSteady<dim, Number>::DriverSteady(std::shared_ptr<Interface::Operator<Numb
     param(param_),
     mpi_comm(mpi_comm_),
     is_test(is_test_),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
     timer_tree(new TimerTree())
 {
 }
@@ -62,7 +60,7 @@ template<int dim, typename Number>
 void
 DriverSteady<dim, Number>::solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessing();
@@ -101,7 +99,7 @@ template<int dim, typename Number>
 void
 DriverSteady<dim, Number>::do_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   pcout << std::endl << "Solving steady state problem ..." << std::endl;
@@ -139,7 +137,7 @@ template<int dim, typename Number>
 void
 DriverSteady<dim, Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessor->do_postprocessing(solution);

--- a/include/exadg/structure/time_integration/driver_steady_problems.h
+++ b/include/exadg/structure/time_integration/driver_steady_problems.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 // forward declarations
 class Parameters;
 
@@ -51,7 +49,7 @@ template<int dim, typename Number>
 class DriverSteady
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   DriverSteady(std::shared_ptr<Interface::Operator<Number>> operator_,
                std::shared_ptr<PostProcessorBase<Number>>   postprocessor_,
@@ -91,7 +89,7 @@ private:
 
   bool is_test;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // vectors
   VectorType solution;

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 TimeIntGenAlpha<dim, Number>::TimeIntGenAlpha(
   std::shared_ptr<Interface::Operator<Number>> operator_,
@@ -51,7 +49,7 @@ TimeIntGenAlpha<dim, Number>::TimeIntGenAlpha(
     refine_steps_time(param_.n_refine_time),
     param(param_),
     mpi_comm(mpi_comm_),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
     use_extrapolation(true),
     store_solution(false),
     iterations({0, {0, 0}})
@@ -100,7 +98,7 @@ TimeIntGenAlpha<dim, Number>::advance_one_timestep_partitioned_solve(bool const 
                                                                      bool const store_solution)
 {
   if(this->use_extrapolation == false)
-    AssertThrow(this->store_solution == true, ExcMessage("Invalid parameters."));
+    AssertThrow(this->store_solution == true, dealii::ExcMessage("Invalid parameters."));
 
   this->use_extrapolation = use_extrapolation;
   this->store_solution    = store_solution;
@@ -114,7 +112,7 @@ TimeIntGenAlpha<dim, Number>::do_timestep_solve()
 {
   // compute right-hand side in case of linear problems or "constant vector"
   // in case of nonlinear problems
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   // compute const_vector
@@ -269,7 +267,7 @@ void
 TimeIntGenAlpha<dim, Number>::do_write_restart(std::string const & filename) const
 {
   (void)filename;
-  AssertThrow(false, ExcMessage("Restart has not been implemented for Structure."));
+  AssertThrow(false, dealii::ExcMessage("Restart has not been implemented for Structure."));
 }
 
 template<int dim, typename Number>
@@ -277,14 +275,14 @@ void
 TimeIntGenAlpha<dim, Number>::do_read_restart(std::ifstream & in)
 {
   (void)in;
-  AssertThrow(false, ExcMessage("Restart has not been implemented for Structure."));
+  AssertThrow(false, dealii::ExcMessage("Restart has not been implemented for Structure."));
 }
 
 template<int dim, typename Number>
 void
 TimeIntGenAlpha<dim, Number>::postprocessing() const
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   postprocessor->do_postprocessing(displacement_n, this->get_time(), this->get_time_step_number());

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.h
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.h
@@ -33,8 +33,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 // forward declarations
 class Parameters;
 
@@ -53,7 +51,7 @@ template<int dim, typename Number>
 class TimeIntGenAlpha : public TimeIntGenAlphaBase<Number>
 {
 private:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
 public:
   TimeIntGenAlpha(std::shared_ptr<Interface::Operator<Number>> operator_,
@@ -120,7 +118,7 @@ private:
 
   MPI_Comm const mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   // DoF vectors
   VectorType displacement_n, displacement_np;

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -39,14 +39,12 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim, typename Number>
 class ApplicationBase
 {
 public:
   virtual void
-  add_parameters(ParameterHandler & prm)
+  add_parameters(dealii::ParameterHandler & prm)
   {
     // clang-format off
     prm.enter_subsection("Output");
@@ -59,7 +57,7 @@ public:
 
   ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
     : mpi_comm(comm),
-      pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
       parameter_file(parameter_file)
   {
   }
@@ -151,7 +149,7 @@ public:
 protected:
   MPI_Comm const & mpi_comm;
 
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   Parameters param;
 

--- a/include/exadg/structure/user_interface/boundary_descriptor.h
+++ b/include/exadg/structure/user_interface/boundary_descriptor.h
@@ -34,8 +34,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 enum class BoundaryType
 {
   Undefined,
@@ -48,26 +46,26 @@ enum class BoundaryType
 template<int dim>
 struct BoundaryDescriptor
 {
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> dirichlet_bc;
-  std::map<types::boundary_id, ComponentMask>                  dirichlet_bc_component_mask;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
+  std::map<dealii::types::boundary_id, dealii::ComponentMask> dirichlet_bc_component_mask;
 
   // another type of Dirichlet boundary condition where the Dirichlet values come
   // from the solution on another domain that is in contact with the actual domain
   // of interest at the given boundary (this type of Dirichlet boundary condition
   // is required for fluid-structure interaction problems)
-  std::map<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>> dirichlet_mortar_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>> dirichlet_mortar_bc;
 
-  std::map<types::boundary_id, std::shared_ptr<Function<dim>>> neumann_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> neumann_bc;
 
   // another type of Neumann boundary condition where the traction force comes
   // from the solution on another domain that is in contact with the actual domain
   // of interest at the given boundary (this type of Neumann boundary condition
   // is required for fluid-structure interaction problems)
-  std::map<types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>> neumann_mortar_bc;
+  std::map<dealii::types::boundary_id, std::shared_ptr<FunctionCached<1, dim>>> neumann_mortar_bc;
 
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryType
-    get_boundary_type(types::boundary_id const & boundary_id) const
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
   {
     if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
       return BoundaryType::Dirichlet;
@@ -79,20 +77,22 @@ struct BoundaryDescriptor
       return BoundaryType::NeumannMortar;
 
     AssertThrow(false,
-                ExcMessage("Could not find a boundary type to the specified boundary_id = " +
-                           std::to_string(boundary_id) +
-                           ". A possible reason is that you "
-                           "forgot to define a boundary condition for this boundary_id, or "
-                           "that the boundary type associated to this boundary has not been "
-                           "implemented."));
+                dealii::ExcMessage(
+                  "Could not find a boundary type to the specified boundary_id = " +
+                  std::to_string(boundary_id) +
+                  ". A possible reason is that you "
+                  "forgot to define a boundary condition for this boundary_id, or "
+                  "that the boundary type associated to this boundary has not been "
+                  "implemented."));
 
     return BoundaryType::Undefined;
   }
 
   inline DEAL_II_ALWAYS_INLINE //
     void
-    verify_boundary_conditions(types::boundary_id const             boundary_id,
-                               std::set<types::boundary_id> const & periodic_boundary_ids) const
+    verify_boundary_conditions(
+      dealii::types::boundary_id const             boundary_id,
+      std::set<dealii::types::boundary_id> const & periodic_boundary_ids) const
   {
     unsigned int counter = 0;
     if(dirichlet_bc.find(boundary_id) != dirichlet_bc.end())
@@ -101,7 +101,7 @@ struct BoundaryDescriptor
 
       AssertThrow(
         dirichlet_bc_component_mask.find(boundary_id) != dirichlet_bc_component_mask.end(),
-        ExcMessage(
+        dealii::ExcMessage(
           "dirichlet_bc_component_mask must contain the same boundary IDs as dirichlet_bc."));
     }
 
@@ -117,7 +117,8 @@ struct BoundaryDescriptor
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())
       counter++;
 
-    AssertThrow(counter == 1, ExcMessage("Boundary face with non-unique boundary type found."));
+    AssertThrow(counter == 1,
+                dealii::ExcMessage("Boundary face with non-unique boundary type found."));
   }
 };
 

--- a/include/exadg/structure/user_interface/enum_types.cpp
+++ b/include/exadg/structure/user_interface/enum_types.cpp
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                                 MATHEMATICAL MODEL                                 */
@@ -58,7 +56,7 @@ enum_to_string(ProblemType const enum_type)
       string_type = "Unsteady";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -82,7 +80,7 @@ enum_to_string(Type2D const enum_type)
       string_type = "PlaneStrain";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -103,7 +101,7 @@ enum_to_string(MaterialType const enum_type)
       string_type = "StVenantKirchhoff";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -163,7 +161,7 @@ enum_to_string(Solver const enum_type)
       string_type = "FGMRES";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -190,7 +188,7 @@ enum_to_string(Preconditioner const enum_type)
       string_type = "AMG";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/structure/user_interface/enum_types.h
+++ b/include/exadg/structure/user_interface/enum_types.h
@@ -29,8 +29,6 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                                 MATHEMATICAL MODEL                                 */

--- a/include/exadg/structure/user_interface/field_functions.h
+++ b/include/exadg/structure/user_interface/field_functions.h
@@ -27,14 +27,12 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
 template<int dim>
 struct FieldFunctions
 {
-  std::shared_ptr<Function<dim>> right_hand_side;
-  std::shared_ptr<Function<dim>> initial_displacement;
-  std::shared_ptr<Function<dim>> initial_velocity;
+  std::shared_ptr<dealii::Function<dim>> right_hand_side;
+  std::shared_ptr<dealii::Function<dim>> initial_displacement;
+  std::shared_ptr<dealii::Function<dim>> initial_velocity;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/user_interface/material_descriptor.h
+++ b/include/exadg/structure/user_interface/material_descriptor.h
@@ -35,9 +35,7 @@ namespace ExaDG
 {
 namespace Structure
 {
-using namespace dealii;
-
-using MaterialDescriptor = std::map<types::material_id, std::shared_ptr<MaterialData>>;
+using MaterialDescriptor = std::map<dealii::types::material_id, std::shared_ptr<MaterialData>>;
 } // namespace Structure
 } // namespace ExaDG
 

--- a/include/exadg/structure/user_interface/parameters.cpp
+++ b/include/exadg/structure/user_interface/parameters.cpp
@@ -78,26 +78,29 @@ void
 Parameters::check() const
 {
   // MATHEMATICAL MODEL
-  AssertThrow(problem_type != ProblemType::Undefined, ExcMessage("Parameter must be defined."));
+  AssertThrow(problem_type != ProblemType::Undefined,
+              dealii::ExcMessage("Parameter must be defined."));
 
   if(problem_type == ProblemType::QuasiStatic)
   {
     AssertThrow(large_deformation == true,
-                ExcMessage("QuasiStatic solver only implemented for nonlinear formulation."));
+                dealii::ExcMessage(
+                  "QuasiStatic solver only implemented for nonlinear formulation."));
   }
 
   if(problem_type == ProblemType::Unsteady)
   {
-    AssertThrow(restarted_simulation == false, ExcMessage("Restart has not been implemented."));
+    AssertThrow(restarted_simulation == false,
+                dealii::ExcMessage("Restart has not been implemented."));
   }
 
   // SPATIAL DISCRETIZATION
   grid.check();
 
-  AssertThrow(degree > 0, ExcMessage("Polynomial degree must be larger than zero."));
+  AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
 
   // SOLVER
-  AssertThrow(solver != Solver::Undefined, ExcMessage("Parameter must be defined."));
+  AssertThrow(solver != Solver::Undefined, dealii::ExcMessage("Parameter must be defined."));
 }
 
 void

--- a/include/exadg/time_integration/bdf_time_integration.cpp
+++ b/include/exadg/time_integration/bdf_time_integration.cpp
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 BDFTimeIntegratorConstants::BDFTimeIntegratorConstants(unsigned int const order_time_integrator,
                                                        bool const start_with_low_order_method)
   : order(order_time_integrator),
@@ -37,7 +35,7 @@ BDFTimeIntegratorConstants::BDFTimeIntegratorConstants(unsigned int const order_
     alpha(order)
 {
   AssertThrow(order >= 1 && order <= 4,
-              ExcMessage("Specified order of BDF scheme not implemented."));
+              dealii::ExcMessage("Specified order of BDF scheme not implemented."));
 
   // The default case is start_with_low_order = false.
   set_constant_time_step(order);
@@ -46,7 +44,7 @@ BDFTimeIntegratorConstants::BDFTimeIntegratorConstants(unsigned int const order_
 double
 BDFTimeIntegratorConstants::get_gamma0() const
 {
-  AssertThrow(gamma0 > 0.0, ExcMessage("Constant gamma0 has not been initialized."));
+  AssertThrow(gamma0 > 0.0, dealii::ExcMessage("Constant gamma0 has not been initialized."));
 
   return gamma0;
 }
@@ -55,8 +53,9 @@ double
 BDFTimeIntegratorConstants::get_alpha(unsigned int const i) const
 {
   AssertThrow(i < order,
-              ExcMessage("In order to access BDF time integrator constants, the index "
-                         "has to be smaller than the order of the time integration scheme."));
+              dealii::ExcMessage(
+                "In order to access BDF time integrator constants, the index "
+                "has to be smaller than the order of the time integration scheme."));
 
   return alpha[i];
 }
@@ -66,7 +65,7 @@ void
 BDFTimeIntegratorConstants::set_constant_time_step(unsigned int const current_order)
 {
   AssertThrow(current_order <= order,
-              ExcMessage(
+              dealii::ExcMessage(
                 "There is a logical error when updating the BDF time integrator constants."));
 
   if(current_order == 1) // BDF 1
@@ -116,11 +115,12 @@ BDFTimeIntegratorConstants::set_adaptive_time_step(unsigned int const          c
                                                    std::vector<double> const & time_steps)
 {
   AssertThrow(current_order <= order,
-              ExcMessage("There is a logical error when updating the time integrator constants."));
+              dealii::ExcMessage(
+                "There is a logical error when updating the time integrator constants."));
 
   AssertThrow(
     time_steps.size() == order,
-    ExcMessage(
+    dealii::ExcMessage(
       "Length of vector containing time step sizes has to be equal to order of time integration scheme."));
 
   if(current_order == 1) // BDF 1
@@ -219,7 +219,7 @@ BDFTimeIntegratorConstants::update(unsigned int const          current_order,
 }
 
 void
-BDFTimeIntegratorConstants::print(ConditionalOStream & pcout) const
+BDFTimeIntegratorConstants::print(dealii::ConditionalOStream & pcout) const
 {
   pcout << "Gamma0   = " << gamma0 << std::endl;
 

--- a/include/exadg/time_integration/bdf_time_integration.h
+++ b/include/exadg/time_integration/bdf_time_integration.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 class BDFTimeIntegratorConstants
 {
 public:
@@ -62,7 +60,7 @@ public:
    *  This function prints the time integrator constants
    */
   void
-  print(ConditionalOStream & pcout) const;
+  print(dealii::ConditionalOStream & pcout) const;
 
 
 private:

--- a/include/exadg/time_integration/enum_types.cpp
+++ b/include/exadg/time_integration/enum_types.cpp
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 std::string
 enum_to_string(CFLConditionType const enum_type)
 {
@@ -43,7 +41,7 @@ enum_to_string(CFLConditionType const enum_type)
       string_type = "VelocityComponents";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 
@@ -70,7 +68,7 @@ enum_to_string(GenAlphaType const enum_type)
       string_type = "BossakAlpha";
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 

--- a/include/exadg/time_integration/enum_types.h
+++ b/include/exadg/time_integration/enum_types.h
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 enum class CFLConditionType
 {
   VelocityNorm,

--- a/include/exadg/time_integration/explicit_runge_kutta.h
+++ b/include/exadg/time_integration/explicit_runge_kutta.h
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Operator, typename VectorType>
 class ExplicitTimeIntegrator
 {
@@ -178,7 +176,8 @@ public:
     else
     {
       AssertThrow(order <= 4,
-                  ExcMessage("Explicit Runge-Kutta method only implemented for order <= 4!"));
+                  dealii::ExcMessage(
+                    "Explicit Runge-Kutta method only implemented for order <= 4!"));
     }
   }
 
@@ -745,7 +744,7 @@ public:
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
 
     // loop over all stages

--- a/include/exadg/time_integration/extrapolation_scheme.cpp
+++ b/include/exadg/time_integration/extrapolation_scheme.cpp
@@ -30,15 +30,14 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 ExtrapolationConstants::ExtrapolationConstants(unsigned int const order_extrapolation_scheme,
                                                bool const         start_with_low_order_method)
   : order(order_extrapolation_scheme),
     start_with_low_order(start_with_low_order_method),
     beta(order)
 {
-  AssertThrow(order <= 4, ExcMessage("Specified order of extrapolation scheme not implemented."));
+  AssertThrow(order <= 4,
+              dealii::ExcMessage("Specified order of extrapolation scheme not implemented."));
 
   // The default case is start_with_low_order = false.
   set_constant_time_step(order);
@@ -48,8 +47,8 @@ double
 ExtrapolationConstants::get_beta(unsigned int const i) const
 {
   AssertThrow(i < order,
-              ExcMessage("In order to access constants of extrapolation scheme, the index "
-                         "has to be smaller than the order of the scheme."));
+              dealii::ExcMessage("In order to access constants of extrapolation scheme, the index "
+                                 "has to be smaller than the order of the scheme."));
 
   return beta[i];
 }
@@ -65,7 +64,7 @@ ExtrapolationConstants::set_constant_time_step(unsigned int const current_order)
 {
   AssertThrow(
     current_order <= order,
-    ExcMessage(
+    dealii::ExcMessage(
       "There is a logical error when updating the constants of the extrapolation scheme."));
 
   if(current_order == 1) // EX 1
@@ -108,12 +107,12 @@ ExtrapolationConstants::set_adaptive_time_step(unsigned int const          curre
 {
   AssertThrow(
     current_order <= order,
-    ExcMessage(
+    dealii::ExcMessage(
       "There is a logical error when updating the constants of the extrapolation scheme."));
 
   AssertThrow(
     order <= time_steps.size(),
-    ExcMessage(
+    dealii::ExcMessage(
       "Length of vector containing time step sizes has to be equal to order of extrapolation scheme."));
 
   if(current_order == 1) // EX 1
@@ -198,7 +197,7 @@ ExtrapolationConstants::update(unsigned int const          current_order,
 }
 
 void
-ExtrapolationConstants::print(ConditionalOStream & pcout) const
+ExtrapolationConstants::print(dealii::ConditionalOStream & pcout) const
 {
   for(unsigned int i = 0; i < order; ++i)
     pcout << "Beta[" << i << "]  = " << beta[i] << std::endl;

--- a/include/exadg/time_integration/extrapolation_scheme.h
+++ b/include/exadg/time_integration/extrapolation_scheme.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 class ExtrapolationConstants
 {
 public:
@@ -61,7 +59,7 @@ public:
    *  This function prints the time integrator constants
    */
   void
-  print(ConditionalOStream & pcout) const;
+  print(dealii::ConditionalOStream & pcout) const;
 
 
 private:

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -26,14 +26,16 @@
 #include <fstream>
 #include <sstream>
 
+// deal.II
+#include <deal.II/base/mpi.h>
+
 namespace ExaDG
 {
-using namespace dealii;
-
 inline std::string
 restart_filename(std::string const & name, MPI_Comm const & mpi_comm)
 {
-  std::string const rank = Utilities::int_to_string(Utilities::MPI::this_mpi_process(mpi_comm));
+  std::string const rank =
+    dealii::Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process(mpi_comm));
 
   std::string const filename = name + "." + rank + ".restart";
 
@@ -52,7 +54,7 @@ rename_restart_files(std::string const & filename)
   {
     int const error = rename(from.c_str(), to.c_str());
 
-    AssertThrow(error == 0, ExcMessage("Can not rename file: " + from + " -> " + to));
+    AssertThrow(error == 0, dealii::ExcMessage("Can not rename file: " + from + " -> " + to));
   }
 }
 

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -33,8 +33,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct RestartData
 {
   RestartData()
@@ -48,7 +46,7 @@ struct RestartData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     pcout << "  Restart:" << std::endl;
     print_parameter(pcout, "Write restart", write_restart);

--- a/include/exadg/time_integration/solver_info_data.h
+++ b/include/exadg/time_integration/solver_info_data.h
@@ -33,8 +33,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct SolverInfoData
 {
   SolverInfoData()
@@ -48,7 +46,7 @@ struct SolverInfoData
   }
 
   void
-  print(ConditionalOStream const & pcout) const
+  print(dealii::ConditionalOStream const & pcout) const
   {
     pcout << "  Solver information:" << std::endl;
     print_parameter(pcout, "Interval physical time", interval_time);

--- a/include/exadg/time_integration/ssp_runge_kutta.h
+++ b/include/exadg/time_integration/ssp_runge_kutta.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  *  Strong-Stability-Preserving Runge-Kutta Methods according to
  *
@@ -69,9 +67,9 @@ private:
   void
   initialize_coeffs(unsigned int const stages);
 
-  FullMatrix<double>  A, B;
-  std::vector<double> c;
-  unsigned int const  order;
+  dealii::FullMatrix<double> A, B;
+  std::vector<double>        c;
+  unsigned int const         order;
 
   std::vector<VectorType> u_vec, F_vec;
 };
@@ -536,7 +534,7 @@ SSPRK<Operator, VectorType>::initialize_coeffs(unsigned int const stages)
     }
     else
     {
-      AssertThrow(false, ExcNotImplemented());
+      AssertThrow(false, dealii::ExcNotImplemented());
     }
   }
   else if(order == 4)
@@ -915,19 +913,19 @@ SSPRK<Operator, VectorType>::initialize_coeffs(unsigned int const stages)
     }
     else
     {
-      AssertThrow(false, ExcNotImplemented());
+      AssertThrow(false, dealii::ExcNotImplemented());
     }
   }
   else
   {
-    AssertThrow(false, ExcNotImplemented());
+    AssertThrow(false, dealii::ExcNotImplemented());
   }
 
-  AssertThrow(coefficients_are_initialized, ExcNotImplemented());
+  AssertThrow(coefficients_are_initialized, dealii::ExcNotImplemented());
 
   // calculate coefficients c_i for non-autonomous systems, i.e.,
   // systems with explicit time-dependency
-  FullMatrix<double> crk;
+  dealii::FullMatrix<double> crk;
   crk.reinit(stages, stages);
 
   for(unsigned int k = 0; k < stages; ++k)

--- a/include/exadg/time_integration/time_int_base.cpp
+++ b/include/exadg/time_integration/time_int_base.cpp
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 TimeIntBase::TimeIntBase(double const &      start_time_,
                          double const &      end_time_,
                          unsigned int const  max_number_of_time_steps_,
@@ -36,7 +34,7 @@ TimeIntBase::TimeIntBase(double const &      start_time_,
     end_time(end_time_),
     time(start_time_),
     eps(1.e-10),
-    pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_) == 0),
     time_step_number(1),
     max_number_of_time_steps(max_number_of_time_steps_),
     restart_data(restart_data_),
@@ -80,7 +78,7 @@ TimeIntBase::advance_one_timestep()
 void
 TimeIntBase::advance_one_timestep_pre_solve(bool const print_header)
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(started() && !finished())
@@ -103,7 +101,7 @@ TimeIntBase::advance_one_timestep_pre_solve(bool const print_header)
 void
 TimeIntBase::advance_one_timestep_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(started() && !finished())
@@ -117,7 +115,7 @@ TimeIntBase::advance_one_timestep_solve()
 void
 TimeIntBase::advance_one_timestep_post_solve()
 {
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   if(started() && !finished())
@@ -143,7 +141,8 @@ TimeIntBase::reset_time(double const & current_time)
   if(current_time <= start_time + eps)
     time = current_time;
   else
-    AssertThrow(false, ExcMessage("The variable time may not be overwritten via public access."));
+    AssertThrow(false,
+                dealii::ExcMessage("The variable time may not be overwritten via public access."));
 }
 
 double
@@ -218,7 +217,7 @@ TimeIntBase::read_restart()
 
   std::string   filename = restart_filename(restart_data.filename, mpi_comm);
   std::ifstream in(filename);
-  AssertThrow(in, ExcMessage("File " + filename + " does not exist."));
+  AssertThrow(in, dealii::ExcMessage("File " + filename + " does not exist."));
 
   do_read_restart(in);
 

--- a/include/exadg/time_integration/time_int_base.h
+++ b/include/exadg/time_integration/time_int_base.h
@@ -41,8 +41,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 class TimeIntBase
 {
 public:
@@ -225,7 +223,7 @@ protected:
   /*
    * Output to screen.
    */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   /*
    * The number of the current time step starting with time_step_number = 1.
@@ -250,7 +248,7 @@ protected:
   /*
    * Computation time (wall clock time).
    */
-  Timer                      global_timer;
+  dealii::Timer              global_timer;
   std::shared_ptr<TimerTree> timer_tree;
   bool                       is_test;
 

--- a/include/exadg/time_integration/time_int_bdf_base.cpp
+++ b/include/exadg/time_integration/time_int_bdf_base.cpp
@@ -23,8 +23,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Number>
 TimeIntBDFBase<Number>::TimeIntBDFBase(double const        start_time_,
                                        double const        end_time_,
@@ -141,7 +139,7 @@ TimeIntBDFBase<Number>::get_previous_time(int const i /* t_{n-i} */) const
    *                 |         |        |           |           /
    *  time_steps-vec:   dt[2]     dt[1]    dt[0]
    */
-  AssertThrow(i >= 0, ExcMessage("Invalid parameter."));
+  AssertThrow(i >= 0, dealii::ExcMessage("Invalid parameter."));
 
   double t = this->time;
 
@@ -169,9 +167,9 @@ TimeIntBDFBase<Number>::get_time_step_size(int const i /* dt[i] */) const
    *                 |         |        |           |           /
    *  time_steps-vec:   dt[2]     dt[1]    dt[0]
    */
-  AssertThrow(i >= 0 && i <= int(order) - 1, ExcMessage("Invalid access."));
+  AssertThrow(i >= 0 && i <= int(order) - 1, dealii::ExcMessage("Invalid access."));
 
-  AssertThrow(time_steps[i] > 0.0, ExcMessage("Invalid or uninitialized time step size."));
+  AssertThrow(time_steps[i] > 0.0, dealii::ExcMessage("Invalid or uninitialized time step size."));
 
   return time_steps[i];
 }
@@ -213,8 +211,8 @@ TimeIntBDFBase<Number>::set_current_time_step_size(double const & time_step_size
   if(adaptive_time_stepping == false)
   {
     AssertThrow(time_step_number == 1,
-                ExcMessage("For time integration with constant time step sizes this "
-                           "function can only be called in the very first time step."));
+                dealii::ExcMessage("For time integration with constant time step sizes this "
+                                   "function can only be called in the very first time step."));
   }
 
   time_steps[0] = time_step_size;
@@ -324,7 +322,7 @@ TimeIntBDFBase<Number>::calculate_sum_alphai_ui_oif_substepping(VectorType & sum
       // number of sub-steps per "macro" time step
       int M = (int)(cfl / (cfl_oif - eps));
 
-      AssertThrow(M >= 1, ExcMessage("Invalid parameters cfl and cfl_oif."));
+      AssertThrow(M >= 1, dealii::ExcMessage("Invalid parameters cfl and cfl_oif."));
 
       // make sure that cfl_oif is not violated
       if(cfl_oif < cfl / double(M) - eps)
@@ -374,12 +372,12 @@ TimeIntBDFBase<Number>::read_restart_preamble(boost::archive::binary_iarchive & 
   unsigned int n_old_ranks = 1;
   ia &         n_old_ranks;
 
-  unsigned int n_ranks = Utilities::MPI::n_mpi_processes(mpi_comm);
+  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
   AssertThrow(n_old_ranks == n_ranks,
-              ExcMessage("Tried to restart with " + Utilities::to_string(n_ranks) +
-                         " processes, "
-                         "but restart was written on " +
-                         Utilities::to_string(n_old_ranks) + " processes."));
+              dealii::ExcMessage("Tried to restart with " + dealii::Utilities::to_string(n_ranks) +
+                                 " processes, "
+                                 "but restart was written on " +
+                                 dealii::Utilities::to_string(n_old_ranks) + " processes."));
 
   // 2. time
   ia & time;
@@ -392,7 +390,7 @@ TimeIntBDFBase<Number>::read_restart_preamble(boost::archive::binary_iarchive & 
   unsigned int old_order = 1;
   ia &         old_order;
 
-  AssertThrow(old_order == order, ExcMessage("Order of time integrator may not change."));
+  AssertThrow(old_order == order, dealii::ExcMessage("Order of time integrator may not change."));
 
   // 4. time step sizes
   for(unsigned int i = 0; i < order; i++)
@@ -416,7 +414,7 @@ template<typename Number>
 void
 TimeIntBDFBase<Number>::write_restart_preamble(boost::archive::binary_oarchive & oa) const
 {
-  unsigned int n_ranks = Utilities::MPI::n_mpi_processes(mpi_comm);
+  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
 
   // 1. ranks
   oa & n_ranks;
@@ -436,21 +434,21 @@ template<typename Number>
 void
 TimeIntBDFBase<Number>::postprocessing_steady_problem() const
 {
-  AssertThrow(false, ExcMessage("This function has to be implemented by derived classes."));
+  AssertThrow(false, dealii::ExcMessage("This function has to be implemented by derived classes."));
 }
 
 template<typename Number>
 void
 TimeIntBDFBase<Number>::solve_steady_problem()
 {
-  AssertThrow(false, ExcMessage("This function has to be implemented by derived classes."));
+  AssertThrow(false, dealii::ExcMessage("This function has to be implemented by derived classes."));
 }
 
 template<typename Number>
 void
 TimeIntBDFBase<Number>::initialize_solution_oif_substepping(VectorType &, unsigned int)
 {
-  AssertThrow(false, ExcMessage("This function has to be implemented by derived classes."));
+  AssertThrow(false, dealii::ExcMessage("This function has to be implemented by derived classes."));
 }
 
 template<typename Number>
@@ -459,7 +457,7 @@ TimeIntBDFBase<Number>::update_sum_alphai_ui_oif_substepping(VectorType &,
                                                              VectorType const &,
                                                              unsigned int)
 {
-  AssertThrow(false, ExcMessage("This function has to be implemented by derived classes."));
+  AssertThrow(false, dealii::ExcMessage("This function has to be implemented by derived classes."));
 }
 
 template<typename Number>
@@ -469,7 +467,7 @@ TimeIntBDFBase<Number>::do_timestep_oif_substepping(VectorType &,
                                                     double const,
                                                     double const)
 {
-  AssertThrow(false, ExcMessage("This function has to be implemented by derived classes."));
+  AssertThrow(false, dealii::ExcMessage("This function has to be implemented by derived classes."));
 }
 
 template class TimeIntBDFBase<float>;

--- a/include/exadg/time_integration/time_int_bdf_base.h
+++ b/include/exadg/time_integration/time_int_bdf_base.h
@@ -32,13 +32,11 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Number>
 class TimeIntBDFBase : public TimeIntBase
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   /*
    * Constructor.

--- a/include/exadg/time_integration/time_int_explicit_runge_kutta_base.cpp
+++ b/include/exadg/time_integration/time_int_explicit_runge_kutta_base.cpp
@@ -23,8 +23,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Number>
 TimeIntExplRKBase<Number>::TimeIntExplRKBase(double const &      start_time_,
                                              double const &      end_time_,
@@ -137,7 +135,7 @@ TimeIntExplRKBase<Number>::do_write_restart(std::string const & filename) const
 
   boost::archive::binary_oarchive oa(oss);
 
-  unsigned int n_ranks = Utilities::MPI::n_mpi_processes(this->mpi_comm);
+  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(this->mpi_comm);
 
   // 1. ranks
   oa & n_ranks;
@@ -166,12 +164,12 @@ TimeIntExplRKBase<Number>::do_read_restart(std::ifstream & in)
   unsigned int n_old_ranks = 1;
   ia &         n_old_ranks;
 
-  unsigned int n_ranks = Utilities::MPI::n_mpi_processes(this->mpi_comm);
+  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(this->mpi_comm);
   AssertThrow(n_old_ranks == n_ranks,
-              ExcMessage("Tried to restart with " + Utilities::to_string(n_ranks) +
-                         " processes, "
-                         "but restart was written on " +
-                         Utilities::to_string(n_old_ranks) + " processes."));
+              dealii::ExcMessage("Tried to restart with " + dealii::Utilities::to_string(n_ranks) +
+                                 " processes, "
+                                 "but restart was written on " +
+                                 dealii::Utilities::to_string(n_old_ranks) + " processes."));
 
   // 2. time
   ia & time;

--- a/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
+++ b/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
@@ -30,13 +30,11 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Number>
 class TimeIntExplRKBase : public TimeIntBase
 {
 public:
-  typedef LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   TimeIntExplRKBase(double const &      start_time_,
                     double const &      end_time_,

--- a/include/exadg/time_integration/time_int_gen_alpha_base.cpp
+++ b/include/exadg/time_integration/time_int_gen_alpha_base.cpp
@@ -24,8 +24,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Number>
 TimeIntGenAlphaBase<Number>::TimeIntGenAlphaBase(double const &       start_time_,
                                                  double const &       end_time_,
@@ -75,7 +73,7 @@ TimeIntGenAlphaBase<Number>::TimeIntGenAlphaBase(double const &       start_time
       gamma   = 0.5 - alpha_m;
       break;
     default:
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
       break;
   }
 }

--- a/include/exadg/time_integration/time_int_gen_alpha_base.h
+++ b/include/exadg/time_integration/time_int_gen_alpha_base.h
@@ -31,8 +31,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 template<typename Number>
 class TimeIntGenAlphaBase : public TimeIntBase
 {

--- a/include/exadg/utilities/create_directories.h
+++ b/include/exadg/utilities/create_directories.h
@@ -33,7 +33,7 @@ namespace ExaDG
 inline void
 create_directories(std::string const & directory, MPI_Comm const & mpi_comm)
 {
-  if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
     std::filesystem::create_directories(directory);
 }
 

--- a/include/exadg/utilities/general_parameters.h
+++ b/include/exadg/utilities/general_parameters.h
@@ -27,8 +27,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct GeneralParameters
 {
   GeneralParameters()
@@ -50,17 +48,17 @@ struct GeneralParameters
       prm.add_parameter("Precision",
                         precision,
                         "Floating point precision.",
-                        Patterns::Selection("float|double"),
+                        dealii::Patterns::Selection("float|double"),
                         false);
       prm.add_parameter("Dim",
                         dim,
                         "Number of space dimension.",
-                        Patterns::Integer(2,3),
+                        dealii::Patterns::Integer(2,3),
                         true);
       prm.add_parameter("IsTest",
                         is_test,
                         "Set to true if the program is run as a test.",
-                        Patterns::Bool(),
+                        dealii::Patterns::Bool(),
                         false);
     prm.leave_subsection();
     // clang-format on

--- a/include/exadg/utilities/hypercube_resolution_parameters.h
+++ b/include/exadg/utilities/hypercube_resolution_parameters.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  * study throughput as a function of polynomial degree or problem size
  */
@@ -49,7 +47,7 @@ string_to_enum(RunType & enum_type, std::string const string_type)
   if     (string_type == "RefineHAndP")           enum_type = RunType::RefineHAndP;
   else if(string_type == "FixedProblemSize")      enum_type = RunType::FixedProblemSize;
   else if(string_type == "IncreasingProblemSize") enum_type = RunType::IncreasingProblemSize;
-  else AssertThrow(false, ExcMessage("Not implemented."));
+  else AssertThrow(false, dealii::ExcMessage("Not implemented."));
   // clang-format on
 }
 
@@ -61,23 +59,24 @@ inline void
 fill_resolutions_vector(
   std::vector<
     std::tuple<unsigned int /*k*/, unsigned int /*l*/, unsigned int /*subdivisions hypercube*/>> &
-                                resolutions,
-  unsigned int const            dim,
-  unsigned int const            degree,
-  unsigned int const            dofs_per_element,
-  types::global_dof_index const n_dofs_min,
-  types::global_dof_index const n_dofs_max,
-  RunType const &               run_type)
+                                        resolutions,
+  unsigned int const                    dim,
+  unsigned int const                    degree,
+  unsigned int const                    dofs_per_element,
+  dealii::types::global_dof_index const n_dofs_min,
+  dealii::types::global_dof_index const n_dofs_max,
+  RunType const &                       run_type)
 {
   unsigned int l = 0, n_subdivisions_1d = 1;
 
-  types::global_dof_index n_cells_min = (n_dofs_min + dofs_per_element - 1) / dofs_per_element;
-  types::global_dof_index n_cells_max = n_dofs_max / dofs_per_element;
+  dealii::types::global_dof_index n_cells_min =
+    (n_dofs_min + dofs_per_element - 1) / dofs_per_element;
+  dealii::types::global_dof_index n_cells_max = n_dofs_max / dofs_per_element;
 
-  int                     refine_level = 0;
-  types::global_dof_index n_cells      = 1;
+  int                             refine_level = 0;
+  dealii::types::global_dof_index n_cells      = 1;
 
-  while(n_cells <= Utilities::pow(2ULL, dim) * n_cells_max)
+  while(n_cells <= dealii::Utilities::pow(2ULL, dim) * n_cells_max)
   {
     // We want to increase the problem size approximately by a factor of two, which is
     // realized by using a coarse grid with {3,4}^dim elements in 2D and {3,4,5}^dim elements
@@ -87,8 +86,8 @@ fill_resolutions_vector(
     if(refine_level >= 2)
     {
       n_subdivisions_1d = 3;
-      n_cells =
-        Utilities::pow(n_subdivisions_1d, dim) * Utilities::pow(2ULL, (refine_level - 2) * dim);
+      n_cells           = dealii::Utilities::pow(n_subdivisions_1d, dim) *
+                dealii::Utilities::pow(2ULL, (refine_level - 2) * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -101,14 +100,14 @@ fill_resolutions_vector(
           resolutions.push_back(
             std::tuple<unsigned int, unsigned int, unsigned int>(degree, l, n_subdivisions_1d));
         else
-          AssertThrow(false, ExcMessage("Not implemented:"));
+          AssertThrow(false, dealii::ExcMessage("Not implemented:"));
       }
     }
 
     // coarse grid with only a single cell, and refine_level uniform refinements
     {
       n_subdivisions_1d = 1;
-      n_cells           = Utilities::pow(2ULL, refine_level * dim);
+      n_cells           = dealii::Utilities::pow(2ULL, refine_level * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -121,7 +120,7 @@ fill_resolutions_vector(
           resolutions.push_back(
             std::tuple<unsigned int, unsigned int, unsigned int>(degree, l, n_subdivisions_1d));
         else
-          AssertThrow(false, ExcMessage("Not implemented:"));
+          AssertThrow(false, dealii::ExcMessage("Not implemented:"));
       }
     }
 
@@ -129,8 +128,8 @@ fill_resolutions_vector(
     if(dim == 3 && refine_level >= 2)
     {
       n_subdivisions_1d = 5;
-      n_cells =
-        Utilities::pow(n_subdivisions_1d, dim) * Utilities::pow(2ULL, (refine_level - 2) * dim);
+      n_cells           = dealii::Utilities::pow(n_subdivisions_1d, dim) *
+                dealii::Utilities::pow(2ULL, (refine_level - 2) * dim);
 
       if(n_cells >= n_cells_min && n_cells <= n_cells_max)
       {
@@ -143,28 +142,29 @@ fill_resolutions_vector(
           resolutions.push_back(
             std::tuple<unsigned int, unsigned int, unsigned int>(degree, l, n_subdivisions_1d));
         else
-          AssertThrow(false, ExcMessage("Not implemented:"));
+          AssertThrow(false, dealii::ExcMessage("Not implemented:"));
       }
     }
 
     // perform one global refinement
     ++refine_level;
-    n_cells = Utilities::pow(2ULL, refine_level * dim);
+    n_cells = dealii::Utilities::pow(2ULL, refine_level * dim);
   }
 
   if(run_type == RunType::FixedProblemSize)
   {
     AssertThrow((n_cells >= n_cells_min && n_cells <= n_cells_max),
-                ExcMessage("No mesh found that meets the requirements regarding problem size. "
-                           "Make sure that maximum number of dofs is sufficiently larger than "
-                           "minimum number of dofs."));
+                dealii::ExcMessage(
+                  "No mesh found that meets the requirements regarding problem size. "
+                  "Make sure that maximum number of dofs is sufficiently larger than "
+                  "minimum number of dofs."));
 
     resolutions.push_back(
       std::tuple<unsigned int, unsigned int, unsigned int>(degree, l, n_subdivisions_1d));
   }
   else
   {
-    AssertThrow(run_type == RunType::IncreasingProblemSize, ExcMessage("Not implemented."));
+    AssertThrow(run_type == RunType::IncreasingProblemSize, dealii::ExcMessage("Not implemented."));
   }
 }
 
@@ -193,37 +193,37 @@ struct HypercubeResolutionParameters
       prm.add_parameter("RunType",
                         run_type_string,
                         "Type of throughput study.",
-                        Patterns::Selection("RefineHAndP|FixedProblemSize|IncreasingProblemSize"),
+                        dealii::Patterns::Selection("RefineHAndP|FixedProblemSize|IncreasingProblemSize"),
                         true);
       prm.add_parameter("DegreeMin",
                         degree_min,
                         "Minimal polynomial degree of shape functions.",
-                        Patterns::Integer(1,EXADG_DEGREE_MAX),
+                        dealii::Patterns::Integer(1,EXADG_DEGREE_MAX),
                         true);
       prm.add_parameter("DegreeMax",
                         degree_max,
                         "Maximal polynomial degree of shape functions.",
-                        Patterns::Integer(1,EXADG_DEGREE_MAX),
+                        dealii::Patterns::Integer(1,EXADG_DEGREE_MAX),
                         true);
       prm.add_parameter("RefineSpaceMin",
                         refine_space_min,
                         "Minimal number of mesh refinements.",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
       prm.add_parameter("RefineSpaceMax",
                         refine_space_max,
                         "Maximal number of mesh refinements.",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
       prm.add_parameter("DofsMin",
                         n_dofs_min,
                         "Minimal number of degrees of freedom.",
-                        Patterns::Integer(1),
+                        dealii::Patterns::Integer(1),
                         true);
       prm.add_parameter("DofsMax",
                         n_dofs_max,
                         "Maximal number of degrees of freedom.",
-                        Patterns::Integer(1),
+                        dealii::Patterns::Integer(1),
                         true);
     prm.leave_subsection();
     // clang-format on
@@ -234,26 +234,26 @@ struct HypercubeResolutionParameters
   {
     if(run_type == RunType::RefineHAndP)
     {
-      AssertThrow(degree_max >= degree_min, ExcMessage("Invalid parameters."));
-      AssertThrow(refine_space_max >= refine_space_min, ExcMessage("Invalid parameters."));
+      AssertThrow(degree_max >= degree_min, dealii::ExcMessage("Invalid parameters."));
+      AssertThrow(refine_space_max >= refine_space_min, dealii::ExcMessage("Invalid parameters."));
     }
     else if(run_type == RunType::FixedProblemSize)
     {
-      AssertThrow(degree_max >= degree_min, ExcMessage("Invalid parameters."));
-      AssertThrow(n_dofs_max >= n_dofs_min, ExcMessage("Invalid parameters."));
+      AssertThrow(degree_max >= degree_min, dealii::ExcMessage("Invalid parameters."));
+      AssertThrow(n_dofs_max >= n_dofs_min, dealii::ExcMessage("Invalid parameters."));
     }
     else if(run_type == RunType::IncreasingProblemSize)
     {
       AssertThrow(
         degree_min == degree_max,
-        ExcMessage(
+        dealii::ExcMessage(
           "Only a single polynomial degree can be considered for RunType::IncreasingProblemSize"));
 
-      AssertThrow(n_dofs_max >= n_dofs_min, ExcMessage("Invalid parameters."));
+      AssertThrow(n_dofs_max >= n_dofs_min, dealii::ExcMessage("Invalid parameters."));
     }
     else
     {
-      AssertThrow(false, ExcMessage("not implemented."));
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
     }
   }
 
@@ -290,7 +290,7 @@ struct HypercubeResolutionParameters
     }
     else
     {
-      AssertThrow(false, ExcMessage("Not implemented."));
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
   }
 
@@ -305,8 +305,8 @@ struct HypercubeResolutionParameters
   unsigned int refine_space_min = 0; // minimal number of global refinements
   unsigned int refine_space_max = 0; // maximal number of global refinements
 
-  types::global_dof_index n_dofs_min = 1e4; // minimal number of unknowns
-  types::global_dof_index n_dofs_max = 3e4; // maximal number of unknowns
+  dealii::types::global_dof_index n_dofs_min = 1e4; // minimal number of unknowns
+  dealii::types::global_dof_index n_dofs_max = 3e4; // maximal number of unknowns
 
   // a vector storing tuples of the form (degree k, refine level l, n_subdivisions_1d)
   std::vector<std::tuple<unsigned int, unsigned int, unsigned int>> resolutions;

--- a/include/exadg/utilities/measure_minimum_time.h
+++ b/include/exadg/utilities/measure_minimum_time.h
@@ -46,10 +46,10 @@ private:
   {
     int rank;
     MPI_Comm_rank(mpi_comm, &rank);
-    Timer  time;
-    double min_time = std::numeric_limits<double>::max();
-    double max_time = 0.0;
-    double sum_time = 0.0;
+    dealii::Timer time;
+    double        min_time = std::numeric_limits<double>::max();
+    double        max_time = 0.0;
+    double        sum_time = 0.0;
     for(int i = 0; i < best_of; i++)
     {
       MPI_Barrier(mpi_comm);

--- a/include/exadg/utilities/mpi.h
+++ b/include/exadg/utilities/mpi.h
@@ -43,9 +43,10 @@ identify_first_process_on_node(MPI_Comm const & mpi_comm)
   MPI_Comm_size(comm_shared, &size_shared);
   MPI_Comm_free(&comm_shared);
 
-  AssertThrow(size_shared == Utilities::MPI::max(size_shared, mpi_comm),
-              ExcMessage("The identification of MPI process groups in terms of compute nodes only "
-                         "works if all nodes are populated with the same number of MPI ranks!"));
+  AssertThrow(size_shared == dealii::Utilities::MPI::max(size_shared, mpi_comm),
+              dealii::ExcMessage(
+                "The identification of MPI process groups in terms of compute nodes only "
+                "works if all nodes are populated with the same number of MPI ranks!"));
   return {rank % size_shared == 0, size_shared};
 }
 

--- a/include/exadg/utilities/print_functions.h
+++ b/include/exadg/utilities/print_functions.h
@@ -30,33 +30,33 @@
 
 namespace ExaDG
 {
-using namespace dealii;
+template<typename ParameterType>
+void
+print_parameter(dealii::ConditionalOStream const & pcout,
+                std::string const                  name,
+                ParameterType const                value);
+
+void
+print_name(dealii::ConditionalOStream const & pcout, std::string const name);
 
 template<typename ParameterType>
 void
-print_parameter(ConditionalOStream const & pcout,
-                std::string const          name,
-                ParameterType const        value);
-
-void
-print_name(ConditionalOStream const & pcout, std::string const name);
-
-template<typename ParameterType>
-void
-print_value(ConditionalOStream const & pcout, ParameterType const value);
+print_value(dealii::ConditionalOStream const & pcout, ParameterType const value);
 
 template<>
 void
-print_value(ConditionalOStream const & pcout, bool const value);
+print_value(dealii::ConditionalOStream const & pcout, bool const value);
 
 template<>
 void
-print_value(ConditionalOStream const & pcout, double const value);
+print_value(dealii::ConditionalOStream const & pcout, double const value);
 
 // print a parameter (which has a name and a value)
 template<typename ParameterType>
 void
-print_parameter(ConditionalOStream const & pcout, std::string const name, ParameterType const value)
+print_parameter(dealii::ConditionalOStream const & pcout,
+                std::string const                  name,
+                ParameterType const                value)
 {
   print_name(pcout, name);
   print_value(pcout, value);
@@ -65,7 +65,7 @@ print_parameter(ConditionalOStream const & pcout, std::string const name, Parame
 // print name and insert spaces so that the output is aligned
 // needs inline because this function has no template
 inline void
-print_name(ConditionalOStream const & pcout, std::string const name)
+print_name(dealii::ConditionalOStream const & pcout, std::string const name)
 {
   unsigned int const max_length_name = 45;
 
@@ -79,7 +79,7 @@ print_name(ConditionalOStream const & pcout, std::string const name)
 // print value for general parameter data type
 template<typename ParameterType>
 void
-print_value(ConditionalOStream const & pcout, ParameterType const value)
+print_value(dealii::ConditionalOStream const & pcout, ParameterType const value)
 {
   pcout << value << std::endl;
 }
@@ -87,7 +87,7 @@ print_value(ConditionalOStream const & pcout, ParameterType const value)
 // specialization of template function for parameters of type bool
 template<>
 inline void
-print_value(ConditionalOStream const & pcout, bool const value)
+print_value(dealii::ConditionalOStream const & pcout, bool const value)
 {
   std::string value_string = "default";
   value_string             = (value == true) ? "true" : "false";
@@ -97,7 +97,7 @@ print_value(ConditionalOStream const & pcout, bool const value)
 // specialization of template function for parameters of type double
 template<>
 inline void
-print_value(ConditionalOStream const & pcout, double const value)
+print_value(dealii::ConditionalOStream const & pcout, double const value)
 {
   pcout << std::scientific << std::setprecision(4) << value << std::endl;
 }

--- a/include/exadg/utilities/print_general_infos.h
+++ b/include/exadg/utilities/print_general_infos.h
@@ -34,10 +34,8 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 inline void
-print_exadg_header(ConditionalOStream const & pcout)
+print_exadg_header(dealii::ConditionalOStream const & pcout)
 {
   // clang-format off
   pcout << std::endl << std::endl << std::endl
@@ -57,10 +55,10 @@ print_exadg_header(ConditionalOStream const & pcout)
 
 // print MPI info
 inline void
-print_MPI_info(ConditionalOStream const & pcout, MPI_Comm const & mpi_comm)
+print_MPI_info(dealii::ConditionalOStream const & pcout, MPI_Comm const & mpi_comm)
 {
   pcout << std::endl << "MPI info:" << std::endl << std::endl;
-  print_parameter(pcout, "Number of processes", Utilities::MPI::n_mpi_processes(mpi_comm));
+  print_parameter(pcout, "Number of processes", dealii::Utilities::MPI::n_mpi_processes(mpi_comm));
 }
 
 template<typename Number>
@@ -84,7 +82,7 @@ get_type(double)
 
 // print deal.II info
 inline void
-print_dealii_info(ConditionalOStream const & pcout)
+print_dealii_info(dealii::ConditionalOStream const & pcout)
 {
   // clang-format off
   pcout << std::endl
@@ -97,11 +95,11 @@ print_dealii_info(ConditionalOStream const & pcout)
 
 template<typename Number>
 inline void
-print_matrixfree_info(ConditionalOStream const & pcout)
+print_matrixfree_info(dealii::ConditionalOStream const & pcout)
 {
-  unsigned int const n_vect_doubles = VectorizedArray<Number>::size();
+  unsigned int const n_vect_doubles = dealii::VectorizedArray<Number>::size();
   unsigned int const n_vect_bits    = 8 * sizeof(Number) * n_vect_doubles;
-  std::string const  vect_level     = Utilities::System::get_current_vectorization_level();
+  std::string const  vect_level     = dealii::Utilities::System::get_current_vectorization_level();
   std::string const  type           = get_type(Number());
 
   // clang-format off
@@ -118,7 +116,7 @@ print_matrixfree_info(ConditionalOStream const & pcout)
 
 template<int dim>
 inline void
-print_grid_info(ConditionalOStream const & pcout, Grid<dim> const & grid)
+print_grid_info(dealii::ConditionalOStream const & pcout, Grid<dim> const & grid)
 {
   pcout << std::endl
         << "Generating grid for " << dim << "-dimensional problem:" << std::endl
@@ -127,15 +125,17 @@ print_grid_info(ConditionalOStream const & pcout, Grid<dim> const & grid)
   print_parameter(pcout, "Max. number of refinements", grid.triangulation->n_global_levels() - 1);
   print_parameter(pcout, "Number of cells", grid.triangulation->n_global_active_cells());
 
-  std::shared_ptr<MappingQGeneric<dim>> mapping_q_generic =
-    std::dynamic_pointer_cast<MappingQGeneric<dim>>(grid.mapping);
+  std::shared_ptr<dealii::MappingQGeneric<dim>> mapping_q_generic =
+    std::dynamic_pointer_cast<dealii::MappingQGeneric<dim>>(grid.mapping);
   if(mapping_q_generic.get() != 0)
     print_parameter(pcout, "Mapping degree", mapping_q_generic->get_degree());
 }
 
 template<typename Number>
 inline void
-print_general_info(ConditionalOStream const & pcout, MPI_Comm const & mpi_comm, bool const is_test)
+print_general_info(dealii::ConditionalOStream const & pcout,
+                   MPI_Comm const &                   mpi_comm,
+                   bool const                         is_test)
 {
   print_exadg_header(pcout);
 

--- a/include/exadg/utilities/print_solver_results.h
+++ b/include/exadg/utilities/print_solver_results.h
@@ -22,26 +22,25 @@
 #ifndef INCLUDE_EXADG_UTILITIES_PRINT_SOLVER_RESULTS_H_
 #define INCLUDE_EXADG_UTILITIES_PRINT_SOLVER_RESULTS_H_
 
+// C/C++
+#include <iostream>
+
 // deal.II
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
-#include <iostream>
-
 namespace ExaDG
 {
-using namespace dealii;
-
 inline void
 print_throughput(
-  std::vector<std::tuple<unsigned int, types::global_dof_index, double>> const & wall_times,
-  std::string const &                                                            operator_type,
-  MPI_Comm const &                                                               mpi_comm)
+  std::vector<std::tuple<unsigned int, dealii::types::global_dof_index, double>> const & wall_times,
+  std::string const & operator_type,
+  MPI_Comm const &    mpi_comm)
 {
-  unsigned int N_mpi_processes = Utilities::MPI::n_mpi_processes(mpi_comm);
+  unsigned int N_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
 
-  if(Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
   {
     // clang-format off
     std::cout << std::endl
@@ -55,7 +54,7 @@ print_throughput(
               << std::setw(15) << std::left << "DoFs/(sec*core)"
               << std::endl << std::flush;
 
-    typedef typename std::vector<std::tuple<unsigned int, types::global_dof_index, double> >::const_iterator ITERATOR;
+    typedef typename std::vector<std::tuple<unsigned int, dealii::types::global_dof_index, double> >::const_iterator ITERATOR;
     for(ITERATOR it = wall_times.begin(); it != wall_times.end(); ++it)
     {
       std::cout << std::setw(5) << std::left << std::get<0>(*it)
@@ -72,10 +71,10 @@ print_throughput(
 }
 
 inline void
-print_throughput_steady(ConditionalOStream const &    pcout,
-                        types::global_dof_index const n_dofs,
-                        double const                  overall_time_avg,
-                        unsigned int const            N_mpi_processes)
+print_throughput_steady(dealii::ConditionalOStream const &    pcout,
+                        dealii::types::global_dof_index const n_dofs,
+                        double const                          overall_time_avg,
+                        unsigned int const                    N_mpi_processes)
 {
   // clang-format off
   pcout << std::endl
@@ -89,10 +88,10 @@ print_throughput_steady(ConditionalOStream const &    pcout,
 }
 
 inline void
-print_throughput_10(ConditionalOStream const &    pcout,
-                    types::global_dof_index const n_dofs,
-                    double const                  t_10,
-                    unsigned int const            N_mpi_processes)
+print_throughput_10(dealii::ConditionalOStream const &    pcout,
+                    dealii::types::global_dof_index const n_dofs,
+                    double const                          t_10,
+                    unsigned int const                    N_mpi_processes)
 {
   double const tau_10 = t_10 * (double)N_mpi_processes / n_dofs;
 
@@ -109,11 +108,11 @@ print_throughput_10(ConditionalOStream const &    pcout,
 }
 
 inline void
-print_throughput_unsteady(ConditionalOStream const &    pcout,
-                          types::global_dof_index const n_dofs,
-                          double const                  overall_time_avg,
-                          unsigned int const            N_time_steps,
-                          unsigned int const            N_mpi_processes)
+print_throughput_unsteady(dealii::ConditionalOStream const &    pcout,
+                          dealii::types::global_dof_index const n_dofs,
+                          double const                          overall_time_avg,
+                          unsigned int const                    N_time_steps,
+                          unsigned int const                    N_mpi_processes)
 {
   double const time_per_timestep = overall_time_avg / (double)N_time_steps;
 
@@ -132,9 +131,9 @@ print_throughput_unsteady(ConditionalOStream const &    pcout,
 
 
 inline void
-print_costs(ConditionalOStream const & pcout,
-            double const               overall_time_avg,
-            unsigned int const         N_mpi_processes)
+print_costs(dealii::ConditionalOStream const & pcout,
+            double const                       overall_time_avg,
+            unsigned int const                 N_mpi_processes)
 
 {
   // clang-format off
@@ -148,10 +147,10 @@ print_costs(ConditionalOStream const & pcout,
 }
 
 inline void
-print_solver_info_nonlinear(ConditionalOStream const & pcout,
-                            unsigned int const         N_iter_nonlinear,
-                            unsigned int const         N_iter_linear,
-                            double const               wall_time)
+print_solver_info_nonlinear(dealii::ConditionalOStream const & pcout,
+                            unsigned int const                 N_iter_nonlinear,
+                            unsigned int const                 N_iter_linear,
+                            double const                       wall_time)
 
 {
   double const N_iter_linear_avg =
@@ -168,9 +167,9 @@ print_solver_info_nonlinear(ConditionalOStream const & pcout,
 }
 
 inline void
-print_solver_info_linear(ConditionalOStream const & pcout,
-                         unsigned int const         N_iter_linear,
-                         double const               wall_time)
+print_solver_info_linear(dealii::ConditionalOStream const & pcout,
+                         unsigned int const                 N_iter_linear,
+                         double const                       wall_time)
 
 {
   // clang-format off
@@ -182,7 +181,7 @@ print_solver_info_linear(ConditionalOStream const & pcout,
 }
 
 inline void
-print_wall_time(ConditionalOStream const & pcout, double const wall_time)
+print_wall_time(dealii::ConditionalOStream const & pcout, double const wall_time)
 
 {
   // clang-format off
@@ -193,9 +192,9 @@ print_wall_time(ConditionalOStream const & pcout, double const wall_time)
 }
 
 inline void
-print_list_of_iterations(ConditionalOStream const &       pcout,
-                         std::vector<std::string> const & names,
-                         std::vector<double> const &      iterations_avg)
+print_list_of_iterations(dealii::ConditionalOStream const & pcout,
+                         std::vector<std::string> const &   names,
+                         std::vector<double> const &        iterations_avg)
 {
   unsigned int length = 1;
   for(unsigned int i = 0; i < names.size(); ++i)

--- a/include/exadg/utilities/resolution_parameters.h
+++ b/include/exadg/utilities/resolution_parameters.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct SpatialResolutionParameters
 {
   SpatialResolutionParameters()
@@ -53,22 +51,22 @@ struct SpatialResolutionParameters
       prm.add_parameter("DegreeMin",
                         degree_min,
                         "Minimal polynomial degree of shape functions.",
-                        Patterns::Integer(1,EXADG_DEGREE_MAX),
+                        dealii::Patterns::Integer(1,EXADG_DEGREE_MAX),
                         true);
       prm.add_parameter("DegreeMax",
                         degree_max,
                         "Maximal polynomial degree of shape functions.",
-                        Patterns::Integer(1,EXADG_DEGREE_MAX),
+                        dealii::Patterns::Integer(1,EXADG_DEGREE_MAX),
                         true);
       prm.add_parameter("RefineSpaceMin",
                         refine_space_min,
                         "Minimal number of mesh refinements.",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
       prm.add_parameter("RefineSpaceMax",
                         refine_space_max,
                         "Maximal number of mesh refinements.",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
     prm.leave_subsection();
     // clang-format on
@@ -102,12 +100,12 @@ struct TemporalResolutionParameters
       prm.add_parameter("RefineTimeMin",
                         refine_time_min,
                         "Minimal number of time refinements.",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
       prm.add_parameter("RefineTimeMax",
                         refine_time_max,
                         "Maximal number of time refinements.",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
     prm.leave_subsection();
     // clang-format on
@@ -138,12 +136,12 @@ struct ResolutionParameters
       prm.add_parameter("Degree",
                         degree,
                         "Polynomial degree of shape functions.",
-                        Patterns::Integer(1,EXADG_DEGREE_MAX),
+                        dealii::Patterns::Integer(1,EXADG_DEGREE_MAX),
                         true);
       prm.add_parameter("RefineSpace",
                         refine_space,
                         "Number of global, uniform mesh refinements.",
-                        Patterns::Integer(0,20),
+                        dealii::Patterns::Integer(0,20),
                         true);
     prm.leave_subsection();
     // clang-format on

--- a/include/exadg/utilities/solver_result.h
+++ b/include/exadg/utilities/solver_result.h
@@ -26,24 +26,22 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 struct SolverResult
 {
   SolverResult() : degree(1), dofs(1), n_10(0), tau_10(0.0)
   {
   }
 
-  SolverResult(unsigned int const            degree_,
-               types::global_dof_index const dofs_,
-               double const                  n_10_,
-               double const                  tau_10_)
+  SolverResult(unsigned int const                    degree_,
+               dealii::types::global_dof_index const dofs_,
+               double const                          n_10_,
+               double const                          tau_10_)
     : degree(degree_), dofs(dofs_), n_10(n_10_), tau_10(tau_10_)
   {
   }
 
   void
-  print_header(ConditionalOStream const & pcout) const
+  print_header(dealii::ConditionalOStream const & pcout) const
   {
     // names
     pcout << std::setw(7) << "degree";
@@ -65,7 +63,7 @@ struct SolverResult
   }
 
   void
-  print_results(ConditionalOStream const & pcout) const
+  print_results(dealii::ConditionalOStream const & pcout) const
   {
     pcout << std::setw(7) << std::fixed << degree;
     pcout << std::setw(15) << std::fixed << dofs;
@@ -75,17 +73,18 @@ struct SolverResult
     pcout << std::endl;
   }
 
-  unsigned int            degree;
-  types::global_dof_index dofs;
-  double                  n_10;
-  double                  tau_10;
+  unsigned int                    degree;
+  dealii::types::global_dof_index dofs;
+  double                          n_10;
+  double                          tau_10;
 };
 
 inline void
 print_results(std::vector<SolverResult> const & results, MPI_Comm const & mpi_comm)
 {
   // summarize results for all polynomial degrees and problem sizes
-  ConditionalOStream pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0);
+  dealii::ConditionalOStream pcout(std::cout,
+                                   dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0);
 
   pcout << std::endl << print_horizontal_line() << std::endl << std::endl;
 

--- a/include/exadg/utilities/throughput_parameters.h
+++ b/include/exadg/utilities/throughput_parameters.h
@@ -30,8 +30,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 inline double
 measure_operator_evaluation_time(std::function<void(void)> const & evaluate_operator,
                                  unsigned int const                degree,
@@ -41,9 +39,9 @@ measure_operator_evaluation_time(std::function<void(void)> const & evaluate_oper
 {
   (void)degree;
 
-  Timer global_timer;
+  dealii::Timer global_timer;
   global_timer.restart();
-  Utilities::MPI::MinMaxAvg global_time;
+  dealii::Utilities::MPI::MinMaxAvg global_time;
 
   double wall_time = std::numeric_limits<double>::max();
 
@@ -51,7 +49,7 @@ measure_operator_evaluation_time(std::function<void(void)> const & evaluate_oper
   {
     for(unsigned int i_outer = 0; i_outer < n_repetitions_outer; ++i_outer)
     {
-      Timer timer;
+      dealii::Timer timer;
       timer.restart();
 
 #ifdef LIKWID_PERFMON
@@ -69,13 +67,13 @@ measure_operator_evaluation_time(std::function<void(void)> const & evaluate_oper
 #endif
 
       MPI_Barrier(mpi_comm);
-      Utilities::MPI::MinMaxAvg wall_time_inner =
-        Utilities::MPI::min_max_avg(timer.wall_time(), mpi_comm);
+      dealii::Utilities::MPI::MinMaxAvg wall_time_inner =
+        dealii::Utilities::MPI::min_max_avg(timer.wall_time(), mpi_comm);
 
       wall_time = std::min(wall_time, wall_time_inner.avg / (double)n_repetitions_inner);
     }
 
-    global_time = Utilities::MPI::min_max_avg(global_timer.wall_time(), mpi_comm);
+    global_time = dealii::Utilities::MPI::min_max_avg(global_timer.wall_time(), mpi_comm);
   } while(global_time.avg < 1.0 /*wall time in seconds*/);
 
   return wall_time;
@@ -102,17 +100,17 @@ struct ThroughputParameters
       prm.add_parameter("OperatorType",
                         operator_type,
                         "Type of operator.",
-                        Patterns::Anything(),
+                        dealii::Patterns::Anything(),
                         true);
       prm.add_parameter("RepetitionsInner",
                         n_repetitions_inner,
                         "Number of operator evaluations.",
-                        Patterns::Integer(1),
+                        dealii::Patterns::Integer(1),
                         true);
       prm.add_parameter("RepetitionsOuter",
                         n_repetitions_outer,
                         "Number of runs (taking minimum wall time).",
-                        Patterns::Integer(1,10),
+                        dealii::Patterns::Integer(1,10),
                         true);
     prm.leave_subsection();
     // clang-format on
@@ -132,7 +130,7 @@ struct ThroughputParameters
   unsigned int n_repetitions_outer = 1;   // take the minimum of outer repetitions
 
   // global variable used to store the wall times for different polynomial degrees and problem sizes
-  mutable std::vector<std::tuple<unsigned int, types::global_dof_index, double>> wall_times;
+  mutable std::vector<std::tuple<unsigned int, dealii::types::global_dof_index, double>> wall_times;
 };
 } // namespace ExaDG
 

--- a/include/exadg/utilities/timer_tree.h
+++ b/include/exadg/utilities/timer_tree.h
@@ -23,11 +23,10 @@
 #define INCLUDE_EXADG_UTILITIES_TIMER_TREE_H_
 
 #include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/exceptions.h>
 
 namespace ExaDG
 {
-using namespace dealii;
-
 class TimerTree
 {
 public:
@@ -56,11 +55,11 @@ public:
   void
   insert(std::vector<std::string> const ids, double const wall_time)
   {
-    AssertThrow(ids.size() > 0, ExcMessage("empty name."));
+    AssertThrow(ids.size() > 0, dealii::ExcMessage("empty name."));
 
     if(this->id == "") // the tree is currently empty
     {
-      AssertThrow(sub_trees.empty(), ExcMessage("invalid state found. aborting."));
+      AssertThrow(sub_trees.empty(), dealii::ExcMessage("invalid state found. aborting."));
 
       this->id = ids[0];
 
@@ -118,8 +117,8 @@ public:
     else // the provided name does not fit to this tree
     {
       AssertThrow(false,
-                  ExcMessage("The name provided is " + ids[0] + ", but must be " + id +
-                             " instead."));
+                  dealii::ExcMessage("The name provided is " + ids[0] + ", but must be " + id +
+                                     " instead."));
     }
   }
 
@@ -135,8 +134,8 @@ public:
          std::shared_ptr<TimerTree> sub_tree,
          std::string const          new_name = "")
   {
-    AssertThrow(ids.size() > 0, ExcMessage("Empty ID specified."));
-    AssertThrow(id == ids[0], ExcMessage("Invalid ID specified."));
+    AssertThrow(ids.size() > 0, dealii::ExcMessage("Empty ID specified."));
+    AssertThrow(id == ids[0], dealii::ExcMessage("Invalid ID specified."));
 
     std::vector<std::string> remaining_id = erase_first(ids);
 
@@ -157,7 +156,7 @@ public:
     {
       AssertThrow(
         remaining_id.size() == 0,
-        ExcMessage(
+        dealii::ExcMessage(
           "Subtree can not be inserted since the specified ID does not exist in this tree."));
 
       std::shared_ptr<TimerTree> new_tree(new TimerTree());
@@ -170,7 +169,7 @@ public:
       {
         AssertThrow(
           new_tree->id != (*it)->id,
-          ExcMessage(
+          dealii::ExcMessage(
             "Subtree can not be inserted since the tree already contains a subtree with the same ID."));
       }
 
@@ -183,7 +182,7 @@ public:
    * the relative share of the children.
    */
   void
-  print_plain(ConditionalOStream const & pcout) const
+  print_plain(dealii::ConditionalOStream const & pcout) const
   {
     unsigned int const length = get_length();
 
@@ -203,7 +202,7 @@ public:
    * covered by timers.
    */
   void
-  print_level(ConditionalOStream const & pcout, unsigned int const level) const
+  print_level(dealii::ConditionalOStream const & pcout, unsigned int const level) const
   {
     unsigned int const length = get_length();
 
@@ -225,7 +224,7 @@ private:
   std::vector<std::string>
   erase_first(std::vector<std::string> const & in) const
   {
-    AssertThrow(in.size() > 0, ExcMessage("empty name."));
+    AssertThrow(in.size() > 0, dealii::ExcMessage("empty name."));
 
     std::vector<std::string> out(in);
     out.erase(out.begin());
@@ -236,8 +235,8 @@ private:
   double
   get_average_wall_time() const
   {
-    Utilities::MPI::MinMaxAvg time_data =
-      Utilities::MPI::min_max_avg(data->wall_time, MPI_COMM_WORLD);
+    dealii::Utilities::MPI::MinMaxAvg time_data =
+      dealii::Utilities::MPI::min_max_avg(data->wall_time, MPI_COMM_WORLD);
     return time_data.avg;
   }
 
@@ -258,9 +257,9 @@ private:
   }
 
   void
-  do_print_plain(ConditionalOStream const & pcout,
-                 unsigned int const         offset,
-                 unsigned int const         length) const
+  do_print_plain(dealii::ConditionalOStream const & pcout,
+                 unsigned int const                 offset,
+                 unsigned int const                 length) const
   {
     if(id.empty())
       return;
@@ -274,10 +273,10 @@ private:
   }
 
   void
-  do_print_level(ConditionalOStream const & pcout,
-                 unsigned int const         level,
-                 unsigned int const         offset,
-                 unsigned int const         length) const
+  do_print_level(dealii::ConditionalOStream const & pcout,
+                 unsigned int const                 level,
+                 unsigned int const                 offset,
+                 unsigned int const                 length) const
   {
     if(id.empty())
       return;
@@ -312,9 +311,9 @@ private:
   }
 
   void
-  print_name(ConditionalOStream const & pcout,
-             unsigned int const         offset,
-             unsigned int const         length) const
+  print_name(dealii::ConditionalOStream const & pcout,
+             unsigned int const                 offset,
+             unsigned int const                 length) const
   {
     pcout << std::setw(offset) << "" << std::setw(length - offset) << std::left << id;
 
@@ -322,16 +321,17 @@ private:
   }
 
   void
-  print_own(ConditionalOStream const & pcout,
-            unsigned int const         offset,
-            unsigned int const         length,
-            bool const                 relative = false,
-            double const               ref_time = -1.0) const
+  print_own(dealii::ConditionalOStream const & pcout,
+            unsigned int const                 offset,
+            unsigned int const                 length,
+            bool const                         relative = false,
+            double const                       ref_time = -1.0) const
   {
     pcout << std::setw(offset) << "" << std::setw(length - offset) << std::left << id;
 
-    Utilities::MPI::MinMaxAvg ref_time_data = Utilities::MPI::min_max_avg(ref_time, MPI_COMM_WORLD);
-    double const              ref_time_avg  = ref_time_data.avg;
+    dealii::Utilities::MPI::MinMaxAvg ref_time_data =
+      dealii::Utilities::MPI::min_max_avg(ref_time, MPI_COMM_WORLD);
+    double const ref_time_avg = ref_time_data.avg;
 
     if(data.get())
     {
@@ -349,11 +349,11 @@ private:
   }
 
   void
-  print_direct_children(ConditionalOStream const & pcout,
-                        unsigned int const         offset,
-                        unsigned int const         length,
-                        bool const                 relative = false,
-                        double const               ref_time = -1.0) const
+  print_direct_children(dealii::ConditionalOStream const & pcout,
+                        unsigned int const                 offset,
+                        unsigned int const                 length,
+                        bool const                         relative = false,
+                        double const                       ref_time = -1.0) const
   {
     TimerTree other;
     if(relative && sub_trees.size() > 0)

--- a/include/exadg/vector_tools/interpolate_solution.h
+++ b/include/exadg/vector_tools/interpolate_solution.h
@@ -28,51 +28,51 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /*
  * For a given vector of adjacent cells and points in reference coordinates, determine
  * and return the dof_indices and shape_values to be used later for interpolation of the
  * solution.
  */
 template<int dim, typename Number>
-std::vector<std::pair<std::vector<types::global_dof_index>, std::vector<Number>>>
+std::vector<std::pair<std::vector<dealii::types::global_dof_index>, std::vector<Number>>>
 get_dof_indices_and_shape_values(
-  std::vector<std::pair<typename Triangulation<dim>::active_cell_iterator, Point<dim>>> const &
-                                                     adjacent_cells,
-  DoFHandler<dim> const &                            dof_handler,
-  Mapping<dim> const &                               mapping,
-  LinearAlgebra::distributed::Vector<Number> const & solution)
+  std::vector<std::pair<typename dealii::Triangulation<dim>::active_cell_iterator,
+                        dealii::Point<dim>>> const &         adjacent_cells,
+  dealii::DoFHandler<dim> const &                            dof_handler,
+  dealii::Mapping<dim> const &                               mapping,
+  dealii::LinearAlgebra::distributed::Vector<Number> const & solution)
 {
   // fill dof_indices_and_shape_values
-  std::vector<std::pair<std::vector<types::global_dof_index>, std::vector<Number>>>
+  std::vector<std::pair<std::vector<dealii::types::global_dof_index>, std::vector<Number>>>
     dof_indices_and_shape_values;
 
   for(auto cell_tria : adjacent_cells)
   {
-    // transform Triangulation::active_cell_iterator into DoFHandler::active_cell_iterator,
+    // transform Triangulation::active_cell_iterator into dealii::DoFHandler::active_cell_iterator,
     // see constructor of DoFCellAccessor
-    typename DoFHandler<dim>::active_cell_iterator cell_dof = {&dof_handler.get_triangulation(),
-                                                               cell_tria.first->level(),
-                                                               cell_tria.first->index(),
-                                                               &dof_handler};
+    typename dealii::DoFHandler<dim>::active_cell_iterator cell_dof = {
+      &dof_handler.get_triangulation(),
+      cell_tria.first->level(),
+      cell_tria.first->index(),
+      &dof_handler};
 
-    typedef std::pair<typename DoFHandler<dim>::active_cell_iterator, Point<dim>> PairDof;
+    typedef std::pair<typename dealii::DoFHandler<dim>::active_cell_iterator, dealii::Point<dim>>
+            PairDof;
     PairDof cell_and_point(cell_dof, cell_tria.second);
 
     // go on only if cell is owned by the processor
     if(cell_and_point.first->is_locally_owned())
     {
-      const Quadrature<dim> quadrature(
-        GeometryInfo<dim>::project_to_unit_cell(cell_and_point.second));
+      const dealii::Quadrature<dim> quadrature(
+        dealii::GeometryInfo<dim>::project_to_unit_cell(cell_and_point.second));
 
-      const FiniteElement<dim> & fe = dof_handler.get_fe();
-      FEValues<dim>              fe_values(mapping, fe, quadrature, update_values);
+      const dealii::FiniteElement<dim> & fe = dof_handler.get_fe();
+      dealii::FEValues<dim>              fe_values(mapping, fe, quadrature, dealii::update_values);
       fe_values.reinit(cell_and_point.first);
-      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+      std::vector<dealii::types::global_dof_index> dof_indices(fe.dofs_per_cell);
       cell_and_point.first->get_dof_indices(dof_indices);
 
-      std::vector<types::global_dof_index> dof_indices_global(fe.dofs_per_cell);
+      std::vector<dealii::types::global_dof_index> dof_indices_global(fe.dofs_per_cell);
       for(unsigned int i = 0; i < fe.dofs_per_cell; ++i)
         dof_indices_global[i] = solution.get_partitioner()->global_to_local(dof_indices[i]);
 
@@ -94,71 +94,71 @@ template<int rank, int dim, typename Number>
 struct Interpolator
 {
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<rank, dim, Number>
-    value(DoFHandler<dim> const &                            dof_handler,
-          LinearAlgebra::distributed::Vector<Number> const & solution,
-          std::vector<types::global_dof_index> const &       dof_indices,
-          std::vector<Number> const &                        fe_shape_values)
+    dealii::Tensor<rank, dim, Number>
+    value(dealii::DoFHandler<dim> const &                            dof_handler,
+          dealii::LinearAlgebra::distributed::Vector<Number> const & solution,
+          std::vector<dealii::types::global_dof_index> const &       dof_indices,
+          std::vector<Number> const &                                fe_shape_values)
   {
     (void)dof_handler;
     (void)solution;
     (void)dof_indices;
     (void)fe_shape_values;
 
-    AssertThrow(false, ExcMessage("not implemented."));
+    AssertThrow(false, dealii::ExcMessage("not implemented."));
 
-    Tensor<rank, dim, Number> result;
+    dealii::Tensor<rank, dim, Number> result;
     return result;
   }
 };
 
 /*
- * The quantity to be evaluated is of type Tensor<0,dim,Number>.
+ * The quantity to be evaluated is of type dealii::Tensor<0,dim,Number>.
  */
 template<int dim, typename Number>
 struct Interpolator<0, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<0, dim, Number>
-    value(DoFHandler<dim> const &                            dof_handler,
-          LinearAlgebra::distributed::Vector<Number> const & solution,
-          std::vector<types::global_dof_index> const &       dof_indices,
-          std::vector<Number> const &                        fe_shape_values)
+    dealii::Tensor<0, dim, Number>
+    value(dealii::DoFHandler<dim> const &                            dof_handler,
+          dealii::LinearAlgebra::distributed::Vector<Number> const & solution,
+          std::vector<dealii::types::global_dof_index> const &       dof_indices,
+          std::vector<Number> const &                                fe_shape_values)
   {
     Assert(dof_handler.get_fe().dofs_per_cell == fe_shape_values.size(),
-           ExcMessage("Vector fe_shape_values has wrong size."));
+           dealii::ExcMessage("Vector fe_shape_values has wrong size."));
 
     Number result = Number(0.0);
 
-    FiniteElement<dim> const & fe = dof_handler.get_fe();
+    dealii::FiniteElement<dim> const & fe = dof_handler.get_fe();
     for(unsigned int i = 0; i < fe.dofs_per_cell; ++i)
       result += solution.local_element(dof_indices[i]) * fe_shape_values[i];
 
-    Tensor<0, dim, Number> result_tensor = result;
+    dealii::Tensor<0, dim, Number> result_tensor = result;
 
     return result_tensor;
   }
 };
 
 /*
- * The quantity to be evaluated is of type Tensor<1, dim, Number>.
+ * The quantity to be evaluated is of type dealii::Tensor<1, dim, Number>.
  */
 template<int dim, typename Number>
 struct Interpolator<1, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
-    Tensor<1, dim, Number>
-    value(DoFHandler<dim> const &                            dof_handler,
-          LinearAlgebra::distributed::Vector<Number> const & solution,
-          std::vector<types::global_dof_index> const &       dof_indices,
-          std::vector<Number> const &                        fe_shape_values)
+    dealii::Tensor<1, dim, Number>
+    value(dealii::DoFHandler<dim> const &                            dof_handler,
+          dealii::LinearAlgebra::distributed::Vector<Number> const & solution,
+          std::vector<dealii::types::global_dof_index> const &       dof_indices,
+          std::vector<Number> const &                                fe_shape_values)
   {
     Assert(dof_handler.get_fe().dofs_per_cell == fe_shape_values.size(),
-           ExcMessage("Vector fe_shape_values has wrong size."));
+           dealii::ExcMessage("Vector fe_shape_values has wrong size."));
 
-    Tensor<1, dim, Number> result;
+    dealii::Tensor<1, dim, Number> result;
 
-    FiniteElement<dim> const & fe = dof_handler.get_fe();
+    dealii::FiniteElement<dim> const & fe = dof_handler.get_fe();
     for(unsigned int i = 0; i < fe.dofs_per_cell; ++i)
       result[fe.system_to_component_index(i).first] +=
         solution.local_element(dof_indices[i]) * fe_shape_values[i];

--- a/tests/solvers_and_preconditioners/elementwise_gmres.cc
+++ b/tests/solvers_and_preconditioners/elementwise_gmres.cc
@@ -40,8 +40,6 @@
 
 namespace ExaDG
 {
-using namespace dealii;
-
 /**************************************************************************************/
 /*                                                                                    */
 /*                                   PARAMETERS                                       */
@@ -79,7 +77,7 @@ public:
   void
   set_value(value_type const value, unsigned int const i)
   {
-    AssertThrow(i < M, ExcMessage("Index exceeds matrix dimensions."));
+    AssertThrow(i < M, dealii::ExcMessage("Index exceeds matrix dimensions."));
 
     data[i] = value;
   }
@@ -106,8 +104,8 @@ public:
 
 private:
   // number of rows and columns of matrix
-  unsigned int const        M;
-  AlignedVector<value_type> data;
+  unsigned int const                M;
+  dealii::AlignedVector<value_type> data;
 };
 
 
@@ -156,15 +154,15 @@ public:
   void
   set_value(value_type const value, unsigned int const i, unsigned int const j)
   {
-    AssertThrow(i < M && j < M, ExcMessage("Index exceeds matrix dimensions."));
+    AssertThrow(i < M && j < M, dealii::ExcMessage("Index exceeds matrix dimensions."));
 
     data[i * M + j] = value;
   }
 
 private:
   // number of rows and columns of matrix
-  unsigned int const        M;
-  AlignedVector<value_type> data;
+  unsigned int const                M;
+  dealii::AlignedVector<value_type> data;
 };
 
 
@@ -299,55 +297,55 @@ gmres_test_2a()
 
   SolverData solver_data(100, tol, tol, 30);
 
-  typedef Elementwise::PreconditionerIdentity<VectorizedArray<double>>      Preconditioner;
-  typedef MyMatrix<VectorizedArray<double>>                                 Matrix;
-  Preconditioner                                                            preconditioner(M);
-  Elementwise::SolverGMRES<VectorizedArray<double>, Matrix, Preconditioner> gmres_solver(
+  typedef Elementwise::PreconditionerIdentity<dealii::VectorizedArray<double>> Preconditioner;
+  typedef MyMatrix<dealii::VectorizedArray<double>>                            Matrix;
+  Preconditioner                                                               preconditioner(M);
+  Elementwise::SolverGMRES<dealii::VectorizedArray<double>, Matrix, Preconditioner> gmres_solver(
     M, solver_data);
 
-  MyVector<VectorizedArray<double>> b(M);
-  b.set_value(make_vectorized_array<double>(1.0), 0);
-  b.set_value(make_vectorized_array<double>(2.0), 1);
-  b.set_value(make_vectorized_array<double>(3.0), 2);
+  MyVector<dealii::VectorizedArray<double>> b(M);
+  b.set_value(dealii::make_vectorized_array<double>(1.0), 0);
+  b.set_value(dealii::make_vectorized_array<double>(2.0), 1);
+  b.set_value(dealii::make_vectorized_array<double>(3.0), 2);
 
-  MyVector<VectorizedArray<double>> x(M);
+  MyVector<dealii::VectorizedArray<double>> x(M);
   x.init();
-  x.set_value(make_vectorized_array<double>(1.0), 0);
-  x.set_value(make_vectorized_array<double>(1.0), 1);
-  x.set_value(make_vectorized_array<double>(1.0), 2);
+  x.set_value(dealii::make_vectorized_array<double>(1.0), 0);
+  x.set_value(dealii::make_vectorized_array<double>(1.0), 1);
+  x.set_value(dealii::make_vectorized_array<double>(1.0), 2);
 
   Matrix A(M);
-  A.set_value(make_vectorized_array<double>(1.0), 0, 0);
-  A.set_value(make_vectorized_array<double>(2.0), 1, 1);
-  A.set_value(make_vectorized_array<double>(3.0), 2, 2);
+  A.set_value(dealii::make_vectorized_array<double>(1.0), 0, 0);
+  A.set_value(dealii::make_vectorized_array<double>(2.0), 1, 1);
+  A.set_value(dealii::make_vectorized_array<double>(3.0), 2, 2);
 
   /*
-  MyVector<VectorizedArray<double>> initial_res(M);
+  MyVector<dealii::VectorizedArray<double>> initial_res(M);
   A.vmult(initial_res.ptr(), x.ptr());
-  initial_res.sadd(make_vectorized_array<double>(-1.0), b.ptr());
+  initial_res.sadd(dealii::make_vectorized_array<double>(-1.0), b.ptr());
 
-  VectorizedArray<double> l2_norm_initial_res = initial_res.l2_norm();
+  dealii::VectorizedArray<double> l2_norm_initial_res = initial_res.l2_norm();
 
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
     std::cout << "L2 norm of initial residual[" << v << "] = " << l2_norm_initial_res[v] <<
   std::endl;
    */
 
   gmres_solver.solve(&A, x.ptr(), b.ptr(), &preconditioner);
 
-  MyVector<VectorizedArray<double>> res(M);
+  MyVector<dealii::VectorizedArray<double>> res(M);
   A.vmult(res.ptr(), x.ptr());
-  res.sadd(make_vectorized_array<double>(-1.0), b.ptr());
+  res.sadd(dealii::make_vectorized_array<double>(-1.0), b.ptr());
 
-  VectorizedArray<double> l2_norm = res.l2_norm();
+  dealii::VectorizedArray<double> l2_norm = res.l2_norm();
 
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
-    AssertThrow(l2_norm[v] < 1.e-12, ExcMessage("Did not converge."));
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
+    AssertThrow(l2_norm[v] < 1.e-12, dealii::ExcMessage("Did not converge."));
 
   std::cout << "converged." << std::endl;
 }
 
-// VectorizedArray: start with zero solution
+// dealii::VectorizedArray: start with zero solution
 void
 gmres_test_2b()
 {
@@ -358,58 +356,58 @@ gmres_test_2b()
 
   SolverData solver_data(100, 1e-12, 1e-12, 30);
 
-  typedef Elementwise::PreconditionerIdentity<VectorizedArray<double>>      Preconditioner;
-  typedef MyMatrix<VectorizedArray<double>>                                 Matrix;
-  Preconditioner                                                            preconditioner(M);
-  Elementwise::SolverGMRES<VectorizedArray<double>, Matrix, Preconditioner> gmres_solver(
+  typedef Elementwise::PreconditionerIdentity<dealii::VectorizedArray<double>> Preconditioner;
+  typedef MyMatrix<dealii::VectorizedArray<double>>                            Matrix;
+  Preconditioner                                                               preconditioner(M);
+  Elementwise::SolverGMRES<dealii::VectorizedArray<double>, Matrix, Preconditioner> gmres_solver(
     M, solver_data);
 
-  MyVector<VectorizedArray<double>> b(M);
-  b.set_value(make_vectorized_array<double>(1.0), 0);
-  b.set_value(make_vectorized_array<double>(4.0), 1);
-  b.set_value(make_vectorized_array<double>(6.0), 2);
+  MyVector<dealii::VectorizedArray<double>> b(M);
+  b.set_value(dealii::make_vectorized_array<double>(1.0), 0);
+  b.set_value(dealii::make_vectorized_array<double>(4.0), 1);
+  b.set_value(dealii::make_vectorized_array<double>(6.0), 2);
 
-  MyVector<VectorizedArray<double>> x(M);
+  MyVector<dealii::VectorizedArray<double>> x(M);
   x.init();
 
   Matrix A(M);
-  A.set_value(make_vectorized_array<double>(1.0), 0, 0);
-  A.set_value(make_vectorized_array<double>(2.0), 0, 1);
-  A.set_value(make_vectorized_array<double>(3.0), 0, 2);
-  A.set_value(make_vectorized_array<double>(2.0), 1, 0);
-  A.set_value(make_vectorized_array<double>(3.0), 1, 1);
-  A.set_value(make_vectorized_array<double>(1.0), 1, 2);
-  A.set_value(make_vectorized_array<double>(3.0), 2, 0);
-  A.set_value(make_vectorized_array<double>(1.0), 2, 1);
-  A.set_value(make_vectorized_array<double>(2.0), 2, 2);
+  A.set_value(dealii::make_vectorized_array<double>(1.0), 0, 0);
+  A.set_value(dealii::make_vectorized_array<double>(2.0), 0, 1);
+  A.set_value(dealii::make_vectorized_array<double>(3.0), 0, 2);
+  A.set_value(dealii::make_vectorized_array<double>(2.0), 1, 0);
+  A.set_value(dealii::make_vectorized_array<double>(3.0), 1, 1);
+  A.set_value(dealii::make_vectorized_array<double>(1.0), 1, 2);
+  A.set_value(dealii::make_vectorized_array<double>(3.0), 2, 0);
+  A.set_value(dealii::make_vectorized_array<double>(1.0), 2, 1);
+  A.set_value(dealii::make_vectorized_array<double>(2.0), 2, 2);
 
   /*
-  MyVector<VectorizedArray<double>> initial_res(M);
+  MyVector<dealii::VectorizedArray<double>> initial_res(M);
   A.vmult(initial_res.ptr(), x.ptr());
-  initial_res.sadd(make_vectorized_array<double>(-1.0), b.ptr());
+  initial_res.sadd(dealii::make_vectorized_array<double>(-1.0), b.ptr());
 
-  VectorizedArray<double> l2_norm_initial_res = initial_res.l2_norm();
+  dealii::VectorizedArray<double> l2_norm_initial_res = initial_res.l2_norm();
 
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
     std::cout << "L2 norm of initial residual[" << v << "] = " << l2_norm_initial_res[v] <<
   std::endl;
   */
 
   gmres_solver.solve(&A, x.ptr(), b.ptr(), &preconditioner);
 
-  MyVector<VectorizedArray<double>> res(M);
+  MyVector<dealii::VectorizedArray<double>> res(M);
   A.vmult(res.ptr(), x.ptr());
-  res.sadd(make_vectorized_array<double>(-1.0), b.ptr());
+  res.sadd(dealii::make_vectorized_array<double>(-1.0), b.ptr());
 
-  VectorizedArray<double> l2_norm = res.l2_norm();
+  dealii::VectorizedArray<double> l2_norm = res.l2_norm();
 
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
-    AssertThrow(l2_norm[v] < 1.e-12, ExcMessage("Did not converge."));
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
+    AssertThrow(l2_norm[v] < 1.e-12, dealii::ExcMessage("Did not converge."));
 
   std::cout << "converged." << std::endl;
 }
 
-// VectorizedArray: solve different systems of equations for the
+// dealii::VectorizedArray: solve different systems of equations for the
 // different components of the vectorized array
 void
 gmres_test_2c()
@@ -421,56 +419,56 @@ gmres_test_2c()
 
   SolverData solver_data(100, tol, tol, 30);
 
-  typedef Elementwise::PreconditionerIdentity<VectorizedArray<double>>      Preconditioner;
-  typedef MyMatrix<VectorizedArray<double>>                                 Matrix;
-  Preconditioner                                                            preconditioner(M);
-  Elementwise::SolverGMRES<VectorizedArray<double>, Matrix, Preconditioner> gmres_solver(
+  typedef Elementwise::PreconditionerIdentity<dealii::VectorizedArray<double>> Preconditioner;
+  typedef MyMatrix<dealii::VectorizedArray<double>>                            Matrix;
+  Preconditioner                                                               preconditioner(M);
+  Elementwise::SolverGMRES<dealii::VectorizedArray<double>, Matrix, Preconditioner> gmres_solver(
     M, solver_data);
 
-  MyVector<VectorizedArray<double>> b(M);
-  b.set_value(make_vectorized_array<double>(1.0), 0);
-  b.set_value(make_vectorized_array<double>(2.0), 1);
-  b.set_value(make_vectorized_array<double>(3.0), 2);
+  MyVector<dealii::VectorizedArray<double>> b(M);
+  b.set_value(dealii::make_vectorized_array<double>(1.0), 0);
+  b.set_value(dealii::make_vectorized_array<double>(2.0), 1);
+  b.set_value(dealii::make_vectorized_array<double>(3.0), 2);
 
-  MyVector<VectorizedArray<double>> x(M);
+  MyVector<dealii::VectorizedArray<double>> x(M);
   x.init();
-  x.set_value(make_vectorized_array<double>(1.0), 0);
-  x.set_value(make_vectorized_array<double>(1.0), 1);
+  x.set_value(dealii::make_vectorized_array<double>(1.0), 0);
+  x.set_value(dealii::make_vectorized_array<double>(1.0), 1);
 
-  VectorizedArray<double> inhom_array = make_vectorized_array<double>(1.0);
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
+  dealii::VectorizedArray<double> inhom_array = dealii::make_vectorized_array<double>(1.0);
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
     if(v > 1)
       inhom_array[v] = 0.0;
 
   x.set_value(inhom_array, 2);
 
   Matrix A(M);
-  A.set_value(make_vectorized_array<double>(1.0), 0, 0);
-  A.set_value(make_vectorized_array<double>(2.0), 1, 1);
-  A.set_value(make_vectorized_array<double>(3.0), 2, 2);
+  A.set_value(dealii::make_vectorized_array<double>(1.0), 0, 0);
+  A.set_value(dealii::make_vectorized_array<double>(2.0), 1, 1);
+  A.set_value(dealii::make_vectorized_array<double>(3.0), 2, 2);
 
   /*
-  MyVector<VectorizedArray<double>> initial_res(M);
+  MyVector<dealii::VectorizedArray<double>> initial_res(M);
   A.vmult(initial_res.ptr(), x.ptr());
-  initial_res.sadd(make_vectorized_array<double>(-1.0), b.ptr());
+  initial_res.sadd(dealii::make_vectorized_array<double>(-1.0), b.ptr());
 
-  VectorizedArray<double> l2_norm_initial_res = initial_res.l2_norm();
+  dealii::VectorizedArray<double> l2_norm_initial_res = initial_res.l2_norm();
 
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
     std::cout << "L2 norm of initial residual[" << v << "] = " << l2_norm_initial_res[v] <<
   std::endl;
    */
 
   gmres_solver.solve(&A, x.ptr(), b.ptr(), &preconditioner);
 
-  MyVector<VectorizedArray<double>> res(M);
+  MyVector<dealii::VectorizedArray<double>> res(M);
   A.vmult(res.ptr(), x.ptr());
-  res.sadd(make_vectorized_array<double>(-1.0), b.ptr());
+  res.sadd(dealii::make_vectorized_array<double>(-1.0), b.ptr());
 
-  VectorizedArray<double> l2_norm = res.l2_norm();
+  dealii::VectorizedArray<double> l2_norm = res.l2_norm();
 
-  for(unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
-    AssertThrow(l2_norm[v] < 1.e-12, ExcMessage("Did not converge."));
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
+    AssertThrow(l2_norm[v] < 1.e-12, dealii::ExcMessage("Did not converge."));
 
   std::cout << "converged." << std::endl;
 }
@@ -490,7 +488,7 @@ main(int argc, char ** argv)
     ExaDG::gmres_test_1a();
     ExaDG::gmres_test_1b();
 
-    // VectorizedArray<double>
+    // dealii::VectorizedArray<double>
     ExaDG::gmres_test_2a();
     ExaDG::gmres_test_2b();
     ExaDG::gmres_test_2c();

--- a/tests/utilities/timer.cc
+++ b/tests/utilities/timer.cc
@@ -30,12 +30,13 @@
 // ExaDG
 #include <exadg/utilities/timer_tree.h>
 
-using namespace dealii;
+
 
 void
 test1()
 {
-  ConditionalOStream pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
+  dealii::ConditionalOStream pcout(std::cout,
+                                   dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
 
   // clang-format off
   pcout << std::endl << std::endl<< std::endl
@@ -46,7 +47,7 @@ test1()
         << std::endl;
   // clang-format on
 
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   ExaDG::TimerTree tree;
@@ -99,7 +100,8 @@ test1()
 void
 test2()
 {
-  ConditionalOStream pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
+  dealii::ConditionalOStream pcout(std::cout,
+                                   dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
 
   // clang-format off
   pcout << std::endl << std::endl<< std::endl
@@ -110,7 +112,7 @@ test2()
         << std::endl;
   // clang-format on
 
-  Timer timer;
+  dealii::Timer timer;
   timer.restart();
 
   ExaDG::TimerTree tree;
@@ -171,7 +173,7 @@ main(int argc, char ** argv)
 {
   try
   {
-    Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+    dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
     test1();
 


### PR DESCRIPTION
I think it is advantageous to see dependencies on dealii explicitly in ExaDG. We do not want to expect ExaDG-developers to also be dealii-developers.