### PR TITLE
make Grid::create_triangulation more flexible

### DIFF
--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -330,7 +330,9 @@ private:
       create_coarse_grid<dim>(tria, this->grid->periodic_faces, cylinder_type_string);
     };
 
-    this->grid->create_triangulation(this->param.grid, lambda_create_coarse_triangulation);
+    this->grid->create_triangulation(this->param.grid,
+                                     lambda_create_coarse_triangulation,
+                                     this->param.grid.n_refine_global);
   }
 
   void

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -43,15 +43,16 @@ MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & m
 template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize(
-  MultigridData const &                       mg_data,
-  dealii::Triangulation<dim> const *          tria,
-  dealii::FiniteElement<dim> const &          fe,
-  std::shared_ptr<dealii::Mapping<dim> const> mapping,
-  PDEOperator const &                         pde_operator,
-  MultigridOperatorType const &               mg_operator_type,
-  bool const                                  mesh_is_moving,
-  Map const &                                 dirichlet_bc,
-  PeriodicFacePairs const &                   periodic_face_pairs)
+  MultigridData const &                                                  mg_data,
+  dealii::Triangulation<dim> const *                                     tria,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+  dealii::FiniteElement<dim> const &                                     fe,
+  std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+  PDEOperator const &                                                    pde_operator,
+  MultigridOperatorType const &                                          mg_operator_type,
+  bool const                                                             mesh_is_moving,
+  Map const &                                                            dirichlet_bc,
+  PeriodicFacePairs const &                                              periodic_face_pairs)
 {
   this->pde_operator     = &pde_operator;
   this->mg_operator_type = mg_operator_type;
@@ -90,8 +91,14 @@ MultigridPreconditioner<dim, Number>::initialize(
     AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
-  Base::initialize(
-    mg_data, tria, fe, mapping, data.operator_is_singular, dirichlet_bc, periodic_face_pairs);
+  Base::initialize(mg_data,
+                   tria,
+                   coarse_triangulations,
+                   fe,
+                   mapping,
+                   data.operator_is_singular,
+                   dirichlet_bc,
+                   periodic_face_pairs);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -63,15 +63,17 @@ public:
    *  This function initializes the multigrid preconditioner.
    */
   void
-  initialize(MultigridData const &                       mg_data,
-             dealii::Triangulation<dim> const *          tria,
-             dealii::FiniteElement<dim> const &          fe,
-             std::shared_ptr<dealii::Mapping<dim> const> mapping,
-             PDEOperator const &                         pde_operator,
-             MultigridOperatorType const &               mg_operator_type,
-             bool const                                  mesh_is_moving,
-             Map const &                                 dirichlet_bc,
-             PeriodicFacePairs const &                   periodic_face_pairs);
+  initialize(
+    MultigridData const &                                                  mg_data,
+    dealii::Triangulation<dim> const *                                     tria,
+    std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+    dealii::FiniteElement<dim> const &                                     fe,
+    std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+    PDEOperator const &                                                    pde_operator,
+    MultigridOperatorType const &                                          mg_operator_type,
+    bool const                                                             mesh_is_moving,
+    Map const &                                                            dirichlet_bc,
+    PeriodicFacePairs const &                                              periodic_face_pairs);
 
   /*
    *  This function updates the multigrid preconditioner.

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -470,6 +470,7 @@ Operator<dim, Number>::initialize_preconditioner()
 
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),
+                                  grid->get_coarse_triangulations(),
                                   dof_handler.get_fe(),
                                   get_dynamic_mapping<dim, Number>(grid, grid_motion),
                                   combined_operator,

--- a/include/exadg/grid/enum_types.cpp
+++ b/include/exadg/grid/enum_types.cpp
@@ -52,6 +52,27 @@ enum_to_string(TriangulationType const enum_type)
 }
 
 std::string
+enum_to_string(ElementType const enum_type)
+{
+  std::string string_type;
+
+  switch(enum_type)
+  {
+    case ElementType::Hypercube:
+      string_type = "Hypercube";
+      break;
+    case ElementType::Simplex:
+      string_type = "Simplex";
+      break;
+    default:
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
+      break;
+  }
+
+  return string_type;
+}
+
+std::string
 enum_to_string(PartitioningType const enum_type)
 {
   std::string string_type;

--- a/include/exadg/grid/enum_types.h
+++ b/include/exadg/grid/enum_types.h
@@ -46,6 +46,18 @@ std::string
 enum_to_string(TriangulationType const enum_type);
 
 /*
+ * Element type
+ */
+enum class ElementType
+{
+  Hypercube,
+  Simplex
+};
+
+std::string
+enum_to_string(ElementType const enum_type);
+
+/*
  * Partitioning type (relevant for fully-distributed triangulation)
  */
 enum class PartitioningType

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -144,6 +144,11 @@ public:
     unsigned int const                                        global_refinements,
     std::vector<unsigned int> const & vector_local_refinements = std::vector<unsigned int>())
   {
+    do_create_triangulation(data,
+                            create_coarse_triangulation,
+                            global_refinements,
+                            vector_local_refinements);
+
     // coarse triangulations need to be created for global coarsening multigrid
     if(data.create_coarse_triangulations)
     {
@@ -152,12 +157,6 @@ public:
       {
         // in case of a serial or distributed triangulation, deal.II can automatically generate the
         // coarse grid triangulations
-
-        do_create_triangulation(data,
-                                create_coarse_triangulation,
-                                global_refinements,
-                                vector_local_refinements);
-
         coarse_triangulations =
           dealii::MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
             *triangulation,
@@ -177,13 +176,6 @@ public:
       {
         AssertThrow(false, dealii::ExcMessage("Invalid parameter triangulation_type."));
       }
-    }
-    else
-    {
-      do_create_triangulation(data,
-                              create_coarse_triangulation,
-                              global_refinements,
-                              vector_local_refinements);
     }
   }
 

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -24,7 +24,6 @@
 
 // deal.II
 #include <deal.II/distributed/fully_distributed_tria.h>
-#include <deal.II/distributed/repartitioning_policy_tools.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/mapping_fe.h>
@@ -54,6 +53,8 @@ public:
     : n_mpi_processes_per_level{n_mpi_processes}
   {
   }
+
+  virtual ~BalancedGranularityPartitionPolicy(){};
 
   virtual dealii::LinearAlgebra::distributed::Vector<double>
   partition(dealii::Triangulation<dim, spacedim> const & tria_coarse_in) const override

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -100,12 +100,23 @@ public:
                             create_coarse_triangulation,
                             global_refinements,
                             vector_local_refinements);
+
+    if(data.create_coarse_triangulations)
+    {
+      // TODO
+      // construct all the coarser triangulations
+    }
   }
 
   /**
    * dealii::Triangulation.
    */
   std::shared_ptr<dealii::Triangulation<dim>> triangulation;
+
+  /**
+   * a vector of coarse triangulations required for global coarsening multigrid
+   */
+  std::vector<std::shared_ptr<dealii::Triangulation<dim>>> coarse_triangulations;
 
   /**
    * dealii::GridTools::PeriodicFacePair's.

--- a/include/exadg/grid/grid_data.h
+++ b/include/exadg/grid/grid_data.h
@@ -22,26 +22,22 @@
 #ifndef INCLUDE_EXADG_GRID_GRID_DATA_H_
 #define INCLUDE_EXADG_GRID_GRID_DATA_H_
 
+// ExaDG
 #include <exadg/grid/enum_types.h>
 #include <exadg/utilities/print_functions.h>
 
 namespace ExaDG
 {
-enum class ElementType
-{
-  Hypercube,
-  Simplex
-};
-
 struct GridData
 {
   GridData()
     : triangulation_type(TriangulationType::Distributed),
+      element_type(ElementType::Hypercube),
       partitioning_type(PartitioningType::Metis),
       n_refine_global(0),
       n_subdivisions_1d_hypercube(1),
-      mapping_degree(1),
-      element_type(ElementType::Hypercube)
+      create_coarse_triangulations(false),
+      mapping_degree(1)
   {
   }
 
@@ -54,6 +50,8 @@ struct GridData
   print(dealii::ConditionalOStream const & pcout) const
   {
     print_parameter(pcout, "Triangulation type", enum_to_string(triangulation_type));
+
+    print_parameter(pcout, "Element type", enum_to_string(element_type));
 
     if(triangulation_type == TriangulationType::FullyDistributed)
       print_parameter(pcout,
@@ -69,6 +67,8 @@ struct GridData
 
   TriangulationType triangulation_type;
 
+  ElementType element_type;
+
   PartitioningType partitioning_type;
 
   unsigned int n_refine_global;
@@ -76,9 +76,11 @@ struct GridData
   // only relevant for hypercube geometry/mesh
   unsigned int n_subdivisions_1d_hypercube;
 
-  unsigned int mapping_degree;
+  // this parameter needs to be activated to use global-coarsening multigrid
+  // (which needs all the coarser triangulations)
+  bool create_coarse_triangulations;
 
-  ElementType element_type;
+  unsigned int mapping_degree;
 
   // TODO: path to a grid file
   // std::string grid_file;

--- a/include/exadg/grid/grid_data.h
+++ b/include/exadg/grid/grid_data.h
@@ -51,7 +51,8 @@ struct GridData
   {
     print_parameter(pcout, "Triangulation type", enum_to_string(triangulation_type));
 
-    print_parameter(pcout, "Element type", enum_to_string(element_type));
+    // TODO: causes tests to fail introduce as a separate PR
+    // print_parameter(pcout, "Element type", enum_to_string(element_type));
 
     if(triangulation_type == TriangulationType::FullyDistributed)
       print_parameter(pcout,

--- a/include/exadg/grid/mapping_dof_vector.h
+++ b/include/exadg/grid/mapping_dof_vector.h
@@ -379,9 +379,9 @@ initialize_multigrid(std::shared_ptr<MappingDoFVector<dim, Number>>      mapping
 template<int dim, typename Number>
 void
 initialize_multigrid(
-  std::vector<std::shared_ptr<MappingDoFVector<dim, Number>>> &    coarse_grid_mappings,
-  std::shared_ptr<dealii::MappingQCache<dim> const> &              mapping_q_cache,
-  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> & coarse_grid_triangulations)
+  std::vector<std::shared_ptr<MappingDoFVector<dim, Number>>> &          coarse_grid_mappings,
+  std::shared_ptr<dealii::MappingQCache<dim> const> &                    mapping_q_cache,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_grid_triangulations)
 {
   typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -37,15 +37,16 @@ MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & c
 template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize(
-  MultigridData const &                       mg_data,
-  dealii::Triangulation<dim> const *          tria,
-  dealii::FiniteElement<dim> const &          fe,
-  std::shared_ptr<dealii::Mapping<dim> const> mapping,
-  PDEOperator const &                         pde_operator,
-  MultigridOperatorType const &               mg_operator_type,
-  bool const                                  mesh_is_moving,
-  Map const &                                 dirichlet_bc,
-  PeriodicFacePairs const &                   periodic_face_pairs)
+  MultigridData const &                                                  mg_data,
+  dealii::Triangulation<dim> const *                                     tria,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+  dealii::FiniteElement<dim> const &                                     fe,
+  std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+  PDEOperator const &                                                    pde_operator,
+  MultigridOperatorType const &                                          mg_operator_type,
+  bool const                                                             mesh_is_moving,
+  Map const &                                                            dirichlet_bc,
+  PeriodicFacePairs const &                                              periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 
@@ -78,8 +79,14 @@ MultigridPreconditioner<dim, Number>::initialize(
     AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
-  Base::initialize(
-    mg_data, tria, fe, mapping, false /*operator_is_singular*/, dirichlet_bc, periodic_face_pairs);
+  Base::initialize(mg_data,
+                   tria,
+                   coarse_triangulations,
+                   fe,
+                   mapping,
+                   false /*operator_is_singular*/,
+                   dirichlet_bc,
+                   periodic_face_pairs);
 }
 
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -57,15 +57,17 @@ public:
   MultigridPreconditioner(MPI_Comm const & comm);
 
   void
-  initialize(MultigridData const &                       mg_data,
-             dealii::Triangulation<dim> const *          tria,
-             dealii::FiniteElement<dim> const &          fe,
-             std::shared_ptr<dealii::Mapping<dim> const> mapping,
-             PDEOperator const &                         pde_operator,
-             MultigridOperatorType const &               mg_operator_type,
-             bool const                                  mesh_is_moving,
-             Map const &                                 dirichlet_bc,
-             PeriodicFacePairs const &                   periodic_face_pairs);
+  initialize(
+    MultigridData const &                                                  mg_data,
+    dealii::Triangulation<dim> const *                                     tria,
+    std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+    dealii::FiniteElement<dim> const &                                     fe,
+    std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+    PDEOperator const &                                                    pde_operator,
+    MultigridOperatorType const &                                          mg_operator_type,
+    bool const                                                             mesh_is_moving,
+    Map const &                                                            dirichlet_bc,
+    PeriodicFacePairs const &                                              periodic_face_pairs);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -36,14 +36,15 @@ MultigridPreconditionerProjection<dim, Number>::MultigridPreconditionerProjectio
 template<int dim, typename Number>
 void
 MultigridPreconditionerProjection<dim, Number>::initialize(
-  MultigridData const &                       mg_data,
-  dealii::Triangulation<dim> const *          tria,
-  dealii::FiniteElement<dim> const &          fe,
-  std::shared_ptr<dealii::Mapping<dim> const> mapping,
-  PDEOperator const &                         pde_operator,
-  bool const                                  mesh_is_moving,
-  Map const &                                 dirichlet_bc,
-  PeriodicFacePairs const &                   periodic_face_pairs)
+  MultigridData const &                                                  mg_data,
+  dealii::Triangulation<dim> const *                                     tria,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+  dealii::FiniteElement<dim> const &                                     fe,
+  std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+  PDEOperator const &                                                    pde_operator,
+  bool const                                                             mesh_is_moving,
+  Map const &                                                            dirichlet_bc,
+  PeriodicFacePairs const &                                              periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 
@@ -51,8 +52,14 @@ MultigridPreconditionerProjection<dim, Number>::initialize(
 
   this->mesh_is_moving = mesh_is_moving;
 
-  Base::initialize(
-    mg_data, tria, fe, mapping, false /*operator_is_singular*/, dirichlet_bc, periodic_face_pairs);
+  Base::initialize(mg_data,
+                   tria,
+                   coarse_triangulations,
+                   fe,
+                   mapping,
+                   false /*operator_is_singular*/,
+                   dirichlet_bc,
+                   periodic_face_pairs);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
@@ -57,14 +57,16 @@ public:
   MultigridPreconditionerProjection(MPI_Comm const & mpi_comm);
 
   void
-  initialize(MultigridData const &                       mg_data,
-             dealii::Triangulation<dim> const *          tria,
-             dealii::FiniteElement<dim> const &          fe,
-             std::shared_ptr<dealii::Mapping<dim> const> mapping,
-             PDEOperator const &                         pde_operator,
-             bool const                                  mesh_is_moving,
-             Map const &                                 dirichlet_bc,
-             PeriodicFacePairs const &                   periodic_face_pairs);
+  initialize(
+    MultigridData const &                                                  mg_data,
+    dealii::Triangulation<dim> const *                                     tria,
+    std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+    dealii::FiniteElement<dim> const &                                     fe,
+    std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+    PDEOperator const &                                                    pde_operator,
+    bool const                                                             mesh_is_moving,
+    Map const &                                                            dirichlet_bc,
+    PeriodicFacePairs const &                                              periodic_face_pairs);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -474,6 +474,7 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_momentum()
 
   mg_preconditioner->initialize(this->param.multigrid_data_velocity_block,
                                 &this->get_dof_handler_u().get_triangulation(),
+                                this->grid->get_coarse_triangulations(),
                                 this->get_dof_handler_u().get_fe(),
                                 this->get_mapping(),
                                 this->momentum_operator,
@@ -600,6 +601,7 @@ OperatorCoupled<dim, Number>::setup_multigrid_preconditioner_schur_complement()
   auto & dof_handler = this->get_dof_handler_p();
   mg_preconditioner->initialize(mg_data,
                                 &dof_handler.get_triangulation(),
+                                this->grid->get_coarse_triangulations(),
                                 dof_handler.get_fe(),
                                 this->get_mapping(),
                                 laplace_operator_data,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -133,6 +133,7 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
 
     mg_preconditioner->initialize(this->param.multigrid_data_viscous,
                                   &this->get_dof_handler_u().get_triangulation(),
+                                  this->grid->get_coarse_triangulations(),
                                   this->get_dof_handler_u().get_fe(),
                                   this->get_mapping(),
                                   this->momentum_operator,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -140,6 +140,7 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
 
     mg_preconditioner->initialize(this->param.multigrid_data_momentum,
                                   &this->get_dof_handler_u().get_triangulation(),
+                                  this->grid->get_coarse_triangulations(),
                                   this->get_dof_handler_u().get_fe(),
                                   this->get_mapping(),
                                   this->momentum_operator,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -175,6 +175,7 @@ OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poiss
     auto & dof_handler = this->get_dof_handler_p();
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),
+                                  this->grid->get_coarse_triangulations(),
                                   dof_handler.get_fe(),
                                   this->get_mapping(),
                                   laplace_operator.get_data(),

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1253,6 +1253,7 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
 
   mg_preconditioner->initialize(mg_data,
                                 &dof_handler_u_scalar.get_triangulation(),
+                                grid->get_coarse_triangulations(),
                                 dof_handler_u_scalar.get_fe(),
                                 get_dynamic_mapping<dim, Number>(grid, grid_motion),
                                 laplace_operator.get_data(),
@@ -1598,6 +1599,7 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
       auto const & dof_handler = this->get_dof_handler_u();
       mg_preconditioner->initialize(this->param.multigrid_data_projection,
                                     &dof_handler.get_triangulation(),
+                                    grid->get_coarse_triangulations(),
                                     dof_handler.get_fe(),
                                     this->get_mapping(),
                                     *this->projection_operator,

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -35,14 +35,15 @@ MultigridPreconditioner<dim, Number, n_components>::MultigridPreconditioner(
 template<int dim, typename Number, int n_components>
 void
 MultigridPreconditioner<dim, Number, n_components>::initialize(
-  MultigridData const &                       mg_data,
-  dealii::Triangulation<dim> const *          tria,
-  dealii::FiniteElement<dim> const &          fe,
-  std::shared_ptr<dealii::Mapping<dim> const> mapping,
-  LaplaceOperatorData<rank, dim> const &      data_in,
-  bool const                                  mesh_is_moving,
-  Map const &                                 dirichlet_bc,
-  PeriodicFacePairs const &                   periodic_face_pairs)
+  MultigridData const &                                                  mg_data,
+  dealii::Triangulation<dim> const *                                     tria,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+  dealii::FiniteElement<dim> const &                                     fe,
+  std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+  LaplaceOperatorData<rank, dim> const &                                 data_in,
+  bool const                                                             mesh_is_moving,
+  Map const &                                                            dirichlet_bc,
+  PeriodicFacePairs const &                                              periodic_face_pairs)
 {
   data = data_in;
 
@@ -50,8 +51,14 @@ MultigridPreconditioner<dim, Number, n_components>::initialize(
 
   this->mesh_is_moving = mesh_is_moving;
 
-  Base::initialize(
-    mg_data, tria, fe, mapping, data.operator_is_singular, dirichlet_bc, periodic_face_pairs);
+  Base::initialize(mg_data,
+                   tria,
+                   coarse_triangulations,
+                   fe,
+                   mapping,
+                   data.operator_is_singular,
+                   dirichlet_bc,
+                   periodic_face_pairs);
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -58,14 +58,16 @@ public:
   MultigridPreconditioner(MPI_Comm const & mpi_comm);
 
   void
-  initialize(MultigridData const &                       mg_data,
-             dealii::Triangulation<dim> const *          tria,
-             dealii::FiniteElement<dim> const &          fe,
-             std::shared_ptr<dealii::Mapping<dim> const> mapping,
-             LaplaceOperatorData<rank, dim> const &      data_in,
-             bool const                                  mesh_is_moving,
-             Map const &                                 dirichlet_bc,
-             PeriodicFacePairs const &                   periodic_face_pairs);
+  initialize(
+    MultigridData const &                                                  mg_data,
+    dealii::Triangulation<dim> const *                                     tria,
+    std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+    dealii::FiniteElement<dim> const &                                     fe,
+    std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+    LaplaceOperatorData<rank, dim> const &                                 data_in,
+    bool const                                                             mesh_is_moving,
+    Map const &                                                            dirichlet_bc,
+    PeriodicFacePairs const &                                              periodic_face_pairs);
 
   void
   update() override;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -359,6 +359,7 @@ Operator<dim, n_components, Number>::setup_solver()
 
     mg_preconditioner->initialize(mg_data,
                                   &dof_handler.get_triangulation(),
+                                  grid->get_coarse_triangulations(),
                                   dof_handler.get_fe(),
                                   grid->mapping,
                                   laplace_operator.get_data(),

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -49,41 +49,38 @@ namespace ExaDG
 {
 template<int dim, typename Number>
 MultigridPreconditionerBase<dim, Number>::MultigridPreconditionerBase(MPI_Comm const & comm)
-  : n_levels(1), coarse_level(0), fine_level(0), mpi_comm(comm) //,
-                                                                // TODO grid
-//    triangulation(nullptr)
+  : n_levels(1), coarse_level(0), fine_level(0), mpi_comm(comm), triangulation(nullptr)
 {
 }
 
 template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::initialize(
-  MultigridData const &                       data,
-  dealii::Triangulation<dim> const *          tria,
-  dealii::FiniteElement<dim> const &          fe,
-  std::shared_ptr<dealii::Mapping<dim> const> mapping,
-  bool const                                  operator_is_singular,
-  Map const &                                 dirichlet_bc,
-  PeriodicFacePairs const &                   periodic_face_pairs)
+  MultigridData const &                                                  data,
+  dealii::Triangulation<dim> const *                                     tria,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+  dealii::FiniteElement<dim> const &                                     fe,
+  std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+  bool const                                                             operator_is_singular,
+  Map const &                                                            dirichlet_bc,
+  PeriodicFacePairs const &                                              periodic_face_pairs)
 {
   this->data = data;
 
-  // TODO grid
-  //  this->triangulation = tria;
-  //
-  //  this->mapping = mapping;
+  this->triangulation = tria;
+
+  this->coarse_triangulations = coarse_triangulations;
+
+  this->mapping = mapping;
 
   bool const is_dg = fe.dofs_per_vertex == 0;
 
-  // TODO grid
-  //  this->initialize_coarse_grid_triangulations(tria);
-
-  this->initialize_levels(tria, fe.degree, is_dg);
+  this->initialize_levels(this->triangulation, fe.degree, is_dg);
 
   this->initialize_mapping();
 
   this->initialize_dof_handler_and_constraints(
-    operator_is_singular, periodic_face_pairs, fe, tria, dirichlet_bc);
+    operator_is_singular, periodic_face_pairs, fe, this->triangulation, dirichlet_bc);
 
   this->initialize_matrix_free();
 
@@ -151,8 +148,7 @@ MultigridPreconditionerBase<dim, Number>::initialize_levels(dealii::Triangulatio
   else // h-MG is involved working on all mesh levels
   {
     unsigned int const n_h_levels =
-      (data.use_global_coarsening ? grid->get_coarse_triangulations().size() :
-                                    tria->n_global_levels());
+      (data.use_global_coarsening ? coarse_triangulations.size() : tria->n_global_levels());
     for(unsigned int h = 0; h < n_h_levels; h++)
       h_levels.push_back(h);
   }
@@ -323,84 +319,6 @@ MultigridPreconditionerBase<dim, Number>::check_levels(std::vector<MGLevelInfo> 
   }
 }
 
-// TODO grid
-///**
-// * A class to use for the deal.II coarsening functionality, where we try to
-// * balance the mesh coarsening with a minimum granularity and the number of
-// * partitions on coarser levels.
-// */
-// template<int dim, int spacedim = dim>
-// class BalancedGranularityPartitionPolicy
-//  : public dealii::RepartitioningPolicyTools::Base<dim, spacedim>
-//{
-// public:
-//  BalancedGranularityPartitionPolicy(unsigned int const n_mpi_processes)
-//    : n_mpi_processes_per_level{n_mpi_processes}
-//  {
-//  }
-//
-//  virtual dealii::LinearAlgebra::distributed::Vector<double>
-//  partition(dealii::Triangulation<dim, spacedim> const & tria_coarse_in) const override
-//  {
-//    dealii::types::global_cell_index const n_cells = tria_coarse_in.n_global_active_cells();
-//
-//    // TODO: We hard-code a grain-size limit of 200 cells per processor
-//    // (assuming linear finite elements and typical behavior of
-//    // supercomputers). In case we have fewer cells on the fine level, we do
-//    // not immediately go to 200 cells per rank, but limit the growth by a
-//    // factor of 8, which limits makes sure that we do not create too many
-//    // messages for individual MPI processes.
-//    unsigned int const grain_size_limit =
-//      std::min<unsigned int>(200, 8 * n_cells / n_mpi_processes_per_level.back() + 1);
-//
-//    dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim, spacedim>
-//    partitioning_policy(
-//      grain_size_limit);
-//    dealii::LinearAlgebra::distributed::Vector<double> const partitions =
-//      partitioning_policy.partition(tria_coarse_in);
-//
-//    // The vector 'partitions' contains the partition numbers. To get the
-//    // number of partitions, we take the infinity norm.
-//    n_mpi_processes_per_level.push_back(static_cast<unsigned int>(partitions.linfty_norm()) + 1);
-//    return partitions;
-//  }
-//
-// private:
-//  mutable std::vector<unsigned int> n_mpi_processes_per_level;
-//};
-
-// TODO: grid
-// template<int dim, typename Number>
-// void
-// MultigridPreconditionerBase<dim, Number>::initialize_coarse_grid_triangulations(
-//  dealii::Triangulation<dim> const * tria)
-//{
-//  // coarse grid triangulations are only required in case of the multigrid transfer
-//  // with global coarsening
-//  if(data.use_global_coarsening)
-//  {
-//    if(data.involves_h_transfer())
-//    {
-//      AssertThrow(
-//        tria->n_global_levels() == 1 ||
-//          dynamic_cast<dealii::parallel::fullydistributed::Triangulation<dim> const *>(tria) ==
-//            nullptr,
-//        dealii::ExcMessage(
-//          "h-transfer is currently not supported for the option use_global_coarsening "
-//          "in combination with a dealii::parallel::fullydistributed::Triangulation that "
-//          "contains refinements. Either use a dealii::parallel::fullydistributed::Triangulation "
-//          "without refinements, a dealii::parallel::distributed::Triangulation, or a "
-//          "MultigridType without h-transfer."));
-//
-//      coarse_grid_triangulations =
-//        dealii::MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
-//          *tria,
-//          BalancedGranularityPartitionPolicy<dim>(
-//            dealii::Utilities::MPI::n_mpi_processes(tria->get_communicator())));
-//    }
-//  }
-//}
-
 template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::initialize_mapping()
@@ -417,16 +335,14 @@ MultigridPreconditionerBase<dim, Number>::initialize_mapping()
     {
       MappingTools::initialize_multigrid(coarse_grid_mappings,
                                          mapping_q_cache,
-                                         grid->get_coarse_triangulations());
+                                         coarse_triangulations);
     }
     else // local smoothing multigrid implementation
     {
       mapping_dof_vector =
         std::make_shared<MappingDoFVector<dim, Number>>(mapping_q_cache->get_degree());
 
-      MappingTools::initialize_multigrid(mapping_dof_vector,
-                                         mapping_q_cache,
-                                         *grid->get_triangulation());
+      MappingTools::initialize_multigrid(mapping_dof_vector, mapping_q_cache, *triangulation);
     }
   }
 }
@@ -508,10 +424,10 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
     {
       auto const & level = level_info[i];
 
-      auto dof_handler = new dealii::DoFHandler<dim>(
-        (level.h_level() + 1 == grid->get_triangulation()->n_global_levels()) ?
-          *(dynamic_cast<dealii::Triangulation<dim> const *>(tria)) :
-          *(grid->get_coarse_triangulations()[level.h_level()]));
+      auto dof_handler =
+        new dealii::DoFHandler<dim>((level.h_level() + 1 == triangulation->n_global_levels()) ?
+                                      *(dynamic_cast<dealii::Triangulation<dim> const *>(tria)) :
+                                      *(coarse_triangulations[level.h_level()]));
 
       if(level.is_dg())
         dof_handler->distribute_dofs(

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -49,7 +49,9 @@ namespace ExaDG
 {
 template<int dim, typename Number>
 MultigridPreconditionerBase<dim, Number>::MultigridPreconditionerBase(MPI_Comm const & comm)
-  : n_levels(1), coarse_level(0), fine_level(0), mpi_comm(comm), triangulation(nullptr)
+  : n_levels(1), coarse_level(0), fine_level(0), mpi_comm(comm) //,
+                                                                // TODO grid
+//    triangulation(nullptr)
 {
 }
 
@@ -66,13 +68,15 @@ MultigridPreconditionerBase<dim, Number>::initialize(
 {
   this->data = data;
 
-  this->triangulation = tria;
-
-  this->mapping = mapping;
+  // TODO grid
+  //  this->triangulation = tria;
+  //
+  //  this->mapping = mapping;
 
   bool const is_dg = fe.dofs_per_vertex == 0;
 
-  this->initialize_coarse_grid_triangulations(tria);
+  // TODO grid
+  //  this->initialize_coarse_grid_triangulations(tria);
 
   this->initialize_levels(tria, fe.degree, is_dg);
 
@@ -147,7 +151,8 @@ MultigridPreconditionerBase<dim, Number>::initialize_levels(dealii::Triangulatio
   else // h-MG is involved working on all mesh levels
   {
     unsigned int const n_h_levels =
-      (data.use_global_coarsening ? coarse_grid_triangulations.size() : tria->n_global_levels());
+      (data.use_global_coarsening ? grid->get_coarse_triangulations().size() :
+                                    tria->n_global_levels());
     for(unsigned int h = 0; h < n_h_levels; h++)
       h_levels.push_back(h);
   }
@@ -318,80 +323,83 @@ MultigridPreconditionerBase<dim, Number>::check_levels(std::vector<MGLevelInfo> 
   }
 }
 
-/**
- * A class to use for the deal.II coarsening functionality, where we try to
- * balance the mesh coarsening with a minimum granularity and the number of
- * partitions on coarser levels.
- */
-template<int dim, int spacedim = dim>
-class BalancedGranularityPartitionPolicy
-  : public dealii::RepartitioningPolicyTools::Base<dim, spacedim>
-{
-public:
-  BalancedGranularityPartitionPolicy(unsigned int const n_mpi_processes)
-    : n_mpi_processes_per_level{n_mpi_processes}
-  {
-  }
+// TODO grid
+///**
+// * A class to use for the deal.II coarsening functionality, where we try to
+// * balance the mesh coarsening with a minimum granularity and the number of
+// * partitions on coarser levels.
+// */
+// template<int dim, int spacedim = dim>
+// class BalancedGranularityPartitionPolicy
+//  : public dealii::RepartitioningPolicyTools::Base<dim, spacedim>
+//{
+// public:
+//  BalancedGranularityPartitionPolicy(unsigned int const n_mpi_processes)
+//    : n_mpi_processes_per_level{n_mpi_processes}
+//  {
+//  }
+//
+//  virtual dealii::LinearAlgebra::distributed::Vector<double>
+//  partition(dealii::Triangulation<dim, spacedim> const & tria_coarse_in) const override
+//  {
+//    dealii::types::global_cell_index const n_cells = tria_coarse_in.n_global_active_cells();
+//
+//    // TODO: We hard-code a grain-size limit of 200 cells per processor
+//    // (assuming linear finite elements and typical behavior of
+//    // supercomputers). In case we have fewer cells on the fine level, we do
+//    // not immediately go to 200 cells per rank, but limit the growth by a
+//    // factor of 8, which limits makes sure that we do not create too many
+//    // messages for individual MPI processes.
+//    unsigned int const grain_size_limit =
+//      std::min<unsigned int>(200, 8 * n_cells / n_mpi_processes_per_level.back() + 1);
+//
+//    dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim, spacedim>
+//    partitioning_policy(
+//      grain_size_limit);
+//    dealii::LinearAlgebra::distributed::Vector<double> const partitions =
+//      partitioning_policy.partition(tria_coarse_in);
+//
+//    // The vector 'partitions' contains the partition numbers. To get the
+//    // number of partitions, we take the infinity norm.
+//    n_mpi_processes_per_level.push_back(static_cast<unsigned int>(partitions.linfty_norm()) + 1);
+//    return partitions;
+//  }
+//
+// private:
+//  mutable std::vector<unsigned int> n_mpi_processes_per_level;
+//};
 
-  virtual dealii::LinearAlgebra::distributed::Vector<double>
-  partition(dealii::Triangulation<dim, spacedim> const & tria_coarse_in) const override
-  {
-    dealii::types::global_cell_index const n_cells = tria_coarse_in.n_global_active_cells();
-
-    // TODO: We hard-code a grain-size limit of 200 cells per processor
-    // (assuming linear finite elements and typical behavior of
-    // supercomputers). In case we have fewer cells on the fine level, we do
-    // not immediately go to 200 cells per rank, but limit the growth by a
-    // factor of 8, which limits makes sure that we do not create too many
-    // messages for individual MPI processes.
-    unsigned int const grain_size_limit =
-      std::min<unsigned int>(200, 8 * n_cells / n_mpi_processes_per_level.back() + 1);
-
-    dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim, spacedim> partitioning_policy(
-      grain_size_limit);
-    dealii::LinearAlgebra::distributed::Vector<double> const partitions =
-      partitioning_policy.partition(tria_coarse_in);
-
-    // The vector 'partitions' contains the partition numbers. To get the
-    // number of partitions, we take the infinity norm.
-    n_mpi_processes_per_level.push_back(static_cast<unsigned int>(partitions.linfty_norm()) + 1);
-    return partitions;
-  }
-
-private:
-  mutable std::vector<unsigned int> n_mpi_processes_per_level;
-};
-
-template<int dim, typename Number>
-void
-MultigridPreconditionerBase<dim, Number>::initialize_coarse_grid_triangulations(
-  dealii::Triangulation<dim> const * tria)
-{
-  // coarse grid triangulations are only required in case of the multigrid transfer
-  // with global coarsening
-  if(data.use_global_coarsening)
-  {
-    if(data.involves_h_transfer())
-    {
-      AssertThrow(
-        tria->n_global_levels() == 1 ||
-          dynamic_cast<dealii::parallel::fullydistributed::Triangulation<dim> const *>(tria) ==
-            nullptr,
-        dealii::ExcMessage(
-          "h-transfer is currently not supported for the option use_global_coarsening "
-          "in combination with a dealii::parallel::fullydistributed::Triangulation that "
-          "contains refinements. Either use a dealii::parallel::fullydistributed::Triangulation "
-          "without refinements, a dealii::parallel::distributed::Triangulation, or a "
-          "MultigridType without h-transfer."));
-
-      coarse_grid_triangulations =
-        dealii::MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
-          *tria,
-          BalancedGranularityPartitionPolicy<dim>(
-            dealii::Utilities::MPI::n_mpi_processes(tria->get_communicator())));
-    }
-  }
-}
+// TODO: grid
+// template<int dim, typename Number>
+// void
+// MultigridPreconditionerBase<dim, Number>::initialize_coarse_grid_triangulations(
+//  dealii::Triangulation<dim> const * tria)
+//{
+//  // coarse grid triangulations are only required in case of the multigrid transfer
+//  // with global coarsening
+//  if(data.use_global_coarsening)
+//  {
+//    if(data.involves_h_transfer())
+//    {
+//      AssertThrow(
+//        tria->n_global_levels() == 1 ||
+//          dynamic_cast<dealii::parallel::fullydistributed::Triangulation<dim> const *>(tria) ==
+//            nullptr,
+//        dealii::ExcMessage(
+//          "h-transfer is currently not supported for the option use_global_coarsening "
+//          "in combination with a dealii::parallel::fullydistributed::Triangulation that "
+//          "contains refinements. Either use a dealii::parallel::fullydistributed::Triangulation "
+//          "without refinements, a dealii::parallel::distributed::Triangulation, or a "
+//          "MultigridType without h-transfer."));
+//
+//      coarse_grid_triangulations =
+//        dealii::MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
+//          *tria,
+//          BalancedGranularityPartitionPolicy<dim>(
+//            dealii::Utilities::MPI::n_mpi_processes(tria->get_communicator())));
+//    }
+//  }
+//}
 
 template<int dim, typename Number>
 void
@@ -409,14 +417,16 @@ MultigridPreconditionerBase<dim, Number>::initialize_mapping()
     {
       MappingTools::initialize_multigrid(coarse_grid_mappings,
                                          mapping_q_cache,
-                                         coarse_grid_triangulations);
+                                         grid->get_coarse_triangulations());
     }
     else // local smoothing multigrid implementation
     {
       mapping_dof_vector =
         std::make_shared<MappingDoFVector<dim, Number>>(mapping_q_cache->get_degree());
 
-      MappingTools::initialize_multigrid(mapping_dof_vector, mapping_q_cache, *triangulation);
+      MappingTools::initialize_multigrid(mapping_dof_vector,
+                                         mapping_q_cache,
+                                         *grid->get_triangulation());
     }
   }
 }
@@ -498,10 +508,10 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
     {
       auto const & level = level_info[i];
 
-      auto dof_handler =
-        new dealii::DoFHandler<dim>((level.h_level() + 1 == tria->n_global_levels()) ?
-                                      *(dynamic_cast<dealii::Triangulation<dim> const *>(tria)) :
-                                      *coarse_grid_triangulations[level.h_level()]);
+      auto dof_handler = new dealii::DoFHandler<dim>(
+        (level.h_level() + 1 == grid->get_triangulation()->n_global_levels()) ?
+          *(dynamic_cast<dealii::Triangulation<dim> const *>(tria)) :
+          *(grid->get_coarse_triangulations()[level.h_level()]));
 
       if(level.is_dg())
         dof_handler->distribute_dofs(

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -28,6 +28,7 @@
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 
 // ExaDG
+#include <exadg/grid/grid.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/multigrid_operator_base.h>
 #include <exadg/solvers_and_preconditioners/multigrid/levels_hybrid_multigrid.h>
@@ -233,11 +234,12 @@ private:
   void
   check_levels(std::vector<MGLevelInfo> const & level_info);
 
-  /*
-   * Coarse grid triangulations in case of global coarsening transfer type.
-   */
-  void
-  initialize_coarse_grid_triangulations(dealii::Triangulation<dim> const * tria);
+  // TODO grid
+  //  /*
+  //   * Coarse grid triangulations in case of global coarsening transfer type.
+  //   */
+  //  void
+  //  initialize_coarse_grid_triangulations(dealii::Triangulation<dim> const * tria);
 
   /*
    * Returns the correct mapping depending on the multigrid transfer type and the current h-level.
@@ -315,11 +317,15 @@ private:
 
   MultigridData data;
 
-  dealii::Triangulation<dim> const * triangulation;
+  std::shared_ptr<Grid<dim> const> grid;
 
-  // Only relevant for global coarsening, where this vector contains coarse level triangulations,
-  // and the fine level triangulation as the last element of the vector.
-  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> coarse_grid_triangulations;
+  // TODO shift this to the Grid class
+  //  dealii::Triangulation<dim> const * triangulation;
+  //
+  //  // Only relevant for global coarsening, where this vector contains coarse level
+  //  triangulations,
+  //  // and the fine level triangulation as the last element of the vector.
+  //  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> coarse_grid_triangulations;
 
   // In case of global coarsening, this is the mapping associated to the fine level triangulation.
   std::shared_ptr<dealii::Mapping<dim> const> mapping;

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -328,9 +328,9 @@ private:
   // and the fine level mapping as the last element of the vector.
   std::vector<std::shared_ptr<MappingDoFVector<dim, Number>>> coarse_grid_mappings;
 
-  // Only relevant for global refinement and in case that a mapping of type MappingDoFVector is
+  // Only relevant for local-smoothing-multigrid and in case that a mapping of type MappingQCache is
   // used.
-  std::shared_ptr<MappingDoFVector<dim, Number>> mapping_global_refinement;
+  std::shared_ptr<MappingDoFVector<dim, Number>> mapping_dof_vector;
 
   dealii::MGLevelObject<std::shared_ptr<Smoother>> smoothers;
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -94,13 +94,15 @@ public:
    * Initialization function.
    */
   void
-  initialize(MultigridData const &                       data,
-             dealii::Triangulation<dim> const *          tria,
-             dealii::FiniteElement<dim> const &          fe,
-             std::shared_ptr<dealii::Mapping<dim> const> mapping,
-             bool const                                  operator_is_singular,
-             Map const &                                 dirichlet_bc,
-             PeriodicFacePairs const &                   periodic_face_pairs);
+  initialize(
+    MultigridData const &                                                  data,
+    dealii::Triangulation<dim> const *                                     tria,
+    std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+    dealii::FiniteElement<dim> const &                                     fe,
+    std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+    bool const                                                             operator_is_singular,
+    Map const &                                                            dirichlet_bc,
+    PeriodicFacePairs const &                                              periodic_face_pairs);
 
   /*
    * This function applies the multigrid preconditioner dst = P^{-1} src.
@@ -234,13 +236,6 @@ private:
   void
   check_levels(std::vector<MGLevelInfo> const & level_info);
 
-  // TODO grid
-  //  /*
-  //   * Coarse grid triangulations in case of global coarsening transfer type.
-  //   */
-  //  void
-  //  initialize_coarse_grid_triangulations(dealii::Triangulation<dim> const * tria);
-
   /*
    * Returns the correct mapping depending on the multigrid transfer type and the current h-level.
    */
@@ -317,15 +312,11 @@ private:
 
   MultigridData data;
 
-  std::shared_ptr<Grid<dim> const> grid;
+  dealii::Triangulation<dim> const * triangulation;
 
-  // TODO shift this to the Grid class
-  //  dealii::Triangulation<dim> const * triangulation;
-  //
-  //  // Only relevant for global coarsening, where this vector contains coarse level
-  //  triangulations,
-  //  // and the fine level triangulation as the last element of the vector.
-  //  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> coarse_grid_triangulations;
+  // Only relevant for global coarsening, where this vector contains coarse level triangulations,
+  // and the fine level triangulation as the last element of the vector.
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> coarse_triangulations;
 
   // In case of global coarsening, this is the mapping associated to the fine level triangulation.
   std::shared_ptr<dealii::Mapping<dim> const> mapping;

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -34,14 +34,15 @@ MultigridPreconditioner<dim, Number>::MultigridPreconditioner(MPI_Comm const & m
 template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::initialize(
-  MultigridData const &                       mg_data,
-  dealii::Triangulation<dim> const *          tria,
-  dealii::FiniteElement<dim> const &          fe,
-  std::shared_ptr<dealii::Mapping<dim> const> mapping,
-  ElasticityOperatorBase<dim, Number> const & pde_operator,
-  bool const                                  nonlinear_operator,
-  Map const &                                 dirichlet_bc,
-  PeriodicFacePairs const &                   periodic_face_pairs)
+  MultigridData const &                                                  mg_data,
+  dealii::Triangulation<dim> const *                                     tria,
+  std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+  dealii::FiniteElement<dim> const &                                     fe,
+  std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+  ElasticityOperatorBase<dim, Number> const &                            pde_operator,
+  bool const                                                             nonlinear_operator,
+  Map const &                                                            dirichlet_bc,
+  PeriodicFacePairs const &                                              periodic_face_pairs)
 {
   this->pde_operator = &pde_operator;
 
@@ -49,8 +50,14 @@ MultigridPreconditioner<dim, Number>::initialize(
 
   this->nonlinear = nonlinear_operator;
 
-  Base::initialize(
-    mg_data, tria, fe, mapping, false /*operator_is_singular*/, dirichlet_bc, periodic_face_pairs);
+  Base::initialize(mg_data,
+                   tria,
+                   coarse_triangulations,
+                   fe,
+                   mapping,
+                   false /*operator_is_singular*/,
+                   dirichlet_bc,
+                   periodic_face_pairs);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -59,14 +59,16 @@ public:
   MultigridPreconditioner(MPI_Comm const & mpi_comm);
 
   void
-  initialize(MultigridData const &                       mg_data,
-             dealii::Triangulation<dim> const *          tria,
-             dealii::FiniteElement<dim> const &          fe,
-             std::shared_ptr<dealii::Mapping<dim> const> mapping,
-             ElasticityOperatorBase<dim, Number> const & pde_operator,
-             bool const                                  nonlinear_operator,
-             Map const &                                 dirichlet_bc,
-             PeriodicFacePairs const &                   periodic_face_pairs);
+  initialize(
+    MultigridData const &                                                  mg_data,
+    dealii::Triangulation<dim> const *                                     tria,
+    std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> const & coarse_triangulations,
+    dealii::FiniteElement<dim> const &                                     fe,
+    std::shared_ptr<dealii::Mapping<dim> const>                            mapping,
+    ElasticityOperatorBase<dim, Number> const &                            pde_operator,
+    bool const                                                             nonlinear_operator,
+    Map const &                                                            dirichlet_bc,
+    PeriodicFacePairs const &                                              periodic_face_pairs);
 
   /*
    * This function updates the multigrid preconditioner.

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -401,6 +401,7 @@ Operator<dim, Number>::initialize_preconditioner()
 
       mg_preconditioner->initialize(param.multigrid_data,
                                     &dof_handler.get_triangulation(),
+                                    grid->get_coarse_triangulations(),
                                     dof_handler.get_fe(),
                                     grid->mapping,
                                     elasticity_operator_nonlinear,
@@ -433,6 +434,7 @@ Operator<dim, Number>::initialize_preconditioner()
 
       mg_preconditioner->initialize(param.multigrid_data,
                                     &dof_handler.get_triangulation(),
+                                    grid->get_coarse_triangulations(),
                                     dof_handler.get_fe(),
                                     grid->mapping,
                                     elasticity_operator_linear,


### PR DESCRIPTION
This PR is a preparation to enable the construction of coarse triangulations required for "global coarsening multigrid" inside the `Grid` class.

I am not sure whether the public function `create_triangulation()` needs the parameter `global_refinements`. I think we need to equip `GridData` with a boolean parameter `construct_coarse_triangulations` for global coarsening. This could all happen inside `create_triangulation`, so that the parameter `global_refinements` could be deduced from `GridData`? Then, probably only the private function `do_create_triangulation()` needs a parameter `global_refinements`.

Then, we need to extend the public function `create_triangulation()` that loops over all global and local refinements and creates the coarser triangulations for global coarsening. How would we implement this? First reduce global refinement level until 0, and then reduce the entries in `vector_local_refinements` by one until all vector entries are 0?

~~Apart from the vector of coarse triangulations, we might also need to transfer the vector of mappings associated to coarser triangulations to the `Grid` class. I am not sure about this. Looks like multigrid could take care of this once we have the vector of triangulations?~~ Not that easy because of moving mesh implementation (see e.g. function `get_dynamic_mapping()`).

@peterrum I would be happy if you could share your opinion.

