### PR TITLE
Generalize and simplify create grid functionality

### DIFF
--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -477,9 +477,9 @@ public:
         create_coarse_grid<dim>(tria, this->grid->periodic_faces, cylinder_type_string);
       };
 
-    this->grid->create_triangulation(this->param.grid,
-                                     std::vector<int>(),
-                                     lambda_create_coarse_triangulation);
+    this->grid->create_and_refine_triangulation(this->param.grid,
+                                                std::vector<int>(),
+                                                lambda_create_coarse_triangulation);
   }
 
   void

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -476,9 +476,7 @@ public:
       create_coarse_grid<dim>(tria, this->grid->periodic_faces, cylinder_type_string);
     };
 
-    this->grid->create_and_refine_triangulation(this->param.grid,
-                                                std::vector<int>(),
-                                                lambda_create_coarse_triangulation);
+    this->grid->create_triangulation(this->param.grid, lambda_create_coarse_triangulation);
   }
 
   void

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -472,10 +472,9 @@ public:
   {
     this->refine_level = this->param.grid.n_refine_global;
 
-    auto const lambda_create_coarse_triangulation =
-      [&](dealii::Triangulation<dim, dim> & tria) mutable {
-        create_coarse_grid<dim>(tria, this->grid->periodic_faces, cylinder_type_string);
-      };
+    auto const lambda_create_coarse_triangulation = [&](dealii::Triangulation<dim, dim> & tria) {
+      create_coarse_grid<dim>(tria, this->grid->periodic_faces, cylinder_type_string);
+    };
 
     this->grid->create_and_refine_triangulation(this->param.grid,
                                                 std::vector<int>(),

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
@@ -124,7 +124,8 @@ set_boundary_ids(dealii::Triangulation<dim> & tria, bool compute_in_2d)
   }
 }
 
-void create_triangulation(dealii::Triangulation<2> & tria, bool const compute_in_2d = true)
+void do_create_coarse_triangulation(dealii::Triangulation<2> & tria,
+                                    bool const                 compute_in_2d = true)
 {
   AssertThrow(std::abs((X_2 - X_1) - 2.0 * (X_C - X_1)) < 1.0e-12,
               dealii::ExcMessage("Geometry parameters X_1, X_2, X_C invalid!"));
@@ -645,10 +646,10 @@ void create_triangulation(dealii::Triangulation<2> & tria, bool const compute_in
 }
 
 
-void create_triangulation(dealii::Triangulation<3> & tria)
+void do_create_coarse_triangulation(dealii::Triangulation<3> & tria)
 {
   dealii::Triangulation<2> tria_2d;
-  create_triangulation(tria_2d, false);
+  do_create_coarse_triangulation(tria_2d, false);
 
   if(MESH_TYPE == MeshType::Type1)
   {
@@ -851,9 +852,9 @@ void create_triangulation(dealii::Triangulation<3> & tria)
 
 template<int dim>
 void
-do_create_coarse_grid(dealii::Triangulation<dim> &                             triangulation,
-                      std::vector<dealii::GridTools::PeriodicFacePair<
-                        typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces)
+create_coarse_triangulation(dealii::Triangulation<dim> &                             triangulation,
+                            std::vector<dealii::GridTools::PeriodicFacePair<
+                              typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces)
 {
   (void)periodic_faces;
 
@@ -890,7 +891,7 @@ do_create_coarse_grid(dealii::Triangulation<dim> &                             t
                 dealii::ExcMessage("Specified manifold type not implemented"));
   }
 
-  create_triangulation(triangulation);
+  do_create_coarse_triangulation(triangulation);
   triangulation.set_manifold(MANIFOLD_ID, *cylinder_manifold);
 
   // generate vector of manifolds and apply manifold to all cells that have been marked
@@ -912,7 +913,7 @@ do_create_coarse_grid(dealii::Triangulation<dim> &                             t
       }
     }
   }
-} // function do_create_coarse_grid
+}
 
 } // namespace CircularCylinder
 
@@ -1032,7 +1033,7 @@ set_boundary_ids(dealii::Triangulation<dim> & tria)
 }
 
 template<unsigned int dim>
-void create_triangulation(dealii::Triangulation<2> & triangulation, bool is_2d = true)
+void do_create_coarse_triangulation(dealii::Triangulation<2> & triangulation, bool is_2d = true)
 {
   dealii::Triangulation<2> left, left_bottom, left_middle, left_top, middle, middle_top,
     middle_bottom, middle_left, middle_right, middle_left_top, middle_left_bottom, middle_right_top,
@@ -1288,19 +1289,19 @@ void create_triangulation(dealii::Triangulation<2> & triangulation, bool is_2d =
 }
 
 template<unsigned int dim>
-void create_triangulation(dealii::Triangulation<3> & triangulation)
+void do_create_coarse_triangulation(dealii::Triangulation<3> & triangulation)
 {
   dealii::Triangulation<2> tria_2D;
-  create_triangulation<2>(tria_2D, false);
+  do_create_coarse_triangulation<2>(tria_2D, false);
 
   dealii::GridGenerator::extrude_triangulation(tria_2D, nele_z, H, triangulation);
 }
 
 template<unsigned int dim>
 void
-do_create_coarse_grid(dealii::Triangulation<dim> & triangulation)
+create_coarse_triangulation(dealii::Triangulation<dim> & triangulation)
 {
-  create_triangulation<dim>(triangulation);
+  do_create_coarse_triangulation<dim>(triangulation);
 
   // set boundary ids
   set_boundary_ids<dim>(triangulation);
@@ -1337,10 +1338,10 @@ create_coarse_grid(dealii::Triangulation<dim> &                             tria
   switch(cylinder_type)
   {
     case circular:
-      CircularCylinder::do_create_coarse_grid<dim>(triangulation, periodic_faces);
+      CircularCylinder::create_coarse_triangulation<dim>(triangulation, periodic_faces);
       break;
     case square:
-      SquareCylinder::do_create_coarse_grid<dim>(triangulation);
+      SquareCylinder::create_coarse_triangulation<dim>(triangulation);
       break;
     default:
       AssertThrow(false, dealii::ExcNotImplemented());

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
@@ -851,10 +851,9 @@ void create_triangulation(dealii::Triangulation<3> & tria)
 
 template<int dim>
 void
-do_create_grid(dealii::Triangulation<dim> &                             triangulation,
-               unsigned int const                                       n_refine_space,
-               std::vector<dealii::GridTools::PeriodicFacePair<
-                 typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces)
+do_create_coarse_grid(dealii::Triangulation<dim> &                             triangulation,
+                      std::vector<dealii::GridTools::PeriodicFacePair<
+                        typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces)
 {
   (void)periodic_faces;
 
@@ -913,9 +912,7 @@ do_create_grid(dealii::Triangulation<dim> &                             triangul
       }
     }
   }
-
-  triangulation.refine_global(n_refine_space);
-} // function do_create_grid
+} // function do_create_coarse_grid
 
 } // namespace CircularCylinder
 
@@ -1301,14 +1298,12 @@ void create_triangulation(dealii::Triangulation<3> & triangulation)
 
 template<unsigned int dim>
 void
-do_create_grid(dealii::Triangulation<dim> & triangulation, unsigned int n_global_refinements)
+do_create_coarse_grid(dealii::Triangulation<dim> & triangulation)
 {
   create_triangulation<dim>(triangulation);
 
   // set boundary ids
   set_boundary_ids<dim>(triangulation);
-
-  triangulation.refine_global(n_global_refinements);
 }
 
 } // namespace SquareCylinder
@@ -1332,21 +1327,20 @@ select_cylinder_type(std::string cylinder_type_string)
 
 template<unsigned int dim>
 void
-create_cylinder_grid(dealii::Triangulation<dim> &                             triangulation,
-                     unsigned int const                                       n_refine_space,
-                     std::vector<dealii::GridTools::PeriodicFacePair<
-                       typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces,
-                     std::string                                              cylinder_type_string)
+create_coarse_grid(dealii::Triangulation<dim> &                             triangulation,
+                   std::vector<dealii::GridTools::PeriodicFacePair<
+                     typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces,
+                   std::string                                              cylinder_type_string)
 {
   select_cylinder_type(cylinder_type_string);
 
   switch(cylinder_type)
   {
     case circular:
-      CircularCylinder::do_create_grid<dim>(triangulation, n_refine_space, periodic_faces);
+      CircularCylinder::do_create_coarse_grid<dim>(triangulation, periodic_faces);
       break;
     case square:
-      SquareCylinder::do_create_grid<dim>(triangulation, n_refine_space);
+      SquareCylinder::do_create_coarse_grid<dim>(triangulation);
       break;
     default:
       AssertThrow(false, dealii::ExcNotImplemented());

--- a/include/exadg/grid/enum_types.cpp
+++ b/include/exadg/grid/enum_types.cpp
@@ -52,6 +52,27 @@ enum_to_string(TriangulationType const enum_type)
 }
 
 std::string
+enum_to_string(PartitioningType const enum_type)
+{
+  std::string string_type;
+
+  switch(enum_type)
+  {
+    case PartitioningType::Metis:
+      string_type = "Metis";
+      break;
+    case PartitioningType::p4est:
+      string_type = "p4est";
+      break;
+    default:
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
+      break;
+  }
+
+  return string_type;
+}
+
+std::string
 enum_to_string(MappingType const enum_type)
 {
   std::string string_type;

--- a/include/exadg/grid/enum_types.cpp
+++ b/include/exadg/grid/enum_types.cpp
@@ -61,8 +61,8 @@ enum_to_string(PartitioningType const enum_type)
     case PartitioningType::Metis:
       string_type = "Metis";
       break;
-    case PartitioningType::p4est:
-      string_type = "p4est";
+    case PartitioningType::z_order:
+      string_type = "z_order";
       break;
     default:
       AssertThrow(false, dealii::ExcMessage("Not implemented."));

--- a/include/exadg/grid/enum_types.h
+++ b/include/exadg/grid/enum_types.h
@@ -46,6 +46,18 @@ std::string
 enum_to_string(TriangulationType const enum_type);
 
 /*
+ * Partitioning type (relevant for fully-distributed triangulation)
+ */
+enum class PartitioningType
+{
+  Metis,
+  p4est
+};
+
+std::string
+enum_to_string(PartitioningType const enum_type);
+
+/*
  *  Mapping type (polynomial degree)
  */
 enum class MappingType

--- a/include/exadg/grid/enum_types.h
+++ b/include/exadg/grid/enum_types.h
@@ -51,7 +51,7 @@ enum_to_string(TriangulationType const enum_type);
 enum class PartitioningType
 {
   Metis,
-  p4est
+  z_order
 };
 
 std::string

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -71,6 +71,7 @@ public:
     }
 
     // mapping
+    // TODO SIMPLEX: this will not work in case of simplex meshes (-> use MappingFE)
     mapping = std::make_shared<dealii::MappingQGeneric<dim>>(data.mapping_degree);
   }
 
@@ -166,6 +167,7 @@ private:
 
       unsigned int const group_size = 1;
 
+      // TODO SIMPLEX: this will not work in case of simplex meshes
       auto const description = dealii::TriangulationDescription::Utilities::
         create_description_from_triangulation_in_groups<dim, dim>(
           serial_grid_generator,

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -102,8 +102,8 @@ public:
       };
 
       auto const serial_grid_partitioner = [&](dealii::Triangulation<dim, dim> & tria_serial,
-                                              MPI_Comm const                    comm,
-                                              unsigned int const                group_size) {
+                                               MPI_Comm const                    comm,
+                                               unsigned int const                group_size) {
         (void)group_size;
         if(data.partitioning_type == PartitioningType::Metis)
         {

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -101,12 +101,24 @@ public:
         tria_serial.refine_global(data.n_refine_global);
       };
 
-      auto const serial_grid_partitioner = [](dealii::Triangulation<dim, dim> & tria_serial,
+      auto const serial_grid_partitioner = [&](dealii::Triangulation<dim, dim> & tria_serial,
                                               MPI_Comm const                    comm,
                                               unsigned int const                group_size) {
         (void)group_size;
-        dealii::GridTools::partition_triangulation_zorder(
-          dealii::Utilities::MPI::n_mpi_processes(comm), tria_serial);
+        if(data.partitioning_type == PartitioningType::Metis)
+        {
+          dealii::GridTools::partition_triangulation(dealii::Utilities::MPI::n_mpi_processes(comm),
+                                                     tria_serial);
+        }
+        else if(data.partitioning_type == PartitioningType::p4est)
+        {
+          dealii::GridTools::partition_triangulation_zorder(
+            dealii::Utilities::MPI::n_mpi_processes(comm), tria_serial);
+        }
+        else
+        {
+          AssertThrow(false, dealii::ExcNotImplemented());
+        }
       };
 
       unsigned int const group_size = 1;

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -110,7 +110,7 @@ public:
           dealii::GridTools::partition_triangulation(dealii::Utilities::MPI::n_mpi_processes(comm),
                                                      tria_serial);
         }
-        else if(data.partitioning_type == PartitioningType::p4est)
+        else if(data.partitioning_type == PartitioningType::z_order)
         {
           dealii::GridTools::partition_triangulation_zorder(
             dealii::Utilities::MPI::n_mpi_processes(comm), tria_serial);
@@ -161,7 +161,7 @@ public:
           dealii::GridTools::partition_triangulation(dealii::Utilities::MPI::n_mpi_processes(comm),
                                                      tria_serial);
         }
-        else if(data.partitioning_type == PartitioningType::p4est)
+        else if(data.partitioning_type == PartitioningType::z_order)
         {
           dealii::GridTools::partition_triangulation_zorder(
             dealii::Utilities::MPI::n_mpi_processes(comm), tria_serial);

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -75,7 +75,7 @@ public:
   }
 
   void
-  create_triangulation(
+  create_and_refine_triangulation(
     GridData const &                                          data,
     std::vector<int> const &                                  vector_local_refinements,
     std::function<void(dealii::Triangulation<dim> &)> const & create_coarse_triangulation)

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -73,6 +73,27 @@ public:
     mapping = std::make_shared<dealii::MappingQGeneric<dim>>(data.mapping_degree);
   }
 
+  void
+  create_triangulation(GridData const & data)
+  {
+    if(data.triangulation_type == TriangulationType::Serial)
+    {
+
+    }
+    else if(data.triangulation_type == TriangulationType::Distributed)
+    {
+
+    }
+    else if(data.triangulation_type == TriangulationType::FullyDistributed)
+    {
+
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcMessage("Invalid parameter triangulation_type."));
+    }
+  }
+
   /**
    * dealii::Triangulation.
    */
@@ -87,6 +108,11 @@ public:
    * dealii::Mapping.
    */
   std::shared_ptr<dealii::Mapping<dim>> mapping;
+
+  /**
+   * vector containing number of local refinements for material IDs = {0, ..., length -1}
+   */
+  std::vector<unsigned int> vector_local_refinements;
 };
 
 } // namespace ExaDG

--- a/include/exadg/grid/grid_data.h
+++ b/include/exadg/grid/grid_data.h
@@ -31,6 +31,7 @@ struct GridData
 {
   GridData()
     : triangulation_type(TriangulationType::Distributed),
+      partitioning_type(PartitioningType::Metis),
       n_refine_global(0),
       n_subdivisions_1d_hypercube(1),
       mapping_degree(1)
@@ -47,6 +48,11 @@ struct GridData
   {
     print_parameter(pcout, "Triangulation type", enum_to_string(triangulation_type));
 
+    if(triangulation_type == TriangulationType::FullyDistributed)
+      print_parameter(pcout,
+                      "Partitioning type (fully-distributed)",
+                      enum_to_string(partitioning_type));
+
     print_parameter(pcout, "Global refinements", n_refine_global);
 
     print_parameter(pcout, "Subdivisions hypercube", n_subdivisions_1d_hypercube);
@@ -55,6 +61,8 @@ struct GridData
   }
 
   TriangulationType triangulation_type;
+
+  PartitioningType partitioning_type;
 
   unsigned int n_refine_global;
 

--- a/include/exadg/grid/perform_local_refinements.h
+++ b/include/exadg/grid/perform_local_refinements.h
@@ -40,9 +40,10 @@ namespace ExaDG
  */
 template<int dim>
 void
-refine_local(dealii::Triangulation<dim> & tria, std::vector<int> const & vector_local_refinements)
+refine_local(dealii::Triangulation<dim> &      tria,
+             std::vector<unsigned int> const & vector_local_refinements)
 {
-  std::vector<int> refine_local = vector_local_refinements;
+  std::vector<unsigned int> refine_local = vector_local_refinements;
 
   // execute refinement until every refinement counter has been decreased to 0
   while(*max_element(refine_local.begin(), refine_local.end()) > 0)


### PR DESCRIPTION
The function `create_grid()` in the various applications often contains the same lines of code. In particular, in case of `parallel::fullydistributed::Tria`, the "complicated" call to `dealii::TriangulationDescription::???` with many lambdas is "duplicated code" in many applications, where we essentially always use the same setting.

This PR suggests to generalize this functionality and equip the `Grid` class with a function `create_triangulation()`, which takes a lambda function (constructing the coarse triangulation) as an argument. This new function distinguishes between `Serial/Distributed/FullyDistributed` triangulation types according to parameters specified in `GridData`. Moreover, local and global refinements are done by this new function. 

This PR therefore generalizes and simplifies the `UserInterface`.

<del> Currently, this PR only contains the implementation of the new function, but it is not used so far in ExaDG applications. </del>