### PR TITLE
use EXADG_WITH_LIKWID instead of LIKWID_PERFMON in ExaDG code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,11 @@ ENDIF()
 # LIKWID
 OPTION(EXADG_WITH_LIKDWID "Use LIKWID" OFF)
 IF(${EXADG_WITH_LIKWID})
+    ADD_DEFINITIONS(-DEXADG_WITH_LIKWID)
     FIND_LIBRARY(LIKWID likwid HINTS ${LIKWID_LIB})
     MESSAGE(STATUS "Found LIKWID lib at ${LIKWID}")
+    # The macro LIKWID_PERFMON is used inside Likwid, i.e., we need to pass
+    # that precise macro into the Likwid machinery for compilation.
     TARGET_COMPILE_DEFINITIONS(exadg PUBLIC LIKWID_PERFMON)
     TARGET_INCLUDE_DIRECTORIES(exadg PUBLIC ${LIKWID_INCLUDE})
     TARGET_LINK_LIBRARIES(exadg ${LIKWID})

--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -20,7 +20,7 @@
  */
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 

--- a/include/exadg/compressible_navier_stokes/throughput.h
+++ b/include/exadg/compressible_navier_stokes/throughput.h
@@ -22,7 +22,7 @@
 #ifndef INCLUDE_EXADG_COMPRESSIBLE_NAVIER_STOKES_THROUGHPUT_H_
 #define INCLUDE_EXADG_COMPRESSIBLE_NAVIER_STOKES_THROUGHPUT_H_
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 
@@ -103,7 +103,7 @@ run(ThroughputParameters const & throughput,
 int
 main(int argc, char ** argv)
 {
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_INIT;
 #endif
 
@@ -172,7 +172,7 @@ main(int argc, char ** argv)
   if(not(general.is_test))
     throughput.print_results(mpi_comm);
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_CLOSE;
 #endif
 

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -20,7 +20,7 @@
  */
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 

--- a/include/exadg/convection_diffusion/throughput.h
+++ b/include/exadg/convection_diffusion/throughput.h
@@ -23,7 +23,7 @@
 #define INCLUDE_EXADG_CONVECTION_DIFFUSION_THROUGHPUT_H_
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 
@@ -111,7 +111,7 @@ run(ThroughputParameters const & throughput,
 int
 main(int argc, char ** argv)
 {
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_INIT;
 #endif
 
@@ -180,7 +180,7 @@ main(int argc, char ** argv)
   if(not(general.is_test))
     throughput.print_results(mpi_comm);
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_CLOSE;
 #endif
 

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -20,7 +20,7 @@
  */
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 

--- a/include/exadg/incompressible_navier_stokes/throughput.h
+++ b/include/exadg/incompressible_navier_stokes/throughput.h
@@ -23,7 +23,7 @@
 #define INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_THROUGHPUT_H_
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 
@@ -105,7 +105,7 @@ run(ThroughputParameters const & throughput,
 int
 main(int argc, char ** argv)
 {
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_INIT;
 #endif
 
@@ -174,7 +174,7 @@ main(int argc, char ** argv)
   if(not(general.is_test))
     throughput.print_results(mpi_comm);
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_CLOSE;
 #endif
 

--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -20,7 +20,7 @@
  */
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 

--- a/include/exadg/poisson/throughput.h
+++ b/include/exadg/poisson/throughput.h
@@ -23,7 +23,7 @@
 #define INCLUDE_EXADG_POISSON_THROUGHPUT_H_
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 
@@ -109,7 +109,7 @@ run(ThroughputParameters const & throughput,
 int
 main(int argc, char ** argv)
 {
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_INIT;
 #endif
 
@@ -176,7 +176,7 @@ main(int argc, char ** argv)
   if(not(general.is_test))
     throughput.print_results(mpi_comm);
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_CLOSE;
 #endif
 

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -20,7 +20,7 @@
  */
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 

--- a/include/exadg/structure/throughput.h
+++ b/include/exadg/structure/throughput.h
@@ -23,7 +23,7 @@
 #define INCLUDE_EXADG_STRUCTURE_THROUGHPUT_H_
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 
@@ -109,7 +109,7 @@ run(ThroughputParameters const & throughput,
 int
 main(int argc, char ** argv)
 {
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_INIT;
 #endif
 
@@ -178,7 +178,7 @@ main(int argc, char ** argv)
   if(not(general.is_test))
     throughput.print_results(mpi_comm);
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
   LIKWID_MARKER_CLOSE;
 #endif
 

--- a/include/exadg/utilities/measure_minimum_time.h
+++ b/include/exadg/utilities/measure_minimum_time.h
@@ -53,7 +53,7 @@ private:
     for(int i = 0; i < best_of; i++)
     {
       MPI_Barrier(mpi_comm);
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
       std::string likwid_label = label + likwid_suffix;
       LIKWID_MARKER_START(likwid_label.c_str());
 #else
@@ -63,7 +63,7 @@ private:
       f();
       MPI_Barrier(mpi_comm);
       double temp = time.wall_time();
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
       LIKWID_MARKER_STOP(likwid_label.c_str());
 #endif
       double temp_global;

--- a/include/exadg/utilities/throughput_parameters.h
+++ b/include/exadg/utilities/throughput_parameters.h
@@ -23,7 +23,7 @@
 #define INCLUDE_EXADG_UTILITIES_THROUGHPUT_PARAMETERS_H_
 
 // likwid
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
 #  include <likwid.h>
 #endif
 
@@ -57,7 +57,7 @@ measure_operator_evaluation_time(std::function<void(void)> const & evaluate_oper
       dealii::Timer timer;
       timer.restart();
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
       LIKWID_MARKER_START(("degree_" + std::to_string(degree)).c_str());
 #endif
 
@@ -67,7 +67,7 @@ measure_operator_evaluation_time(std::function<void(void)> const & evaluate_oper
         evaluate_operator();
       }
 
-#ifdef LIKWID_PERFMON
+#ifdef EXADG_WITH_LIKWID
       LIKWID_MARKER_STOP(("degree_" + std::to_string(degree)).c_str());
 #endif
 


### PR DESCRIPTION
related to comment https://github.com/exadg/exadg/pull/207#discussion_r842460458.

I think we should not use `LIKWID_PERFMON` in the ExaDG code, but only in the top-level CMakeLists.txt file (in the section dealing with likwid).

@kronbichler what do you think?