### PR TITLE
MultigridPreconditionerBase::initialize(): use reference

### DIFF
--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -50,8 +50,8 @@ MultigridPreconditioner<dim, Number>::initialize(
   PDEOperator const &                         pde_operator,
   MultigridOperatorType const &               mg_operator_type,
   bool const                                  mesh_is_moving,
-  Map const *                                 dirichlet_bc,
-  PeriodicFacePairs const *                   periodic_face_pairs)
+  Map const &                                 dirichlet_bc,
+  PeriodicFacePairs const &                   periodic_face_pairs)
 {
   this->pde_operator     = &pde_operator;
   this->mg_operator_type = mg_operator_type;
@@ -199,10 +199,10 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize_dof_handler_and_constraints(
   bool const                         operator_is_singular,
-  PeriodicFacePairs const *          periodic_face_pairs,
+  PeriodicFacePairs const &          periodic_face_pairs,
   dealii::FiniteElement<dim> const & fe,
   dealii::Triangulation<dim> const * tria,
-  Map const *                        dirichlet_bc)
+  Map const &                        dirichlet_bc)
 {
   Base::initialize_dof_handler_and_constraints(
     operator_is_singular, periodic_face_pairs, fe, tria, dirichlet_bc);
@@ -213,7 +213,7 @@ MultigridPreconditioner<dim, Number>::initialize_dof_handler_and_constraints(
     dealii::FESystem<dim> fe_velocity(dealii::FE_DGQ<dim>(fe.degree), dim);
     Map                   dirichlet_bc_velocity;
     this->do_initialize_dof_handler_and_constraints(false,
-                                                    *periodic_face_pairs,
+                                                    periodic_face_pairs,
                                                     fe_velocity,
                                                     tria,
                                                     dirichlet_bc_velocity,

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -70,8 +70,8 @@ public:
              PDEOperator const &                         pde_operator,
              MultigridOperatorType const &               mg_operator_type,
              bool const                                  mesh_is_moving,
-             Map const *                                 dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
+             Map const &                                 dirichlet_bc,
+             PeriodicFacePairs const &                   periodic_face_pairs);
 
   /*
    *  This function updates the multigrid preconditioner.
@@ -90,10 +90,10 @@ private:
 
   void
   initialize_dof_handler_and_constraints(bool const                         operator_is_singular,
-                                         PeriodicFacePairs const *          periodic_face_pairs,
+                                         PeriodicFacePairs const &          periodic_face_pairs,
                                          dealii::FiniteElement<dim> const & fe,
                                          dealii::Triangulation<dim> const * tria,
-                                         Map const *                        dirichlet_bc) override;
+                                         Map const &                        dirichlet_bc) override;
 
   void
   initialize_transfer_operators() override;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -475,8 +475,8 @@ Operator<dim, Number>::initialize_preconditioner()
                                   combined_operator,
                                   param.mg_operator_type,
                                   param.ale_formulation,
-                                  &data.bc->dirichlet_bc,
-                                  &grid->periodic_faces);
+                                  data.bc->dirichlet_bc,
+                                  grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -44,8 +44,8 @@ MultigridPreconditioner<dim, Number>::initialize(
   PDEOperator const &                         pde_operator,
   MultigridOperatorType const &               mg_operator_type,
   bool const                                  mesh_is_moving,
-  Map const *                                 dirichlet_bc,
-  PeriodicFacePairs const *                   periodic_face_pairs)
+  Map const &                                 dirichlet_bc,
+  PeriodicFacePairs const &                   periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -64,8 +64,8 @@ public:
              PDEOperator const &                         pde_operator,
              MultigridOperatorType const &               mg_operator_type,
              bool const                                  mesh_is_moving,
-             Map const *                                 dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
+             Map const &                                 dirichlet_bc,
+             PeriodicFacePairs const &                   periodic_face_pairs);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -42,8 +42,8 @@ MultigridPreconditionerProjection<dim, Number>::initialize(
   std::shared_ptr<dealii::Mapping<dim> const> mapping,
   PDEOperator const &                         pde_operator,
   bool const                                  mesh_is_moving,
-  Map const *                                 dirichlet_bc,
-  PeriodicFacePairs const *                   periodic_face_pairs)
+  Map const &                                 dirichlet_bc,
+  PeriodicFacePairs const &                   periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
@@ -63,8 +63,8 @@ public:
              std::shared_ptr<dealii::Mapping<dim> const> mapping,
              PDEOperator const &                         pde_operator,
              bool const                                  mesh_is_moving,
-             Map const *                                 dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
+             Map const &                                 dirichlet_bc,
+             PeriodicFacePairs const &                   periodic_face_pairs);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -465,8 +465,8 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_momentum()
                                 this->momentum_operator,
                                 this->param.multigrid_operator_type_velocity_block,
                                 this->param.ale_formulation,
-                                &this->momentum_operator.get_data().bc->dirichlet_bc,
-                                &this->grid->periodic_faces);
+                                this->momentum_operator.get_data().bc->dirichlet_bc,
+                                this->grid->periodic_faces);
 }
 
 template<int dim, typename Number>
@@ -590,8 +590,8 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_schur_complement()
                                 this->get_mapping(),
                                 laplace_operator_data,
                                 this->param.ale_formulation,
-                                &laplace_operator_data.bc->dirichlet_bc,
-                                &this->grid->periodic_faces);
+                                laplace_operator_data.bc->dirichlet_bc,
+                                this->grid->periodic_faces);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -124,8 +124,8 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
                                   this->momentum_operator,
                                   MultigridOperatorType::ReactionDiffusion,
                                   this->param.ale_formulation,
-                                  &this->momentum_operator.get_data().bc->dirichlet_bc,
-                                  &this->grid->periodic_faces);
+                                  this->momentum_operator.get_data().bc->dirichlet_bc,
+                                  this->grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -131,8 +131,8 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
                                   this->momentum_operator,
                                   this->param.multigrid_operator_type_momentum,
                                   this->param.ale_formulation,
-                                  &this->momentum_operator.get_data().bc->dirichlet_bc,
-                                  &this->grid->periodic_faces);
+                                  this->momentum_operator.get_data().bc->dirichlet_bc,
+                                  this->grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -179,8 +179,8 @@ OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poiss
                                   this->get_mapping(),
                                   laplace_operator.get_data(),
                                   this->param.ale_formulation,
-                                  &laplace_operator.get_data().bc->dirichlet_bc,
-                                  &this->grid->periodic_faces);
+                                  laplace_operator.get_data().bc->dirichlet_bc,
+                                  this->grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1140,8 +1140,8 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
                                 get_dynamic_mapping<dim, Number>(grid, grid_motion),
                                 laplace_operator.get_data(),
                                 param.ale_formulation,
-                                &laplace_operator.get_data().bc->dirichlet_bc,
-                                &grid->periodic_faces);
+                                laplace_operator.get_data().bc->dirichlet_bc,
+                                grid->periodic_faces);
 
   // setup solver
   Krylov::SolverDataCG solver_data;
@@ -1478,8 +1478,8 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
                                     this->get_mapping(),
                                     *this->projection_operator,
                                     this->param.ale_formulation,
-                                    &this->projection_operator->get_data().bc->dirichlet_bc,
-                                    &grid->periodic_faces);
+                                    this->projection_operator->get_data().bc->dirichlet_bc,
+                                    grid->periodic_faces);
     }
     else
     {

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -41,8 +41,8 @@ MultigridPreconditioner<dim, Number, n_components>::initialize(
   std::shared_ptr<dealii::Mapping<dim> const> mapping,
   LaplaceOperatorData<rank, dim> const &      data_in,
   bool const                                  mesh_is_moving,
-  Map const *                                 dirichlet_bc,
-  PeriodicFacePairs const *                   periodic_face_pairs)
+  Map const &                                 dirichlet_bc,
+  PeriodicFacePairs const &                   periodic_face_pairs)
 {
   data = data_in;
 

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -64,8 +64,8 @@ public:
              std::shared_ptr<dealii::Mapping<dim> const> mapping,
              LaplaceOperatorData<rank, dim> const &      data_in,
              bool const                                  mesh_is_moving,
-             Map const *                                 dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
+             Map const &                                 dirichlet_bc,
+             PeriodicFacePairs const &                   periodic_face_pairs);
 
   void
   update() override;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -283,8 +283,8 @@ Operator<dim, Number, n_components>::setup_solver()
                                   grid->mapping,
                                   laplace_operator.get_data(),
                                   false /* moving_mesh */,
-                                  &laplace_operator.get_data().bc->dirichlet_bc,
-                                  &grid->periodic_faces);
+                                  laplace_operator.get_data().bc->dirichlet_bc,
+                                  grid->periodic_faces);
   }
   else
   {

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -63,8 +63,8 @@ MultigridPreconditionerBase<dim, Number>::initialize(
   dealii::FiniteElement<dim> const &          fe,
   std::shared_ptr<dealii::Mapping<dim> const> mapping,
   bool const                                  operator_is_singular,
-  Map const *                                 dirichlet_bc,
-  PeriodicFacePairs const *                   periodic_face_pairs)
+  Map const &                                 dirichlet_bc,
+  PeriodicFacePairs const &                   periodic_face_pairs)
 {
   this->data = data;
 
@@ -701,32 +701,11 @@ template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::initialize_dof_handler_and_constraints(
   bool const                         operator_is_singular,
-  PeriodicFacePairs const *          periodic_face_pairs_in,
+  PeriodicFacePairs const &          periodic_face_pairs,
   dealii::FiniteElement<dim> const & fe,
   dealii::Triangulation<dim> const * tria,
-  Map const *                        dirichlet_bc_in)
+  Map const &                        dirichlet_bc)
 {
-  bool const is_dg = (fe.dofs_per_vertex == 0);
-
-  if(data.coarse_problem.preconditioner == MultigridCoarseGridPreconditioner::AMG ||
-     data.coarse_problem.solver == MultigridCoarseGridSolver::AMG || !is_dg ||
-     data.involves_c_transfer())
-  {
-    AssertThrow(
-      dirichlet_bc_in != nullptr && periodic_face_pairs_in != nullptr,
-      dealii::ExcMessage(
-        "You have to provide Dirichlet BCs and periodic face pairs if you want to use continuous elements or AMG!"));
-  }
-
-  // In the case of nullptr, these data structures simply remain empty.
-  Map dirichlet_bc;
-  if(dirichlet_bc_in != nullptr)
-    dirichlet_bc = *dirichlet_bc_in;
-
-  PeriodicFacePairs periodic_face_pairs;
-  if(dirichlet_bc_in != nullptr)
-    periodic_face_pairs = *periodic_face_pairs_in;
-
   this->do_initialize_dof_handler_and_constraints(operator_is_singular,
                                                   periodic_face_pairs,
                                                   fe,

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -97,9 +97,9 @@ public:
              dealii::Triangulation<dim> const *          tria,
              dealii::FiniteElement<dim> const &          fe,
              std::shared_ptr<dealii::Mapping<dim> const> mapping,
-             bool const                                  operator_is_singular = false,
-             Map const *                                 dirichlet_bc         = nullptr,
-             PeriodicFacePairs const *                   periodic_face_pairs  = nullptr);
+             bool const                                  operator_is_singular,
+             Map const &                                 dirichlet_bc,
+             PeriodicFacePairs const &                   periodic_face_pairs);
 
   /*
    * This function applies the multigrid preconditioner dst = P^{-1} src.
@@ -172,10 +172,10 @@ protected:
    */
   virtual void
   initialize_dof_handler_and_constraints(bool                               is_singular,
-                                         PeriodicFacePairs const *          periodic_face_pairs,
+                                         PeriodicFacePairs const &          periodic_face_pairs,
                                          dealii::FiniteElement<dim> const & fe,
                                          dealii::Triangulation<dim> const * tria,
-                                         Map const *                        dirichlet_bc);
+                                         Map const &                        dirichlet_bc);
 
   void
   do_initialize_dof_handler_and_constraints(

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -40,8 +40,8 @@ MultigridPreconditioner<dim, Number>::initialize(
   std::shared_ptr<dealii::Mapping<dim> const> mapping,
   ElasticityOperatorBase<dim, Number> const & pde_operator,
   bool const                                  nonlinear_operator,
-  Map const *                                 dirichlet_bc,
-  PeriodicFacePairs const *                   periodic_face_pairs)
+  Map const &                                 dirichlet_bc,
+  PeriodicFacePairs const &                   periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -65,8 +65,8 @@ public:
              std::shared_ptr<dealii::Mapping<dim> const> mapping,
              ElasticityOperatorBase<dim, Number> const & pde_operator,
              bool const                                  nonlinear_operator,
-             Map const *                                 dirichlet_bc        = nullptr,
-             PeriodicFacePairs const *                   periodic_face_pairs = nullptr);
+             Map const &                                 dirichlet_bc,
+             PeriodicFacePairs const &                   periodic_face_pairs);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -390,8 +390,8 @@ Operator<dim, Number>::initialize_preconditioner()
                                     grid->mapping,
                                     elasticity_operator_nonlinear,
                                     true,
-                                    &elasticity_operator_nonlinear.get_data().bc->dirichlet_bc,
-                                    &grid->periodic_faces);
+                                    elasticity_operator_nonlinear.get_data().bc->dirichlet_bc,
+                                    grid->periodic_faces);
     }
     else
     {
@@ -407,8 +407,8 @@ Operator<dim, Number>::initialize_preconditioner()
                                     grid->mapping,
                                     elasticity_operator_linear,
                                     false,
-                                    &elasticity_operator_linear.get_data().bc->dirichlet_bc,
-                                    &grid->periodic_faces);
+                                    elasticity_operator_linear.get_data().bc->dirichlet_bc,
+                                    grid->periodic_faces);
     }
   }
   else if(param.preconditioner == Preconditioner::AMG)


### PR DESCRIPTION
I think we do not make use of the default option `nullptr`, so that we can actually remove this and use the more convenient call-by-value/call-by-reference semantics.