### PR TITLE
remove distribute_mg_dofs from poisson spatial operator

### DIFF
--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -130,10 +130,6 @@ Operator<dim, n_components, Number>::distribute_dofs()
 
   dof_handler.distribute_dofs(*fe);
 
-  // TODO: might need adjustments for simplices
-  if(this->grid->triangulation->all_reference_cells_are_hyper_cube())
-    dof_handler.distribute_mg_dofs();
-
   // affine constraints only relevant for continuous FE discretization
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {


### PR DESCRIPTION
Closes https://github.com/exadg/exadg/issues/277

distrubute_mg_dofs() function call was unnecessary, since it is already called in: https://github.com/exadg/exadg/blob/97f92fdc00e514b892e167cdf2f3bcbe4f0f6a0f/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp#L485

It was also causing problems because it was being called regardless if one uses `local_smoothing`or `global_coarsening`. For `global_coarsening` it is not needed. 