### PR TITLE
[WIP] choose mesh smoothing

### DIFF
--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -174,6 +174,11 @@ private:
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
     this->param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-3;
+
+    AssertThrow(this->param.grid.create_coarse_triangulations ==
+                  this->param.multigrid_data.use_global_coarsening,
+                dealii::ExcMessage(
+                  "Can't use global_coarsening without activating create_coarse_triangulations"))
   }
 
   void
@@ -280,10 +285,7 @@ private:
     pp_data.output_data.directory                   = this->output_parameters.directory + "vtu/";
     pp_data.output_data.filename                    = this->output_parameters.filename;
     pp_data.output_data.write_higher_order          = true;
-    if(this->param.grid.element_type == ElementType::Simplex and dim == 3)
-      AssertThrow(pp_data.output_data.write_higher_order == false,
-                  dealii::ExcMessage("Can't use higher order output with 3D Simplices."));
-    pp_data.output_data.degree = this->param.degree;
+    pp_data.output_data.degree                      = this->param.degree;
 
     pp_data.error_data.time_control_data.is_active = true;
     pp_data.error_data.analytical_solution.reset(new Solution<dim>());
@@ -291,6 +293,10 @@ private:
 
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
     pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+
+    if(this->param.grid.element_type == ElementType::Simplex and dim == 3)
+      AssertThrow(pp_data.output_data.write_higher_order == false,
+                  dealii::ExcMessage("Can't use higher order output with 3D Simplices."));
 
     return pp;
   }

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -174,11 +174,6 @@ private:
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
     this->param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-3;
-
-    AssertThrow(this->param.grid.create_coarse_triangulations ==
-                  this->param.multigrid_data.use_global_coarsening,
-                dealii::ExcMessage(
-                  "Can't use global_coarsening without activating create_coarse_triangulations"))
   }
 
   void

--- a/include/exadg/grid/grid.cpp
+++ b/include/exadg/grid/grid.cpp
@@ -72,19 +72,10 @@ BalancedGranularityPartitionPolicy<dim, spacedim>::partition(
 template<int dim>
 Grid<dim>::Grid(const GridData & data, MPI_Comm const & mpi_comm)
 {
-  typename dealii::parallel::distributed::Triangulation<dim>::Settings distributed_settings;
-
   if(data.create_coarse_triangulations)
-  {
-    mesh_smoothing       = dealii::Triangulation<dim>::none;
-    distributed_settings = dealii::parallel::distributed::Triangulation<dim>::default_setting;
-  }
+    mesh_smoothing = dealii::Triangulation<dim>::none;
   else
-  {
     mesh_smoothing = dealii::Triangulation<dim>::limit_level_difference_at_vertices;
-    distributed_settings =
-      dealii::parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy;
-  }
 
   // triangulation
   if(data.triangulation_type == TriangulationType::Serial)
@@ -94,6 +85,14 @@ Grid<dim>::Grid(const GridData & data, MPI_Comm const & mpi_comm)
   }
   else if(data.triangulation_type == TriangulationType::Distributed)
   {
+    typename dealii::parallel::distributed::Triangulation<dim>::Settings distributed_settings;
+
+    if(data.create_coarse_triangulations)
+      distributed_settings = dealii::parallel::distributed::Triangulation<dim>::default_setting;
+    else
+      distributed_settings =
+        dealii::parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy;
+
     triangulation =
       std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(mpi_comm,
                                                                           mesh_smoothing,

--- a/include/exadg/grid/grid.cpp
+++ b/include/exadg/grid/grid.cpp
@@ -72,18 +72,32 @@ BalancedGranularityPartitionPolicy<dim, spacedim>::partition(
 template<int dim>
 Grid<dim>::Grid(const GridData & data, MPI_Comm const & mpi_comm)
 {
+  typename dealii::parallel::distributed::Triangulation<dim>::Settings distributed_settings;
+
+  if(data.create_coarse_triangulations)
+  {
+    mesh_smoothing       = dealii::Triangulation<dim>::none;
+    distributed_settings = dealii::parallel::distributed::Triangulation<dim>::default_setting;
+  }
+  else
+  {
+    mesh_smoothing = dealii::Triangulation<dim>::limit_level_difference_at_vertices;
+    distributed_settings =
+      dealii::parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy;
+  }
+
   // triangulation
   if(data.triangulation_type == TriangulationType::Serial)
   {
     AssertDimension(dealii::Utilities::MPI::n_mpi_processes(mpi_comm), 1);
-    triangulation = std::make_shared<dealii::Triangulation<dim>>();
+    triangulation = std::make_shared<dealii::Triangulation<dim>>(mesh_smoothing);
   }
   else if(data.triangulation_type == TriangulationType::Distributed)
   {
-    triangulation = std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(
-      mpi_comm,
-      dealii::Triangulation<dim>::none,
-      dealii::parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+    triangulation =
+      std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(mpi_comm,
+                                                                          mesh_smoothing,
+                                                                          distributed_settings);
   }
   else if(data.triangulation_type == TriangulationType::FullyDistributed)
   {
@@ -233,15 +247,22 @@ Grid<dim>::do_create_triangulation(
 
     unsigned int const group_size = 1;
 
+    typename dealii::TriangulationDescription::Settings triangulation_description_setting;
+
+    if(data.create_coarse_triangulations)
+      triangulation_description_setting = dealii::TriangulationDescription::default_setting;
+    else
+      triangulation_description_setting =
+        dealii::TriangulationDescription::construct_multigrid_hierarchy;
+
     // TODO SIMPLEX: this will not work in case of simplex meshes
     auto const description = dealii::TriangulationDescription::Utilities::
-      create_description_from_triangulation_in_groups<dim, dim>(
-        serial_grid_generator,
-        serial_grid_partitioner,
-        triangulation->get_communicator(),
-        group_size,
-        dealii::Triangulation<dim>::none,
-        dealii::TriangulationDescription::construct_multigrid_hierarchy);
+      create_description_from_triangulation_in_groups<dim, dim>(serial_grid_generator,
+                                                                serial_grid_partitioner,
+                                                                triangulation->get_communicator(),
+                                                                group_size,
+                                                                mesh_smoothing,
+                                                                triangulation_description_setting);
 
     triangulation->create_triangulation(description);
   }

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -82,6 +82,11 @@ public:
   get_mapping() const;
 
   /**
+   * dealii::Triangulation::MeshSmoothing
+   */
+  typename dealii::Triangulation<dim>::MeshSmoothing mesh_smoothing;
+
+  /**
    * dealii::Triangulation.
    */
   std::shared_ptr<dealii::Triangulation<dim>> triangulation;

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -147,6 +147,10 @@ MultigridPreconditionerBase<dim, Number>::initialize_levels(dealii::Triangulatio
   }
   else // h-MG is involved working on all mesh levels
   {
+    if(data.use_global_coarsening)
+      AssertThrow(coarse_triangulations.size() > 0,
+                  dealii::ExcMessage("coarse_triangulations vector is not build correctly."));
+
     unsigned int const n_h_levels =
       (data.use_global_coarsening ? coarse_triangulations.size() : tria->n_global_levels());
     for(unsigned int h = 0; h < n_h_levels; h++)


### PR DESCRIPTION
Changed the  mesh smoothing to [none](https://github.com/necioglu/dealii/blob/bdae22407dc0425211e9f4772fa2255dae1e315b/include/deal.II/grid/tria.h#L1155), the distributed triangulation setting to [default_setting](https://github.com/necioglu/dealii/blob/bdae22407dc0425211e9f4772fa2255dae1e315b/include/deal.II/distributed/tria.h#L302) and the triangulation description setting to [default_setting](https://github.com/necioglu/dealii/blob/bdae22407dc0425211e9f4772fa2255dae1e315b/include/deal.II/grid/tria_description.h#L304) for global coarsening, since the options limit_level_differences_at_vertices and construct_multigrid_hierarchy are not needed for global coarsening. For local smoothing they are set.

Also added an Assert for using use_global_coarsening but not activating create_coarse_triangulations.