### PR TITLE
do not impose Dirichlet constraints after Newton solve

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -243,6 +243,20 @@ OperatorBase<dim, Number, n_components>::set_constrained_values_to_zero(VectorTy
 }
 
 template<int dim, typename Number, int n_components>
+bool
+OperatorBase<dim, Number, n_components>::check_constrained_values_are_zero(
+  VectorType const & vector) const
+{
+  for(unsigned int i = 0; i < constrained_indices.size(); ++i)
+  {
+    if(vector.local_element(constrained_indices[i]) > std::numeric_limits<Number>::min())
+      return false;
+  }
+
+  return true;
+}
+
+template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::calculate_inverse_diagonal(VectorType & diagonal) const
 {

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -172,6 +172,9 @@ public:
   void
   set_constrained_values_to_zero(VectorType & vector) const;
 
+  bool
+  check_constrained_values_are_zero(VectorType const & vector) const;
+
   void
   calculate_inverse_diagonal(VectorType & diagonal) const;
 

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -263,6 +263,9 @@ public:
   void
   set_constrained_values_to_zero(VectorType & vector) const;
 
+  bool
+  check_constrained_values_are_zero(VectorType const & vector) const;
+
   /*
    * This function solves the (non-)linear system of equations.
    */


### PR DESCRIPTION
It should not be necessary to apply Dirichlet constraints in the nonlinear `Structure` solver after the Newton solve. The constraints have already been set before the solve and no contributions to the constrained degrees of freedom should be added in the Newton solver by the linearized solver.

I added a check that the residual vector is really zero for the constrained degrees of freedom. One might argue that this is not necessary since the Newton solver would otherwise not converge, on the other hand the problem might not be detected by the Newton solver depending on the chosen solver tolerances. The costs of this additional check should be irrelevant compared to the rest.

@sebproell FYI