### PR TITLE
Only evaluate quantities if necessary

### DIFF
--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -271,9 +271,8 @@ private:
     pp_data.output_data.time_control_data.is_active        = this->output_parameters.write;
     pp_data.output_data.time_control_data.start_time       = start_time;
     pp_data.output_data.time_control_data.trigger_interval = (end_time - start_time) / 20.0;
-    pp_data.output_data.directory = this->output_parameters.directory + "vtu/";
-    pp_data.output_data.filename  = this->output_parameters.filename;
-    pp_data.calculate_velocity = true; // activate this for kinetic energy calculations (see below)
+    pp_data.output_data.directory         = this->output_parameters.directory + "vtu/";
+    pp_data.output_data.filename          = this->output_parameters.filename;
     pp_data.output_data.write_pressure    = true;
     pp_data.output_data.write_velocity    = true;
     pp_data.output_data.write_temperature = true;

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -252,8 +252,7 @@ public:
     if(statistics_turb_ch->time_control_statistics.time_control.needs_evaluation(time,
                                                                                  time_step_number))
     {
-      statistics_turb_ch->evaluate(evaluate_get(this->velocity,
-                                                Utilities::is_unsteady_timestep(time_step_number)),
+      statistics_turb_ch->evaluate(evaluate_get(this->velocity),
                                    Utilities::is_unsteady_timestep(time_step_number));
     }
 

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -252,7 +252,8 @@ public:
     if(statistics_turb_ch->time_control_statistics.time_control.needs_evaluation(time,
                                                                                  time_step_number))
     {
-      statistics_turb_ch->evaluate(this->velocity,
+      statistics_turb_ch->evaluate(evaluate_get(this->velocity,
+                                                Utilities::is_unsteady_timestep(time_step_number)),
                                    Utilities::is_unsteady_timestep(time_step_number));
     }
 
@@ -412,9 +413,8 @@ private:
     pp_data.output_data.time_control_data.is_active        = this->output_parameters.write;
     pp_data.output_data.time_control_data.start_time       = START_TIME;
     pp_data.output_data.time_control_data.trigger_interval = 1.0;
-    pp_data.output_data.directory = this->output_parameters.directory + "vtu/";
-    pp_data.output_data.filename  = this->output_parameters.filename;
-    pp_data.calculate_velocity = true; // activate this for kinetic energy calculations (see below)
+    pp_data.output_data.directory          = this->output_parameters.directory + "vtu/";
+    pp_data.output_data.filename           = this->output_parameters.filename;
     pp_data.output_data.write_pressure     = true;
     pp_data.output_data.write_velocity     = true;
     pp_data.output_data.write_temperature  = true;

--- a/include/exadg/compressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/output_generator.h
@@ -93,10 +93,10 @@ public:
         OutputData const &              output_data_in);
 
   void
-  evaluate(VectorType const &                              solution_conserved,
-           std::vector<SolutionField<dim, Number>> const & additional_fields,
-           double const                                    time,
-           bool const                                      unsteady);
+  evaluate(VectorType const &                                                    solution_conserved,
+           std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
+           double const                                                          time,
+           bool const                                                            unsteady);
 
   TimeControl time_control;
 

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -102,8 +102,7 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
   if(output_generator.time_control.needs_evaluation(time, time_step_number))
   {
     output_generator.evaluate(solution,
-                              evaluate_get(additional_fields_vtu,
-                                           Utilities::is_unsteady_timestep(time_step_number)),
+                              evaluate_get(additional_fields_vtu),
                               time,
                               Utilities::is_unsteady_timestep(time_step_number));
   }
@@ -127,27 +126,22 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
    *  calculation of lift and drag coefficients
    */
   if(lift_and_drag_calculator.time_control.needs_evaluation(time, time_step_number))
-    lift_and_drag_calculator.evaluate(
-      evaluate_get(velocity, Utilities::is_unsteady_timestep(time_step_number)),
-      evaluate_get(pressure, Utilities::is_unsteady_timestep(time_step_number)),
-      time);
+    lift_and_drag_calculator.evaluate(evaluate_get(velocity), evaluate_get(pressure), time);
 
   /*
    *  calculation of pressure difference
    */
   if(pressure_difference_calculator.time_control.needs_evaluation(time, time_step_number))
-    pressure_difference_calculator.evaluate(
-      evaluate_get(pressure, Utilities::is_unsteady_timestep(time_step_number)), time);
+    pressure_difference_calculator.evaluate(evaluate_get(pressure), time);
 
   /*
    *  calculation of kinetic energy
    */
   if(kinetic_energy_calculator.time_control.needs_evaluation(time, time_step_number))
   {
-    kinetic_energy_calculator.evaluate(
-      evaluate_get(velocity, Utilities::is_unsteady_timestep(time_step_number)),
-      time,
-      Utilities::is_unsteady_timestep(time_step_number));
+    kinetic_energy_calculator.evaluate(evaluate_get(velocity),
+                                       time,
+                                       Utilities::is_unsteady_timestep(time_step_number));
   }
 
   /*
@@ -155,10 +149,9 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
    */
   if(kinetic_energy_spectrum_calculator.time_control.needs_evaluation(time, time_step_number))
   {
-    kinetic_energy_spectrum_calculator.evaluate(
-      evaluate_get(velocity, Utilities::is_unsteady_timestep(time_step_number)),
-      time,
-      Utilities::is_unsteady_timestep(time_step_number));
+    kinetic_energy_spectrum_calculator.evaluate(evaluate_get(velocity),
+                                                time,
+                                                Utilities::is_unsteady_timestep(time_step_number));
   }
 }
 
@@ -173,7 +166,7 @@ PostProcessor<dim, Number>::initialize_additional_vectors()
     pressure.name        = "pressure";
     pressure.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
     navier_stokes_operator->initialize_dof_vector_scalar(pressure.get_vector_reference());
-    pressure.recompute_solution_field = [&](VectorType & dst, VectorType const & src, bool const) {
+    pressure.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_pressure(dst, src);
     };
 
@@ -192,7 +185,7 @@ PostProcessor<dim, Number>::initialize_additional_vectors()
     velocity.name        = "velocity";
     velocity.dof_handler = &navier_stokes_operator->get_dof_handler_vector();
     navier_stokes_operator->initialize_dof_vector_dim_components(velocity.get_vector_reference());
-    velocity.recompute_solution_field = [&](VectorType & dst, VectorType const & src, bool const) {
+    velocity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_velocity(dst, src);
     };
 
@@ -207,10 +200,9 @@ PostProcessor<dim, Number>::initialize_additional_vectors()
     temperature.name        = "temperature";
     temperature.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
     navier_stokes_operator->initialize_dof_vector_scalar(temperature.get_vector_reference());
-    temperature.recompute_solution_field =
-      [&](VectorType & dst, VectorType const & src, bool const) {
-        navier_stokes_operator->compute_temperature(dst, src);
-      };
+    temperature.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
+      navier_stokes_operator->compute_temperature(dst, src);
+    };
 
     additional_fields_vtu.push_back(&temperature);
   }
@@ -222,7 +214,7 @@ PostProcessor<dim, Number>::initialize_additional_vectors()
     vorticity.name        = "vorticity";
     vorticity.dof_handler = &navier_stokes_operator->get_dof_handler_vector();
     navier_stokes_operator->initialize_dof_vector_dim_components(vorticity.get_vector_reference());
-    vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const &, bool const) {
+    vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const &) {
       navier_stokes_operator->compute_vorticity(dst, velocity.get_vector());
     };
 
@@ -236,7 +228,7 @@ PostProcessor<dim, Number>::initialize_additional_vectors()
     divergence.name        = "velocity_divergence";
     divergence.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
     navier_stokes_operator->initialize_dof_vector_scalar(divergence.get_vector_reference());
-    divergence.recompute_solution_field = [&](VectorType & dst, VectorType const &, bool const) {
+    divergence.recompute_solution_field = [&](VectorType & dst, VectorType const &) {
       navier_stokes_operator->compute_divergence(dst, velocity.get_vector());
     };
 

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -94,10 +94,7 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
                                               double const           time,
                                               types::time_step const time_step_number)
 {
-  /*
-   * calculate derived quantities such as velocity, pressure, etc.
-   */
-  calculate_additional_vectors(solution);
+  reinit_additional_fields(solution);
 
   /*
    *  write output
@@ -105,7 +102,8 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
   if(output_generator.time_control.needs_evaluation(time, time_step_number))
   {
     output_generator.evaluate(solution,
-                              additional_fields,
+                              evaluate_get(additional_fields_vtu,
+                                           Utilities::is_unsteady_timestep(time_step_number)),
                               time,
                               Utilities::is_unsteady_timestep(time_step_number));
   }
@@ -129,22 +127,27 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
    *  calculation of lift and drag coefficients
    */
   if(lift_and_drag_calculator.time_control.needs_evaluation(time, time_step_number))
-    lift_and_drag_calculator.evaluate(velocity, pressure, time);
+    lift_and_drag_calculator.evaluate(
+      evaluate_get(velocity, Utilities::is_unsteady_timestep(time_step_number)),
+      evaluate_get(pressure, Utilities::is_unsteady_timestep(time_step_number)),
+      time);
 
   /*
    *  calculation of pressure difference
    */
   if(pressure_difference_calculator.time_control.needs_evaluation(time, time_step_number))
-    pressure_difference_calculator.evaluate(pressure, time);
+    pressure_difference_calculator.evaluate(
+      evaluate_get(pressure, Utilities::is_unsteady_timestep(time_step_number)), time);
 
   /*
    *  calculation of kinetic energy
    */
   if(kinetic_energy_calculator.time_control.needs_evaluation(time, time_step_number))
   {
-    kinetic_energy_calculator.evaluate(velocity,
-                                       time,
-                                       Utilities::is_unsteady_timestep(time_step_number));
+    kinetic_energy_calculator.evaluate(
+      evaluate_get(velocity, Utilities::is_unsteady_timestep(time_step_number)),
+      time,
+      Utilities::is_unsteady_timestep(time_step_number));
   }
 
   /*
@@ -152,9 +155,10 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
    */
   if(kinetic_energy_spectrum_calculator.time_control.needs_evaluation(time, time_step_number))
   {
-    kinetic_energy_spectrum_calculator.evaluate(velocity,
-                                                time,
-                                                Utilities::is_unsteady_timestep(time_step_number));
+    kinetic_energy_spectrum_calculator.evaluate(
+      evaluate_get(velocity, Utilities::is_unsteady_timestep(time_step_number)),
+      time,
+      Utilities::is_unsteady_timestep(time_step_number));
   }
 }
 
@@ -162,109 +166,93 @@ template<int dim, typename Number>
 void
 PostProcessor<dim, Number>::initialize_additional_vectors()
 {
-  if(pp_data.output_data.write_pressure == true)
+  if(pp_data.output_data.write_pressure || pp_data.lift_and_drag_data.time_control_data.is_active ||
+     pp_data.pressure_difference_data.time_control_data.is_active)
   {
-    navier_stokes_operator->initialize_dof_vector_scalar(pressure);
+    pressure.type        = SolutionFieldType::scalar;
+    pressure.name        = "pressure";
+    pressure.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
+    navier_stokes_operator->initialize_dof_vector_scalar(pressure.get_vector_reference());
+    pressure.recompute_solution_field = [&](VectorType & dst, VectorType const & src, bool const) {
+      navier_stokes_operator->compute_pressure(dst, src);
+    };
 
-    SolutionField<dim, Number> field;
-    field.type        = SolutionFieldType::scalar;
-    field.name        = "pressure";
-    field.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
-    field.vector      = &pressure;
-    additional_fields.push_back(field);
+    if(pp_data.output_data.write_pressure)
+      additional_fields_vtu.push_back(&pressure);
   }
 
   // velocity
-  if(pp_data.output_data.write_velocity == true)
+  if(pp_data.output_data.write_velocity || pp_data.output_data.write_vorticity ||
+     pp_data.output_data.write_divergence ||
+     pp_data.lift_and_drag_data.time_control_data.is_active ||
+     pp_data.kinetic_energy_data.time_control_data.is_active ||
+     pp_data.kinetic_energy_spectrum_data.time_control_data.is_active)
   {
-    navier_stokes_operator->initialize_dof_vector_dim_components(velocity);
+    velocity.type        = SolutionFieldType::vector;
+    velocity.name        = "velocity";
+    velocity.dof_handler = &navier_stokes_operator->get_dof_handler_vector();
+    navier_stokes_operator->initialize_dof_vector_dim_components(velocity.get_vector_reference());
+    velocity.recompute_solution_field = [&](VectorType & dst, VectorType const & src, bool const) {
+      navier_stokes_operator->compute_velocity(dst, src);
+    };
 
-    SolutionField<dim, Number> field;
-    field.type        = SolutionFieldType::vector;
-    field.name        = "velocity";
-    field.dof_handler = &navier_stokes_operator->get_dof_handler_vector();
-    field.vector      = &velocity;
-    additional_fields.push_back(field);
+    if(pp_data.output_data.write_velocity)
+      additional_fields_vtu.push_back(&velocity);
   }
 
   // temperature
-  if(pp_data.output_data.write_temperature == true)
+  if(pp_data.output_data.write_temperature)
   {
-    navier_stokes_operator->initialize_dof_vector_scalar(temperature);
+    temperature.type        = SolutionFieldType::scalar;
+    temperature.name        = "temperature";
+    temperature.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
+    navier_stokes_operator->initialize_dof_vector_scalar(temperature.get_vector_reference());
+    temperature.recompute_solution_field =
+      [&](VectorType & dst, VectorType const & src, bool const) {
+        navier_stokes_operator->compute_temperature(dst, src);
+      };
 
-    SolutionField<dim, Number> field;
-    field.type        = SolutionFieldType::scalar;
-    field.name        = "temperature";
-    field.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
-    field.vector      = &temperature;
-    additional_fields.push_back(field);
+    additional_fields_vtu.push_back(&temperature);
   }
 
   // vorticity
-  if(pp_data.output_data.write_vorticity == true)
+  if(pp_data.output_data.write_vorticity)
   {
-    navier_stokes_operator->initialize_dof_vector_dim_components(vorticity);
+    vorticity.type        = SolutionFieldType::vector;
+    vorticity.name        = "vorticity";
+    vorticity.dof_handler = &navier_stokes_operator->get_dof_handler_vector();
+    navier_stokes_operator->initialize_dof_vector_dim_components(vorticity.get_vector_reference());
+    vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const &, bool const) {
+      navier_stokes_operator->compute_vorticity(dst, velocity.get_vector());
+    };
 
-    SolutionField<dim, Number> field;
-    field.type        = SolutionFieldType::vector;
-    field.name        = "vorticity";
-    field.dof_handler = &navier_stokes_operator->get_dof_handler_vector();
-    field.vector      = &vorticity;
-    additional_fields.push_back(field);
+    additional_fields_vtu.push_back(&vorticity);
   }
 
   // divergence
-  if(pp_data.output_data.write_divergence == true)
+  if(pp_data.output_data.write_divergence)
   {
-    navier_stokes_operator->initialize_dof_vector_scalar(divergence);
+    divergence.type        = SolutionFieldType::scalar;
+    divergence.name        = "velocity_divergence";
+    divergence.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
+    navier_stokes_operator->initialize_dof_vector_scalar(divergence.get_vector_reference());
+    divergence.recompute_solution_field = [&](VectorType & dst, VectorType const &, bool const) {
+      navier_stokes_operator->compute_divergence(dst, velocity.get_vector());
+    };
 
-    SolutionField<dim, Number> field;
-    field.type        = SolutionFieldType::scalar;
-    field.name        = "velocity_divergence";
-    field.dof_handler = &navier_stokes_operator->get_dof_handler_scalar();
-    field.vector      = &divergence;
-    additional_fields.push_back(field);
+    additional_fields_vtu.push_back(&divergence);
   }
 }
 
 template<int dim, typename Number>
 void
-PostProcessor<dim, Number>::calculate_additional_vectors(VectorType const & solution)
+PostProcessor<dim, Number>::reinit_additional_fields(VectorType const & solution)
 {
-  if((pp_data.output_data.time_control_data.is_active == true &&
-      pp_data.output_data.write_pressure == true) ||
-     pp_data.calculate_pressure == true)
-  {
-    navier_stokes_operator->compute_pressure(pressure, solution);
-  }
-
-  if((pp_data.output_data.time_control_data.is_active == true &&
-      pp_data.output_data.write_velocity == true) ||
-     (pp_data.output_data.time_control_data.is_active == true &&
-      pp_data.output_data.write_vorticity == true) ||
-     (pp_data.output_data.time_control_data.is_active == true &&
-      pp_data.output_data.write_divergence == true) ||
-     pp_data.calculate_velocity == true)
-  {
-    navier_stokes_operator->compute_velocity(velocity, solution);
-  }
-
-  if(pp_data.output_data.time_control_data.is_active &&
-     pp_data.output_data.write_temperature == true)
-  {
-    navier_stokes_operator->compute_temperature(temperature, solution);
-  }
-
-  if(pp_data.output_data.time_control_data.is_active && pp_data.output_data.write_vorticity == true)
-  {
-    navier_stokes_operator->compute_vorticity(vorticity, velocity);
-  }
-
-  if(pp_data.output_data.time_control_data.is_active == true &&
-     pp_data.output_data.write_divergence == true)
-  {
-    navier_stokes_operator->compute_divergence(divergence, velocity);
-  }
+  pressure.reinit(solution);
+  velocity.reinit(solution);
+  temperature.reinit(solution);
+  vorticity.reinit(solution);
+  divergence.reinit(solution);
 }
 
 template class PostProcessor<2, float>;

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
@@ -38,13 +38,6 @@ namespace CompNS
 template<int dim>
 struct PostProcessorData
 {
-  PostProcessorData() : calculate_velocity(false), calculate_pressure(false)
-  {
-  }
-
-  bool calculate_velocity;
-  bool calculate_pressure;
-
   OutputData                  output_data;
   PointwiseOutputData<dim>    pointwise_output_data;
   ErrorCalculationData<dim>   error_data;
@@ -73,21 +66,20 @@ public:
                     types::time_step const time_step_number) override;
 
 protected:
-  // DoF vectors for derived quantities: (p, u, T)
-  VectorType pressure;
-  VectorType velocity;
-  VectorType temperature;
-  VectorType vorticity;
-  VectorType divergence;
+  SolutionField<dim, Number> pressure;
+  SolutionField<dim, Number> velocity;
+  SolutionField<dim, Number> temperature;
+  SolutionField<dim, Number> vorticity;
+  SolutionField<dim, Number> divergence;
 
-  std::vector<SolutionField<dim, Number>> additional_fields;
+  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> additional_fields_vtu;
 
 private:
   void
   initialize_additional_vectors();
 
   void
-  calculate_additional_vectors(VectorType const & solution);
+  reinit_additional_fields(VectorType const & solution);
 
   MPI_Comm const mpi_comm;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
@@ -37,15 +37,16 @@ namespace IncNS
 {
 template<int dim, typename Number>
 void
-write_output(OutputData const &                                         output_data,
-             dealii::DoFHandler<dim> const &                            dof_handler_velocity,
-             dealii::DoFHandler<dim> const &                            dof_handler_pressure,
-             dealii::Mapping<dim> const &                               mapping,
-             dealii::LinearAlgebra::distributed::Vector<Number> const & velocity,
-             dealii::LinearAlgebra::distributed::Vector<Number> const & pressure,
-             std::vector<SolutionField<dim, Number>> const &            additional_fields,
-             unsigned int const                                         output_counter,
-             MPI_Comm const &                                           mpi_comm)
+write_output(
+  OutputData const &                                                    output_data,
+  dealii::DoFHandler<dim> const &                                       dof_handler_velocity,
+  dealii::DoFHandler<dim> const &                                       dof_handler_pressure,
+  dealii::Mapping<dim> const &                                          mapping,
+  dealii::LinearAlgebra::distributed::Vector<Number> const &            velocity,
+  dealii::LinearAlgebra::distributed::Vector<Number> const &            pressure,
+  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
+  unsigned int const                                                    output_counter,
+  MPI_Comm const &                                                      mpi_comm)
 {
   std::string folder = output_data.directory, file = output_data.filename;
 
@@ -78,27 +79,29 @@ write_output(OutputData const &                                         output_d
     data_out.add_data_vector(aspect_ratios, "aspect_ratio");
   }
 
-  for(typename std::vector<SolutionField<dim, Number>>::const_iterator it =
-        additional_fields.begin();
-      it != additional_fields.end();
-      ++it)
+  for(auto & additional_field : additional_fields)
   {
-    if(it->type == SolutionFieldType::scalar)
+    if(additional_field->get_type() == SolutionFieldType::scalar)
     {
-      data_out.add_data_vector(*it->dof_handler, *it->vector, it->name);
+      data_out.add_data_vector(additional_field->get_dof_handler(),
+                               additional_field->get_vector(),
+                               additional_field->get_name());
     }
-    else if(it->type == SolutionFieldType::cellwise)
+    else if(additional_field->get_type() == SolutionFieldType::cellwise)
     {
-      data_out.add_data_vector(*it->vector, it->name);
+      data_out.add_data_vector(additional_field->get_vector(), additional_field->get_name());
     }
-    else if(it->type == SolutionFieldType::vector)
+    else if(additional_field->get_type() == SolutionFieldType::vector)
     {
-      std::vector<std::string> names(dim, it->name);
+      std::vector<std::string> names(dim, additional_field->get_name());
       std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
         component_interpretation(dim,
                                  dealii::DataComponentInterpretation::component_is_part_of_vector);
 
-      data_out.add_data_vector(*it->dof_handler, *it->vector, names, component_interpretation);
+      data_out.add_data_vector(additional_field->get_dof_handler(),
+                               additional_field->get_vector(),
+                               names,
+                               component_interpretation);
     }
     else
     {
@@ -180,11 +183,11 @@ OutputGenerator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_
 template<int dim, typename Number>
 void
 OutputGenerator<dim, Number>::evaluate(
-  VectorType const &                              velocity,
-  VectorType const &                              pressure,
-  std::vector<SolutionField<dim, Number>> const & additional_fields,
-  double const                                    time,
-  bool const                                      unsteady)
+  VectorType const &                                                    velocity,
+  VectorType const &                                                    pressure,
+  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
+  double const                                                          time,
+  bool const                                                            unsteady)
 {
   print_write_output_time(time, time_control.get_counter(), unsteady, mpi_comm);
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
@@ -116,11 +116,11 @@ public:
         OutputData const &              output_data_in);
 
   void
-  evaluate(VectorType const &                              velocity,
-           VectorType const &                              pressure,
-           std::vector<SolutionField<dim, Number>> const & additional_fields,
-           double const                                    time,
-           bool const                                      unsteady);
+  evaluate(VectorType const &                                                    velocity,
+           VectorType const &                                                    pressure,
+           std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
+           double const                                                          time,
+           bool const                                                            unsteady);
 
   TimeControl time_control;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -109,12 +109,17 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     velocity,
                                               double const           time,
                                               types::time_step const time_step_number)
 {
-  // TODO: NOTE THAT CALLING THE FUNCTION HERE RESULTS IN SLOWER CODE. THIS IS REPORTED AN RESOLVED
-  // IN PR #245. SO WE SHOULD ONLY MERGE THIS PR IF ALSO #245 IS READY
+  reinit_additional_fields(velocity);
+
   /*
-   * calculate derived quantities such as vorticity, divergence, etc.
+   *  compute mean velocity
    */
-  calculate_additional_vectors(velocity, time, time_step_number);
+  if(time_control_mean_velocity.needs_evaluation(time, time_step_number))
+  {
+    if(time_control_mean_velocity.needs_evaluation(time, time_step_number))
+      mean_velocity.evaluate(Utilities::is_unsteady_timestep(time_step_number));
+  }
+
 
   /*
    *  write output
@@ -123,7 +128,8 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     velocity,
   {
     output_generator.evaluate(velocity,
                               pressure,
-                              additional_fields,
+                              evaluate_get(additional_fields_vtu,
+                                           Utilities::is_unsteady_timestep(time_step_number)),
                               time,
                               Utilities::is_unsteady_timestep(time_step_number));
   }
@@ -193,103 +199,126 @@ PostProcessor<dim, Number>::initialize_additional_vectors()
   if(pp_data.output_data.write_vorticity || pp_data.output_data.write_streamfunction ||
      pp_data.output_data.write_vorticity_magnitude)
   {
-    navier_stokes_operator->initialize_vector_velocity(vorticity);
+    vorticity.type        = SolutionFieldType::vector;
+    vorticity.name        = "vorticity";
+    vorticity.dof_handler = &navier_stokes_operator->get_dof_handler_u();
+    navier_stokes_operator->initialize_vector_velocity(vorticity.get_vector_reference());
+    vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const & src, bool const) {
+      navier_stokes_operator->compute_vorticity(dst, src);
+    };
 
-    SolutionField<dim, Number> sol;
-    sol.type        = SolutionFieldType::vector;
-    sol.name        = "vorticity";
-    sol.dof_handler = &navier_stokes_operator->get_dof_handler_u();
-    sol.vector      = &vorticity;
-    this->additional_fields.push_back(sol);
+    this->additional_fields_vtu.push_back(&vorticity);
   }
 
   // divergence
-  if(pp_data.output_data.write_divergence == true)
+  if(pp_data.output_data.write_divergence)
   {
-    navier_stokes_operator->initialize_vector_velocity_scalar(divergence);
+    divergence.type        = SolutionFieldType::vector;
+    divergence.name        = "div_u";
+    divergence.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
+    navier_stokes_operator->initialize_vector_velocity_scalar(divergence.get_vector_reference());
+    divergence.recompute_solution_field =
+      [&](VectorType & dst, VectorType const & src, bool const) {
+        navier_stokes_operator->compute_divergence(dst, src);
+      };
 
-    SolutionField<dim, Number> sol;
-    sol.type        = SolutionFieldType::scalar;
-    sol.name        = "div_u";
-    sol.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
-    sol.vector      = &divergence;
-    this->additional_fields.push_back(sol);
+    this->additional_fields_vtu.push_back(&divergence);
   }
 
   // velocity magnitude
-  if(pp_data.output_data.write_velocity_magnitude == true)
+  if(pp_data.output_data.write_velocity_magnitude)
   {
-    navier_stokes_operator->initialize_vector_velocity_scalar(velocity_magnitude);
+    velocity_magnitude.type        = SolutionFieldType::scalar;
+    velocity_magnitude.name        = "velocity_magnitude";
+    velocity_magnitude.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
+    navier_stokes_operator->initialize_vector_velocity_scalar(
+      velocity_magnitude.get_vector_reference());
+    velocity_magnitude.recompute_solution_field =
+      [&](VectorType & dst, VectorType const & src, bool const) {
+        navier_stokes_operator->compute_velocity_magnitude(dst, src);
+      };
 
-    SolutionField<dim, Number> sol;
-    sol.type        = SolutionFieldType::scalar;
-    sol.name        = "velocity_magnitude";
-    sol.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
-    sol.vector      = &velocity_magnitude;
-    this->additional_fields.push_back(sol);
+    this->additional_fields_vtu.push_back(&velocity_magnitude);
   }
 
   // vorticity magnitude
-  if(pp_data.output_data.write_vorticity_magnitude == true)
+  if(pp_data.output_data.write_vorticity_magnitude)
   {
-    navier_stokes_operator->initialize_vector_velocity_scalar(vorticity_magnitude);
+    vorticity_magnitude.type        = SolutionFieldType::scalar;
+    vorticity_magnitude.name        = "vorticity_magnitude";
+    vorticity_magnitude.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
+    navier_stokes_operator->initialize_vector_velocity_scalar(
+      vorticity_magnitude.get_vector_reference());
+    vorticity_magnitude.recompute_solution_field =
+      [&](VectorType & dst, VectorType const &, bool const unsteady) {
+        navier_stokes_operator->compute_vorticity_magnitude(dst, evaluate_get(vorticity, unsteady));
+      };
 
-    SolutionField<dim, Number> sol;
-    sol.type        = SolutionFieldType::scalar;
-    sol.name        = "vorticity_magnitude";
-    sol.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
-    sol.vector      = &vorticity_magnitude;
-    this->additional_fields.push_back(sol);
+    this->additional_fields_vtu.push_back(&vorticity_magnitude);
   }
 
 
   // streamfunction
-  if(pp_data.output_data.write_streamfunction == true)
+  if(pp_data.output_data.write_streamfunction)
   {
-    navier_stokes_operator->initialize_vector_velocity_scalar(streamfunction);
+    streamfunction.type        = SolutionFieldType::scalar;
+    streamfunction.name        = "streamfunction";
+    streamfunction.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
+    navier_stokes_operator->initialize_vector_velocity_scalar(
+      streamfunction.get_vector_reference());
+    streamfunction.recompute_solution_field =
+      [&](VectorType & dst, VectorType const &, bool const unsteady) {
+        navier_stokes_operator->compute_streamfunction(dst, evaluate_get(vorticity, unsteady));
+      };
 
-    SolutionField<dim, Number> sol;
-    sol.type        = SolutionFieldType::scalar;
-    sol.name        = "streamfunction";
-    sol.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
-    sol.vector      = &streamfunction;
-    this->additional_fields.push_back(sol);
+    this->additional_fields_vtu.push_back(&streamfunction);
   }
 
   // q criterion
-  if(pp_data.output_data.write_q_criterion == true)
+  if(pp_data.output_data.write_q_criterion)
   {
-    navier_stokes_operator->initialize_vector_velocity_scalar(q_criterion);
+    q_criterion.type        = SolutionFieldType::scalar;
+    q_criterion.name        = "q_criterion";
+    q_criterion.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
+    navier_stokes_operator->initialize_vector_velocity_scalar(q_criterion.get_vector_reference());
+    q_criterion.recompute_solution_field =
+      [&](VectorType & dst, VectorType const & src, bool const) {
+        navier_stokes_operator->compute_q_criterion(dst, src);
+      };
 
-    SolutionField<dim, Number> sol;
-    sol.type        = SolutionFieldType::scalar;
-    sol.name        = "q_criterion";
-    sol.dof_handler = &navier_stokes_operator->get_dof_handler_u_scalar();
-    sol.vector      = &q_criterion;
-    this->additional_fields.push_back(sol);
+    this->additional_fields_vtu.push_back(&q_criterion);
   }
 
   // mean velocity
-  if(pp_data.output_data.mean_velocity.is_active == true)
+  if(pp_data.output_data.mean_velocity.is_active)
   {
-    navier_stokes_operator->initialize_vector_velocity(mean_velocity);
+    mean_velocity.type        = SolutionFieldType::vector;
+    mean_velocity.name        = "mean_velocity";
+    mean_velocity.dof_handler = &navier_stokes_operator->get_dof_handler_u();
+    navier_stokes_operator->initialize_vector_velocity(mean_velocity.get_vector_reference());
+    mean_velocity.recompute_solution_field =
+      [&](VectorType & dst, VectorType const & src, bool const unsteady) {
+        compute_mean_velocity(dst, src, unsteady);
+      };
 
-    SolutionField<dim, Number> sol;
-    sol.type        = SolutionFieldType::vector;
-    sol.name        = "mean_velocity";
-    sol.dof_handler = &navier_stokes_operator->get_dof_handler_u();
-    sol.vector      = &mean_velocity;
-    this->additional_fields.push_back(sol);
+    this->additional_fields_vtu.push_back(&mean_velocity);
   }
 
   // cfl
   if(pp_data.output_data.write_cfl)
   {
-    SolutionField<dim, Number> sol;
-    sol.type   = SolutionFieldType::cellwise;
-    sol.name   = "cfl_relative";
-    sol.vector = &cfl_vector;
-    this->additional_fields.push_back(sol);
+    cfl_vector.type = SolutionFieldType::cellwise;
+    cfl_vector.name = "cfl_relative";
+    cfl_vector.recompute_solution_field =
+      [&](VectorType & dst, VectorType const & src, bool const) {
+        // This time step size corresponds to CFL = 1.
+        auto const time_step_size = navier_stokes_operator->calculate_time_step_cfl(src);
+        // The computed cell-vector of CFL values contains relative CFL numbers with a value of
+        // CFL = 1 in the most critical cell and CFL < 1 in other cells.
+        navier_stokes_operator->calculate_cfl_from_time_step(dst, src, time_step_size);
+      };
+
+    this->additional_fields_vtu.push_back(&cfl_vector);
   }
 }
 
@@ -310,72 +339,17 @@ PostProcessor<dim, Number>::compute_mean_velocity(VectorType &       mean_veloci
 
 template<int dim, typename Number>
 void
-PostProcessor<dim, Number>::calculate_additional_vectors(VectorType const &     velocity,
-                                                         double const           time,
-                                                         types::time_step const time_step_number)
+PostProcessor<dim, Number>::reinit_additional_fields(VectorType const & velocity)
 {
-  bool vorticity_is_up_to_date = false;
-  if(pp_data.output_data.write_vorticity || pp_data.output_data.write_streamfunction ||
-     pp_data.output_data.write_vorticity_magnitude)
-  {
-    navier_stokes_operator->compute_vorticity(vorticity, velocity);
-    vorticity_is_up_to_date = true;
-  }
-
-  if(pp_data.output_data.write_divergence == true)
-  {
-    navier_stokes_operator->compute_divergence(divergence, velocity);
-  }
-
-  if(pp_data.output_data.write_velocity_magnitude == true)
-  {
-    navier_stokes_operator->compute_velocity_magnitude(velocity_magnitude, velocity);
-  }
-
-  if(pp_data.output_data.write_vorticity_magnitude == true)
-  {
-    AssertThrow(vorticity_is_up_to_date == true,
-                dealii::ExcMessage(
-                  "Vorticity vector needs to be updated to compute its magnitude."));
-
-    navier_stokes_operator->compute_vorticity_magnitude(vorticity_magnitude, vorticity);
-  }
-
-  if(pp_data.output_data.write_streamfunction == true)
-  {
-    AssertThrow(vorticity_is_up_to_date == true,
-                dealii::ExcMessage(
-                  "Vorticity vector needs to be updated to compute its magnitude."));
-
-    navier_stokes_operator->compute_streamfunction(streamfunction, vorticity);
-  }
-
-  if(pp_data.output_data.write_q_criterion == true)
-  {
-    navier_stokes_operator->compute_q_criterion(q_criterion, velocity);
-  }
-
-  if(pp_data.output_data.mean_velocity.is_active == true)
-  {
-    if(time_control_mean_velocity.needs_evaluation(time, time_step_number))
-    {
-      compute_mean_velocity(mean_velocity,
-                            velocity,
-                            Utilities::is_unsteady_timestep(time_step_number));
-    }
-  }
-
-  if(pp_data.output_data.write_cfl)
-  {
-    // This time step size corresponds to CFL = 1.
-    auto const time_step_size = navier_stokes_operator->calculate_time_step_cfl(velocity);
-
-    // The computed cell-vector of CFL values contains relative CFL numbers with a value of
-    // CFL = 1 in the most critical cell and CFL < 1 in other cells.
-    navier_stokes_operator->calculate_cfl_from_time_step(cfl_vector, velocity, time_step_size);
-  }
+  vorticity.reinit(velocity);
+  divergence.reinit(velocity);
+  velocity_magnitude.reinit(velocity);
+  vorticity_magnitude.reinit(velocity);
+  streamfunction.reinit(velocity);
+  q_criterion.reinit(velocity);
+  cfl_vector.reinit(velocity);
+  mean_velocity.reinit(velocity);
 }
-
 
 template class PostProcessor<2, float>;
 template class PostProcessor<2, double>;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -95,28 +95,25 @@ private:
                         bool const         unsteady);
 
   void
-  calculate_additional_vectors(VectorType const &     velocity,
-                               double const           time,
-                               types::time_step const time_step_number);
+  reinit_additional_fields(VectorType const & velocity);
 
   PostProcessorData<dim> pp_data;
 
   dealii::SmartPointer<NavierStokesOperator const> navier_stokes_operator;
 
-
   // DoF vectors for derived quantities
-  VectorType vorticity;
-  VectorType divergence;
-  VectorType velocity_magnitude;
-  VectorType vorticity_magnitude;
-  VectorType streamfunction;
-  VectorType q_criterion;
-  VectorType cfl_vector;
+  SolutionField<dim, Number> vorticity;
+  SolutionField<dim, Number> divergence;
+  SolutionField<dim, Number> velocity_magnitude;
+  SolutionField<dim, Number> vorticity_magnitude;
+  SolutionField<dim, Number> streamfunction;
+  SolutionField<dim, Number> q_criterion;
+  SolutionField<dim, Number> cfl_vector;
 
-  TimeControl time_control_mean_velocity;
-  VectorType  mean_velocity; // velocity field averaged over time
+  TimeControl                time_control_mean_velocity;
+  SolutionField<dim, Number> mean_velocity; // velocity field averaged over time
 
-  std::vector<SolutionField<dim, Number>> additional_fields;
+  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> additional_fields_vtu;
 
   // write output for visualization of results (e.g., using paraview)
   OutputGenerator<dim, Number> output_generator;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -90,9 +90,7 @@ private:
   // TODO: FOR A MODULAR DESIGN THERE SHOULD PROBALY BE A CLASS CALLED MEAN_VECTOR_CALCULATION IN
   // WHICH RELEVANT SAMPLES CAN JUST BE SUBMITTED.
   void
-  compute_mean_velocity(VectorType &       mean_velocity,
-                        VectorType const & velocity,
-                        bool const         unsteady);
+  compute_mean_velocity(VectorType & mean_velocity, VectorType const & velocity);
 
   void
   reinit_additional_fields(VectorType const & velocity);

--- a/include/exadg/postprocessor/pressure_difference_calculation.h
+++ b/include/exadg/postprocessor/pressure_difference_calculation.h
@@ -30,6 +30,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 // ExaDG
+#include <exadg/postprocessor/solution_field.h>
 #include <exadg/postprocessor/time_control.h>
 
 namespace ExaDG

--- a/include/exadg/postprocessor/solution_field.h
+++ b/include/exadg/postprocessor/solution_field.h
@@ -41,7 +41,7 @@ public:
   using VectorType = dealii::LinearAlgebra::distributed::Vector<Number>;
 
   SolutionField()
-    : recompute_solution_field([](VectorType &, VectorType const &, bool const) {}),
+    : recompute_solution_field([](VectorType &, VectorType const &) {}),
       type(SolutionFieldType::scalar),
       name("solution"),
       dof_handler(nullptr),
@@ -58,11 +58,11 @@ public:
   }
 
   void
-  evaluate(bool const unsteady)
+  evaluate()
   {
     if(!is_available)
     {
-      recompute_solution_field(vector, *solution, unsteady);
+      recompute_solution_field(vector, *solution);
       is_available = true;
     }
   }
@@ -100,7 +100,7 @@ public:
     return type;
   }
 
-  std::function<void(VectorType &, VectorType const &, bool const)> recompute_solution_field;
+  std::function<void(VectorType &, VectorType const &)> recompute_solution_field;
 
   SolutionFieldType type;
 
@@ -116,19 +116,18 @@ private:
 
 template<int dim, typename Number>
 std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const &
-evaluate_get(std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> & vec,
-             const bool                                                      unsteady)
+evaluate_get(std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> & vec)
 {
   for(auto & v : vec)
-    v->evaluate(unsteady);
+    v->evaluate();
   return vec;
 }
 
 template<int dim, typename Number>
 typename SolutionField<dim, Number>::VectorType const &
-evaluate_get(SolutionField<dim, Number> & sol, const bool unsteady)
+evaluate_get(SolutionField<dim, Number> & sol)
 {
-  sol.evaluate(unsteady);
+  sol.evaluate();
   return sol.get_vector();
 }
 

--- a/include/exadg/postprocessor/solution_field.h
+++ b/include/exadg/postprocessor/solution_field.h
@@ -35,13 +35,72 @@ enum class SolutionFieldType
 };
 
 template<int dim, typename Number>
-class SolutionField
+class SolutionField : public dealii::Subscriptor
 {
 public:
+  using VectorType = dealii::LinearAlgebra::distributed::Vector<Number>;
+
   SolutionField()
-    : type(SolutionFieldType::scalar), name("solution"), dof_handler(nullptr), vector(nullptr)
+    : recompute_solution_field([](VectorType &, VectorType const &, bool const) {}),
+      type(SolutionFieldType::scalar),
+      name("solution"),
+      dof_handler(nullptr),
+      is_available(false),
+      solution(nullptr)
   {
   }
+
+  void
+  reinit(VectorType const & solution_in)
+  {
+    is_available = false;
+    solution     = &solution_in;
+  }
+
+  void
+  evaluate(bool const unsteady)
+  {
+    if(!is_available)
+    {
+      recompute_solution_field(vector, *solution, unsteady);
+      is_available = true;
+    }
+  }
+
+  VectorType &
+  get_vector_reference()
+  {
+    return vector;
+  }
+
+  VectorType const &
+  get_vector() const
+  {
+    AssertThrow(is_available,
+                dealii::ExcMessage("You are trying to access a Vector that is not available."));
+
+    return vector;
+  }
+
+  std::string const &
+  get_name() const
+  {
+    return name;
+  }
+
+  dealii::DoFHandler<dim> const &
+  get_dof_handler() const
+  {
+    return *dof_handler;
+  }
+
+  SolutionFieldType
+  get_type() const
+  {
+    return type;
+  }
+
+  std::function<void(VectorType &, VectorType const &, bool const)> recompute_solution_field;
 
   SolutionFieldType type;
 
@@ -49,8 +108,29 @@ public:
 
   dealii::DoFHandler<dim> const * dof_handler;
 
-  dealii::LinearAlgebra::distributed::Vector<Number> const * vector;
+private:
+  bool               is_available;
+  VectorType         vector;
+  VectorType const * solution;
 };
+
+template<int dim, typename Number>
+std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const &
+evaluate_get(std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> & vec,
+             const bool                                                      unsteady)
+{
+  for(auto & v : vec)
+    v->evaluate(unsteady);
+  return vec;
+}
+
+template<int dim, typename Number>
+typename SolutionField<dim, Number>::VectorType const &
+evaluate_get(SolutionField<dim, Number> & sol, const bool unsteady)
+{
+  sol.evaluate(unsteady);
+  return sol.get_vector();
+}
 
 } // namespace ExaDG
 


### PR DESCRIPTION
Add possibility to preprocess data before computing the error. With the current code design, such preprocessing is done in do_postprocessing() functions, which are called each time step. This PR helps to reduce the work per time step by preprocessing data only if necessary. Similar functionality should be added in some places, e.g. for the compressible NSE. If we merge this, I can tackle this in a follow-up PR when I find some time.
