### PR TITLE
Bug-fix for preconditioner=none

### DIFF
--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -155,7 +155,8 @@ public:
   std::shared_ptr<TimerTree>
   get_timings() const override
   {
-    this->timer_tree->insert({"SolverCG"}, preconditioner.get_timings());
+    if(solver_data.use_preconditioner)
+      this->timer_tree->insert({"SolverCG"}, preconditioner.get_timings());
 
     return this->timer_tree;
   }


### PR DESCRIPTION
`Preconditioner::None` was not working because of the line: `preconditioner.get_timings()`. Adapted it with an if-check. @bergbauer  