### PR TITLE
TimerTree: only print results if level <= max_level

### DIFF
--- a/include/exadg/utilities/timer_tree.h
+++ b/include/exadg/utilities/timer_tree.h
@@ -210,9 +210,39 @@ public:
   {
     unsigned int const length = get_length();
 
-    pcout << std::endl;
+    unsigned int const max_level = get_max_level();
 
-    do_print_level(pcout, level, 0, length);
+    if(level <= max_level)
+    {
+      pcout << std::endl;
+
+      do_print_level(pcout, level, 0, length);
+    }
+    else
+    {
+      pcout << std::endl
+            << "Timings can not be printed for level = " << level << "," << std::endl
+            << "since the maximum level of the timer tree is max_level = " << max_level << "."
+            << std::endl;
+    }
+  }
+
+  /**
+   * Returns the maximum number of levels of the timer tree.
+   */
+  unsigned int
+  get_max_level() const
+  {
+    unsigned int max_level = 0;
+
+    for(auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+    {
+      // add + 1 since we only arrive here if a sub-tree exists, i.e.
+      // if there is at least one more level
+      max_level = std::max(max_level, (*it)->get_max_level() + 1);
+    }
+
+    return max_level;
   }
 
 private:

--- a/tests/utilities/timer.cc
+++ b/tests/utilities/timer.cc
@@ -93,6 +93,10 @@ test1()
   tree.print_level(pcout, 1);
   pcout << std::endl << "timings for level = 2:" << std::endl;
   tree.print_level(pcout, 2);
+  pcout << std::endl << "timings for level = 3:" << std::endl;
+  tree.print_level(pcout, 3);
+  pcout << std::endl << "timings for level = 4:" << std::endl;
+  tree.print_level(pcout, 4);
   pcout << std::endl << "timings all:" << std::endl;
   tree.print_plain(pcout);
 }

--- a/tests/utilities/timer.output
+++ b/tests/utilities/timer.output
@@ -31,6 +31,21 @@ General
     Sub b        9.88e+02 s     24.69 %
     Other        2.51e+03 s     62.81 %
 
+timings for level = 3:
+
+General        
+  Part 1       
+  Part 2       
+  Part 3       
+    Sub a        5.00e+02 s    100.00 %
+      sub-sub a  4.00e+01 s      8.00 %
+      Other      4.60e+02 s     92.00 %
+
+timings for level = 4:
+
+Timings can not be printed for level = 4,
+since the maximum level of the timer tree is max_level = 3.
+
 timings all:
 
 General          2.20e+04 s
@@ -93,9 +108,13 @@ timings for level = 0:
 
 timings for level = 1:
 
+Timings can not be printed for level = 1,
+since the maximum level of the timer tree is max_level = 0.
 
 timings for level = 2:
 
+Timings can not be printed for level = 2,
+since the maximum level of the timer tree is max_level = 0.
 
 timings all:
 
@@ -114,7 +133,8 @@ Structure          2.50e+01 s    100.00 %
 
 timings for level = 2:
 
-Structure        
+Timings can not be printed for level = 2,
+since the maximum level of the timer tree is max_level = 1.
 
 timings all:
 


### PR DESCRIPTION
This might fix the comment described here https://github.com/exadg/exadg/pull/148#discussion_r808047907

The corresponding test needs to be adjusted, but I currently can not run tests due to ubuntu issues ...