### PR TITLE
generalize InterfaceCoupling towards both surface- and volume-coupled problems

### DIFF
--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -111,7 +111,7 @@ Driver<dim, Number>::setup_interface_coupling()
 
     if(application->fluid->get_parameters().mesh_movement_type == IncNS::MeshMovementType::Poisson)
     {
-      structure_to_ale = std::make_shared<InterfaceCoupling<1, dim, Number>>();
+      structure_to_ale = std::make_shared<SolutionInterpolator<1, dim, Number>>();
       structure_to_ale->setup(fluid->ale_poisson_operator->get_container_interface_data(),
                               structure->pde_operator->get_dof_handler(),
                               *application->structure->get_grid()->mapping,
@@ -121,7 +121,7 @@ Driver<dim, Number>::setup_interface_coupling()
     else if(application->fluid->get_parameters().mesh_movement_type ==
             IncNS::MeshMovementType::Elasticity)
     {
-      structure_to_ale = std::make_shared<InterfaceCoupling<1, dim, Number>>();
+      structure_to_ale = std::make_shared<SolutionInterpolator<1, dim, Number>>();
       structure_to_ale->setup(
         fluid->ale_elasticity_operator->get_container_interface_data_dirichlet(),
         structure->pde_operator->get_dof_handler(),
@@ -151,7 +151,7 @@ Driver<dim, Number>::setup_interface_coupling()
       application->structure->get_boundary_descriptor()->neumann_cached_bc);
     auto const marked_vertices_structure = get_marked_vertices_via_boundary_ids(tria, boundary_ids);
 
-    structure_to_fluid = std::make_shared<InterfaceCoupling<1, dim, Number>>();
+    structure_to_fluid = std::make_shared<SolutionInterpolator<1, dim, Number>>();
     structure_to_fluid->setup(fluid->pde_operator->get_container_interface_data(),
                               structure->pde_operator->get_dof_handler(),
                               *application->structure->get_grid()->mapping,
@@ -178,7 +178,7 @@ Driver<dim, Number>::setup_interface_coupling()
       application->fluid->get_boundary_descriptor()->velocity->dirichlet_cached_bc);
     auto const marked_vertices_fluid = get_marked_vertices_via_boundary_ids(tria, boundary_ids);
 
-    fluid_to_structure = std::make_shared<InterfaceCoupling<1, dim, Number>>();
+    fluid_to_structure = std::make_shared<SolutionInterpolator<1, dim, Number>>();
     fluid_to_structure->setup(structure->pde_operator->get_container_interface_data_neumann(),
                               fluid->pde_operator->get_dof_handler_u(),
                               *mapping_fluid,

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -101,9 +101,9 @@ private:
   std::shared_ptr<SolverFluid<dim, Number>> fluid;
 
   // interface coupling
-  std::shared_ptr<InterfaceCoupling<1, dim, Number>> structure_to_fluid;
-  std::shared_ptr<InterfaceCoupling<1, dim, Number>> structure_to_ale;
-  std::shared_ptr<InterfaceCoupling<1, dim, Number>> fluid_to_structure;
+  std::shared_ptr<SolutionInterpolator<1, dim, Number>> structure_to_fluid;
+  std::shared_ptr<SolutionInterpolator<1, dim, Number>> structure_to_ale;
+  std::shared_ptr<SolutionInterpolator<1, dim, Number>> fluid_to_structure;
 
   // Parameters for partitioned FSI schemes
   Parameters parameters;

--- a/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
@@ -47,8 +47,8 @@ public:
 #ifdef EXADG_WITH_PRECICE
     std::shared_ptr<precice::SolverInterface> precice,
 #endif
-    std::string const                                          mesh_name,
-    std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_,
+    std::string const                                       mesh_name,
+    std::shared_ptr<CouplingDataSurface<rank, dim, double>> interface_data_,
     dealii::types::boundary_id const surface_id = dealii::numbers::invalid_unsigned_int);
 
   /**
@@ -75,7 +75,7 @@ public:
 
 private:
   /// Accessor for ExaDG data structures
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data;
+  std::shared_ptr<CouplingDataSurface<rank, dim, double>> interface_data;
 
   /// The preCICE IDs
   std::vector<int> coupling_nodes_ids;
@@ -92,9 +92,9 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::ExaDGCoupling(
 #ifdef EXADG_WITH_PRECICE
   std::shared_ptr<precice::SolverInterface> precice,
 #endif
-  std::string const                                          mesh_name,
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_,
-  dealii::types::boundary_id const                           surface_id)
+  std::string const                                       mesh_name,
+  std::shared_ptr<CouplingDataSurface<rank, dim, double>> interface_data_,
+  dealii::types::boundary_id const                        surface_id)
   : CouplingBase<dim, data_dim, VectorizedArrayType>(data,
 #ifdef EXADG_WITH_PRECICE
                                                      precice,

--- a/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
+++ b/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
@@ -115,9 +115,9 @@ public:
 
   void
   add_read_surface(std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
-                   std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data,
-                   std::string const &                                        mesh_name,
-                   std::vector<std::string> const &                           read_data_name);
+                   std::shared_ptr<CouplingDataSurface<rank, dim, double>> interface_data,
+                   std::string const &                                     mesh_name,
+                   std::vector<std::string> const &                        read_data_name);
 
   /**
    * @brief      Advances preCICE after every timestep
@@ -295,7 +295,7 @@ template<int dim, int data_dim, typename VectorType, typename VectorizedArrayTyp
 void
 Adapter<dim, data_dim, VectorType, VectorizedArrayType>::add_read_surface(
   std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>>                  interface_data,
+  std::shared_ptr<CouplingDataSurface<rank, dim, double>>                     interface_data,
   std::string const &                                                         mesh_name,
   std::vector<std::string> const &                                            read_data_names)
 {

--- a/include/exadg/functions_and_boundary_conditions/container_interface_data.cpp
+++ b/include/exadg/functions_and_boundary_conditions/container_interface_data.cpp
@@ -25,55 +25,34 @@
 namespace ExaDG
 {
 template<int rank, int dim, typename number_type>
-ContainerInterfaceData<rank, dim, number_type>::ContainerInterfaceData()
+CouplingDataSurface<rank, dim, number_type>::CouplingDataSurface()
 {
 }
 
 template<int rank, int dim, typename number_type>
-typename ContainerInterfaceData<rank, dim, number_type>::data_type
-ContainerInterfaceData<rank, dim, number_type>::get_data(unsigned int const q_index,
-                                                         unsigned int const face,
-                                                         unsigned int const q,
-                                                         unsigned int const v) const
+typename CouplingDataSurface<rank, dim, number_type>::data_type
+CouplingDataSurface<rank, dim, number_type>::get_data(unsigned int const q_index,
+                                                      unsigned int const face,
+                                                      unsigned int const q,
+                                                      unsigned int const v) const
 {
   Assert(map_vector_index.find(q_index) != map_vector_index.end(),
          dealii::ExcMessage("Specified q_index does not exist in map_vector_index."));
 
-  Assert(map_solution.find(q_index) != map_solution.end(),
+  Assert(this->map_solution.find(q_index) != this->map_solution.end(),
          dealii::ExcMessage("Specified q_index does not exist in map_solution."));
 
   Id                              id    = std::make_tuple(face, q, v);
   dealii::types::global_dof_index index = map_vector_index.find(q_index)->second.find(id)->second;
 
-  ArraySolutionValues const & array_solution = map_solution.find(q_index)->second;
+  ArraySolutionValues const & array_solution = this->map_solution.find(q_index)->second;
   Assert(index < array_solution.size(), dealii::ExcMessage("Index exceeds dimensions of vector."));
 
   return array_solution[index];
 }
 
-template<int rank, int dim, typename number_type>
-std::vector<typename ContainerInterfaceData<rank, dim, number_type>::quad_index> const &
-ContainerInterfaceData<rank, dim, number_type>::get_quad_indices()
-{
-  return quad_indices;
-}
-
-template<int rank, int dim, typename number_type>
-typename ContainerInterfaceData<rank, dim, number_type>::ArrayQuadraturePoints &
-ContainerInterfaceData<rank, dim, number_type>::get_array_q_points(quad_index const & q_index)
-{
-  return map_q_points[q_index];
-}
-
-template<int rank, int dim, typename number_type>
-typename ContainerInterfaceData<rank, dim, number_type>::ArraySolutionValues &
-ContainerInterfaceData<rank, dim, number_type>::get_array_solution(quad_index const & q_index)
-{
-  return map_solution[q_index];
-}
-
-template class ContainerInterfaceData<0, 2, double>;
-template class ContainerInterfaceData<1, 2, double>;
-template class ContainerInterfaceData<0, 3, double>;
-template class ContainerInterfaceData<1, 3, double>;
+template class CouplingDataSurface<0, 2, double>;
+template class CouplingDataSurface<1, 2, double>;
+template class CouplingDataSurface<0, 3, double>;
+template class CouplingDataSurface<1, 3, double>;
 } // namespace ExaDG

--- a/include/exadg/functions_and_boundary_conditions/function_cached.cpp
+++ b/include/exadg/functions_and_boundary_conditions/function_cached.cpp
@@ -32,7 +32,7 @@ FunctionCached<rank, dim>::FunctionCached()
 template<int rank, int dim>
 void
 FunctionCached<rank, dim>::set_data_pointer(
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>> const interface_data_)
+  std::shared_ptr<CouplingDataSurface<rank, dim, double>> const interface_data_)
 {
   interface_data = interface_data_;
 }

--- a/include/exadg/functions_and_boundary_conditions/function_cached.h
+++ b/include/exadg/functions_and_boundary_conditions/function_cached.h
@@ -28,16 +28,16 @@
 namespace ExaDG
 {
 /*
- * The only reason why we do not integrate ContainerInterfaceData directly into
+ * The only reason why we do not integrate CouplingDataSurface directly into
  * FunctionCached is that we want to use only one object of type
- * ContainerInterfaceData for (potentially) many boundary IDs and, therefore,
+ * CouplingDataSurface for (potentially) many boundary IDs and, therefore,
  * many objects of type FunctionCached.
  */
 template<int rank, int dim>
 class FunctionCached
 {
 private:
-  typedef typename ContainerInterfaceData<rank, dim, double>::data_type data_type;
+  typedef typename CouplingDataSurface<rank, dim, double>::data_type data_type;
 
 public:
   FunctionCached();
@@ -54,11 +54,10 @@ public:
 
   // initialize data pointer
   void
-  set_data_pointer(
-    std::shared_ptr<ContainerInterfaceData<rank, dim, double>> const interface_data_);
+  set_data_pointer(std::shared_ptr<CouplingDataSurface<rank, dim, double>> const interface_data_);
 
 private:
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data;
+  std::shared_ptr<CouplingDataSurface<rank, dim, double>> interface_data;
 };
 
 } // namespace ExaDG

--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
@@ -25,20 +25,20 @@
 namespace ExaDG
 {
 template<int rank, int dim, typename Number>
-InterfaceCoupling<rank, dim, Number>::InterfaceCoupling() : dof_handler_src(nullptr)
+SolutionInterpolator<rank, dim, Number>::SolutionInterpolator() : dof_handler_src(nullptr)
 {
 }
 
 template<int rank, int dim, typename Number>
 void
-InterfaceCoupling<rank, dim, Number>::setup(
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_dst_,
-  dealii::DoFHandler<dim> const &                            dof_handler_src_,
-  dealii::Mapping<dim> const &                               mapping_src_,
-  std::vector<bool> const &                                  marked_vertices_src_,
-  double const                                               tolerance_)
+SolutionInterpolator<rank, dim, Number>::setup(
+  std::shared_ptr<CouplingDataBase<rank, dim, double>> coupling_data_dst_,
+  dealii::DoFHandler<dim> const &                      dof_handler_src_,
+  dealii::Mapping<dim> const &                         mapping_src_,
+  std::vector<bool> const &                            marked_vertices_src_,
+  double const                                         tolerance_)
 {
-  AssertThrow(interface_data_dst_.get(),
+  AssertThrow(coupling_data_dst_.get(),
               dealii::ExcMessage("Received uninitialized variable. Aborting."));
 
   if(marked_vertices_src_.size() > 0)
@@ -48,10 +48,10 @@ InterfaceCoupling<rank, dim, Number>::setup(
                 dealii::ExcMessage("Vector marked_vertices_src_ has invalid size."));
   }
 
-  interface_data_dst = interface_data_dst_;
-  dof_handler_src    = &dof_handler_src_;
+  coupling_data_dst = coupling_data_dst_;
+  dof_handler_src   = &dof_handler_src_;
 
-  for(auto quad_index : interface_data_dst->get_quad_indices())
+  for(auto quad_index : coupling_data_dst->get_quad_indices())
   {
     // exchange quadrature points with their owners
     map_evaluator.emplace(quad_index,
@@ -60,24 +60,24 @@ InterfaceCoupling<rank, dim, Number>::setup(
                               return marked_vertices_src_;
                             }));
 
-    map_evaluator[quad_index].reinit(interface_data_dst->get_array_q_points(quad_index),
+    map_evaluator[quad_index].reinit(coupling_data_dst->get_array_q_points(quad_index),
                                      dof_handler_src_.get_triangulation(),
                                      mapping_src_);
 
     AssertThrow(
       map_evaluator[quad_index].all_points_found() == true,
       dealii::ExcMessage(
-        "Setup of InterfaceCoupling was not successful. Not all points have been found."));
+        "Setup of SolutionInterpolator was not successful. Not all points have been found."));
   }
 }
 
 template<int rank, int dim, typename Number>
 void
-InterfaceCoupling<rank, dim, Number>::update_data(VectorType const & dof_vector_src)
+SolutionInterpolator<rank, dim, Number>::update_data(VectorType const & dof_vector_src)
 {
   dof_vector_src.update_ghost_values();
 
-  for(auto quadrature : interface_data_dst->get_quad_indices())
+  for(auto quadrature : coupling_data_dst->get_quad_indices())
   {
     auto const result =
       dealii::VectorTools::point_values<n_components>(map_evaluator[quadrature],
@@ -85,7 +85,7 @@ InterfaceCoupling<rank, dim, Number>::update_data(VectorType const & dof_vector_
                                                       dof_vector_src,
                                                       dealii::VectorTools::EvaluationFlags::avg);
 
-    auto & array_solution = interface_data_dst->get_array_solution(quadrature);
+    auto & array_solution = coupling_data_dst->get_array_solution(quadrature);
 
     Assert(result.size() == array_solution.size(),
            dealii::ExcMessage("Vectors must have the same length."));
@@ -95,14 +95,14 @@ InterfaceCoupling<rank, dim, Number>::update_data(VectorType const & dof_vector_
   }
 }
 
-template class InterfaceCoupling<0, 2, float>;
-template class InterfaceCoupling<1, 2, float>;
-template class InterfaceCoupling<0, 3, float>;
-template class InterfaceCoupling<1, 3, float>;
+template class SolutionInterpolator<0, 2, float>;
+template class SolutionInterpolator<1, 2, float>;
+template class SolutionInterpolator<0, 3, float>;
+template class SolutionInterpolator<1, 3, float>;
 
-template class InterfaceCoupling<0, 2, double>;
-template class InterfaceCoupling<1, 2, double>;
-template class InterfaceCoupling<0, 3, double>;
-template class InterfaceCoupling<1, 3, double>;
+template class SolutionInterpolator<0, 2, double>;
+template class SolutionInterpolator<1, 2, double>;
+template class SolutionInterpolator<0, 3, double>;
+template class SolutionInterpolator<1, 3, double>;
 
 } // namespace ExaDG

--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.h
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.h
@@ -32,7 +32,7 @@
 namespace ExaDG
 {
 template<int rank, int dim, typename Number>
-class InterfaceCoupling
+class SolutionInterpolator
 {
 private:
   static unsigned int const n_components = rank_to_n_components<rank, dim>();
@@ -42,7 +42,7 @@ private:
   using VectorType = dealii::LinearAlgebra::distributed::Vector<Number>;
 
 public:
-  InterfaceCoupling();
+  SolutionInterpolator();
 
   /**
    * setup() function.
@@ -55,11 +55,11 @@ public:
    * the search of points on the src side.
    */
   void
-  setup(std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_dst_,
-        dealii::DoFHandler<dim> const &                            dof_handler_src_,
-        dealii::Mapping<dim> const &                               mapping_src_,
-        std::vector<bool> const &                                  marked_vertices_src_,
-        double const                                               tolerance_);
+  setup(std::shared_ptr<CouplingDataBase<rank, dim, double>> coupling_data_dst_,
+        dealii::DoFHandler<dim> const &                      dof_handler_src_,
+        dealii::Mapping<dim> const &                         mapping_src_,
+        std::vector<bool> const &                            marked_vertices_src_,
+        double const                                         tolerance_);
 
   void
   update_data(VectorType const & dof_vector_src);
@@ -68,7 +68,7 @@ private:
   /*
    * dst-side
    */
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_dst;
+  std::shared_ptr<CouplingDataBase<rank, dim, double>> coupling_data_dst;
 
   /*
    *  Evaluates solution on src-side in those points specified by dst-side

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -179,7 +179,7 @@ SpatialOperatorBase<dim, Number>::setup(
   // initialize data container for DirichletCached boundary conditions
   if(not(boundary_descriptor->velocity->dirichlet_cached_bc.empty()))
   {
-    interface_data_dirichlet_cached = std::make_shared<ContainerInterfaceData<1, dim, double>>();
+    interface_data_dirichlet_cached = std::make_shared<CouplingDataSurface<1, dim, double>>();
     std::vector<unsigned int> quad_indices;
     quad_indices.emplace_back(get_quad_index_velocity_linear());
     quad_indices.emplace_back(get_quad_index_velocity_nonlinear());
@@ -879,7 +879,7 @@ SpatialOperatorBase<dim, Number>::get_viscosity_boundary_face(unsigned int const
 }
 
 template<int dim, typename Number>
-std::shared_ptr<ContainerInterfaceData<1, dim, double>>
+std::shared_ptr<CouplingDataSurface<1, dim, double>>
 SpatialOperatorBase<dim, Number>::get_container_interface_data()
 {
   return interface_data_dirichlet_cached;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -194,7 +194,7 @@ public:
   get_viscosity_boundary_face(unsigned int const face, unsigned int const q) const;
 
   // Multiphysics coupling via "Cached" boundary conditions
-  std::shared_ptr<ContainerInterfaceData<1, dim, double>>
+  std::shared_ptr<CouplingDataSurface<1, dim, double>>
   get_container_interface_data();
 
   void
@@ -513,7 +513,7 @@ private:
   /*
    * Interface coupling
    */
-  std::shared_ptr<ContainerInterfaceData<1, dim, double>> interface_data_dirichlet_cached;
+  std::shared_ptr<CouplingDataSurface<1, dim, double>> interface_data_dirichlet_cached;
 
 protected:
   /*

--- a/include/exadg/poisson/overset_grids/driver.cpp
+++ b/include/exadg/poisson/overset_grids/driver.cpp
@@ -60,10 +60,10 @@ DriverOversetGrids<dim, n_components, Number>::setup()
     // domain 1 to domain 2
     pcout << std::endl << "Setup interface coupling first -> second ..." << std::endl;
 
-    first_to_second = std::make_shared<InterfaceCoupling<rank, dim, Number>>();
+    first_to_second = std::make_shared<SolutionInterpolator<rank, dim, Number>>();
     // No map of boundary IDs can be provided to make the search more efficient. The reason behind
     // is that the two domains are not connected along boundaries but are overlapping instead. To
-    // resolve this, the implementation of InterfaceCoupling needs to be generalized.
+    // resolve this, the implementation of SolutionInterpolator needs to be generalized.
     first_to_second->setup(poisson2->pde_operator->get_container_interface_data(),
                            poisson1->pde_operator->get_dof_handler(),
                            *application->domain1->get_grid()->mapping,
@@ -75,7 +75,7 @@ DriverOversetGrids<dim, n_components, Number>::setup()
     // domain 2 to domain 1
     pcout << std::endl << "Setup interface coupling second -> first ..." << std::endl;
 
-    second_to_first = std::make_shared<InterfaceCoupling<rank, dim, Number>>();
+    second_to_first = std::make_shared<SolutionInterpolator<rank, dim, Number>>();
     second_to_first->setup(poisson1->pde_operator->get_container_interface_data(),
                            poisson2->pde_operator->get_dof_handler(),
                            *application->domain2->get_grid()->mapping,

--- a/include/exadg/poisson/overset_grids/driver.h
+++ b/include/exadg/poisson/overset_grids/driver.h
@@ -60,7 +60,7 @@ private:
   std::shared_ptr<SolverPoisson<dim, n_components, Number>> poisson1, poisson2;
 
   // interface coupling
-  std::shared_ptr<InterfaceCoupling<rank, dim, Number>> first_to_second, second_to_first;
+  std::shared_ptr<SolutionInterpolator<rank, dim, Number>> first_to_second, second_to_first;
 };
 
 } // namespace Poisson

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -277,7 +277,7 @@ Operator<dim, n_components, Number>::setup(
 
   if(not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
-    interface_data_dirichlet_cached = std::make_shared<ContainerInterfaceData<rank, dim, double>>();
+    interface_data_dirichlet_cached = std::make_shared<CouplingDataSurface<rank, dim, double>>();
     std::vector<unsigned int> quad_indices;
     if(param.spatial_discretization == SpatialDiscretization::DG)
       quad_indices.emplace_back(get_quad_index());
@@ -637,7 +637,7 @@ Operator<dim, n_components, Number>::get_quad_index_gauss_lobatto() const
 }
 
 template<int dim, int n_components, typename Number>
-std::shared_ptr<ContainerInterfaceData<Operator<dim, n_components, Number>::rank, dim, double>>
+std::shared_ptr<CouplingDataSurface<Operator<dim, n_components, Number>::rank, dim, double>>
 Operator<dim, n_components, Number>::get_container_interface_data()
 {
   return interface_data_dirichlet_cached;

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -98,7 +98,7 @@ public:
   get_average_convergence_rate() const;
 
   // Multiphysics coupling via "Cached" boundary conditions
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>>
+  std::shared_ptr<CouplingDataSurface<rank, dim, double>>
   get_container_interface_data();
 
   std::shared_ptr<TimerTree>
@@ -195,7 +195,7 @@ private:
   /*
    * Interface coupling
    */
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_dirichlet_cached;
+  std::shared_ptr<CouplingDataSurface<rank, dim, double>> interface_data_dirichlet_cached;
 
   RHSOperator<dim, Number, n_components> rhs_operator;
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -75,7 +75,7 @@ Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> ma
 
   if(not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
-    interface_data_dirichlet_cached = std::make_shared<ContainerInterfaceData<1, dim, double>>();
+    interface_data_dirichlet_cached = std::make_shared<CouplingDataSurface<1, dim, double>>();
     std::vector<unsigned int> quad_indices;
     // Gauss-Lobatto quadrature rule for DirichletCached boundary conditions!
     quad_indices.emplace_back(get_quad_index_gauss_lobatto());
@@ -92,7 +92,7 @@ Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number>> ma
 
   if(not(boundary_descriptor->neumann_cached_bc.empty()))
   {
-    interface_data_neumann_cached = std::make_shared<ContainerInterfaceData<1, dim, double>>();
+    interface_data_neumann_cached = std::make_shared<CouplingDataSurface<1, dim, double>>();
     std::vector<unsigned int> quad_indices;
     quad_indices.emplace_back(get_quad_index());
 
@@ -215,14 +215,14 @@ Operator<dim, Number>::get_quad_index_gauss_lobatto() const
 }
 
 template<int dim, typename Number>
-std::shared_ptr<ContainerInterfaceData<1, dim, double>>
+std::shared_ptr<CouplingDataSurface<1, dim, double>>
 Operator<dim, Number>::get_container_interface_data_neumann()
 {
   return interface_data_neumann_cached;
 }
 
 template<int dim, typename Number>
-std::shared_ptr<ContainerInterfaceData<1, dim, double>>
+std::shared_ptr<CouplingDataSurface<1, dim, double>>
 Operator<dim, Number>::get_container_interface_data_dirichlet()
 {
   return interface_data_dirichlet_cached;

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -291,10 +291,10 @@ public:
   get_number_of_dofs() const;
 
   // Multiphysics coupling via "Cached" boundary conditions
-  std::shared_ptr<ContainerInterfaceData<1, dim, double>>
+  std::shared_ptr<CouplingDataSurface<1, dim, double>>
   get_container_interface_data_neumann();
 
-  std::shared_ptr<ContainerInterfaceData<1, dim, double>>
+  std::shared_ptr<CouplingDataSurface<1, dim, double>>
   get_container_interface_data_dirichlet();
 
   // TODO: we currently need this function public for precice-based FSI
@@ -389,8 +389,8 @@ private:
   /*
    * Interface coupling
    */
-  std::shared_ptr<ContainerInterfaceData<1, dim, double>> interface_data_dirichlet_cached;
-  std::shared_ptr<ContainerInterfaceData<1, dim, double>> interface_data_neumann_cached;
+  std::shared_ptr<CouplingDataSurface<1, dim, double>> interface_data_dirichlet_cached;
+  std::shared_ptr<CouplingDataSurface<1, dim, double>> interface_data_neumann_cached;
 
   /*
    * Basic operators.


### PR DESCRIPTION
`InterfaceCoupling` currently depends on `ContainerInterfaceData`, which itself depends on a set of boundary IDs. However, the implementation of `InterfaceCoupling` via `deallii::RemotePointEvaluation` is actually more generally and would allow to treat both surface- and volume-coupled problems.

Therefore, I introduce in this PR the class `CouplingDataBase`, a data structure storing the quadrature points and solution values for both surface- and volume-coupled problems.

Two classes derive from `CouplingDataBase`:
1. `CouplingDataSurface` (formerly `ContainerInterfaceData`)
2. `CouplingDataVolume` (a new class to be filled in the future, i.e. this PR or subsequent PR(s))

With these changes, `InterfaceCoupling` only depends on `CouplingDataBase` and can be used for both surface- and volume-coupled problems. For this reason, I also performed the renaming
- `InterfaceCoupling` -> `SolutionInterpolator`

@kronbichler @peterrum For surface coupled problems, we use the three parameters {face index, q-point index, vectorized array index} to obtain the global vector index accessing the array of q-points and solution values. For volume-coupled problems with the coupling data to be used by `MatrixFree` cell/face/boundary-face loops, I do not know whether we want to have the basic data type `Tensor<rank, dim, VectorizedArray<Number>>` instead of `Tensor<rank, dim, Number>` without unrolling the vectorized array (which we do for surface-coupled problems because of the interface of `dealii::Function<dim>`). If you agree on this, I would have to change `CouplingDataBase` a bit in the sense that the template `number_type` needs to have a more general meaning, i.e. not just `double` vs. `float` but also cover `VectorizedArray`.

@jh66637 FYI