### PR TITLE
make usage of TimerTree robust

### DIFF
--- a/tests/utilities/timer.cc
+++ b/tests/utilities/timer.cc
@@ -99,6 +99,28 @@ test1()
   tree.print_level(pcout, 4);
   pcout << std::endl << "timings all:" << std::endl;
   tree.print_plain(pcout);
+
+  tree.clear();
+
+  tree.insert({"General", "Part 2", "Sub a"}, 1.234);
+  tree.insert({"General", "Part 3", "Sub a"}, 0.123);
+  tree.insert({"General", "Part 4"}, 5.678);
+
+  pcout << std::endl << "timings for level = 0:" << std::endl;
+  tree.print_level(pcout, 0);
+  // relative timings for level 1 are not possible
+  pcout << std::endl << "timings for level = 1:" << std::endl;
+  tree.print_level(pcout, 1);
+  pcout << std::endl << "timings for level = 2:" << std::endl;
+  tree.print_level(pcout, 2);
+  pcout << std::endl << "timings all:" << std::endl;
+  tree.print_plain(pcout);
+
+  // now, enable relative timings for level 1
+  tree.insert({"General"}, 10.0);
+
+  pcout << std::endl << "timings for level = 1:" << std::endl;
+  tree.print_level(pcout, 1);
 }
 
 void

--- a/tests/utilities/timer.output
+++ b/tests/utilities/timer.output
@@ -58,6 +58,40 @@ General          2.20e+04 s
       sub-sub a  4.00e+01 s
     Sub b        9.88e+02 s
 
+timings for level = 0:
+
+General  
+
+timings for level = 1:
+
+General  
+  Part 2 
+  Part 3 
+  Part 4   5.68e+00 s
+
+timings for level = 2:
+
+General  
+  Part 2 
+    Sub a  1.23e+00 s
+  Part 3 
+    Sub a  1.23e-01 s
+
+timings all:
+
+General  
+  Part 2 
+    Sub a  1.23e+00 s
+  Part 3 
+    Sub a  1.23e-01 s
+  Part 4   5.68e+00 s
+
+timings for level = 1:
+
+General    1.00e+01 s    100.00 %
+  Part 4   5.68e+00 s     56.78 %
+  Other    4.32e+00 s     43.22 %
+
 
 
 _____________________________________________________________


### PR DESCRIPTION
Current behavior: The `TimerTree` class might segfault in `print()` functions if items of the tree do not contain wall-clock data. However, this must not occur and the implementation has to be able to deal with such cases.

This PR fixes those problems and hopefully ensures that segfaults can not occur any more.

Additional tests check the behavior of `TimerTree` in case that only some items of the tree contain data. Particularly decisive is the question when to print the additional item "Other" in such cases. Note that an output like the following one (where Part 1 does not contain data, while Part 2 contains wall-time data)
```bash
General    1.00e+01 s    100.00 %
  Part 1  
  Part 2   5.68e+00 s     56.78 %
  Other    4.32e+00 s     43.22 %
```
should be avoided, since interpretation of the results is not clear: Does "Other" contain the wall-time of (sub-trees) of Part 1 or not? In fact it does, and - for this simple example - one could also deduce this information from the printed numbers, but this is probably difficult to see immediately for complicated examples with many sub-trees. The solution is to not print "Part 1" in this case, to obtain
```bash
General    1.00e+01 s    100.00 %
  Part 2   5.68e+00 s     56.78 %
  Other    4.32e+00 s     43.22 %
```

@DavidSCN FYI

@sebproell FYI