### PR TITLE
take DirichletCached BCs into account for multigrid setup

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -457,15 +457,29 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_momentum()
   std::shared_ptr<Multigrid> mg_preconditioner =
     std::dynamic_pointer_cast<Multigrid>(preconditioner_momentum);
 
-  auto & dof_handler = this->get_dof_handler_u();
+  typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+    pair;
+
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+    dirichlet_boundary_conditions = this->momentum_operator->get_data().bc->dirichlet_bc;
+
+  // We also need to add DirichletCached boundary conditions. From the
+  // perspective of multigrid, there is no difference between standard
+  // and cached Dirichlet BCs. Since multigrid does not need information
+  // about inhomogeneous boundary data, we simply fill the map with
+  // dealii::Functions::ZeroFunction for DirichletCached BCs.
+  for(auto iter : this->momentum_operator->get_data().bc->dirichlet_cached_bc)
+    dirichlet_boundary_conditions.insert(
+      pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
+
   mg_preconditioner->initialize(this->param.multigrid_data_velocity_block,
-                                &dof_handler.get_triangulation(),
-                                dof_handler.get_fe(),
+                                &this->get_dof_handler_u().get_triangulation(),
+                                this->get_dof_handler_u().get_fe(),
                                 this->get_mapping(),
                                 this->momentum_operator,
                                 this->param.multigrid_operator_type_velocity_block,
                                 this->param.ale_formulation,
-                                this->momentum_operator.get_data().bc->dirichlet_bc,
+                                dirichlet_boundary_conditions,
                                 this->grid->periodic_faces);
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -461,14 +461,14 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_momentum()
     pair;
 
   std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
-    dirichlet_boundary_conditions = this->momentum_operator->get_data().bc->dirichlet_bc;
+    dirichlet_boundary_conditions = this->momentum_operator.get_data().bc->dirichlet_bc;
 
   // We also need to add DirichletCached boundary conditions. From the
   // perspective of multigrid, there is no difference between standard
   // and cached Dirichlet BCs. Since multigrid does not need information
   // about inhomogeneous boundary data, we simply fill the map with
   // dealii::Functions::ZeroFunction for DirichletCached BCs.
-  for(auto iter : this->momentum_operator->get_data().bc->dirichlet_cached_bc)
+  for(auto iter : this->momentum_operator.get_data().bc->dirichlet_cached_bc)
     dirichlet_boundary_conditions.insert(
       pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -120,14 +120,14 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
       pair;
 
     std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
-      dirichlet_boundary_conditions = this->momentum_operator->get_data().bc->dirichlet_bc;
+      dirichlet_boundary_conditions = this->momentum_operator.get_data().bc->dirichlet_bc;
 
     // We also need to add DirichletCached boundary conditions. From the
     // perspective of multigrid, there is no difference between standard
     // and cached Dirichlet BCs. Since multigrid does not need information
     // about inhomogeneous boundary data, we simply fill the map with
     // dealii::Functions::ZeroFunction for DirichletCached BCs.
-    for(auto iter : this->momentum_operator->get_data().bc->dirichlet_cached_bc)
+    for(auto iter : this->momentum_operator.get_data().bc->dirichlet_cached_bc)
       dirichlet_boundary_conditions.insert(
         pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -116,10 +116,24 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
     std::shared_ptr<Multigrid> mg_preconditioner =
       std::dynamic_pointer_cast<Multigrid>(helmholtz_preconditioner);
 
-    auto & dof_handler = this->get_dof_handler_u();
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
+
+    std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      dirichlet_boundary_conditions = this->momentum_operator->get_data().bc->dirichlet_bc;
+
+    // We also need to add DirichletCached boundary conditions. From the
+    // perspective of multigrid, there is no difference between standard
+    // and cached Dirichlet BCs. Since multigrid does not need information
+    // about inhomogeneous boundary data, we simply fill the map with
+    // dealii::Functions::ZeroFunction for DirichletCached BCs.
+    for(auto iter : this->momentum_operator->get_data().bc->dirichlet_cached_bc)
+      dirichlet_boundary_conditions.insert(
+        pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
+
     mg_preconditioner->initialize(this->param.multigrid_data_viscous,
-                                  &dof_handler.get_triangulation(),
-                                  dof_handler.get_fe(),
+                                  &this->get_dof_handler_u().get_triangulation(),
+                                  this->get_dof_handler_u().get_fe(),
                                   this->get_mapping(),
                                   this->momentum_operator,
                                   MultigridOperatorType::ReactionDiffusion,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -123,15 +123,29 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
     std::shared_ptr<Multigrid> mg_preconditioner =
       std::dynamic_pointer_cast<Multigrid>(momentum_preconditioner);
 
-    auto & dof_handler = this->get_dof_handler_u();
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
+
+    std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      dirichlet_boundary_conditions = this->momentum_operator->get_data().bc->dirichlet_bc;
+
+    // We also need to add DirichletCached boundary conditions. From the
+    // perspective of multigrid, there is no difference between standard
+    // and cached Dirichlet BCs. Since multigrid does not need information
+    // about inhomogeneous boundary data, we simply fill the map with
+    // dealii::Functions::ZeroFunction for DirichletCached BCs.
+    for(auto iter : this->momentum_operator->get_data().bc->dirichlet_cached_bc)
+      dirichlet_boundary_conditions.insert(
+        pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
+
     mg_preconditioner->initialize(this->param.multigrid_data_momentum,
-                                  &dof_handler.get_triangulation(),
-                                  dof_handler.get_fe(),
+                                  &this->get_dof_handler_u().get_triangulation(),
+                                  this->get_dof_handler_u().get_fe(),
                                   this->get_mapping(),
                                   this->momentum_operator,
                                   this->param.multigrid_operator_type_momentum,
                                   this->param.ale_formulation,
-                                  this->momentum_operator.get_data().bc->dirichlet_bc,
+                                  dirichlet_boundary_conditions,
                                   this->grid->periodic_faces);
   }
   else

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -127,14 +127,14 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
       pair;
 
     std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
-      dirichlet_boundary_conditions = this->momentum_operator->get_data().bc->dirichlet_bc;
+      dirichlet_boundary_conditions = this->momentum_operator.get_data().bc->dirichlet_bc;
 
     // We also need to add DirichletCached boundary conditions. From the
     // perspective of multigrid, there is no difference between standard
     // and cached Dirichlet BCs. Since multigrid does not need information
     // about inhomogeneous boundary data, we simply fill the map with
     // dealii::Functions::ZeroFunction for DirichletCached BCs.
-    for(auto iter : this->momentum_operator->get_data().bc->dirichlet_cached_bc)
+    for(auto iter : this->momentum_operator.get_data().bc->dirichlet_cached_bc)
       dirichlet_boundary_conditions.insert(
         pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
 

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -285,7 +285,9 @@ Operator<dim, Number, n_components>::setup_solver()
 
     // We also need to add DirichletCached boundary conditions. From the
     // perspective of multigrid, there is no difference between standard
-    // and cached Dirichlet BCs.
+    // and cached Dirichlet BCs. Since multigrid does not need information
+    // about inhomogeneous boundary data, we simply fill the map with
+    // dealii::Functions::ZeroFunction for DirichletCached BCs.
     for(auto iter : laplace_operator.get_data().bc->dirichlet_cached_bc)
       dirichlet_boundary_conditions.insert(
         pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -290,7 +290,7 @@ Operator<dim, Number, n_components>::setup_solver()
     // dealii::Functions::ZeroFunction for DirichletCached BCs.
     for(auto iter : laplace_operator.get_data().bc->dirichlet_cached_bc)
       dirichlet_boundary_conditions.insert(
-        pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
+        pair(iter.first, new dealii::Functions::ZeroFunction<dim>(n_components)));
 
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -277,13 +277,26 @@ Operator<dim, Number, n_components>::setup_solver()
     std::shared_ptr<Multigrid> mg_preconditioner =
       std::dynamic_pointer_cast<Multigrid>(preconditioner);
 
+    typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      pair;
+
+    std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+      dirichlet_boundary_conditions = laplace_operator.get_data().bc->dirichlet_bc;
+
+    // We also need to add DirichletCached boundary conditions. From the
+    // perspective of multigrid, there is no difference between standard
+    // and cached Dirichlet BCs.
+    for(auto iter : laplace_operator.get_data().bc->dirichlet_cached_bc)
+      dirichlet_boundary_conditions.insert(
+        pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
+
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),
                                   dof_handler.get_fe(),
                                   grid->mapping,
                                   laplace_operator.get_data(),
                                   false /* moving_mesh */,
-                                  laplace_operator.get_data().bc->dirichlet_bc,
+                                  dirichlet_boundary_conditions,
                                   grid->periodic_faces);
   }
   else

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -390,6 +390,11 @@ Operator<dim, Number>::initialize_preconditioner()
       std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
         dirichlet_boundary_conditions = elasticity_operator_nonlinear.get_data().bc->dirichlet_bc;
 
+      // We also need to add DirichletCached boundary conditions. From the
+      // perspective of multigrid, there is no difference between standard
+      // and cached Dirichlet BCs. Since multigrid does not need information
+      // about inhomogeneous boundary data, we simply fill the map with
+      // dealii::Functions::ZeroFunction for DirichletCached BCs.
       for(auto iter : elasticity_operator_nonlinear.get_data().bc->dirichlet_cached_bc)
         dirichlet_boundary_conditions.insert(
           pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
@@ -417,6 +422,11 @@ Operator<dim, Number>::initialize_preconditioner()
       std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
         dirichlet_boundary_conditions = elasticity_operator_linear.get_data().bc->dirichlet_bc;
 
+      // We also need to add DirichletCached boundary conditions. From the
+      // perspective of multigrid, there is no difference between standard
+      // and cached Dirichlet BCs. Since multigrid does not need information
+      // about inhomogeneous boundary data, we simply fill the map with
+      // dealii::Functions::ZeroFunction for DirichletCached BCs.
       for(auto iter : elasticity_operator_linear.get_data().bc->dirichlet_cached_bc)
         dirichlet_boundary_conditions.insert(
           pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -384,13 +384,23 @@ Operator<dim, Number>::initialize_preconditioner()
       std::shared_ptr<Multigrid> mg_preconditioner =
         std::dynamic_pointer_cast<Multigrid>(preconditioner);
 
+      typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+        pair;
+
+      std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+        dirichlet_boundary_conditions = elasticity_operator_nonlinear.get_data().bc->dirichlet_bc;
+
+      for(auto iter : elasticity_operator_nonlinear.get_data().bc->dirichlet_cached_bc)
+        dirichlet_boundary_conditions.insert(
+          pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
+
       mg_preconditioner->initialize(param.multigrid_data,
                                     &dof_handler.get_triangulation(),
                                     dof_handler.get_fe(),
                                     grid->mapping,
                                     elasticity_operator_nonlinear,
-                                    true,
-                                    elasticity_operator_nonlinear.get_data().bc->dirichlet_bc,
+                                    param.large_deformation,
+                                    dirichlet_boundary_conditions,
                                     grid->periodic_faces);
     }
     else
@@ -401,13 +411,23 @@ Operator<dim, Number>::initialize_preconditioner()
       std::shared_ptr<Multigrid> mg_preconditioner =
         std::dynamic_pointer_cast<Multigrid>(preconditioner);
 
+      typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+        pair;
+
+      std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+        dirichlet_boundary_conditions = elasticity_operator_linear.get_data().bc->dirichlet_bc;
+
+      for(auto iter : elasticity_operator_linear.get_data().bc->dirichlet_cached_bc)
+        dirichlet_boundary_conditions.insert(
+          pair(iter.first, new dealii::Functions::ZeroFunction<dim>(dim)));
+
       mg_preconditioner->initialize(param.multigrid_data,
                                     &dof_handler.get_triangulation(),
                                     dof_handler.get_fe(),
                                     grid->mapping,
                                     elasticity_operator_linear,
-                                    false,
-                                    elasticity_operator_linear.get_data().bc->dirichlet_bc,
+                                    param.large_deformation,
+                                    dirichlet_boundary_conditions,
                                     grid->periodic_faces);
     }
   }


### PR DESCRIPTION
Currently, the code ignores DirichletCached BCs for the setup of multigrid (which requires a map of Dirichlet BCs). From the perspective of multigrid, there is no difference between both types of Dirichlet BCs. Hence, the present PR is a bugfix.

Note that the code currently crashed in case of pure `DirichletCached` BCs, as mentioned in PR #186.

One might argue that the current design is not optimal if it is possible to produce such bugs without noticing this for a while. However, it is also not clear how to incorporate DirichletCached BCs into standard Dirichlet BCs using dealii::Function. One could derive FunctionCached from dealii::Function (maybe even introduce this in dealii later ...), and then use dynamic casts to identify whether a boundary is of type DirichletCached (which is probably also not nice but maybe less error prone?). What do you think?