### PR TITLE
remove templates from make_sparsity_pattern

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -786,8 +786,7 @@ OperatorBase<dim, Number, n_components>::internal_init_system_matrix(
   else if(is_dg && !is_mg)
     dealii::DoFTools::make_flux_sparsity_pattern(dof_handler, dsp);
   else if(/*!is_dg &&*/ is_mg)
-    dealii::MGTools::make_sparsity_pattern<dim, dim, dealii::DynamicSparsityPattern, Number>(
-      dof_handler, dsp, this->level, *this->constraint);
+    dealii::MGTools::make_sparsity_pattern(dof_handler, dsp, this->level, *this->constraint);
   else /* if (!is_dg && !is_mg)*/
     dealii::DoFTools::make_sparsity_pattern(dof_handler, dsp, *this->constraint);
 


### PR DESCRIPTION
Following PR of dealii  https://github.com/dealii/dealii/pull/14433 removes the templates from https://github.com/exadg/exadg/blob/f7c3c2fe427a4c625f22eb9a5da1be35821e9b3f/include/exadg/operators/operator_base.cpp#L789. 

Made Exadg compatible with the changes. Thanks to @bergbauer 

Closes https://github.com/exadg/exadg/issues/279 