### PR TITLE
fix bug introduces while deprecating old FEEval interface

### DIFF
--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -41,8 +41,8 @@ ElasticityOperatorBase<dim, Number>::get_integrator_flags(bool const unsteady) c
 {
   IntegratorFlags flags;
 
-  auto const unsteady_flag = this->operator_data.unsteady ? dealii::EvaluationFlags::values :
-                                                            dealii::EvaluationFlags::nothing;
+  auto const unsteady_flag =
+    unsteady ? dealii::EvaluationFlags::values : dealii::EvaluationFlags::nothing;
 
   flags.cell_evaluate  = unsteady_flag | dealii::EvaluationFlags::gradients;
   flags.cell_integrate = unsteady_flag | dealii::EvaluationFlags::gradients;


### PR DESCRIPTION
Obviously, the function parameter should be used. I introduced this copy and paste error in https://github.com/exadg/exadg/pull/243.