### PR TITLE
follow-up to #245

### DIFF
--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -252,7 +252,7 @@ public:
     if(statistics_turb_ch->time_control_statistics.time_control.needs_evaluation(time,
                                                                                  time_step_number))
     {
-      statistics_turb_ch->evaluate(evaluate_get(this->velocity),
+      statistics_turb_ch->evaluate(this->velocity.get_vector(),
                                    Utilities::is_unsteady_timestep(time_step_number));
     }
 

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -252,7 +252,7 @@ public:
     if(statistics_turb_ch->time_control_statistics.time_control.needs_evaluation(time,
                                                                                  time_step_number))
     {
-      statistics_turb_ch->evaluate(this->velocity.get_vector(),
+      statistics_turb_ch->evaluate(this->velocity.evaluate_get(solution),
                                    Utilities::is_unsteady_timestep(time_step_number));
     }
 

--- a/include/exadg/compressible_navier_stokes/postprocessor/output_generator.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/output_generator.cpp
@@ -74,7 +74,7 @@ write_output(
     if(additional_field->get_type() == SolutionFieldType::scalar)
     {
       data_out.add_data_vector(additional_field->get_dof_handler(),
-                               additional_field->get_vector(),
+                               additional_field->get(),
                                additional_field->get_name());
     }
     else if(additional_field->get_type() == SolutionFieldType::vector)
@@ -85,7 +85,7 @@ write_output(
                                  dealii::DataComponentInterpretation::component_is_part_of_vector);
 
       data_out.add_data_vector(additional_field->get_dof_handler(),
-                               additional_field->get_vector(),
+                               additional_field->get(),
                                names,
                                component_interpretation);
     }

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -112,17 +112,16 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
     {
       velocity.evaluate(solution);
       additional_fields_vtu.push_back(&velocity);
-
-      if(pp_data.output_data.write_vorticity)
-      {
-        vorticity.evaluate(velocity.get());
-        additional_fields_vtu.push_back(&vorticity);
-      }
-      if(pp_data.output_data.write_divergence)
-      {
-        divergence.evaluate(velocity.get());
-        additional_fields_vtu.push_back(&divergence);
-      }
+    }
+    if(pp_data.output_data.write_vorticity)
+    {
+      vorticity.evaluate(velocity.evaluate_get(solution));
+      additional_fields_vtu.push_back(&vorticity);
+    }
+    if(pp_data.output_data.write_divergence)
+    {
+      divergence.evaluate(velocity.evaluate_get(solution));
+      additional_fields_vtu.push_back(&divergence);
     }
     if(pp_data.output_data.write_temperature)
     {
@@ -224,44 +223,44 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     };
 
     velocity.reinit();
+  }
 
-    // vorticity
-    if(pp_data.output_data.write_vorticity)
-    {
-      AssertThrow(pp_data.output_data.write_velocity == true,
-                  dealii::ExcMessage("You need to activate write_velocity."));
+  // vorticity
+  if(pp_data.output_data.write_vorticity)
+  {
+    AssertThrow(pp_data.output_data.write_velocity == true,
+                dealii::ExcMessage("You need to activate write_velocity."));
 
-      vorticity.type              = SolutionFieldType::vector;
-      vorticity.name              = "vorticity";
-      vorticity.dof_handler       = &navier_stokes_operator->get_dof_handler_vector();
-      vorticity.initialize_vector = [&](VectorType & dst) {
-        navier_stokes_operator->initialize_dof_vector_dim_components(dst);
-      };
-      vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
-        navier_stokes_operator->compute_vorticity(dst, src);
-      };
+    vorticity.type              = SolutionFieldType::vector;
+    vorticity.name              = "vorticity";
+    vorticity.dof_handler       = &navier_stokes_operator->get_dof_handler_vector();
+    vorticity.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_dof_vector_dim_components(dst);
+    };
+    vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
+      navier_stokes_operator->compute_vorticity(dst, src);
+    };
 
-      vorticity.reinit();
-    }
+    vorticity.reinit();
+  }
 
-    // divergence
-    if(pp_data.output_data.write_divergence)
-    {
-      AssertThrow(pp_data.output_data.write_velocity == true,
-                  dealii::ExcMessage("You need to activate write_velocity."));
+  // divergence
+  if(pp_data.output_data.write_divergence)
+  {
+    AssertThrow(pp_data.output_data.write_velocity == true,
+                dealii::ExcMessage("You need to activate write_velocity."));
 
-      divergence.type              = SolutionFieldType::scalar;
-      divergence.name              = "velocity_divergence";
-      divergence.dof_handler       = &navier_stokes_operator->get_dof_handler_scalar();
-      divergence.initialize_vector = [&](VectorType & dst) {
-        navier_stokes_operator->initialize_dof_vector_scalar(dst);
-      };
-      divergence.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
-        navier_stokes_operator->compute_divergence(dst, src);
-      };
+    divergence.type              = SolutionFieldType::scalar;
+    divergence.name              = "velocity_divergence";
+    divergence.dof_handler       = &navier_stokes_operator->get_dof_handler_scalar();
+    divergence.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_dof_vector_scalar(dst);
+    };
+    divergence.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
+      navier_stokes_operator->compute_divergence(dst, src);
+    };
 
-      divergence.reinit();
-    }
+    divergence.reinit();
   }
 
   // temperature

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -196,9 +196,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     pressure.type              = SolutionFieldType::scalar;
     pressure.name              = "pressure";
     pressure.dof_handler       = &navier_stokes_operator->get_dof_handler_scalar();
-    pressure.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_dof_vector_scalar(*dst);
+    pressure.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_dof_vector_scalar(dst);
     };
     pressure.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_pressure(dst, src);
@@ -217,9 +216,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     velocity.type              = SolutionFieldType::vector;
     velocity.name              = "velocity";
     velocity.dof_handler       = &navier_stokes_operator->get_dof_handler_vector();
-    velocity.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_dof_vector_dim_components(*dst);
+    velocity.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_dof_vector_dim_components(dst);
     };
     velocity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_velocity(dst, src);
@@ -236,9 +234,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
       vorticity.type              = SolutionFieldType::vector;
       vorticity.name              = "vorticity";
       vorticity.dof_handler       = &navier_stokes_operator->get_dof_handler_vector();
-      vorticity.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-        dst = std::make_shared<VectorType>();
-        navier_stokes_operator->initialize_dof_vector_dim_components(*dst);
+      vorticity.initialize_vector = [&](VectorType & dst) {
+        navier_stokes_operator->initialize_dof_vector_dim_components(dst);
       };
       vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
         navier_stokes_operator->compute_vorticity(dst, src);
@@ -256,9 +253,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
       divergence.type              = SolutionFieldType::scalar;
       divergence.name              = "velocity_divergence";
       divergence.dof_handler       = &navier_stokes_operator->get_dof_handler_scalar();
-      divergence.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-        dst = std::make_shared<VectorType>();
-        navier_stokes_operator->initialize_dof_vector_scalar(*dst);
+      divergence.initialize_vector = [&](VectorType & dst) {
+        navier_stokes_operator->initialize_dof_vector_scalar(dst);
       };
       divergence.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
         navier_stokes_operator->compute_divergence(dst, src);
@@ -274,9 +270,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     temperature.type              = SolutionFieldType::scalar;
     temperature.name              = "temperature";
     temperature.dof_handler       = &navier_stokes_operator->get_dof_handler_scalar();
-    temperature.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_dof_vector_scalar(*dst);
+    temperature.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_dof_vector_scalar(dst);
     };
     temperature.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_temperature(dst, src);

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
@@ -72,14 +72,12 @@ protected:
   SolutionField<dim, Number> vorticity;
   SolutionField<dim, Number> divergence;
 
-  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> additional_fields_vtu;
-
 private:
   void
-  initialize_additional_vectors();
+  initialize_derived_fields();
 
   void
-  reinit_additional_fields(VectorType const & solution);
+  invalidate_derived_fields();
 
   MPI_Comm const mpi_comm;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
@@ -84,12 +84,12 @@ write_output(
     if(additional_field->get_type() == SolutionFieldType::scalar)
     {
       data_out.add_data_vector(additional_field->get_dof_handler(),
-                               additional_field->get_vector(),
+                               additional_field->get(),
                                additional_field->get_name());
     }
     else if(additional_field->get_type() == SolutionFieldType::cellwise)
     {
-      data_out.add_data_vector(additional_field->get_vector(), additional_field->get_name());
+      data_out.add_data_vector(additional_field->get(), additional_field->get_name());
     }
     else if(additional_field->get_type() == SolutionFieldType::vector)
     {
@@ -99,7 +99,7 @@ write_output(
                                  dealii::DataComponentInterpretation::component_is_part_of_vector);
 
       data_out.add_data_vector(additional_field->get_dof_handler(),
-                               additional_field->get_vector(),
+                               additional_field->get(),
                                names,
                                component_interpretation);
     }

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -134,17 +134,16 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     velocity,
     {
       vorticity.evaluate(velocity);
       additional_fields_vtu.push_back(&vorticity);
-
-      if(pp_data.output_data.write_vorticity_magnitude)
-      {
-        vorticity_magnitude.evaluate(vorticity.get());
-        additional_fields_vtu.push_back(&vorticity_magnitude);
-      }
-      if(pp_data.output_data.write_streamfunction)
-      {
-        streamfunction.evaluate(vorticity.get());
-        additional_fields_vtu.push_back(&streamfunction);
-      }
+    }
+    if(pp_data.output_data.write_vorticity_magnitude)
+    {
+      vorticity_magnitude.evaluate(vorticity.evaluate_get(velocity));
+      additional_fields_vtu.push_back(&vorticity_magnitude);
+    }
+    if(pp_data.output_data.write_streamfunction)
+    {
+      streamfunction.evaluate(vorticity.evaluate_get(velocity));
+      additional_fields_vtu.push_back(&streamfunction);
     }
     if(pp_data.output_data.write_divergence)
     {
@@ -254,45 +253,45 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     };
 
     vorticity.reinit();
+  }
 
-    // vorticity magnitude
-    if(pp_data.output_data.write_vorticity_magnitude)
-    {
-      AssertThrow(pp_data.output_data.write_vorticity == true,
-                  dealii::ExcMessage("You need to activate write_vorticity."));
+  // vorticity magnitude
+  if(pp_data.output_data.write_vorticity_magnitude)
+  {
+    AssertThrow(pp_data.output_data.write_vorticity == true,
+                dealii::ExcMessage("You need to activate write_vorticity."));
 
-      vorticity_magnitude.type              = SolutionFieldType::scalar;
-      vorticity_magnitude.name              = "vorticity_magnitude";
-      vorticity_magnitude.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
-      vorticity_magnitude.initialize_vector = [&](VectorType & dst) {
-        navier_stokes_operator->initialize_vector_velocity_scalar(dst);
-      };
-      vorticity_magnitude.recompute_solution_field = [&](VectorType & dst, const VectorType & src) {
-        navier_stokes_operator->compute_vorticity_magnitude(dst, src);
-      };
+    vorticity_magnitude.type              = SolutionFieldType::scalar;
+    vorticity_magnitude.name              = "vorticity_magnitude";
+    vorticity_magnitude.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
+    vorticity_magnitude.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity_scalar(dst);
+    };
+    vorticity_magnitude.recompute_solution_field = [&](VectorType & dst, const VectorType & src) {
+      navier_stokes_operator->compute_vorticity_magnitude(dst, src);
+    };
 
-      vorticity_magnitude.reinit();
-    }
+    vorticity_magnitude.reinit();
+  }
 
 
-    // streamfunction
-    if(pp_data.output_data.write_streamfunction)
-    {
-      AssertThrow(pp_data.output_data.write_vorticity == true,
-                  dealii::ExcMessage("You need to activate write_vorticity."));
+  // streamfunction
+  if(pp_data.output_data.write_streamfunction)
+  {
+    AssertThrow(pp_data.output_data.write_vorticity == true,
+                dealii::ExcMessage("You need to activate write_vorticity."));
 
-      streamfunction.type              = SolutionFieldType::scalar;
-      streamfunction.name              = "streamfunction";
-      streamfunction.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
-      streamfunction.initialize_vector = [&](VectorType & dst) {
-        navier_stokes_operator->initialize_vector_velocity_scalar(dst);
-      };
-      streamfunction.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
-        navier_stokes_operator->compute_streamfunction(dst, src);
-      };
+    streamfunction.type              = SolutionFieldType::scalar;
+    streamfunction.name              = "streamfunction";
+    streamfunction.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
+    streamfunction.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity_scalar(dst);
+    };
+    streamfunction.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
+      navier_stokes_operator->compute_streamfunction(dst, src);
+    };
 
-      streamfunction.reinit();
-    }
+    streamfunction.reinit();
   }
 
   // divergence

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -297,7 +297,7 @@ PostProcessor<dim, Number>::initialize_derived_fields()
   // divergence
   if(pp_data.output_data.write_divergence)
   {
-    divergence.type              = SolutionFieldType::vector;
+    divergence.type              = SolutionFieldType::scalar;
     divergence.name              = "div_u";
     divergence.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
     divergence.initialize_vector = [&](VectorType & dst) {

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -246,9 +246,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     vorticity.type              = SolutionFieldType::vector;
     vorticity.name              = "vorticity";
     vorticity.dof_handler       = &navier_stokes_operator->get_dof_handler_u();
-    vorticity.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_vector_velocity(*dst);
+    vorticity.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity(dst);
     };
     vorticity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_vorticity(dst, src);
@@ -265,9 +264,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
       vorticity_magnitude.type              = SolutionFieldType::scalar;
       vorticity_magnitude.name              = "vorticity_magnitude";
       vorticity_magnitude.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
-      vorticity_magnitude.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-        dst = std::make_shared<VectorType>();
-        navier_stokes_operator->initialize_vector_velocity_scalar(*dst);
+      vorticity_magnitude.initialize_vector = [&](VectorType & dst) {
+        navier_stokes_operator->initialize_vector_velocity_scalar(dst);
       };
       vorticity_magnitude.recompute_solution_field = [&](VectorType & dst, const VectorType & src) {
         navier_stokes_operator->compute_vorticity_magnitude(dst, src);
@@ -286,9 +284,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
       streamfunction.type              = SolutionFieldType::scalar;
       streamfunction.name              = "streamfunction";
       streamfunction.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
-      streamfunction.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-        dst = std::make_shared<VectorType>();
-        navier_stokes_operator->initialize_vector_velocity_scalar(*dst);
+      streamfunction.initialize_vector = [&](VectorType & dst) {
+        navier_stokes_operator->initialize_vector_velocity_scalar(dst);
       };
       streamfunction.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
         navier_stokes_operator->compute_streamfunction(dst, src);
@@ -304,9 +301,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     divergence.type              = SolutionFieldType::vector;
     divergence.name              = "div_u";
     divergence.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
-    divergence.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_vector_velocity_scalar(*dst);
+    divergence.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity_scalar(dst);
     };
     divergence.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_divergence(dst, src);
@@ -321,9 +317,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     velocity_magnitude.type              = SolutionFieldType::scalar;
     velocity_magnitude.name              = "velocity_magnitude";
     velocity_magnitude.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
-    velocity_magnitude.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_vector_velocity_scalar(*dst);
+    velocity_magnitude.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity_scalar(dst);
     };
     velocity_magnitude.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_velocity_magnitude(dst, src);
@@ -338,9 +333,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     q_criterion.type              = SolutionFieldType::scalar;
     q_criterion.name              = "q_criterion";
     q_criterion.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
-    q_criterion.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_vector_velocity_scalar(*dst);
+    q_criterion.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity_scalar(dst);
     };
     q_criterion.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       navier_stokes_operator->compute_q_criterion(dst, src);
@@ -355,9 +349,8 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     mean_velocity.type              = SolutionFieldType::vector;
     mean_velocity.name              = "mean_velocity";
     mean_velocity.dof_handler       = &navier_stokes_operator->get_dof_handler_u();
-    mean_velocity.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-      navier_stokes_operator->initialize_vector_velocity(*dst);
+    mean_velocity.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity(dst);
     };
     mean_velocity.recompute_solution_field = [&](VectorType & dst, VectorType const & velocity) {
       unsigned int const counter = time_control_mean_velocity.get_counter();
@@ -371,11 +364,9 @@ PostProcessor<dim, Number>::initialize_derived_fields()
   // cfl
   if(pp_data.output_data.write_cfl)
   {
-    cfl_vector.type              = SolutionFieldType::cellwise;
-    cfl_vector.name              = "cfl_relative";
-    cfl_vector.initialize_vector = [&](std::shared_ptr<VectorType> & dst) {
-      dst = std::make_shared<VectorType>();
-    };
+    cfl_vector.type                     = SolutionFieldType::cellwise;
+    cfl_vector.name                     = "cfl_relative";
+    cfl_vector.initialize_vector        = [&](VectorType &) {};
     cfl_vector.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
       // This time step size corresponds to CFL = 1.
       auto const time_step_size = navier_stokes_operator->calculate_time_step_cfl(src);

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -87,11 +87,6 @@ private:
   void
   initialize_derived_fields();
 
-  // TODO: FOR A MODULAR DESIGN THERE SHOULD PROBALY BE A CLASS CALLED MEAN_VECTOR_CALCULATION IN
-  // WHICH RELEVANT SAMPLES CAN JUST BE SUBMITTED.
-  void
-  compute_mean_velocity(VectorType & mean_velocity, VectorType const & velocity);
-
   void
   invalidate_derived_fields();
 
@@ -108,9 +103,8 @@ private:
   SolutionField<dim, Number> q_criterion;
   SolutionField<dim, Number> cfl_vector;
 
-  TimeControl                 time_control_mean_velocity;
-  std::shared_ptr<VectorType> mean_velocity_vector;
-  SolutionField<dim, Number>  mean_velocity; // velocity field averaged over time
+  TimeControl                time_control_mean_velocity;
+  SolutionField<dim, Number> mean_velocity; // velocity field averaged over time
 
   // write output for visualization of results (e.g., using paraview)
   OutputGenerator<dim, Number> output_generator;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -85,7 +85,7 @@ protected:
 
 private:
   void
-  initialize_additional_vectors();
+  initialize_derived_fields();
 
   // TODO: FOR A MODULAR DESIGN THERE SHOULD PROBALY BE A CLASS CALLED MEAN_VECTOR_CALCULATION IN
   // WHICH RELEVANT SAMPLES CAN JUST BE SUBMITTED.
@@ -93,7 +93,7 @@ private:
   compute_mean_velocity(VectorType & mean_velocity, VectorType const & velocity);
 
   void
-  reinit_additional_fields(VectorType const & velocity);
+  invalidate_derived_fields();
 
   PostProcessorData<dim> pp_data;
 
@@ -108,11 +108,9 @@ private:
   SolutionField<dim, Number> q_criterion;
   SolutionField<dim, Number> cfl_vector;
 
-  TimeControl                time_control_mean_velocity;
-  VectorType                 mean_velocity_vector;
-  SolutionField<dim, Number> mean_velocity; // velocity field averaged over time
-
-  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> additional_fields_vtu;
+  TimeControl                 time_control_mean_velocity;
+  std::shared_ptr<VectorType> mean_velocity_vector;
+  SolutionField<dim, Number>  mean_velocity; // velocity field averaged over time
 
   // write output for visualization of results (e.g., using paraview)
   OutputGenerator<dim, Number> output_generator;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -109,6 +109,7 @@ private:
   SolutionField<dim, Number> cfl_vector;
 
   TimeControl                time_control_mean_velocity;
+  VectorType                 mean_velocity_vector;
   SolutionField<dim, Number> mean_velocity; // velocity field averaged over time
 
   std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> additional_fields_vtu;

--- a/include/exadg/postprocessor/solution_field.h
+++ b/include/exadg/postprocessor/solution_field.h
@@ -41,7 +41,7 @@ public:
   using VectorType = dealii::LinearAlgebra::distributed::Vector<Number>;
 
   SolutionField()
-    : initialize_vector([](std::shared_ptr<VectorType> &) {}),
+    : initialize_vector([](VectorType &) {}),
       recompute_solution_field([](VectorType &, VectorType const &) {}),
       type(SolutionFieldType::scalar),
       name("solution"),
@@ -75,7 +75,7 @@ public:
   {
     if(!is_available)
     {
-      recompute_solution_field(*solution_vector, src);
+      recompute_solution_field(solution_vector, src);
       is_available = true;
     }
   }
@@ -86,7 +86,7 @@ public:
     AssertThrow(is_available,
                 dealii::ExcMessage("You are trying to access a Vector that is invalid."));
 
-    return *solution_vector;
+    return solution_vector;
   }
 
   VectorType const &
@@ -116,7 +116,7 @@ public:
   }
 
   // TODO: these element variables should not be public but instead be passed to the reinit function
-  std::function<void(std::shared_ptr<VectorType> &)> initialize_vector;
+  std::function<void(VectorType &)> initialize_vector;
 
   std::function<void(VectorType &, VectorType const &)> recompute_solution_field;
 
@@ -127,8 +127,8 @@ public:
   dealii::DoFHandler<dim> const * dof_handler;
 
 private:
-  mutable bool                        is_available;
-  mutable std::shared_ptr<VectorType> solution_vector;
+  bool       is_available;
+  VectorType solution_vector;
 };
 
 } // namespace ExaDG

--- a/include/exadg/postprocessor/solution_field.h
+++ b/include/exadg/postprocessor/solution_field.h
@@ -52,8 +52,7 @@ public:
 
   /**
    * This function initializes the DoF vector, the main data object of this class.
-   * This is done by using the lambda initialize_vector. The vector solution_vector
-   * may also point to external data.
+   * This is done by using the lambda initialize_vector.
    */
   void
   reinit()

--- a/include/exadg/postprocessor/solution_field.h
+++ b/include/exadg/postprocessor/solution_field.h
@@ -46,8 +46,7 @@ public:
       type(SolutionFieldType::scalar),
       name("solution"),
       dof_handler(nullptr),
-      is_available(false),
-      src_vector(nullptr)
+      is_available(false)
   {
   }
 
@@ -85,7 +84,7 @@ public:
   get() const
   {
     AssertThrow(is_available,
-                dealii::ExcMessage("You are trying to access a Vector that is not available."));
+                dealii::ExcMessage("You are trying to access a Vector that is invalid."));
 
     return *solution_vector;
   }
@@ -130,7 +129,6 @@ public:
 private:
   mutable bool                        is_available;
   mutable std::shared_ptr<VectorType> solution_vector;
-  VectorType const *                  src_vector;
 };
 
 } // namespace ExaDG


### PR DESCRIPTION
I think the design of `SolutionField` needs to be further improved. 

On the one hand, certain names are not intuitive regarding their meaning or what the functions actually do.

On the other hand, solution field has been misused for certain purposes, which should be avoided. E.g. implementing `get_vector_reference()` and at the same time also the lambda function `recompute_solution_field()` is a mixture of concepts in my opinion (i.e. it would be better to follow one or the other approach for clarity). Also the free functions `evaluate_get()` are irritating in my opinion due to the order of arguments and which variables are returned by these functions. Finally, passing the source vector to `SolutionField` via a `reinit()` function and using the vector later somewhere is unclear and should be avoided. The source vector should in my opinion directly appear in the interface of the `evaluate()` or `evaluate_get()` functions.

I also think there might be subtle bugs in the present implementation that are hopefully removed (at least partly) by this PR.

~~We still need to find a better solution for the "mean velocity" problem/computation.~~ should be resolved now

@jh66637 FYI. I am happy about a review.

Latest update:

closes #284