### PR TITLE
Fix missing "map" include

### DIFF
--- a/include/exadg/functions_and_boundary_conditions/function_cached.h
+++ b/include/exadg/functions_and_boundary_conditions/function_cached.h
@@ -24,6 +24,7 @@
 
 // deal.II
 #include <deal.II/base/tensor.h>
+#include <map>
 
 namespace ExaDG
 {


### PR DESCRIPTION
Using deal.II 9.3 and gcc 9.2. I run into the following error

```bash
~/exadg/include/exadg/functions_and_boundary_conditions/function_cached.h:45:36: error: ‘map’ in namespace ‘std’ does not name a template type
   45 |   using MapVectorIndex      = std::map<Id, dealii::types::global_dof_index>;
      |                                    ^~~
~/exadg/include/exadg/functions_and_boundary_conditions/function_cached.h:27:1: note: ‘std::map’ is defined in header ‘<map>’; did you forget to ‘#include <map>’?
   26 | #include <deal.II/base/tensor.h>
  +++ |+#include <map>
```