### PR TITLE
remove parameter store_solution

### DIFF
--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -587,13 +587,13 @@ Driver<dim, Number>::apply_dirichlet_neumann_scheme(VectorType &       d_tilde,
   coupling_structure_to_fluid(iteration == 0);
 
   // solve fluid problem
-  fluid_time_integrator->advance_one_timestep_partitioned_solve(iteration == 0, true);
+  fluid_time_integrator->advance_one_timestep_partitioned_solve(iteration == 0);
 
   // update stress boundary condition for solid
   coupling_fluid_to_structure();
 
   // solve structural problem
-  structure_time_integrator->advance_one_timestep_partitioned_solve(iteration == 0, true);
+  structure_time_integrator->advance_one_timestep_partitioned_solve(iteration == 0);
 
   d_tilde = structure_time_integrator->get_displacement_np();
 }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -166,14 +166,10 @@ TimeIntBDF<dim, Number>::ale_update()
 
 template<int dim, typename Number>
 void
-TimeIntBDF<dim, Number>::advance_one_timestep_partitioned_solve(bool const use_extrapolation,
-                                                                bool const store_solution)
+TimeIntBDF<dim, Number>::advance_one_timestep_partitioned_solve(bool const use_extrapolation)
 {
-  if(this->use_extrapolation == false)
-    AssertThrow(this->store_solution == true, dealii::ExcMessage("Invalid parameters."));
-
   this->use_extrapolation = use_extrapolation;
-  this->store_solution    = store_solution;
+  this->store_solution    = true;
 
   Base::advance_one_timestep_solve();
 }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -85,7 +85,7 @@ public:
   ale_update();
 
   void
-  advance_one_timestep_partitioned_solve(bool const use_extrapolation, bool const store_solution);
+  advance_one_timestep_partitioned_solve(bool const use_extrapolation);
 
   virtual void
   print_iterations() const = 0;

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -94,14 +94,10 @@ TimeIntGenAlpha<dim, Number>::setup(bool const do_restart)
 
 template<int dim, typename Number>
 void
-TimeIntGenAlpha<dim, Number>::advance_one_timestep_partitioned_solve(bool const use_extrapolation,
-                                                                     bool const store_solution)
+TimeIntGenAlpha<dim, Number>::advance_one_timestep_partitioned_solve(bool const use_extrapolation)
 {
-  if(this->use_extrapolation == false)
-    AssertThrow(this->store_solution == true, dealii::ExcMessage("Invalid parameters."));
-
   this->use_extrapolation = use_extrapolation;
-  this->store_solution    = store_solution;
+  this->store_solution    = true;
 
   this->advance_one_timestep_solve();
 }

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.h
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.h
@@ -85,7 +85,7 @@ public:
   set_displacement(VectorType const & displacement);
 
   void
-  advance_one_timestep_partitioned_solve(bool const use_extrapolation, bool const store_solution);
+  advance_one_timestep_partitioned_solve(bool const use_extrapolation);
 
 private:
   void


### PR DESCRIPTION
The function `advance_one_time_step_partitioned_solve()` has two parameters, but the second one `store_solution` is currently not used. Hence, it should better be removed (and reintroduced if really needed).