### PR TITLE
always compile preCICE based FSI (also when preCICE is not installed)

### DIFF
--- a/applications/fluid_structure_interaction/perpendicular_flap/CMakeLists.txt
+++ b/applications/fluid_structure_interaction/perpendicular_flap/CMakeLists.txt
@@ -25,12 +25,8 @@
 #
 #########################################################################
 
-IF(${EXADG_WITH_PRECICE})
-
 TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
 
 PROJECT(${TARGET_NAME})
 
 EXADG_PICKUP_EXE(solver_precice.cpp ${TARGET_NAME} solver_precice)
-
-ENDIF()


### PR DESCRIPTION
We need this in order to detect compilation errors in the preCICE-based FSI code when developing ExaDG (where we can not require developers to install preCICE).

For example, the present PR is required to proceed with #230 .

As a potential follow-up, a more elegant solution might be to define `precice::SolverInterface` (only the relevant functions used in ExaDG) for `#ifndef EXADG_WITH_PRECICE` in the precice-based FSI code in ExaDG. Then, only a single ifdef might be needed. 