### PR TITLE
Interface and Volume Coupling

### DIFF
--- a/applications/poisson/overset_grids2/CMakeLists.txt
+++ b/applications/poisson/overset_grids2/CMakeLists.txt
@@ -1,0 +1,32 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2021 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
+
+PROJECT(${TARGET_NAME})
+
+EXADG_PICKUP_EXE(solver.cpp ${TARGET_NAME} solver)

--- a/applications/poisson/overset_grids2/application.h
+++ b/applications/poisson/overset_grids2/application.h
@@ -1,0 +1,324 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+#ifndef APPLICATIONS_POISSON_TEST_CASES_TEMPLATE_H_
+#define APPLICATIONS_POISSON_TEST_CASES_TEMPLATE_H_
+
+namespace ExaDG
+{
+namespace Poisson
+{
+template<int dim, int n_components, typename Number>
+class Application : public ApplicationBase<dim, n_components, Number>
+{
+public:
+  Application(std::string input_file, MPI_Comm const & comm)
+    : ApplicationBase<dim, n_components, Number>(input_file, comm)
+  {
+  }
+
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, n_components, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+
+    prm.add_parameter("MeshType",
+                      mesh_type,
+                      "Type of mesh (Matching, ArtificialNonmatching, Nonmatching or Overset).",
+                      dealii::Patterns::Selection(
+                        "Matching|ArtificialNonmatching|Nonmatching|Overset"));
+    prm.add_parameter("Preconditioner",
+                      preconditioner,
+                      "Which preconditioner is used.",
+                      dealii::Patterns::Selection("None|PointJacobi|BlockJacobi|Multigrid"));
+
+    prm.leave_subsection();
+  }
+
+private:
+  void
+  set_parameters() final
+  {
+    // MATHEMATICAL MODEL
+    this->param.right_hand_side = true;
+
+    // SPATIAL DISCRETIZATION
+    this->param.grid.triangulation_type = TriangulationType::Distributed;
+    this->param.spatial_discretization  = SpatialDiscretization::DG;
+    this->param.IP_factor               = 1.0e0;
+
+    if(mesh_type == "Matching" || mesh_type == "ArtificialNonmatching")
+    {
+      // in case of ArtificialNonmatching the system is symmetrical, generally this is not the case
+      // for non-matching or overset meshes
+      this->param.solver = Solver::CG;
+    }
+    else
+    {
+      // we need GMRES since the system is not symmetrical
+      this->param.solver = Solver::GMRES;
+    }
+
+    this->param.solver_data.abs_tol         = 1.e-20;
+    this->param.solver_data.rel_tol         = 1.e-10;
+    this->param.solver_data.max_iter        = 1e4;
+    this->param.compute_performance_metrics = true;
+
+    if(preconditioner == "None")
+    {
+      this->param.preconditioner = Preconditioner::None;
+    }
+    else if(preconditioner == "PointJacobi")
+    {
+      this->param.preconditioner = Preconditioner::PointJacobi;
+    }
+    else if(preconditioner == "BlockJacobi")
+    {
+      this->param.preconditioner = Preconditioner::BlockJacobi;
+    }
+    else if(preconditioner == "Multigrid")
+    {
+      this->param.preconditioner            = Preconditioner::Multigrid;
+      this->param.multigrid_data.type       = MultigridType::cphMG;
+      this->param.multigrid_data.p_sequence = PSequenceType::Bisect;
+      // MG smoother
+      this->param.multigrid_data.smoother_data.smoother        = MultigridSmoother::Chebyshev;
+      this->param.multigrid_data.smoother_data.iterations      = 5;
+      this->param.multigrid_data.smoother_data.smoothing_range = 20;
+      // MG coarse grid solver
+      this->param.multigrid_data.coarse_problem.solver = MultigridCoarseGridSolver::CG;
+      this->param.multigrid_data.coarse_problem.preconditioner =
+        MultigridCoarseGridPreconditioner::AMG;
+      this->param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-3;
+    }
+  }
+
+  void
+  create_grid() final
+  {
+    if(mesh_type == "Overset")
+    {
+      dealii::Triangulation<dim> domain1;
+      {
+        double const       right = 1.0;
+        dealii::Point<dim> p1, p2;
+        p1[0] = 0.0;
+        p1[1] = 0.0;
+        p2[0] = right;
+        p2[1] = 1.0;
+        dealii::GridGenerator::subdivided_hyper_rectangle(domain1, {3, 3}, p1, p2);
+
+        for(const auto & face : domain1.active_face_iterators())
+          if(face->at_boundary())
+          {
+            if(face->center()[0] > right - 1e-6)
+              face->set_boundary_id(0 + 10);
+            else
+              face->set_boundary_id(0);
+          }
+      }
+
+      dealii::Triangulation<dim> domain2;
+      {
+        double const       left = 0.95;
+        dealii::Point<dim> p1, p2;
+        p1[0] = left;
+        p1[1] = 0.0;
+        p2[0] = left + 1.0;
+        p2[1] = 1.0;
+        dealii::GridGenerator::subdivided_hyper_rectangle(domain2, {2, 2}, p1, p2);
+
+        for(const auto & face : domain2.active_face_iterators())
+          if(face->at_boundary())
+          {
+            if(face->center()[0] < left + 1e-6)
+              face->set_boundary_id(0 + 11);
+            else
+              face->set_boundary_id(0);
+          }
+      }
+
+      dealii::GridGenerator::merge_triangulations(
+        domain1, domain2, *this->grid->triangulation, 0.0, true, true);
+    }
+    else if(mesh_type == "Nonmatching")
+    {
+      dealii::Triangulation<dim> domain1;
+      {
+        double const       right = 1.0;
+        dealii::Point<dim> p1, p2;
+        p1[0] = 0.0;
+        p1[1] = 0.0;
+        p2[0] = right;
+        p2[1] = 1.0;
+        dealii::GridGenerator::subdivided_hyper_rectangle(domain1, {2, 2}, p1, p2);
+
+        for(const auto & face : domain1.active_face_iterators())
+          if(face->at_boundary())
+          {
+            if(face->center()[0] > right - 1e-6)
+              face->set_boundary_id(0 + 10);
+            else
+              face->set_boundary_id(0);
+          }
+      }
+
+      dealii::Triangulation<dim> domain2;
+      {
+        double const       left = 1.0;
+        dealii::Point<dim> p1, p2;
+        p1[0] = left;
+        p1[1] = 0.0;
+        p2[0] = left + 1.0;
+        p2[1] = 1.0;
+        dealii::GridGenerator::subdivided_hyper_rectangle(domain2, {3, 3}, p1, p2);
+
+        for(const auto & face : domain2.active_face_iterators())
+          if(face->at_boundary())
+          {
+            if(face->center()[0] < left + 1e-6)
+              face->set_boundary_id(0 + 11);
+            else
+              face->set_boundary_id(0);
+          }
+      }
+
+      dealii::GridGenerator::merge_triangulations(
+        domain1, domain2, *this->grid->triangulation, 0.0, true, true);
+    }
+    else if(mesh_type == "ArtificialNonmatching")
+    {
+      // ArtificialNonmatching is designed, such that the same mesh is used as in the Matching case.
+      // Therefore, results and iterations should be equivalent even though the overset
+      // implementation is uesd
+
+      dealii::Triangulation<dim> domain1;
+      {
+        double const       right = 1.0;
+        dealii::Point<dim> p1, p2;
+        p1[0] = 0.0;
+        p1[1] = 0.0;
+        p2[0] = right;
+        p2[1] = 1.0;
+        dealii::GridGenerator::subdivided_hyper_rectangle(domain1, {3, 3}, p1, p2);
+
+        for(const auto & face : domain1.active_face_iterators())
+          if(face->at_boundary())
+          {
+            if(face->center()[0] > right - 1e-6)
+              face->set_boundary_id(0 + 10);
+            else
+              face->set_boundary_id(0);
+          }
+      }
+
+      dealii::Triangulation<dim> domain2;
+      {
+        double const       left = 1.0;
+        dealii::Point<dim> p1, p2;
+        p1[0] = left;
+        p1[1] = 0.0;
+        p2[0] = left + 1.0;
+        p2[1] = 1.0;
+        dealii::GridGenerator::subdivided_hyper_rectangle(domain2, {3, 3}, p1, p2);
+
+        for(const auto & face : domain2.active_face_iterators())
+          if(face->at_boundary())
+          {
+            if(face->center()[0] < left + 1e-6)
+              face->set_boundary_id(0 + 11);
+            else
+              face->set_boundary_id(0);
+          }
+      }
+
+      dealii::GridGenerator::merge_triangulations(
+        domain1, domain2, *this->grid->triangulation, 0.0, true, true);
+    }
+    else if(mesh_type == "Matching")
+    {
+      dealii::Point<dim> p1, p2;
+      p1[0] = 0.0;
+      p1[1] = 0.0;
+      p2[0] = 2.0;
+      p2[1] = 1.0;
+      dealii::GridGenerator::subdivided_hyper_rectangle(*this->grid->triangulation, {6, 3}, p1, p2);
+
+      for(const auto & face : this->grid->triangulation->active_face_iterators())
+        if(face->at_boundary())
+          face->set_boundary_id(0);
+    }
+
+
+    this->grid->triangulation->refine_global(this->param.grid.n_refine_global);
+  }
+
+  void
+  set_boundary_descriptor() final
+  {
+    this->boundary_descriptor->dirichlet_bc.insert(
+      std::make_pair(0, std::make_shared<dealii::Functions::ZeroFunction<dim>>(dim)));
+
+    if(mesh_type == "Nonmatching" || mesh_type == "Overset" || mesh_type == "ArtificialNonmatching")
+    {
+      this->boundary_descriptor->overset_boundaries.insert(std::make_pair(10, 11));
+      this->boundary_descriptor->overset_boundaries.insert(std::make_pair(11, 10));
+    }
+  }
+
+  void
+  set_field_functions() final
+  {
+    this->field_functions->initial_solution.reset(
+      new dealii::Functions::ZeroFunction<dim>(n_components));
+    this->field_functions->right_hand_side.reset(
+      new dealii::Functions::ConstantFunction<dim>(1.0, n_components));
+  }
+
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
+  create_postprocessor() final
+  {
+    PostProcessorData<dim> pp_data;
+    pp_data.output_data.time_control_data.is_active = this->output_parameters.write;
+    pp_data.output_data.directory                   = this->output_parameters.directory + "vtu/";
+    pp_data.output_data.filename           = this->output_parameters.filename + "_" + mesh_type;
+    pp_data.output_data.write_higher_order = true;
+    pp_data.output_data.degree             = this->param.degree;
+    pp_data.output_data.write_boundary_IDs = true;
+
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
+
+    return pp;
+  }
+
+  std::string mesh_type      = "Overset";
+  std::string preconditioner = "Multigrid";
+};
+
+
+} // namespace Poisson
+} // namespace ExaDG
+
+#include <exadg/poisson/user_interface/implement_get_application.h>
+
+#endif /*APPLICATIONS_POISSON_TEST_CASES_TEMPLATE_H_*/

--- a/applications/poisson/overset_grids2/input.json
+++ b/applications/poisson/overset_grids2/input.json
@@ -1,0 +1,25 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "2",
+        "IsTest": "false"
+    },
+    "Resolution": {
+        "RunType": "RefineHAndP",
+        "DegreeMin": "3",
+        "DegreeMax": "3",
+        "RefineSpaceMin": "2",
+        "RefineSpaceMax": "2",
+        "DofsMin": "1000",
+        "DofsMax": "10000"
+    },
+    "Application": {
+        "MeshType": "Overset",
+        "Preconditioner": "Multigrid"
+    },
+    "Output": {
+        "OutputDirectory": "output/overset_grids2/",
+        "OutputName": "solution",
+        "WriteOutput": "true"
+    }
+}

--- a/applications/poisson/overset_grids2/solver.cpp
+++ b/applications/poisson/overset_grids2/solver.cpp
@@ -1,0 +1,26 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// solver
+#include <exadg/poisson/solver.h>
+
+// application
+#include "application.h"

--- a/include/exadg/coupling/fe_remote_point_evaluation.h
+++ b/include/exadg/coupling/fe_remote_point_evaluation.h
@@ -1,0 +1,147 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_H_
+#define INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_H_
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+
+#include <exadg/coupling/fe_remote_point_evaluation_communicator.h>
+
+namespace ExaDG
+{
+/**
+ * A class to access the fields in FERemotePointEvaluationData.
+ *
+ * The function gather_evaluate() allow also to fill
+ * FERemotePointEvaluationData but one could imagine that one
+ * works on an external instance of FERemotePointEvaluationData
+ * which is handled and filled outside by the user.
+ */
+template<int dim,
+         int n_components,
+         typename Number,
+         typename VectorizedArrayType = dealii::VectorizedArray<Number>>
+class FERemotePointEvaluation
+{
+public:
+  using data_type     = FERemotePointEvaluationData<dim, n_components, Number, VectorizedArrayType>;
+  using value_type    = typename data_type::value_type;
+  using gradient_type = typename data_type::gradient_type;
+
+  template<template<int> class MeshType>
+  FERemotePointEvaluation(const FERemotePointEvaluationCommunicator<dim, Number> &    comm,
+                          const MeshType<dim> &                                       mesh,
+                          const dealii::VectorTools::EvaluationFlags::EvaluationFlags vt_flags =
+                            dealii::VectorTools::EvaluationFlags::avg)
+    : comm(&comm), vt_flags(vt_flags), cell(dealii::numbers::invalid_unsigned_int)
+  {
+    set_mesh(mesh);
+  }
+
+  FERemotePointEvaluation(const FERemotePointEvaluationCommunicator<dim, Number> &    comm_in,
+                          const dealii::VectorTools::EvaluationFlags::EvaluationFlags vt_flags =
+                            dealii::VectorTools::EvaluationFlags::avg)
+    : comm(&comm_in), vt_flags(vt_flags), cell(dealii::numbers::invalid_unsigned_int)
+  {
+  }
+
+  template<template<int> class MeshType>
+  void
+  setup_mesh_type(const MeshType<dim> & mesh_in)
+  {
+    AssertThrow((!tria) && (!dof_handler), dealii::ExcMessage("Mesh has already been set!"));
+
+    set_mesh(mesh_in);
+  }
+
+
+  template<typename VectorType>
+  void
+  gather_evaluate(const VectorType & vector, const dealii::EvaluationFlags::EvaluationFlags flags)
+  {
+    if(tria)
+    {
+      AssertThrow(n_components == 1, dealii::ExcNotImplemented());
+      comm->update_ghost_values(this->data, *tria, vector, flags, vt_flags);
+    }
+    else if(dof_handler)
+      comm->update_ghost_values(this->data, *dof_handler, vector, flags, vt_flags);
+    else
+      AssertThrow(false, dealii::ExcNotImplemented());
+  }
+
+  void
+  reinit(const unsigned int cell)
+  {
+    this->cell = cell;
+  }
+
+  value_type
+  get_value(const unsigned int q) const
+  {
+    Assert(this->cell != dealii::numbers::invalid_unsigned_int, dealii::ExcInternalError());
+
+    const unsigned int index = comm->get_shift(cell) + q;
+
+    AssertIndexRange(index, data.values.size());
+
+    return data.values[index];
+  }
+
+  gradient_type
+  get_gradient(const unsigned int q) const
+  {
+    Assert(this->cell != dealii::numbers::invalid_unsigned_int, dealii::ExcInternalError());
+
+    const unsigned int index = comm->get_shift(cell) + q;
+
+    AssertIndexRange(index, data.gradients.size());
+
+    return data.gradients[index];
+  }
+
+private:
+  void
+  set_mesh(const dealii::Triangulation<dim> & tria)
+  {
+    this->tria = &tria;
+  }
+
+  void
+  set_mesh(const dealii::DoFHandler<dim> & dof_handler)
+  {
+    this->dof_handler = &dof_handler;
+  }
+
+  data_type data;
+
+  dealii::SmartPointer<const FERemotePointEvaluationCommunicator<dim, Number>> comm;
+  const dealii::VectorTools::EvaluationFlags::EvaluationFlags                  vt_flags;
+
+  dealii::SmartPointer<const dealii::Triangulation<dim>> tria;
+  dealii::SmartPointer<const dealii::DoFHandler<dim>>    dof_handler;
+
+  unsigned int cell;
+};
+} // namespace ExaDG
+
+#endif /*INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_H_*/

--- a/include/exadg/coupling/fe_remote_point_evaluation_communicator.h
+++ b/include/exadg/coupling/fe_remote_point_evaluation_communicator.h
@@ -1,0 +1,576 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_COMMUNICATOR_H_
+#define INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_COMMUNICATOR_H_
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/smartpointer.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <exadg/coupling/fe_remote_point_evaluation_data.h>
+#include <exadg/coupling/fe_remote_point_evaluation_data_view.h>
+
+namespace ExaDG
+{
+template<int dim, typename Number, typename VectorizedArrayType>
+std::tuple<std::vector<std::pair<unsigned int, unsigned int>>, std::vector<dealii::Point<dim>>>
+get_points_of_cells(const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+                    const unsigned int                                           this_dof_index,
+                    const unsigned int                                           this_quad_index)
+{
+  std::vector<std::pair<unsigned int, unsigned int>> cells;
+  std::vector<dealii::Point<dim>>                    points;
+
+  // TODO: can we access quadrature points without FEEval?
+  dealii::FEEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                         this_dof_index,
+                                                                         this_quad_index);
+
+  for(unsigned int cell = 0; cell < this_matrix_free.n_cell_batches(); ++cell)
+  {
+    phi_m.reinit(cell);
+    cells.emplace_back(cell, this_matrix_free.n_active_entries_per_cell_batch(cell));
+
+    for(unsigned int v = 0; v < this_matrix_free.n_active_entries_per_cell_batch(cell); ++v)
+    {
+      for(unsigned int q = 0; q < phi_m.n_q_points; ++q)
+      {
+        const auto         point = phi_m.quadrature_point(q);
+        dealii::Point<dim> temp;
+        for(unsigned int i = 0; i < dim; ++i)
+          temp[i] = point[i][v];
+
+        points.emplace_back(temp);
+      }
+    }
+  }
+
+  return {cells, points};
+}
+
+template<int dim, typename Number, typename VectorizedArrayType>
+std::tuple<std::vector<std::pair<unsigned int, unsigned int>>, std::vector<dealii::Point<dim>>>
+get_points_of_inner_faces(
+  const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+  const unsigned int                                           this_dof_index,
+  const unsigned int                                           this_quad_index)
+{
+  std::vector<std::pair<unsigned int, unsigned int>> faces;
+  std::vector<dealii::Point<dim>>                    points;
+
+  // TODO: can we access quadrature points without FEFaceEval?
+  dealii::FEFaceEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                             true,
+                                                                             this_dof_index,
+                                                                             this_quad_index);
+
+  for(unsigned int face = 0; face < this_matrix_free.n_inner_face_batches(); ++face)
+  {
+    phi_m.reinit(face);
+    faces.emplace_back(face, this_matrix_free.n_active_entries_per_face_batch(face));
+
+    for(unsigned int v = 0; v < this_matrix_free.n_active_entries_per_face_batch(face); ++v)
+    {
+      for(unsigned int q = 0; q < phi_m.n_q_points; ++q)
+      {
+        const auto         point = phi_m.quadrature_point(q);
+        dealii::Point<dim> temp;
+        for(unsigned int i = 0; i < dim; ++i)
+          temp[i] = point[i][v];
+
+        points.emplace_back(temp);
+      }
+    }
+  }
+  return {faces, points};
+}
+
+template<int dim, typename Number, typename VectorizedArrayType>
+std::tuple<std::vector<std::pair<unsigned int, unsigned int>>, std::vector<dealii::Point<dim>>>
+get_points_of_boundary_faces(
+  const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+  const unsigned int                                           this_dof_index,
+  const unsigned int                                           this_quad_index)
+{
+  std::vector<std::pair<unsigned int, unsigned int>> faces;
+  std::vector<dealii::Point<dim>>                    points;
+
+  // TODO: can we access quadrature points without FEFaceEval?
+  dealii::FEFaceEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                             true,
+                                                                             this_dof_index,
+                                                                             this_quad_index);
+
+  for(unsigned int bface = 0; bface < this_matrix_free.n_boundary_face_batches(); ++bface)
+  {
+    const unsigned int face = bface + this_matrix_free.n_inner_face_batches();
+
+    phi_m.reinit(face);
+    faces.emplace_back(face, this_matrix_free.n_active_entries_per_face_batch(face));
+
+    for(unsigned int v = 0; v < this_matrix_free.n_active_entries_per_face_batch(face); ++v)
+    {
+      for(unsigned int q = 0; q < phi_m.n_q_points; ++q)
+      {
+        const auto         point = phi_m.quadrature_point(q);
+        dealii::Point<dim> temp;
+        for(unsigned int i = 0; i < dim; ++i)
+          temp[i] = point[i][v];
+
+        points.emplace_back(temp);
+      }
+    }
+  }
+  return {faces, points};
+}
+
+
+template<int dim, typename Number, typename VectorizedArrayType>
+std::tuple<std::vector<std::pair<unsigned int, unsigned int>>, std::vector<dealii::Point<dim>>>
+get_points_on_boundary_face(
+  const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+  const unsigned int                                           this_dof_index,
+  const unsigned int                                           this_quad_index,
+  const dealii::types::boundary_id                             primary_id)
+{
+  std::vector<std::pair<unsigned int, unsigned int>> faces;
+  std::vector<dealii::Point<dim>>                    points;
+
+  // TODO: can we access quadrature points without FEFaceEval?
+  dealii::FEFaceEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                             true,
+                                                                             this_dof_index,
+                                                                             this_quad_index);
+
+  for(unsigned int bface = 0; bface < this_matrix_free.n_boundary_face_batches(); ++bface)
+  {
+    const unsigned int face = bface + this_matrix_free.n_inner_face_batches();
+
+    if(this_matrix_free.get_boundary_id(face) == primary_id)
+    {
+      phi_m.reinit(face);
+      faces.emplace_back(face, this_matrix_free.n_active_entries_per_face_batch(face));
+
+      for(unsigned int v = 0; v < this_matrix_free.n_active_entries_per_face_batch(face); ++v)
+      {
+        for(unsigned int q = 0; q < phi_m.n_q_points; ++q)
+        {
+          const auto         point = phi_m.quadrature_point(q);
+          dealii::Point<dim> temp;
+          for(unsigned int i = 0; i < dim; ++i)
+            temp[i] = point[i][v];
+
+          points.emplace_back(temp);
+        }
+      }
+    }
+  }
+
+  return {faces, points};
+}
+
+template<int dim>
+class MarkVerticesAtBoundaryID
+{
+public:
+  MarkVerticesAtBoundaryID(const dealii::Triangulation<dim> & tria, dealii::types::boundary_id id)
+    : tria(tria), id(id)
+  {
+  }
+
+  std::vector<bool>
+  operator()()
+  {
+    std::vector<bool> mask(tria.n_vertices(), false);
+
+    for(const auto & face : tria.active_face_iterators())
+      if(face->at_boundary() && face->boundary_id() == id)
+        for(const auto v : face->vertex_indices())
+          mask[face->vertex_index(v)] = true;
+
+    return mask;
+  }
+
+private:
+  const dealii::Triangulation<dim> & tria;
+  const dealii::types::boundary_id   id;
+};
+
+template<int dim>
+class MarkVerticesAtBoundaryIDs
+{
+public:
+  MarkVerticesAtBoundaryIDs(const dealii::Triangulation<dim> &           tria,
+                            const std::set<dealii::types::boundary_id> & ids)
+    : tria(tria), ids(ids)
+  {
+  }
+
+  std::vector<bool>
+  operator()()
+  {
+    std::vector<bool> mask(tria.n_vertices(), false);
+
+    for(const auto & face : tria.active_face_iterators())
+      if(face->at_boundary() && ids.find(face->boundary_id()) != ids.end())
+        for(const auto v : face->vertex_indices())
+          mask[face->vertex_index(v)] = true;
+
+    return mask;
+  }
+
+private:
+  const dealii::Triangulation<dim> &         tria;
+  const std::set<dealii::types::boundary_id> ids;
+};
+
+/**
+ * A class to fill the fields in FERemotePointEvaluationData.
+ */
+template<int dim, typename Number>
+class FERemotePointEvaluationCommunicator : public dealii::Subscriptor
+{
+public:
+  template<typename VectorizedArrayType>
+  void
+  initialize_volume_coupling(
+    const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+    const unsigned int                                           this_dof_index,
+    const unsigned int                                           this_quad_index,
+    const dealii::Triangulation<dim> &                           other_tria,
+    const dealii::Mapping<dim> &                                 other_mapping,
+    const double                                                 tol = 1e-6)
+  {
+    view.initialize_volume(this_matrix_free, this_dof_index, this_quad_index);
+
+    const auto [cells, points] =
+      get_points_of_cells(this_matrix_free, this_dof_index, this_quad_index);
+
+    auto rpe = std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(tol, false, 0);
+
+    rpe->reinit(points, other_tria, other_mapping);
+
+    communication_objects.emplace_back(rpe, cells);
+  }
+
+  template<typename VectorizedArrayType>
+  void
+  initialize_inner_face_coupling(
+    const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+    const unsigned int                                           this_dof_index,
+    const unsigned int                                           this_quad_index,
+    const dealii::Triangulation<dim> &                           other_tria,
+    const dealii::Mapping<dim> &                                 other_mapping,
+    const double                                                 tol = 1e-6)
+  {
+    view.initialize_inner_faces(this_matrix_free, this_dof_index, this_quad_index);
+
+    const auto [faces, points] =
+      get_points_of_inner_faces(this_matrix_free, this_dof_index, this_quad_index);
+
+    auto rpe = std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(tol, false, 0);
+
+    rpe->reinit(points, other_tria, other_mapping);
+
+    communication_objects.emplace_back(rpe, faces);
+  }
+
+  template<typename VectorizedArrayType>
+  void
+  initialize_boundary_face_coupling(
+    const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+    const unsigned int                                           this_dof_index,
+    const unsigned int                                           this_quad_index,
+    const dealii::Triangulation<dim> &                           other_tria,
+    const dealii::Mapping<dim> &                                 other_mapping,
+    const double                                                 tol = 1e-6)
+  {
+    view.initialize_boundary_faces(this_matrix_free, this_dof_index, this_quad_index);
+
+    const auto [faces, points] =
+      get_points_of_boundary_faces(this_matrix_free, this_dof_index, this_quad_index);
+
+    auto rpe = std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(tol, false, 0);
+
+    rpe->reinit(points, other_tria, other_mapping);
+
+    communication_objects.emplace_back(rpe, faces);
+  }
+
+  bool
+  all_points_found() const
+  {
+    for(auto const [rpe, _] : communication_objects)
+      if(!rpe->all_points_found())
+        return false;
+
+    return true;
+  }
+
+
+  template<typename VectorizedArrayType>
+  void
+  initialize_face_pairs(
+    const std::vector<std::pair<dealii::types::boundary_id, dealii::types::boundary_id>> &
+                                                                 face_pairs,
+    const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+    const unsigned int                                           this_dof_index,
+    const unsigned int                                           this_quad_index,
+    const dealii::Triangulation<dim> &                           other_tria,
+    const dealii::Mapping<dim> &                                 other_mapping,
+    const double                                                 tol = 1e-6)
+  {
+    std::set<dealii::types::boundary_id> faces;
+    for(const auto & face_pair : face_pairs)
+      faces.insert(face_pair.first);
+
+    view.initialize_faces(this_matrix_free, this_dof_index, this_quad_index, faces);
+
+    // loop could be eliminated if we would use a single RPE
+    for(const auto & face_pair : face_pairs)
+    {
+      const unsigned int primary_id   = face_pair.first;
+      const unsigned int secondary_id = face_pair.second;
+
+      const auto [faces, points] =
+        get_points_on_boundary_face(this_matrix_free, this_dof_index, this_quad_index, primary_id);
+
+      auto rpe = std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(
+        tol, false, 0, MarkVerticesAtBoundaryID(other_tria, secondary_id));
+
+      rpe->reinit(points, other_tria, other_mapping);
+
+      AssertThrow(rpe->all_points_found(), dealii::ExcMessage("Not all remote points found."));
+
+      communication_objects.emplace_back(rpe, faces);
+    }
+  }
+
+  template<typename VectorizedArrayType>
+  void
+  reinit(const std::vector<std::pair<dealii::types::boundary_id, dealii::types::boundary_id>> &
+                                                                      face_pairs,
+         const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+         const unsigned int                                           this_dof_index,
+         const unsigned int                                           this_quad_index,
+         const dealii::Triangulation<dim> &                           other_tria,
+         const dealii::Mapping<dim> &                                 other_mapping)
+  {
+    AssertThrow(face_pairs.size() == communication_objects.size(),
+                dealii::ExcMessage("FacePairs and Comm Objects have to fit!"));
+
+    auto face_pair = face_pairs.begin();
+    for(auto & [rpe, faces_old] : communication_objects)
+    {
+      AssertThrow(&rpe->get_triangulation() == &other_tria,
+                  dealii::ExcMessage("Triangulations in RemotePointEvaluation can not change."));
+
+      const unsigned int primary_id = face_pair->first;
+
+      const auto [faces_new, points] =
+        get_points_on_boundary_face(this_matrix_free, this_dof_index, this_quad_index, primary_id);
+
+      rpe->reinit(points, other_tria, other_mapping);
+
+      AssertThrow(rpe->all_points_found(), dealii::ExcMessage("Not all remote points found."));
+
+      faces_old = std::move(faces_new);
+
+      ++face_pair;
+    }
+  }
+
+
+  template<typename VectorizedArrayType>
+  void
+  initialize_face_pairs(
+    const std::vector<std::pair<dealii::types::boundary_id, dealii::types::boundary_id>> &
+                                                                 face_pairs,
+    const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+    const unsigned int                                           this_dof_index,
+    const unsigned int                                           this_quad_index,
+    const double                                                 tol = 1e-6)
+  {
+    this->initialize_face_pairs(
+      face_pairs,
+      this_matrix_free,
+      this_dof_index,
+      this_quad_index,
+      this_matrix_free.get_dof_handler(this_dof_index).get_triangulation(),
+      *this_matrix_free.get_mapping_info().mapping,
+      tol);
+  }
+
+  template<int n_components,
+           typename VectorizedArrayType,
+           typename VectorType,
+           template<int>
+           class MeshType>
+  void
+  update_ghost_values(
+    FERemotePointEvaluationData<dim, n_components, Number, VectorizedArrayType> & dst,
+    const MeshType<dim> &                                                         mesh,
+    const VectorType &                                                            src,
+    const dealii::EvaluationFlags::EvaluationFlags                                eval_flags,
+    const dealii::VectorTools::EvaluationFlags::EvaluationFlags                   vec_flags) const
+  {
+    const bool has_ghost_elements = src.has_ghost_elements();
+
+    if(has_ghost_elements == false)
+      src.update_ghost_values();
+
+    // loop could be eliminitated if we would use a single RPE
+    for(const auto & communication_object : communication_objects)
+    {
+      if(eval_flags & dealii::EvaluationFlags::values)
+      {
+        copy_data(dst.values,
+                  dealii::VectorTools::point_values<n_components>(
+                    *communication_object.first, mesh, src, vec_flags),
+                  communication_object.second);
+      }
+
+      if(eval_flags & dealii::EvaluationFlags::gradients)
+      {
+        copy_data(dst.gradients,
+                  dealii::VectorTools::point_gradients<n_components>(
+                    *communication_object.first, mesh, src, vec_flags),
+                  communication_object.second);
+      }
+
+      Assert(!(eval_flags & dealii::EvaluationFlags::hessians), dealii::ExcNotImplemented());
+    }
+
+    if(has_ghost_elements == false)
+      zero_out_ghost_values(src); // TODO: move to deal.II
+  }
+
+  unsigned int
+  get_shift(const unsigned int cell) const
+  {
+    return view.get_shift(cell);
+  }
+
+private:
+  FERemotePointEvaluationDataView<dim, Number> view;
+  std::vector<std::pair<std::shared_ptr<dealii::Utilities::MPI::RemotePointEvaluation<dim>>,
+                        std::vector<std::pair<unsigned int, unsigned int>>>>
+    communication_objects;
+
+  template<typename T>
+  static void
+  zero_out_ghost_values(const dealii::Vector<T> &)
+  {
+    // nothing to do
+  }
+
+  template<typename T>
+  static void
+  zero_out_ghost_values(const dealii::LinearAlgebra::distributed::Vector<T> & vec)
+  {
+    vec.zero_out_ghost_values();
+  }
+
+  template<typename T1, std::size_t n_lanes>
+  void
+  copy_data(dealii::VectorizedArray<T1, n_lanes> & dst, const unsigned int v, const T1 & src) const
+  {
+    AssertIndexRange(v, n_lanes);
+
+    dst[v] = src;
+  }
+
+  template<typename T1, int rank_, std::size_t n_lanes, int dim_>
+  void
+  copy_data(dealii::Tensor<rank_, dim_, dealii::VectorizedArray<T1, n_lanes>> & dst,
+            const unsigned int                                                  v,
+            const dealii::Tensor<rank_, dim_, T1> &                             src) const
+  {
+    AssertIndexRange(v, n_lanes);
+
+    if constexpr(rank_ == 1)
+    {
+      for(unsigned int i = 0; i < dim_; ++i)
+        dst[i][v] = src[i];
+    }
+    else
+    {
+      for(unsigned int i = 0; i < rank_; ++i)
+        for(unsigned int j = 0; j < dim_; ++j)
+          dst[i][j][v] = src[i][j];
+    }
+  }
+
+  template<typename T1, int rank_, std::size_t n_lanes, int n_components_, int dim_>
+  void
+  copy_data(dealii::Tensor<rank_,
+                           n_components_,
+                           dealii::Tensor<rank_, dim_, dealii::VectorizedArray<T1, n_lanes>>> & dst,
+            const unsigned int                                                                  v,
+            const dealii::Tensor<rank_, n_components_, dealii::Tensor<rank_, dim_, T1>> & src) const
+  {
+    if constexpr(rank_ == 1)
+    {
+      for(unsigned int i = 0; i < n_components_; ++i)
+        copy_data(dst[i], v, src[i]);
+    }
+    else
+    {
+      for(unsigned int i = 0; i < rank_; ++i)
+        for(unsigned int j = 0; j < n_components_; ++j)
+          dst[i][j][v] = src[i][j];
+    }
+  }
+
+  template<typename T1, typename T2>
+  void
+  copy_data(std::vector<T1> &                                          dst,
+            const std::vector<T2> &                                    src,
+            const std::vector<std::pair<unsigned int, unsigned int>> & data_ptrs) const
+  {
+    dst.resize(view.size());
+
+    unsigned int c = 0;
+    for(const auto data_ptr : data_ptrs)
+    {
+      const unsigned int bface     = data_ptr.first;
+      const unsigned int n_entries = data_ptr.second;
+
+      for(unsigned int v = 0; v < n_entries; ++v)
+        for(unsigned int j = view.get_shift(bface); j < view.get_shift(bface + 1); ++j, ++c)
+        {
+          AssertIndexRange(j, dst.size());
+          AssertIndexRange(c, src.size());
+
+          copy_data(dst[j], v, src[c]);
+        }
+    }
+  }
+};
+} // namespace ExaDG
+#endif /*INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_COMMUNICATOR_H_*/

--- a/include/exadg/coupling/fe_remote_point_evaluation_data.h
+++ b/include/exadg/coupling/fe_remote_point_evaluation_data.h
@@ -19,33 +19,31 @@
  *  ______________________________________________________________________
  */
 
-#ifndef INCLUDE_EXADG_MATRIX_FREE_INTEGRATORS_H_
-#define INCLUDE_EXADG_MATRIX_FREE_INTEGRATORS_H_
+#ifndef INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_DATA_H_
+#define INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_DATA_H_
 
-// deal.II
-#include <deal.II/base/config.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
 
-#include <exadg/coupling/fe_remote_point_evaluation.h>
-
+namespace ExaDG
+{
+/**
+ * A class that stores quantities at the quadrature points.
+ */
 template<int dim,
          int n_components,
          typename Number,
          typename VectorizedArrayType = dealii::VectorizedArray<Number>>
-using CellIntegrator = dealii::FEEvaluation<dim, -1, 0, n_components, Number, VectorizedArrayType>;
+class FERemotePointEvaluationData
+{
+public:
+  using integrator_type =
+    dealii::FEEvaluation<dim, -1, 0, n_components, Number, VectorizedArrayType>;
 
-template<int dim,
-         int n_components,
-         typename Number,
-         typename VectorizedArrayType = dealii::VectorizedArray<Number>>
-using FaceIntegrator =
-  dealii::FEFaceEvaluation<dim, -1, 0, n_components, Number, VectorizedArrayType>;
+  using value_type    = typename integrator_type::value_type;
+  using gradient_type = typename integrator_type::gradient_type;
 
-template<int dim,
-         int n_components,
-         typename Number,
-         typename VectorizedArrayType = dealii::VectorizedArray<Number>>
-using RemoteFaceIntegrator =
-  ExaDG::FERemotePointEvaluation<dim, n_components, Number, VectorizedArrayType>;
-
-#endif
+  std::vector<value_type>    values;
+  std::vector<gradient_type> gradients;
+};
+} // namespace ExaDG
+#endif /*INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_DATA_H_*/

--- a/include/exadg/coupling/fe_remote_point_evaluation_data_view.h
+++ b/include/exadg/coupling/fe_remote_point_evaluation_data_view.h
@@ -1,0 +1,168 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_DATA_VIEW_H_
+#define INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_DATA_VIEW_H_
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+
+namespace ExaDG
+{
+template<int dim, typename Number>
+class FERemotePointEvaluationDataView
+{
+public:
+  template<typename VectorizedArrayType>
+  void
+  initialize_volume(const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+                    const unsigned int                                           this_dof_index,
+                    const unsigned int                                           this_quad_index)
+  {
+    // TODO: can we access quadrature points without FEFEval?
+    dealii::FEEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                           this_dof_index,
+                                                                           this_quad_index);
+
+    // determine relevant boundary faces and determine how much space each needs
+    cell_ptrs.resize(this_matrix_free.n_cell_batches() + 1);
+    cell_ptrs[0] = 0;
+
+    for(unsigned int cell = 0; cell < this_matrix_free.n_cell_batches(); ++cell)
+    {
+      phi_m.reinit(cell);
+      cell_ptrs[cell + 1] = cell_ptrs[cell] + phi_m.n_q_points;
+    }
+
+    cell_start = 0;
+  }
+
+  template<typename VectorizedArrayType>
+  void
+  initialize_inner_faces(
+    const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+    const unsigned int                                           this_dof_index,
+    const unsigned int                                           this_quad_index)
+  {
+    // TODO: can we access quadrature points without FEFaceEval?
+    dealii::FEFaceEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                               true,
+                                                                               this_dof_index,
+                                                                               this_quad_index);
+
+    // determine relevant boundary faces and determine how much space each needs
+    cell_ptrs.resize(this_matrix_free.n_inner_face_batches() + 1);
+    cell_ptrs[0] = 0;
+
+    for(unsigned int face = 0; face < this_matrix_free.n_inner_face_batches(); ++face)
+    {
+      phi_m.reinit(face);
+      cell_ptrs[face + 1] = cell_ptrs[face] + phi_m.n_q_points;
+    }
+
+    cell_start = 0;
+  }
+
+  template<typename VectorizedArrayType>
+  void
+  initialize_boundary_faces(
+    const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+    const unsigned int                                           this_dof_index,
+    const unsigned int                                           this_quad_index)
+  {
+    // TODO: can we access quadrature points without FEFaceEval?
+    dealii::FEFaceEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                               true,
+                                                                               this_dof_index,
+                                                                               this_quad_index);
+
+    // determine relevant boundary faces and determine how much space each needs
+    cell_ptrs.resize(this_matrix_free.n_boundary_face_batches() + 1);
+    cell_ptrs[0] = 0;
+
+    for(unsigned int bface = 0; bface < this_matrix_free.n_boundary_face_batches(); ++bface)
+    {
+      const unsigned int face = bface + this_matrix_free.n_inner_face_batches();
+
+      phi_m.reinit(face);
+      cell_ptrs[bface + 1] = cell_ptrs[bface] + phi_m.n_q_points;
+    }
+
+    cell_start = this_matrix_free.n_inner_face_batches();
+  }
+
+  template<typename VectorizedArrayType>
+  void
+  initialize_faces(const dealii::MatrixFree<dim, Number, VectorizedArrayType> & this_matrix_free,
+                   const unsigned int                                           this_dof_index,
+                   const unsigned int                                           this_quad_index,
+                   const std::set<dealii::types::boundary_id> &                 faces)
+  {
+    // TODO: can we access quadrature points without FEFaceEval?
+    dealii::FEFaceEvaluation<dim, -1, 0, 1, Number, VectorizedArrayType> phi_m(this_matrix_free,
+                                                                               true,
+                                                                               this_dof_index,
+                                                                               this_quad_index);
+
+    // determine relevant boundary faces and determine how much space each needs
+    cell_ptrs.resize(this_matrix_free.n_boundary_face_batches() + 1);
+    cell_ptrs[0] = 0;
+
+    for(unsigned int bface = 0; bface < this_matrix_free.n_boundary_face_batches(); ++bface)
+    {
+      const unsigned int face = bface + this_matrix_free.n_inner_face_batches();
+
+      if(faces.find(this_matrix_free.get_boundary_id(face)) != faces.end())
+      {
+        phi_m.reinit(face);
+        cell_ptrs[bface + 1] = cell_ptrs[bface] + phi_m.n_q_points;
+      }
+      else
+      {
+        cell_ptrs[bface + 1] = cell_ptrs[bface];
+      }
+    }
+
+    cell_start = this_matrix_free.n_inner_face_batches();
+  }
+
+  unsigned int
+  get_shift(const unsigned int cell) const
+  {
+    Assert(cell_start <= cell, dealii::ExcInternalError());
+    AssertIndexRange(cell - cell_start, cell_ptrs.size());
+    return cell_ptrs[cell - cell_start];
+  }
+
+  unsigned int
+  size() const
+  {
+    Assert(cell_ptrs.size() > 0, dealii::ExcInternalError());
+    return cell_ptrs.back();
+  }
+
+private:
+  std::vector<unsigned int> cell_ptrs;
+
+  unsigned int cell_start;
+};
+} // namespace ExaDG
+#endif /*INCLUDE_COUPLING_FE_REMOTE_POINT_EVALUATION_DATA_VIEW_H_*/

--- a/include/exadg/poisson/user_interface/boundary_descriptor.h
+++ b/include/exadg/poisson/user_interface/boundary_descriptor.h
@@ -38,7 +38,8 @@ enum class BoundaryType
   Undefined,
   Dirichlet,
   DirichletCached,
-  Neumann
+  Neumann,
+  Overset
 };
 
 template<int rank, int dim>
@@ -63,6 +64,9 @@ struct BoundaryDescriptor
   // Neumann
   std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> neumann_bc;
 
+  // Overset
+  std::map<dealii::types::boundary_id, dealii::types::boundary_id> overset_boundaries;
+
   // returns the boundary type
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryType
@@ -74,6 +78,8 @@ struct BoundaryDescriptor
       return BoundaryType::DirichletCached;
     else if(this->neumann_bc.find(boundary_id) != this->neumann_bc.end())
       return BoundaryType::Neumann;
+    else if(this->overset_boundaries.find(boundary_id) != this->overset_boundaries.end())
+      return BoundaryType::Overset;
 
     AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
 
@@ -97,6 +103,9 @@ struct BoundaryDescriptor
       counter++;
 
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())
+      counter++;
+
+    if(overset_boundaries.find(boundary_id) != overset_boundaries.end())
       counter++;
 
     AssertThrow(counter == 1,

--- a/include/exadg/poisson/user_interface/enum_types.cpp
+++ b/include/exadg/poisson/user_interface/enum_types.cpp
@@ -78,6 +78,9 @@ enum_to_string(Solver const enum_type)
     case Solver::CG:
       string_type = "CG";
       break;
+    case Solver::GMRES:
+      string_type = "GMRES";
+      break;
     case Solver::FGMRES:
       string_type = "FGMRES";
       break;

--- a/include/exadg/poisson/user_interface/enum_types.h
+++ b/include/exadg/poisson/user_interface/enum_types.h
@@ -58,6 +58,7 @@ enum class Solver
 {
   Undefined,
   CG,
+  GMRES,
   FGMRES
 };
 

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -287,7 +287,8 @@ public:
   std::shared_ptr<TimerTree>
   get_timings() const override
   {
-    this->timer_tree->insert({"SolverGMRES"}, preconditioner.get_timings());
+    if(solver_data.use_preconditioner)
+      this->timer_tree->insert({"SolverGMRES"}, preconditioner.get_timings());
 
     return this->timer_tree;
   }
@@ -384,7 +385,8 @@ public:
   std::shared_ptr<TimerTree>
   get_timings() const override
   {
-    this->timer_tree->insert({"SolverFGMRES"}, preconditioner.get_timings());
+    if(solver_data.use_preconditioner)
+      this->timer_tree->insert({"SolverFGMRES"}, preconditioner.get_timings());
 
     return this->timer_tree;
   }

--- a/include/exadg/utilities/solver_result.h
+++ b/include/exadg/utilities/solver_result.h
@@ -28,7 +28,12 @@ namespace ExaDG
 {
 struct SolverResult
 {
-  SolverResult() : degree(1), dofs(1), n_10(0), tau_10(0.0)
+  SolverResult() : degree(1), dofs(1), n_10(0), tau_10(0.0), print_10(false)
+  {
+  }
+
+  SolverResult(unsigned int const degree_, dealii::types::global_dof_index const dofs_)
+    : degree(degree_), dofs(dofs_), print_10(false)
   {
   }
 
@@ -36,7 +41,7 @@ struct SolverResult
                dealii::types::global_dof_index const dofs_,
                double const                          n_10_,
                double const                          tau_10_)
-    : degree(degree_), dofs(dofs_), n_10(n_10_), tau_10(tau_10_)
+    : degree(degree_), dofs(dofs_), n_10(n_10_), tau_10(tau_10_), print_10(true)
   {
   }
 
@@ -46,17 +51,23 @@ struct SolverResult
     // names
     pcout << std::setw(7) << "degree";
     pcout << std::setw(15) << "dofs";
-    pcout << std::setw(8) << "n_10";
-    pcout << std::setw(15) << "tau_10";
-    pcout << std::setw(15) << "throughput";
+    if(print_10)
+    {
+      pcout << std::setw(8) << "n_10";
+      pcout << std::setw(15) << "tau_10";
+      pcout << std::setw(15) << "throughput";
+    }
     pcout << std::endl;
 
     // units
     pcout << std::setw(7) << " ";
     pcout << std::setw(15) << " ";
-    pcout << std::setw(8) << " ";
-    pcout << std::setw(15) << "in s*core/DoF";
-    pcout << std::setw(15) << "in DoF/s/core";
+    if(print_10)
+    {
+      pcout << std::setw(8) << " ";
+      pcout << std::setw(15) << "in s*core/DoF";
+      pcout << std::setw(15) << "in DoF/s/core";
+    }
     pcout << std::endl;
 
     pcout << std::endl;
@@ -67,9 +78,12 @@ struct SolverResult
   {
     pcout << std::setw(7) << std::fixed << degree;
     pcout << std::setw(15) << std::fixed << dofs;
-    pcout << std::setw(8) << std::fixed << std::setprecision(1) << n_10;
-    pcout << std::setw(15) << std::scientific << std::setprecision(2) << tau_10;
-    pcout << std::setw(15) << std::scientific << std::setprecision(2) << 1.0 / tau_10;
+    if(print_10)
+    {
+      pcout << std::setw(8) << std::fixed << std::setprecision(1) << n_10;
+      pcout << std::setw(15) << std::scientific << std::setprecision(2) << tau_10;
+      pcout << std::setw(15) << std::scientific << std::setprecision(2) << 1.0 / tau_10;
+    }
     pcout << std::endl;
   }
 
@@ -77,6 +91,7 @@ struct SolverResult
   dealii::types::global_dof_index dofs;
   double                          n_10;
   double                          tau_10;
+  bool                            print_10;
 };
 
 inline void


### PR DESCRIPTION
@peterrum and I recently wrote a class that gets the data from (cell, quadrature) pairs as suggested by @kronbichler in https://github.com/exadg/exadg/pull/287.
This is a draft PR which aims to integrate this class into ExaDG. 

Currently, the class is only used for non-matching and overset discretizations in the Poisson case. I successfully tested it for volume coupling, though. Instead of removing the other overset implementation, (which uses Cached DBCs) I added another test case.

To check whether the approach works, I added a test case which does the same thing but uses the overset implementation once. Using GMRES in both cases, I got following Iteration counts.

Iterations GMRES (Matching vs ArtificialNonmatching)
None:  2522  vs 2521
PointJacobi: 1053 vs 1053
BlockJacobi: 688 vs 687
Multigrid: 11 vs 15

@peterrum @nfehn Any obligations before extending to incompressible Navier Stokes?
