### PR TITLE
fix bug introduced in PR #147

### DIFF
--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -93,7 +93,10 @@ public:
     GridData const &                                          data,
     std::function<void(dealii::Triangulation<dim> &)> const & create_fine_triangulation)
   {
-    do_create_triangulation(data, create_fine_triangulation, false /* do not refine */);
+    do_create_triangulation(data,
+                            create_fine_triangulation,
+                            false /* do not refine */,
+                            std::vector<unsigned int>() /* no local refinements */);
   }
 
   /**


### PR DESCRIPTION
bug was not detected since function `create_but_do_not_refine_triangulation()` is not called in ExaDG (only in derived projects).