### PR TITLE
Generalizations for overset grids functionality

### DIFF
--- a/applications/poisson/overset_grids/application.h
+++ b/applications/poisson/overset_grids/application.h
@@ -77,21 +77,10 @@ public:
     double const       right = 1.0;
     dealii::Point<dim> p1, p2;
     p1[0] = 0.0;
-    p1[1] = 0.0;
+    p1[1] = 0.5;
     p2[0] = right;
-    p2[1] = 1.0;
+    p2[1] = 1.5;
     dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation, {3, 3}, p1, p2);
-
-    for(auto cell : *this->grid->triangulation)
-    {
-      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
-      {
-        if((std::fabs(cell.face(f)->center()(0) - right) < 1e-12))
-        {
-          cell.face(f)->set_boundary_id(1);
-        }
-      }
-    }
 
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
@@ -110,7 +99,8 @@ public:
       pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
 
     this->boundary_descriptor->dirichlet_cached_bc.insert(
-      pair_cached(1, new FunctionCached<rank, dim>()));
+      pair_cached(std::numeric_limits<dealii::types::boundary_id>::max() - 1,
+                  new FunctionCached<rank, dim>()));
   }
 
   void
@@ -199,17 +189,6 @@ private:
     p2[1] = 1.0;
     dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation, {2, 2}, p1, p2);
 
-    for(auto cell : *this->grid->triangulation)
-    {
-      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
-      {
-        if((std::fabs(cell.face(f)->center()(0) - left) < 1e-12))
-        {
-          cell.face(f)->set_boundary_id(1);
-        }
-      }
-    }
-
     this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
   }
 
@@ -226,7 +205,8 @@ private:
     this->boundary_descriptor->dirichlet_bc.insert(
       pair(0, new dealii::Functions::ZeroFunction<dim>(n_components)));
     this->boundary_descriptor->dirichlet_cached_bc.insert(
-      pair_cached(1, new FunctionCached<rank, dim>()));
+      pair_cached(std::numeric_limits<dealii::types::boundary_id>::max() - 1,
+                  new FunctionCached<rank, dim>()));
   }
 
   void
@@ -261,7 +241,7 @@ class Application : public ApplicationOversetGridsBase<dim, n_components, Number
 {
 public:
   Application(std::string input_file, MPI_Comm const & comm)
-    : ApplicationOversetGridsBase<dim, n_components, Number>(input_file)
+    : ApplicationOversetGridsBase<dim, n_components, Number>(input_file, comm)
   {
     this->domain1 = std::make_shared<Domain1<dim, n_components, Number>>(input_file, comm);
     this->domain2 = std::make_shared<Domain2<dim, n_components, Number>>(input_file, comm);

--- a/include/exadg/poisson/overset_grids/user_interface/application_base.h
+++ b/include/exadg/poisson/overset_grids/user_interface/application_base.h
@@ -22,6 +22,9 @@
 #ifndef INCLUDE_EXADG_POISSON_OVERSET_GRIDS_USER_INTERFACE_APPLICATION_BASE_H_
 #define INCLUDE_EXADG_POISSON_OVERSET_GRIDS_USER_INTERFACE_APPLICATION_BASE_H_
 
+// deal.II
+#include <deal.II/grid/grid_tools_cache.h>
+
 // ExaDG
 #include <exadg/poisson/user_interface/application_base.h>
 
@@ -29,11 +32,70 @@ namespace ExaDG
 {
 namespace Poisson
 {
+/**
+ * Use to classify the location of an object (e.g. cell, face) relative to a triangulation.
+ */
+enum class Location
+{
+  Inside,
+  Outside,
+  Intersected
+};
+
+/**
+ * This function determines the location of an object defined by a cloud of points (e.g. the mapping
+ * support points of a cell or face, or just the vertices) relative to a triangulation @param tria
+ * with corresponding mapping @param mapping.
+ */
+template<int dim>
+Location
+locate_object_relative_to_triangulation(
+  dealii::Mapping<dim> const &                                mapping,
+  dealii::Triangulation<dim> const &                          tria,
+  std::vector<dealii::Point<dim>> const &                     points,
+  typename dealii::Triangulation<dim>::active_cell_iterator & cell_hint,
+  std::vector<bool> const &                                   marked_vertices,
+  double const &                                              tolerance)
+{
+  AssertThrow(dealii::Utilities::MPI::n_mpi_processes(tria.get_communicator()) == 1,
+              dealii::ExcMessage(
+                "This function has so far only been implemented for the serial case."));
+
+  dealii::GridTools::Cache<dim, dim> cache(tria, mapping);
+
+  std::vector<bool> inside = std::vector<bool>(points.size(), false);
+  for(unsigned int i = 0; i < points.size(); ++i)
+  {
+    auto cell_and_ref_point = dealii::GridTools::find_active_cell_around_point(
+      cache, points[i], cell_hint, marked_vertices, tolerance);
+
+    if(cell_and_ref_point.first != tria.end())
+    {
+      // use current cell as hint for the next point
+      cell_hint = cell_and_ref_point.first;
+
+      inside[i] = true;
+    }
+  }
+
+  if(std::all_of(inside.begin(), inside.end(), [](bool is_inside) {
+       return is_inside == true;
+     })) // all inside
+    return Location::Inside;
+  else if(std::all_of(inside.begin(), inside.end(), [](bool is_inside) {
+            return is_inside == false;
+          })) // all outside
+    return Location::Outside;
+  else // must be of type Intersected
+    return Location::Intersected;
+}
+
 template<int dim, int n_components, typename Number>
 class ApplicationOversetGridsBase
 {
 public:
-  ApplicationOversetGridsBase(std::string parameter_file) : parameter_file(parameter_file)
+  ApplicationOversetGridsBase(std::string parameter_file, MPI_Comm const & comm)
+    : mpi_comm(comm), parameter_file(parameter_file)
   {
   }
 
@@ -63,11 +125,23 @@ public:
                                              resolution2.refine_space,
                                              0 /* not used */);
 
-    domain1->setup();
-    domain2->setup();
+    domain1->setup_pre();
+    domain2->setup_pre();
+
+    set_boundary_ids();
+
+    domain1->setup_post();
+    domain2->setup_post();
   }
 
   std::shared_ptr<ApplicationBase<dim, n_components, Number>> domain1, domain2;
+
+protected:
+  MPI_Comm const & mpi_comm;
+
+  // use "-1" since max() is defined invalid by deal.II
+  dealii::types::boundary_id boundary_id_overlap =
+    std::numeric_limits<dealii::types::boundary_id>::max() - 1;
 
 private:
   /**
@@ -83,6 +157,69 @@ private:
     resolution2.add_parameters(prm, "ResolutionDomain2");
 
     prm.parse_input(parameter_file, "", true, true);
+  }
+
+  void
+  set_boundary_ids()
+  {
+    AssertThrow(dealii::Utilities::MPI::n_mpi_processes(mpi_comm) == 1,
+                dealii::ExcMessage(
+                  "This function has so far only been implemented for the serial case."));
+
+    std::vector<bool> marked_vertices = {};
+    double const      tolerance       = 1.e-10;
+
+    // loop over faces of first triangulation and check whether they are located inside the second
+    // triangulation
+    auto cell_hint_2 = typename dealii::Triangulation<dim>::active_cell_iterator();
+    for(auto cell : domain1->get_grid()->triangulation->active_cell_iterators())
+    {
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
+      {
+        if(cell->face(f)->at_boundary())
+        {
+          std::vector<dealii::Point<dim>> points;
+          for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+            points.push_back(cell->face(f)->vertex(v));
+
+          Location location =
+            locate_object_relative_to_triangulation(*domain2->get_grid()->mapping,
+                                                    *domain2->get_grid()->triangulation,
+                                                    points,
+                                                    cell_hint_2,
+                                                    marked_vertices,
+                                                    tolerance);
+          if(location == Location::Inside)
+            cell->face(f)->set_boundary_id(boundary_id_overlap);
+        }
+      }
+    }
+
+    // loop over faces of second triangulation and check whether they are located inside the first
+    // triangulation
+    auto cell_hint_1 = typename dealii::Triangulation<dim>::active_cell_iterator();
+    for(auto cell : domain2->get_grid()->triangulation->active_cell_iterators())
+    {
+      for(unsigned int f = 0; f < dealii::GeometryInfo<dim>::faces_per_cell; ++f)
+      {
+        if(cell->face(f)->at_boundary())
+        {
+          std::vector<dealii::Point<dim>> points;
+          for(unsigned int v = 0; v < dealii::GeometryInfo<dim - 1>::vertices_per_cell; ++v)
+            points.push_back(cell->face(f)->vertex(v));
+
+          Location location =
+            locate_object_relative_to_triangulation(*domain1->get_grid()->mapping,
+                                                    *domain1->get_grid()->triangulation,
+                                                    points,
+                                                    cell_hint_1,
+                                                    marked_vertices,
+                                                    tolerance);
+          if(location == Location::Inside)
+            cell->face(f)->set_boundary_id(boundary_id_overlap);
+        }
+      }
+    }
   }
 
   std::string parameter_file;

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -84,9 +84,18 @@ public:
   void
   setup()
   {
-    parse_parameters();
+    setup_pre();
 
+    calculate_aspect_ratio();
+
+    setup_post();
+  }
+
+  void
+  setup_pre()
+  {
     // parameters
+    parse_parameters();
     set_parameters();
     param.check();
     param.print(pcout, "List of parameters:");
@@ -95,19 +104,11 @@ public:
     grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
+  }
 
-    if(compute_aspect_ratio)
-    {
-      // this variant is only for comparison
-      double AR = calculate_aspect_ratio_vertex_distance(*grid->triangulation, mpi_comm);
-      pcout << std::endl << "Maximum aspect ratio (vertex distance) = " << AR << std::endl;
-
-      dealii::QGauss<dim> quad(param.degree + 1);
-      AR =
-        dealii::GridTools::compute_maximum_aspect_ratio(*grid->mapping, *grid->triangulation, quad);
-      pcout << std::endl << "Maximum aspect ratio (Jacobian) = " << AR << std::endl;
-    }
-
+  void
+  setup_post()
+  {
     // boundary conditions
     boundary_descriptor = std::make_shared<BoundaryDescriptor<rank, dim>>();
     set_boundary_descriptor();
@@ -152,6 +153,22 @@ protected:
     dealii::ParameterHandler prm;
     this->add_parameters(prm);
     prm.parse_input(parameter_file, "", true, true);
+  }
+
+  void
+  calculate_aspect_ratio()
+  {
+    if(compute_aspect_ratio)
+    {
+      // this variant is only for comparison
+      double AR = calculate_aspect_ratio_vertex_distance(*grid->triangulation, mpi_comm);
+      pcout << std::endl << "Maximum aspect ratio (vertex distance) = " << AR << std::endl;
+
+      dealii::QGauss<dim> quad(param.degree + 1);
+      AR =
+        dealii::GridTools::compute_maximum_aspect_ratio(*grid->mapping, *grid->triangulation, quad);
+      pcout << std::endl << "Maximum aspect ratio (Jacobian) = " << AR << std::endl;
+    }
   }
 
   MPI_Comm const & mpi_comm;


### PR DESCRIPTION
This PR implements generalizations of the overset grids functionality. The overlap region is determined automatically and boundary IDs are set accordingly for DirichletCached BCs.

The function is written generically with a vector of points (which could be a single point (e.g. vertex), or represent a cell/face). Regarding the nomenclature, this vector (or cloud) of points is called an "object" -> `locate_object_relative_to_triangulation()`.

Limitations: 

- only works in serial. For the parallel case, something like `RemotePointEvaluation` could be helpful. @peterrum are you interested to discuss how we could use/extend `RemotePointEvaluation` for this purpose?
- Only takes into account the vertices of a face when classifying a face in terms of `Location::Inside/Outside/Intersected`. For a correct identification of `Location::Inside/Outside/Intersected` all the mapping support points of the (potentially high-order) mapping should be taken into account.

Here are examples for coarse and fine meshes for domain1:

![automatic_coarse](https://user-images.githubusercontent.com/26224507/158610449-f1090e8d-569d-4a41-ad6c-5d8cd348a2d6.png)
![automatic_fine](https://user-images.githubusercontent.com/26224507/158610465-33e00742-3f3c-4a30-9cd0-b5d282be397e.png)

