### PR TITLE
Refactoring of InterfaceCoupling: remove setup of marked_vertices from InterfaceCoupling::setup()

### DIFF
--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
@@ -135,7 +135,7 @@ InterfaceCoupling<dim, n_components, Number>::setup(
   if(marked_vertices_src_.size() > 0)
   {
     AssertThrow(marked_vertices_src_.size() ==
-                  (unsigned int)dof_handler_src_.get_triangulation().n_active_cells(),
+                  (unsigned int)dof_handler_src_.get_triangulation().n_vertices(),
                 dealii::ExcMessage("Vector marked_vertices_src_ has invalid size."));
   }
 

--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
@@ -124,52 +124,23 @@ template<int dim, int n_components, typename Number>
 void
 InterfaceCoupling<dim, n_components, Number>::setup(
   std::shared_ptr<ContainerInterfaceData<dim, n_components, Number>> interface_data_dst_,
-  MapBoundaryCondition const &                                       map_bc_src_,
   dealii::DoFHandler<dim> const &                                    dof_handler_src_,
   dealii::Mapping<dim> const &                                       mapping_src_,
+  std::vector<bool> const &                                          marked_vertices_src_,
   double const                                                       tolerance_)
 {
   AssertThrow(interface_data_dst_.get(),
               dealii::ExcMessage("Received uninitialized variable. Aborting."));
 
+  if(marked_vertices_src_.size() > 0)
+  {
+    AssertThrow(marked_vertices_src_.size() ==
+                  (unsigned int)dof_handler_src_.get_triangulation().n_active_cells,
+                dealii::ExcMessage("Vector marked_vertices_src_ has invalid size."));
+  }
+
   interface_data_dst = interface_data_dst_;
   dof_handler_src    = &dof_handler_src_;
-
-#if DEAL_II_VERSION_GTE(10, 0, 0)
-  // mark vertices at interface in order to make search of active cells around point more
-  // efficient
-  std::vector<bool> marked_vertices(dof_handler_src_.get_triangulation().n_vertices(), false);
-
-  for(auto const & cell : dof_handler_src_.get_triangulation().active_cell_iterators())
-  {
-    if(!cell->is_artificial() && cell->at_boundary())
-    {
-      for(unsigned int const f : cell->face_indices())
-      {
-        if(cell->face(f)->at_boundary())
-        {
-          if(map_bc_src_.find(cell->face(f)->boundary_id()) != map_bc_src_.end())
-          {
-            for(unsigned int const v : cell->face(f)->vertex_indices())
-            {
-              marked_vertices[cell->face(f)->vertex_index(v)] = true;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // To improve robustness, make sure that not all entries of marked_vertices are false.
-  // Otherwise, points will simply not be found by RemotePointEvaluation and results will
-  // probably be wrong.
-  if(std::all_of(marked_vertices.begin(), marked_vertices.end(), [](bool vertex_is_marked) {
-       return vertex_is_marked == false;
-     }))
-  {
-    marked_vertices.clear();
-  }
-#endif
 
   for(auto quad_index : interface_data_dst->get_quad_indices())
   {
@@ -181,7 +152,7 @@ InterfaceCoupling<dim, n_components, Number>::setup(
 #if DEAL_II_VERSION_GTE(10, 0, 0)
                             ,
                             0,
-                            [marked_vertices]() { return marked_vertices; }
+                            [marked_vertices_src_]() { return marked_vertices_src_; }
 #endif
                             ));
 

--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
@@ -135,7 +135,7 @@ InterfaceCoupling<dim, n_components, Number>::setup(
   if(marked_vertices_src_.size() > 0)
   {
     AssertThrow(marked_vertices_src_.size() ==
-                  (unsigned int)dof_handler_src_.get_triangulation().n_active_cells,
+                  (unsigned int)dof_handler_src_.get_triangulation().n_active_cells(),
                 dealii::ExcMessage("Vector marked_vertices_src_ has invalid size."));
   }
 

--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.h
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.h
@@ -99,14 +99,18 @@ public:
   /**
    * setup() function.
    *
-   * TODO: The part dealing with marked vertices needs to be generalized. Currently,
-   * use an empty map_bc_src_ to deactivate the feature marked_vertices.
+   * The aim of @param marked_vertices_src_ is to make the search of points on the src side
+   * computationally more efficient. If no useful information can be provided for this parameter, an
+   * empty vector has to be passed to this function.
+   *
+   * @param tolerance_ is a geometric tolerance passed to dealii::RemotePointEvaluation and used for
+   * the search of points on the src side.
    */
   void
   setup(std::shared_ptr<ContainerInterfaceData<dim, n_components, Number>> interface_data_dst_,
-        MapBoundaryCondition const &                                       map_bc_src_,
         dealii::DoFHandler<dim> const &                                    dof_handler_src_,
         dealii::Mapping<dim> const &                                       mapping_src_,
+        std::vector<bool> const &                                          marked_vertices_src_,
         double const                                                       tolerance_);
 
   void

--- a/include/exadg/grid/marked_vertices.h
+++ b/include/exadg/grid/marked_vertices.h
@@ -1,0 +1,85 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_GRID_MARKED_VERTICES_H_
+#define INCLUDE_EXADG_GRID_MARKED_VERTICES_H_
+
+// deal.II
+#include <deal.II/grid/tria.h>
+
+template<typename Key, typename Data>
+std::set<Key>
+extract_set_of_keys_from_map(std::map<Key, Data> const & map)
+{
+  std::set<Key> set;
+  for(auto iter : map)
+  {
+    set.insert(iter.first);
+  }
+
+  return set;
+}
+
+template<int dim>
+std::vector<bool>
+get_marked_vertices_via_boundary_ids(dealii::Triangulation<dim> const &           triangulation,
+                                     std::set<dealii::types::boundary_id> const & boundary_ids)
+{
+  // mark vertices at interface in order to make search of active cells around point more
+  // efficient
+  std::vector<bool> marked_vertices(triangulation.n_vertices(), false);
+
+  for(auto const & cell : triangulation.active_cell_iterators())
+  {
+    if(!cell->is_artificial() && cell->at_boundary())
+    {
+      for(unsigned int const f : cell->face_indices())
+      {
+        if(cell->face(f)->at_boundary())
+        {
+          if(boundary_ids.find(cell->face(f)->boundary_id()) != boundary_ids.end())
+          {
+            for(unsigned int const v : cell->face(f)->vertex_indices())
+            {
+              marked_vertices[cell->face(f)->vertex_index(v)] = true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // To improve robustness, make sure that not all entries of marked_vertices are false.
+  // If no useful information about marked vertices can be provided, an empty vector should
+  // be used.
+  if(std::all_of(marked_vertices.begin(), marked_vertices.end(), [](bool vertex_is_marked) {
+       return vertex_is_marked == false;
+     }))
+  {
+    marked_vertices.clear();
+  }
+
+  return marked_vertices;
+}
+
+
+
+#endif /* INCLUDE_EXADG_GRID_MARKED_VERTICES_H_ */

--- a/include/exadg/poisson/overset_grids/driver.cpp
+++ b/include/exadg/poisson/overset_grids/driver.cpp
@@ -64,11 +64,10 @@ DriverOversetGrids<dim, n_components, Number>::setup()
     // No map of boundary IDs can be provided to make the search more efficient. The reason behind
     // is that the two domains are not connected along boundaries but are overlapping instead. To
     // resolve this, the implementation of InterfaceCoupling needs to be generalized.
-    std::map<dealii::types::boundary_id, std::shared_ptr<FunctionCached<rank, dim, double>>> dummy;
     first_to_second->setup(poisson2->pde_operator->get_container_interface_data(),
-                           dummy,
                            poisson1->pde_operator->get_dof_handler(),
                            *application->domain1->get_grid()->mapping,
+                           {} /* marked_vertices */,
                            1.e-8 /* geometric tolerance */);
 
     pcout << std::endl << "... done." << std::endl;
@@ -78,9 +77,9 @@ DriverOversetGrids<dim, n_components, Number>::setup()
 
     second_to_first = std::make_shared<InterfaceCoupling<dim, n_components, Number>>();
     second_to_first->setup(poisson1->pde_operator->get_container_interface_data(),
-                           dummy,
                            poisson2->pde_operator->get_dof_handler(),
                            *application->domain2->get_grid()->mapping,
+                           {} /* marked_vertices */,
                            1.e-8 /* geometric tolerance */);
 
     pcout << std::endl << "... done." << std::endl;


### PR DESCRIPTION
. . . and pass `marked_vertices` as a parameter to `InterfaceCoupling::setup()` instead.

The reason behind is that the current version passing a map of boundary conditions to `InterfaceCoupling::setup()` is not general enough, e.g. this does not have a meaning for the recently introduced overset grids functionality (where "cached" data is still prescribed along boundaries, but the two domains do not touch along boundaries, but intersect each other).