### PR TITLE
Fix compilation

### DIFF
--- a/include/exadg/functions_and_boundary_conditions/function_cached.h
+++ b/include/exadg/functions_and_boundary_conditions/function_cached.h
@@ -24,7 +24,10 @@
 
 // deal.II
 #include <deal.II/base/tensor.h>
+
 #include <map>
+#include <tuple>
+#include <vector>
 
 namespace ExaDG
 {

--- a/include/exadg/functions_and_boundary_conditions/linear_interpolation.h
+++ b/include/exadg/functions_and_boundary_conditions/linear_interpolation.h
@@ -24,6 +24,8 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 
+#include <vector>
+
 namespace ExaDG
 {
 template<int dim, typename Number>


### PR DESCRIPTION
On deal.II master, I noticed that beyond #280 some more includes are needed for my system, as `<vector>` does not get include any more. While there, I also included `<tuple>` in a file that obviously uses it, to be explicit in which libraries we are using.