### PR TITLE
Constraints for continuous Galerkin discretizations

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -249,7 +249,7 @@ OperatorBase<dim, Number, n_components>::check_constrained_values_are_zero(
 {
   for(unsigned int i = 0; i < constrained_indices.size(); ++i)
   {
-    if(std::abs(vector.local_element(constrained_indices[i])) > std::numeric_limits<Number>::min())
+    if(vector.local_element(constrained_indices[i]) != 0.0)
       return false;
   }
 

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -384,19 +384,6 @@ OperatorBase<dim, Number, n_components>::rhs_add(VectorType & rhs) const
     matrix_free->initialize_dof_vector(temp2, data.dof_index);
     matrix_free->cell_loop(&This::cell_loop_dbc, this, temp2, temp1);
     rhs -= temp2;
-
-    // Finally, set entries of rhs vector equal to Dirichlet boundary values for the
-    // constrained degrees of freedom. This procedure is related to a linear system of equations
-    // where we do not eliminate rows corresponding to constrained degrees of freedom, but where
-    // the associated "matrix" contains a value of 1 on the diagonal for these rows.
-    // Using this technique, the linear system of equations is solvable and the initially solution
-    // does not have to contain the correct solution values for constrained degrees of freedom.
-    // Instead, the iteration procedure will converge towards the correct solution according to the
-    // convergence criteria specified for the linear solver.
-    for(unsigned int i = 0; i < constrained_indices.size(); ++i)
-    {
-      rhs.local_element(constrained_indices[i]) = temp1.local_element(constrained_indices[i]);
-    }
   }
 }
 

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -243,6 +243,20 @@ OperatorBase<dim, Number, n_components>::set_constrained_values_to_zero(VectorTy
 }
 
 template<int dim, typename Number, int n_components>
+bool
+OperatorBase<dim, Number, n_components>::check_constrained_values_are_zero(
+  VectorType const & vector) const
+{
+  for(unsigned int i = 0; i < constrained_indices.size(); ++i)
+  {
+    if(vector.local_element(constrained_indices[i]) > std::numeric_limits<Number>::min())
+      return false;
+  }
+
+  return true;
+}
+
+template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::calculate_inverse_diagonal(VectorType & diagonal) const
 {

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -243,20 +243,6 @@ OperatorBase<dim, Number, n_components>::set_constrained_values_to_zero(VectorTy
 }
 
 template<int dim, typename Number, int n_components>
-bool
-OperatorBase<dim, Number, n_components>::check_constrained_values_are_zero(
-  VectorType const & vector) const
-{
-  for(unsigned int i = 0; i < constrained_indices.size(); ++i)
-  {
-    if(vector.local_element(constrained_indices[i]) != 0.0)
-      return false;
-  }
-
-  return true;
-}
-
-template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::calculate_inverse_diagonal(VectorType & diagonal) const
 {

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -249,7 +249,7 @@ OperatorBase<dim, Number, n_components>::check_constrained_values_are_zero(
 {
   for(unsigned int i = 0; i < constrained_indices.size(); ++i)
   {
-    if(vector.local_element(constrained_indices[i]) > std::numeric_limits<Number>::min())
+    if(std::abs(vector.local_element(constrained_indices[i])) > std::numeric_limits<Number>::min())
       return false;
   }
 

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -172,6 +172,9 @@ public:
   void
   set_constrained_values_to_zero(VectorType & vector) const;
 
+  bool
+  check_constrained_values_are_zero(VectorType const & vector) const;
+
   void
   calculate_inverse_diagonal(VectorType & diagonal) const;
 

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -172,9 +172,6 @@ public:
   void
   set_constrained_values_to_zero(VectorType & vector) const;
 
-  bool
-  check_constrained_values_are_zero(VectorType const & vector) const;
-
   void
   calculate_inverse_diagonal(VectorType & diagonal) const;
 

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -405,7 +405,11 @@ Operator<dim, Number, n_components>::solve(VectorType &       sol,
 
   unsigned int iterations = iterative_solver->solve(sol, rhs, /* update_preconditioner = */ false);
 
-  // apply Dirichlet boundary conditions in case of continuous elements
+  // set Dirichlet values: Note that it does not matter whether we set
+  // the constrained degrees of freedom before or after the solve. The
+  // constrained degrees of freedom have been taken into account in the
+  // rhs vector and the linear solver (and matrix_free) may not touch
+  // the constrained degrees of freedom.
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {
     laplace_operator.set_constrained_values(sol, time);

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -410,6 +410,10 @@ Operator<dim, Number, n_components>::solve(VectorType &       sol,
   // constrained degrees of freedom have been taken into account in the
   // rhs vector and the linear solver (and matrix_free) may not touch
   // the constrained degrees of freedom.
+  // We are on the safe side if we set the constraints afterwards,
+  // because the solution might be wrong for the constrained degrees of
+  // freedom if the rhs vector does not contain the correct values for
+  // the constrained degrees of freedom.
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {
     laplace_operator.set_constrained_values(sol, time);

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -414,6 +414,10 @@ Operator<dim, Number, n_components>::solve(VectorType &       sol,
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {
     laplace_operator.set_constrained_values_to_zero(rhs_mutable);
+    // we can reduce iteration counts considerably if we set solution entries
+    // consistent to the rhs vector (the linear operator contains values of 1 on the
+    // diagonal).
+    laplace_operator.set_constrained_values_to_zero(sol);
   }
 
   unsigned int iterations =

--- a/include/exadg/structure/spatial_discretization/interface.h
+++ b/include/exadg/structure/spatial_discretization/interface.h
@@ -64,9 +64,6 @@ public:
   virtual void
   compute_rhs_linear(VectorType & dst, double const time) const = 0;
 
-  virtual void
-  set_constrained_values_to_zero(VectorType & vector) const = 0;
-
   virtual std::tuple<unsigned int, unsigned int>
   solve_nonlinear(VectorType &       sol,
                   VectorType const & rhs,

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -760,18 +760,23 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   elasticity_operator_linear.set_scaling_factor_mass_operator(factor);
   elasticity_operator_linear.set_time(time);
 
-  // solve linear system of equations
-  unsigned int const iterations = linear_solver->solve(sol, rhs, false);
+  // Set entries of rhs vector that correspond to constrained degrees of freedom to zero.
+  // As a result, constrained degrees of freedom of the solution vector will be zero
+  // after the solve. The correct inhomogeneous boundary conditions have to be applied
+  // after the solution of the linear system of equations. This means that this step is
+  // optional, with the consequence that the constrained degrees of freedom of the
+  // solution would contain any unknown values (since we do not which values the rhs
+  // vector contains for the constrained degrees of freedom).
+  VectorType & rhs_mutable = const_cast<VectorType &>(rhs);
+  set_constrained_values_to_zero(rhs_mutable);
 
-  // set Dirichlet values: Note that it does not matter whether we set
-  // the constrained degrees of freedom before or after the solve. The
-  // constrained degrees of freedom have been taken into account in the
-  // rhs vector and the linear solver (and matrix_free) may not touch
-  // the constrained degrees of freedom.
-  // We are on the safe side if we set the constraints afterwards,
-  // because the solution might be wrong for the constrained degrees of
-  // freedom if the rhs vector does not contain the correct values for
-  // the constrained degrees of freedom.
+  // solve linear system of equations
+  unsigned int const iterations = linear_solver->solve(sol, rhs_mutable, false);
+
+  // set Dirichlet values: The constrained degrees of freedom are zero after the solve
+  // since we have set the corresponding entries of the rhs vector to zero. Hence, we
+  // now need to set the constrained degrees of freedom according to the Dirichlet
+  // boundary conditions.
   elasticity_operator_linear.set_constrained_values(sol, time);
 
   return iterations;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -759,6 +759,10 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   // vector contains for the constrained degrees of freedom).
   VectorType & rhs_mutable = const_cast<VectorType &>(rhs);
   elasticity_operator_linear.set_constrained_values_to_zero(rhs_mutable);
+  // we can reduce iteration counts considerably if we set solution entries
+  // consistent to the rhs vector (the linear operator contains values of 1 on the
+  // diagonal).
+  elasticity_operator_linear.set_constrained_values_to_zero(sol);
 
   // solve linear system of equations
   unsigned int const iterations = linear_solver->solve(sol, rhs_mutable, false);

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -667,7 +667,7 @@ Operator<dim, Number>::evaluate_nonlinear_residual(VectorType &       dst,
   // for constrained degrees of freedom as well, which might not be the case
   // in general, e.g. due to const_vector. Hence, we set the constrained
   // degrees of freedom explicitly to zero.
-  set_constrained_values_to_zero(dst);
+  elasticity_operator_nonlinear.set_constrained_values_to_zero(dst);
 }
 
 template<int dim, typename Number>
@@ -711,16 +711,6 @@ Operator<dim, Number>::apply_linear_operator(VectorType &       dst,
   elasticity_operator_linear.set_scaling_factor_mass_operator(factor);
   elasticity_operator_linear.set_time(time);
   elasticity_operator_linear.vmult(dst, src);
-}
-
-template<int dim, typename Number>
-void
-Operator<dim, Number>::set_constrained_values_to_zero(VectorType & vector) const
-{
-  if(param.large_deformation)
-    elasticity_operator_nonlinear.set_constrained_values_to_zero(vector);
-  else
-    elasticity_operator_linear.set_constrained_values_to_zero(vector);
 }
 
 template<int dim, typename Number>
@@ -768,7 +758,7 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   // solution would contain any unknown values (since we do not which values the rhs
   // vector contains for the constrained degrees of freedom).
   VectorType & rhs_mutable = const_cast<VectorType &>(rhs);
-  set_constrained_values_to_zero(rhs_mutable);
+  elasticity_operator_linear.set_constrained_values_to_zero(rhs_mutable);
 
   // solve linear system of equations
   unsigned int const iterations = linear_solver->solve(sol, rhs_mutable, false);

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -780,6 +780,10 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   // constrained degrees of freedom have been taken into account in the
   // rhs vector and the linear solver (and matrix_free) may not touch
   // the constrained degrees of freedom.
+  // We are on the safe side if we set the constraints afterwards,
+  // because the solution might be wrong for the constrained degrees of
+  // freedom if the rhs vector does not contain the correct values for
+  // the constrained degrees of freedom.
   elasticity_operator_linear.set_constrained_values(sol, time);
 
   return iterations;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -742,7 +742,7 @@ Operator<dim, Number>::solve_nonlinear(VectorType &       sol,
   // (because the residual vector forming the rhs of the linearized problem is zero
   // for constrained degrees of freedom, the initial solution of the linearized
   // solver is also zero, and the linearized operator contains values of 1 on the
-  // diagonal for constrained degrees of freedom.
+  // diagonal for constrained degrees of freedom).
   elasticity_operator_nonlinear.set_constrained_values(sol, time);
 
   return iter;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -643,6 +643,10 @@ Operator<dim, Number>::evaluate_nonlinear_residual(VectorType &       dst,
                                                    double const       factor,
                                                    double const       time) const
 {
+  // Note that constrained degrees of freedom have to be zero for dst and const_vector
+  // in order to ensure convergence of the Newton solver. This is checked at the
+  // end of this function.
+
   // elasticity operator
   elasticity_operator_nonlinear.set_scaling_factor_mass_operator(factor);
   elasticity_operator_nonlinear.set_time(time);

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -772,7 +772,11 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   // solve linear system of equations
   unsigned int const iterations = linear_solver->solve(sol, rhs, false);
 
-  // set Dirichlet values
+  // set Dirichlet values: Note that it does not matter whether we set
+  // the constrained degrees of freedom before or after the solve. The
+  // constrained degrees of freedom have been taken into account in the
+  // rhs vector and the linear solver (and matrix_free) may not touch
+  // the constrained degrees of freedom.
   elasticity_operator_linear.set_constrained_values(sol, time);
 
   return iterations;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -664,9 +664,8 @@ Operator<dim, Number>::evaluate_nonlinear_residual(VectorType &       dst,
   }
 
   // check that constrained degrees of freedom are really zero
-  AssertThrow(check_constrained_values_are_zero(dst),
-              dealii::ExcMessage(
-                "Expected that constrained degrees of freedom are zero. Aborting."));
+  Assert(check_constrained_values_are_zero(dst),
+         dealii::ExcMessage("Expected that constrained degrees of freedom are zero. Aborting."));
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -263,6 +263,9 @@ public:
   void
   set_constrained_values_to_zero(VectorType & vector) const;
 
+  bool
+  check_constrained_values_are_zero(VectorType const & vector) const;
+
   /*
    * This function solves the (non-)linear system of equations.
    */

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -260,9 +260,6 @@ public:
                         double const       factor,
                         double const       time) const;
 
-  void
-  set_constrained_values_to_zero(VectorType & vector) const;
-
   /*
    * This function solves the (non-)linear system of equations.
    */

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -263,9 +263,6 @@ public:
   void
   set_constrained_values_to_zero(VectorType & vector) const;
 
-  bool
-  check_constrained_values_are_zero(VectorType const & vector) const;
-
   /*
    * This function solves the (non-)linear system of equations.
    */

--- a/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
+++ b/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
@@ -52,7 +52,10 @@ template<int dim, typename Number>
 void
 DriverQuasiStatic<dim, Number>::setup()
 {
-  AssertThrow(param.large_deformation, dealii::ExcMessage("Not implemented."));
+  AssertThrow(
+    param.large_deformation,
+    dealii::ExcMessage(
+      "DriverQuasiStatic makes only sense for nonlinear problems. For linear problems, use DriverSteady instead."));
 
   // initialize global solution vectors (allocation)
   initialize_vectors();

--- a/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
+++ b/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
@@ -226,17 +226,19 @@ DriverQuasiStatic<dim, Number>::solve_step(double const load_factor)
 
   output_solver_info_header(load_factor);
 
-  VectorType const const_vector;
-
   bool const update_preconditioner =
     this->param.update_preconditioner &&
     ((this->step_number - 1) % this->param.update_preconditioner_every_time_steps == 0);
 
-  auto const iter = pde_operator->solve_nonlinear(
+  VectorType const const_vector; // will not be used
+  auto const       iter = pde_operator->solve_nonlinear(
     solution, const_vector, 0.0 /*no mass term*/, load_factor /* = time */, update_preconditioner);
 
+  unsigned int const N_iter_nonlinear = std::get<0>(iter);
+  unsigned int const N_iter_linear    = std::get<1>(iter);
+
   if(not(is_test))
-    print_solver_info_nonlinear(pcout, std::get<0>(iter), std::get<1>(iter), timer.wall_time());
+    print_solver_info_nonlinear(pcout, N_iter_nonlinear, N_iter_linear, timer.wall_time());
 
   return iter;
 }

--- a/include/exadg/structure/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/structure/time_integration/driver_steady_problems.cpp
@@ -106,9 +106,12 @@ DriverSteady<dim, Number>::do_solve()
 
   if(param.large_deformation) // nonlinear problem
   {
-    VectorType const_vector;
-    auto const iter = pde_operator->solve_nonlinear(
-      solution, const_vector, 0.0 /* no mass term */, 0.0 /* time */, param.update_preconditioner);
+    VectorType const const_vector_dummy; // will not be used
+    auto const       iter = pde_operator->solve_nonlinear(solution,
+                                                    const_vector_dummy,
+                                                    0.0 /* no mass term */,
+                                                    0.0 /* time */,
+                                                    param.update_preconditioner);
 
     unsigned int const N_iter_nonlinear = std::get<0>(iter);
     unsigned int const N_iter_linear    = std::get<1>(iter);

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -131,7 +131,6 @@ TimeIntGenAlpha<dim, Number>::do_timestep_solve()
   {
     // calculate right-hand side vector
     pde_operator->compute_rhs_linear(rhs, this->get_mid_time());
-
     // shift const_vector to right-hand side
     rhs.add(-1.0, const_vector);
   }

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -127,23 +127,17 @@ TimeIntGenAlpha<dim, Number>::do_timestep_solve()
   this->compute_const_vector(rhs, displacement_n, velocity_n, acceleration_n);
   pde_operator->apply_mass_operator(const_vector, rhs);
 
-  // Set entries of const_vector corresponding to Dirichlet degrees of freedom
-  // to zero in order to allow convergence of solvers (especially for the Newton
-  // solver).
-  // The linear solver should converge without this line because the linear operator
-  // has values of 1 on the diagonal for constrained degrees of freedom. Note,
-  // however, that without the line below the solution obtained by the linear solver
-  // would then be inconsistent with the inhomogeneous Dirichlet BCs, i.e., the
-  // constrained degrees of freedom would have to be set according to the Dirichlet
-  // BCs after the solution of the linear system of equations (even if the linear
-  // system of equations uses an initial solution that contains the correct
-  // constrained degrees of freedom).
-  pde_operator->set_constrained_values_to_zero(const_vector);
-
   if(param.large_deformation == false) // linear case
   {
     // calculate right-hand side vector
     pde_operator->compute_rhs_linear(rhs, this->get_mid_time());
+
+    // Constrained degrees of freedom have already been set
+    // correctly in the function compute_rhs_vector() for the rhs vector.
+    // Hence, the following line ensures that adding const_vector to rhs
+    // does not alter the constrained degrees of freedom of rhs.
+    pde_operator->set_constrained_values_to_zero(const_vector);
+
     // shift const_vector to right-hand side
     rhs.add(-1.0, const_vector);
   }

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -132,12 +132,6 @@ TimeIntGenAlpha<dim, Number>::do_timestep_solve()
     // calculate right-hand side vector
     pde_operator->compute_rhs_linear(rhs, this->get_mid_time());
 
-    // Constrained degrees of freedom have already been set
-    // correctly in the function compute_rhs_vector() for the rhs vector.
-    // Hence, the following line ensures that adding const_vector to rhs
-    // does not alter the constrained degrees of freedom of rhs.
-    pde_operator->set_constrained_values_to_zero(const_vector);
-
     // shift const_vector to right-hand side
     rhs.add(-1.0, const_vector);
   }

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -126,10 +126,18 @@ TimeIntGenAlpha<dim, Number>::do_timestep_solve()
   rhs.reinit(displacement_n);
   this->compute_const_vector(rhs, displacement_n, velocity_n, acceleration_n);
   pde_operator->apply_mass_operator(const_vector, rhs);
-  // set entries of constant vector corresponding to Dirichlet degrees of freedom
-  // to zero in order to allow convergence of solvers (especially for Newton solver,
-  // linear solver should converge without this line because the linear operator
-  // has values of 1 on the diagonal for constrained degrees of freedom).
+
+  // Set entries of const_vector corresponding to Dirichlet degrees of freedom
+  // to zero in order to allow convergence of solvers (especially for the Newton
+  // solver).
+  // The linear solver should converge without this line because the linear operator
+  // has values of 1 on the diagonal for constrained degrees of freedom. Note,
+  // however, that without the line below the solution obtained by the linear solver
+  // would then be inconsistent with the inhomogeneous Dirichlet BCs, i.e., the
+  // constrained degrees of freedom would have to be set according to the Dirichlet
+  // BCs after the solution of the linear system of equations (even if the linear
+  // system of equations uses an initial solution that contains the correct
+  // constrained degrees of freedom).
   pde_operator->set_constrained_values_to_zero(const_vector);
 
   if(param.large_deformation == false) // linear case


### PR DESCRIPTION
<del> This is a follow-up PR to #183.</del> This supersedes PR #183. 

Currently, the code contains calls like `set_constrained_values_to_zero()` in the time integrator class. However, this is a detail of the spatial discretization operator and should not occur in the time integrator. With these changes, I hope that the code is clearer in terms of single responsibility and easier to understand.

Currently, the function of `OperatorBase` that shifts contributions of inhomogeneous BCs to the right-hand side vector also sets the constrained degrees of freedom of the rhs vector to the inhomogeneous boundary conditions. However, we can not ensure that other operators overwrite or add values to these vector entries and thereby invalidate what `OperatorBase` has done before. Hence, I believe the code is clearer if we remove these lines of code and instead apply constraints (if desired) immediately before the linear solver is called. For `OperatorBase`, it is only relevant that (i) `vmult()` is computed correctly in case of constrained DoFs, and (ii) that contributions of constrained DoFs are taken into account in unconstrained vector entries of the rhs vector (by accumulating into the rhs-vector!).

<del> It should not be necessary to apply Dirichlet constraints in the nonlinear Structure solver after the Newton solve. The constraints have already been set before the solve and no contributions to the constrained degrees of freedom should be added in the Newton solver by the linearized solver.</del>

<del> This PR currently contains changes from #183. Hence, I have to rebase once #183 is merged. Alternatively, we could just close PR #183 and consider the present one.</del>

@sebproell FYI