### PR TITLE
Avoid Copy

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -93,7 +93,7 @@ public:
 
     if(data.ale)
     {
-      matrix_free.initialize_dof_vector(grid_velocity, dof_index);
+      matrix_free.initialize_dof_vector(grid_velocity.own(), dof_index);
 
       AssertThrow(data.formulation == FormulationConvectiveTerm::ConvectiveFormulation,
                   dealii::ExcMessage(
@@ -159,7 +159,7 @@ public:
   }
 
   void
-  set_velocity_copy(VectorType const & src) const
+  set_velocity_copy(VectorType const & src)
   {
     velocity.own() = src;
 
@@ -167,7 +167,7 @@ public:
   }
 
   void
-  set_velocity_ptr(VectorType const & src) const
+  set_velocity_ptr(VectorType const & src)
   {
     velocity.reset(src);
 
@@ -175,16 +175,17 @@ public:
   }
 
   void
-  set_grid_velocity_ptr(VectorType const & src) const
+  set_grid_velocity_ptr(VectorType const & src)
   {
-    grid_velocity = src;
-    grid_velocity.update_ghost_values();
+    grid_velocity.reset(src);
+
+    grid_velocity->update_ghost_values();
   }
 
   VectorType const &
   get_grid_velocity() const
   {
-    return grid_velocity;
+    return *grid_velocity;
   }
 
   inline DEAL_II_ALWAYS_INLINE //
@@ -253,7 +254,7 @@ public:
                                              dealii::EvaluationFlags::gradients);
 
       if(data.ale)
-        integrator_grid_velocity->gather_evaluate(grid_velocity, dealii::EvaluationFlags::values);
+        integrator_grid_velocity->gather_evaluate(*grid_velocity, dealii::EvaluationFlags::values);
     }
     else
     {
@@ -273,7 +274,7 @@ public:
     if(data.ale)
     {
       integrator_grid_velocity_face->reinit(face);
-      integrator_grid_velocity_face->gather_evaluate(grid_velocity,
+      integrator_grid_velocity_face->gather_evaluate(*grid_velocity,
                                                      dealii::EvaluationFlags::values);
     }
   }
@@ -287,7 +288,7 @@ public:
     if(data.ale)
     {
       integrator_grid_velocity_face->reinit(face);
-      integrator_grid_velocity_face->gather_evaluate(grid_velocity,
+      integrator_grid_velocity_face->gather_evaluate(*grid_velocity,
                                                      dealii::EvaluationFlags::values);
     }
   }
@@ -303,7 +304,7 @@ public:
     if(data.ale)
     {
       integrator_grid_velocity_face->reinit(cell, face);
-      integrator_grid_velocity_face->gather_evaluate(grid_velocity,
+      integrator_grid_velocity_face->gather_evaluate(*grid_velocity,
                                                      dealii::EvaluationFlags::values);
     }
 
@@ -813,8 +814,8 @@ public:
 private:
   ConvectiveKernelData data;
 
-  mutable lazy_ptr<VectorType> velocity;
-  mutable VectorType           grid_velocity;
+  lazy_ptr<VectorType> velocity;
+  lazy_ptr<VectorType> grid_velocity;
 
   std::shared_ptr<IntegratorCell> integrator_velocity;
   std::shared_ptr<IntegratorFace> integrator_velocity_m;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1333,7 +1333,7 @@ SpatialOperatorBase<dim, Number>::update_after_grid_motion()
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::set_grid_velocity(VectorType u_grid_in)
+SpatialOperatorBase<dim, Number>::set_grid_velocity(VectorType const & u_grid_in)
 {
   convective_kernel->set_grid_velocity_ptr(u_grid_in);
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -406,7 +406,7 @@ public:
    * Sets the grid velocity.
    */
   void
-  set_grid_velocity(VectorType velocity);
+  set_grid_velocity(VectorType const & velocity);
 
 protected:
   /*

--- a/include/exadg/operators/lazy_ptr.h
+++ b/include/exadg/operators/lazy_ptr.h
@@ -53,12 +53,12 @@ public:
     return t;
   }
 
-  T const * operator->()
+  T const * operator->() const
   {
     return t_ptr;
   }
 
-  T const & operator*()
+  T const & operator*() const
   {
     return *t_ptr;
   }

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -353,7 +353,7 @@ protected:
   /*
    * Matrix-free object.
    */
-  mutable lazy_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
+  lazy_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
 
   /*
    * Physical time (required for time-dependent problems).
@@ -363,7 +363,7 @@ protected:
   /*
    * Constraint matrix.
    */
-  mutable lazy_ptr<dealii::AffineConstraints<Number>> constraint;
+  lazy_ptr<dealii::AffineConstraints<Number>> constraint;
 
   mutable dealii::AffineConstraints<double> constraint_double;
 


### PR DESCRIPTION
Currently, the grid velocity is copied and not passed by const reference.

Also, set_grid_velocity_ptr() should not be const in my opinion since a member is set. This might be up to discussion, since the member is mutable. However, the mutable keyword is only used to be able to access the member in the matrix free loops and has nothing to do with setting the velocity.