### PR TITLE
[preCICE FSI] Support adaptive-time stepping in serial coupling schemes

### DIFF
--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -151,12 +151,13 @@ private:
     param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     param.order_time_integrator           = 1;
     param.start_with_low_order            = true;
-    param.adaptive_time_stepping          = false;
-    param.calculation_of_time_step_size   = TimeStepCalculation::UserSpecified;
+    param.adaptive_time_stepping          = true;
+    param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
     param.time_step_size                  = DELTA_T;
+    param.time_step_size_max              = DELTA_T;
     param.max_velocity                    = U_MEAN;
-    param.cfl                             = 0.5;
-    param.cfl_exponent_fe_degree_velocity = 1.5;
+    param.cfl                             = 0.75;
+    param.cfl_exponent_fe_degree_velocity = 1.2;
 
     // output of solver information
     param.solver_info_data.interval_time_steps = OUTPUT_SOLVER_INFO_EVERY_TIME_STEPS;
@@ -619,7 +620,7 @@ public:
     param.problem_type         = ProblemType::Unsteady;
     param.body_force           = false;
     param.pull_back_body_force = false;
-    param.large_deformation    = true;
+    param.large_deformation    = false;
     param.pull_back_traction   = true;
 
     param.density = DENSITY_STRUCTURE;

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -156,8 +156,8 @@ private:
     param.time_step_size                  = DELTA_T;
     param.time_step_size_max              = DELTA_T;
     param.max_velocity                    = U_MEAN;
-    param.cfl                             = 0.75;
-    param.cfl_exponent_fe_degree_velocity = 1.2;
+    param.cfl                             = 0.9;
+    param.cfl_exponent_fe_degree_velocity = 1.5;
 
     // output of solver information
     param.solver_info_data.interval_time_steps = OUTPUT_SOLVER_INFO_EVERY_TIME_STEPS;

--- a/applications/fluid_structure_interaction/perpendicular_flap/precice-config.xml
+++ b/applications/fluid_structure_interaction/perpendicular_flap/precice-config.xml
@@ -74,7 +74,7 @@
     <m2n:sockets from="Fluid" to="Solid" exchange-directory=".." />
 
     <coupling-scheme:serial-explicit>
-      <time-window-size value="0.01" />
+      <time-window-size valid-digits="16" method="first-participant" />
       <max-time value="5" />
       <participants first="Fluid" second="Solid" />
       <exchange data="Stress" mesh="Fluid-Mesh-write" from="Fluid" to="Solid" />

--- a/include/exadg/fluid_structure_interaction/precice/driver.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver.h
@@ -83,6 +83,9 @@ protected:
   std::shared_ptr<ExaDG::preCICE::Adapter<dim, dim, VectorType>> precice;
   ExaDG::preCICE::ConfigurationParameters                        precice_parameters;
 
+  // maximum allowed time-step size until we reach a new coupling time window
+  mutable double allowed_time_step_size = 0;
+
   // do not print wall times if is_test
   bool const is_test;
 

--- a/include/exadg/fluid_structure_interaction/precice/driver.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver.h
@@ -83,6 +83,23 @@ protected:
   std::shared_ptr<ExaDG::preCICE::Adapter<dim, dim, VectorType>> precice;
   ExaDG::preCICE::ConfigurationParameters                        precice_parameters;
 
+  // Nomenclature
+  // time window: denotes time interval after which FSi coupling takes place
+  // subcycling: a single field solver performs several time steps until the next FSI coupling time
+  // window is reached
+  // time step size: refers to single field solvers. In case of subcycling, one
+  // time window consists of several time step sizes.
+
+  // The time-window size is determined through the preCICE configuration by the user:
+  // The <coupling-scheme.. tag has options for
+  // <time-window-size method="fixed" ... /> which refers to a constant time window size
+  // <time-window-size method="first-participant" ... /> which refers to an adaptive time window
+  // size prescribed by the first (which is usually the Fluid) participant. The latter is only
+  // applicable in serial coupling schemes.
+  // Both solvers can exploit subcycling, but they need to synchronize at the end of a certain
+  // time-window size. Therefore, the allowed time-step size until we reach the next synchronization
+  // point needs to be determined.
+
   // maximum allowed time-step size until we reach a new coupling time window
   mutable double allowed_time_step_size = 0;
 

--- a/include/exadg/fluid_structure_interaction/precice/driver.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver.h
@@ -89,9 +89,13 @@ protected:
   // window is reached
   // time step size: refers to single field solvers. In case of subcycling, one
   // time window consists of several time step sizes.
+  // serial coupling scheme: the single-field solvers are called sequentially/consecutively with
+  // data transfer from one field to another after in single-field solver.
+  // parallel coupling scheme: the single-field solvers are called simultaneously with data transfer
+  // in both directions afterwards.
 
   // The time-window size is determined through the preCICE configuration by the user:
-  // The <coupling-scheme.. tag has options for
+  // The <coupling-scheme.. /> tag has options for
   // <time-window-size method="fixed" ... /> which refers to a constant time window size
   // <time-window-size method="first-participant" ... /> which refers to an adaptive time window
   // size prescribed by the first (which is usually the Fluid) participant. The latter is only
@@ -101,7 +105,7 @@ protected:
   // point needs to be determined.
 
   // maximum allowed time-step size until we reach a new coupling time window
-  mutable double allowed_time_step_size = 0;
+  mutable double time_until_next_coupling_window = 0;
 
   // do not print wall times if is_test
   bool const is_test;

--- a/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
@@ -219,19 +219,18 @@ public:
       {
         // computes new time-step size
         fluid->time_integrator->advance_one_timestep_post_solve();
-        // next, we synchronize the time-step sizes. Subcycling would in theory be compatible in
-        // explicit coupling schemes here. In implicit coupling schemes, we need matching
-        // time-window sizes (either constant (serial or parallel schemes) or adaptively (serial
-        // scheme)) as the time-step size push back happens in the
-        // 'advance_one_timestep_post_solve()' and we cannot change two subsequent time-step sizes
-        // without a push back operation, otherwise we falsify the time integrator. However, the
-        // treatment of the boundary conditions is not handled correctly when using subcycling, as
-        // we apply the 'whole displacement' within the first time-step. In order to cope with
-        // subcycling, either the boundary condition needs to be adopted or we need to wait for a
-        // newer preCICE version (currently v2.3.0) which can handle this.
-        // Hence, we do not adjust the time-step-size of the fluid solver, but rather Assert that it
-        // is still valid. Note that we would run into a preCICE error otherwise reporting the same
-        // issue otherwise.
+        // next, we synchronize the time-step sizes. Have a look in the base class for more
+        // explanations. Subcycling would in theory be compatible in explicit coupling schemes here.
+        // In implicit coupling schemes, we need matching time-window sizes as the time-step size
+        // push back happens in the 'advance_one_timestep_post_solve()' and we cannot change two
+        // subsequent time-step sizes without a push back operation, otherwise we falsify the time
+        // integrator. However, the treatment of the boundary conditions is not handled correctly
+        // when using subcycling, as we would apply the 'whole displacement' within the first
+        // time-step (being potentially only a fractio of the whole time-windo). In order to cope
+        // with subcycling, either the boundary condition needs to be adapted or we need to wait for
+        // a newer preCICE version (currently v2.3.0) which can handle this. Hence, we do not adjust
+        // the time-step-size of the fluid solver, but rather Assert that it is still valid. Note
+        // that we would otherwise run into a preCICE assert reporting the same issue.
         // fluid->time_integrator->set_current_time_step_size(
         //   std::min(this->allowed_time_step_size, fluid->time_integrator->get_time_step_size()));
         Assert(
@@ -240,6 +239,7 @@ public:
           dealii::ExcMessage(
             "The solver time-step size exceeded the maximum admissible time-step size allowed by preCICE. "
             "If you select adaptive time-stepping, make sure to let the Fluid participant steer the time-window size. "
+            "(precice config: <coupling-scheme:serial... > <time-window-size method=\"first-participant\" />) "
             "In any other case, please disable adaptive time-stepping."));
       }
     }

--- a/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
@@ -151,7 +151,7 @@ public:
     // initialize preCICE with initial stress data
     VectorType initial_stress;
     fluid->pde_operator->initialize_vector_velocity(initial_stress);
-    this->precice->initialize_precice(initial_stress);
+    this->allowed_time_step_size = this->precice->initialize_precice(initial_stress);
   }
 
 
@@ -178,10 +178,9 @@ public:
   void
   solve() const final
   {
-    Assert(this->application->fluid->get_parameters().adaptive_time_stepping == false,
-           dealii::ExcNotImplemented());
-
     bool is_new_time_window = true;
+    fluid->time_integrator->set_current_time_step_size(
+      std::min(this->allowed_time_step_size, fluid->time_integrator->get_time_step_size()));
     // preCICE dictates when the time loop is finished
     while(this->precice->is_coupling_ongoing())
     {
@@ -205,10 +204,9 @@ public:
         // compute and send stress to solid
         coupling_fluid_to_structure();
 
-        // TODO: Add synchronization for the time-step size here. For now, we only allow a constant
-        // time-step size
         dealii::Timer precice_timer;
-        this->precice->advance(fluid->time_integrator->get_time_step_size());
+        this->allowed_time_step_size =
+          this->precice->advance(fluid->time_integrator->get_time_step_size());
         is_new_time_window = this->precice->is_time_window_complete();
         this->timer_tree.insert({"FSI", "preCICE"}, precice_timer.wall_time());
       }
@@ -218,7 +216,19 @@ public:
 
       // post-solve
       if(is_new_time_window)
+      {
+        // computes new time-step size
         fluid->time_integrator->advance_one_timestep_post_solve();
+        // next, we synchronize the time-step sizes. Subcycling would be possible in explicit
+        // coupling schemes. In implicit coupling schemes, we need matching time-window sizes
+        // (either constant (serial or parallel schemes) or adaptively (serial scheme)) as the
+        // time-step size push back happens in the 'advance_one_timestep_post_solve()' and we cannot
+        // change two subsequent time-step sizes without a push back operation, otherwise we falsify
+        // the time integrator. In case one selects an adaptive time-step scheme here and a constant
+        // time-window size in preCICE, preCICE will throw an error
+        fluid->time_integrator->set_current_time_step_size(
+          std::min(this->allowed_time_step_size, fluid->time_integrator->get_time_step_size()));
+      }
     }
   }
 

--- a/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
@@ -237,7 +237,7 @@ public:
         Assert(
           fluid->time_integrator->get_time_step_size() <
             this->allowed_time_step_size + std::numeric_limits<double>::min(),
-          ExcMessage(
+          dealii::ExcMessage(
             "The solver time-step size exceeded the maximum admissible time-step size allowed by preCICE. "
             "If you select adaptive time-stepping, make sure to let the Fluid participant steer the time-window size. "
             "In any other case, please disable adaptive time-stepping."));

--- a/include/exadg/fluid_structure_interaction/precice/driver_solid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_solid.h
@@ -180,16 +180,16 @@ public:
       is_new_time_window = this->precice->is_time_window_complete();
       this->timer_tree.insert({"FSI", "preCICE"}, precice_timer.wall_time());
 
-      // Needs to be called before the swaps in post_solve
+      // Needs to be called before the swaps in post_solve.
       this->precice->reload_old_state_if_required([&]() {});
 
       if(is_new_time_window)
         structure->time_integrator->advance_one_timestep_post_solve();
 
-      // We need to adjust the time-step size in case we reach a coupling time-wimdow
+      // We need to adjust the time-step size in case we reach a coupling time-wimdow.
       // We don't take the time-step size of the solver here into account, but rather apply the
       // available time-step size reported by preCICE, as the GenAlpha time integrator doesn't
-      // compute a time-step size on its own
+      // compute a time-step size on its own.
       structure->time_integrator->set_current_time_step_size(this->allowed_time_step_size);
     }
   }

--- a/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
+++ b/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
@@ -94,7 +94,7 @@ public:
    *             automatically. In many cases, this data will just represent
    *             your initial condition.
    *
-   * @return     double the allowed time-step size until the next coupling time-window is reached
+   * @return     double the time until the next coupling time-window is reached
    */
   double
   initialize_precice(VectorType const & dealii_to_precice);
@@ -121,7 +121,7 @@ public:
    *
    * @param computed_timestep_length the time-step size computed by the solver
    *
-   * @return double the allowed time-step size until the next coupling time-window is reached
+   * @return double the time until the next coupling time-window is reached
    */
   double
   advance(double const computed_timestep_length);
@@ -297,7 +297,7 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::initialize_precice(
   //   dealii_to_precice.update_ghost_values();
 
   // Initialize preCICE internally
-  double allowed_time_step_size = precice->initialize();
+  double time_until_next_coupling_window = precice->initialize();
 
   // Only the writer needs potentially to process the coupling mesh, if the
   // mapping is carried out in the solver
@@ -319,7 +319,7 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::initialize_precice(
   //                                   read_nodes_ids.size(),
   //                                   read_nodes_ids.data(),
   //                                   read_data.data());
-  return allowed_time_step_size;
+  return time_until_next_coupling_window;
 }
 
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>

--- a/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
+++ b/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
@@ -93,8 +93,10 @@ public:
    *             individual configuration and preCICE determines it
    *             automatically. In many cases, this data will just represent
    *             your initial condition.
+   *
+   * @return     double the allowed time-step size until the next coupling time-window is reached
    */
-  void
+  double
   initialize_precice(VectorType const & dealii_to_precice);
 
   void
@@ -115,9 +117,13 @@ public:
                    std::vector<std::string> const &                               read_data_name);
 
   /**
-   * @brief      Advances preCICE after every timestep
+   * @brief Advances preCICE after every timestep
+   *
+   * @param computed_timestep_length the time-step size computed by the solver
+   *
+   * @return double the allowed time-step size until the next coupling time-window is reached
    */
-  void
+  double
   advance(double const computed_timestep_length);
 
   /**
@@ -283,7 +289,7 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::add_read_surface(
 
 
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
-void
+double
 Adapter<dim, data_dim, VectorType, VectorizedArrayType>::initialize_precice(
   VectorType const & dealii_to_precice)
 {
@@ -291,7 +297,7 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::initialize_precice(
   //   dealii_to_precice.update_ghost_values();
 
   // Initialize preCICE internally
-  precice->initialize();
+  double allowed_time_step_size = precice->initialize();
 
   // Only the writer needs potentially to process the coupling mesh, if the
   // mapping is carried out in the solver
@@ -313,6 +319,7 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::initialize_precice(
   //                                   read_nodes_ids.size(),
   //                                   read_nodes_ids.data(),
   //                                   read_data.data());
+  return allowed_time_step_size;
 }
 
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
@@ -328,14 +335,13 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::write_data(
 }
 
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
-void
+double
 Adapter<dim, data_dim, VectorType, VectorizedArrayType>::advance(
   double const computed_timestep_length)
 {
   // Here, we need to specify the computed time step length and pass it to
   // preCICE
-  // TODO: The function returns the available time-step size which is required for time-step sync
-  precice->advance(computed_timestep_length);
+  return precice->advance(computed_timestep_length);
 }
 
 


### PR DESCRIPTION
As promised in #209. While doing this, I realized that subcycling is somewhat challenging and I guess the effort doesn't pay off right now. The current implementation would essentially do the same as ExaDG's implementation in terms of the time-step size, i.e., an adaptive time stepping for staggered coupling schemes and a constant time-window size for parallel coupling schemes. I tried to document capabilities in a more comprehensive way in the code. 