### PR TITLE
add barrier in create_directories()

### DIFF
--- a/include/exadg/utilities/create_directories.h
+++ b/include/exadg/utilities/create_directories.h
@@ -28,13 +28,16 @@
 namespace ExaDG
 {
 /**
- * Creates directories if not already existing.
+ * Creates directories if not already existing. An MPI barrier ensures that
+ * directories have been created for all processes when completing this function.
  */
 inline void
 create_directories(std::string const & directory, MPI_Comm const & mpi_comm)
 {
   if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
     std::filesystem::create_directories(directory);
+
+  MPI_Barrier(mpi_comm);
 }
 
 } // namespace ExaDG


### PR DESCRIPTION
In parallel computations, it might happen that the output directory has not been created when calling functions that write the output, even though `create_directories()` has been called. This behavior can be considered a bug and is suggested to be resolved by a barrier.