### PR TITLE
Convergence problems Structure::DriverQuasiStatic

### DIFF
--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -209,7 +209,7 @@ private:
   void
   set_parameters() final
   {
-    this->param.problem_type         = ProblemType::QuasiStatic; //Steady;
+    this->param.problem_type         = ProblemType::QuasiStatic;
     this->param.body_force           = use_volume_force;
     this->param.large_deformation    = true;
     this->param.pull_back_body_force = false;
@@ -227,11 +227,11 @@ private:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = 1;
 
-    this->param.load_increment            = 0.025;
+    this->param.load_increment            = 0.1;
     this->param.adjust_load_increment     = false;
     this->param.desired_newton_iterations = 20;
 
-    this->param.newton_solver_data                   = Newton::SolverData(1e4, 1.e-10, 1.e-10);
+    this->param.newton_solver_data                   = Newton::SolverData(1e2, 1.e-8, 1.e-8);
     this->param.solver                               = Solver::FGMRES;
     this->param.solver_data                          = SolverData(1e4, 1.e-12, 1.e-6, 100);
     this->param.preconditioner                       = Preconditioner::Multigrid;
@@ -463,7 +463,7 @@ private:
     pp_data.output_data.time_control_data.trigger_interval = (end_time - start_time) / 20.0;
     pp_data.output_data.directory          = this->output_parameters.directory + "vtu/";
     pp_data.output_data.filename           = this->output_parameters.filename;
-    pp_data.output_data.write_higher_order = false;
+    pp_data.output_data.write_higher_order = true;
     pp_data.output_data.degree             = this->param.degree;
 
     pp_data.error_data.time_control_data.is_active = true;

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -209,7 +209,7 @@ private:
   void
   set_parameters() final
   {
-    this->param.problem_type         = ProblemType::Steady;
+    this->param.problem_type         = ProblemType::QuasiStatic; //Steady;
     this->param.body_force           = use_volume_force;
     this->param.large_deformation    = true;
     this->param.pull_back_body_force = false;
@@ -227,7 +227,7 @@ private:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = 1;
 
-    this->param.load_increment            = 0.1;
+    this->param.load_increment            = 0.025;
     this->param.adjust_load_increment     = false;
     this->param.desired_newton_iterations = 20;
 
@@ -334,7 +334,7 @@ private:
     // right face
     if(boundary_type == "Dirichlet")
     {
-      bool const        clamp_at_right_boundary = true;
+      bool const        clamp_at_right_boundary = false;
       std::vector<bool> mask_right              = {true, clamp_at_right_boundary};
       if(dim == 3)
       {

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -227,9 +227,7 @@ private:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = 1;
 
-    this->param.load_increment            = 0.1;
-    this->param.adjust_load_increment     = false;
-    this->param.desired_newton_iterations = 20;
+    this->param.load_increment = 0.1;
 
     this->param.newton_solver_data                   = Newton::SolverData(1e2, 1.e-8, 1.e-8);
     this->param.solver                               = Solver::FGMRES;
@@ -240,7 +238,7 @@ private:
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
 
-    this->param.update_preconditioner                         = true;
+    this->param.update_preconditioner                         = false;
     this->param.update_preconditioner_every_time_steps        = 1;
     this->param.update_preconditioner_every_newton_iterations = 1;
   }

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -229,18 +229,20 @@ private:
 
     this->param.load_increment = 0.1;
 
-    this->param.newton_solver_data                   = Newton::SolverData(1e2, 1.e-8, 1.e-8);
+    this->param.newton_solver_data                   = Newton::SolverData(1e1, 1.e-9, 1.e-9);
     this->param.solver                               = Solver::FGMRES;
-    this->param.solver_data                          = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.solver_data                          = SolverData(1e2, 1.e-12, 1.e-8, 100);
     this->param.preconditioner                       = Preconditioner::Multigrid;
     this->param.multigrid_data.type                  = MultigridType::phMG;
     this->param.multigrid_data.coarse_problem.solver = MultigridCoarseGridSolver::CG;
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
 
-    this->param.update_preconditioner                         = false;
-    this->param.update_preconditioner_every_time_steps        = 1;
-    this->param.update_preconditioner_every_newton_iterations = 1;
+    this->param.update_preconditioner                  = true;
+    this->param.update_preconditioner_every_time_steps = 1;
+    this->param.update_preconditioner_every_newton_iterations =
+      this->param.newton_solver_data.max_iter;
+    this->param.update_preconditioner_once_newton_converged = true;
   }
 
   void

--- a/applications/structure/bar/input.json
+++ b/applications/structure/bar/input.json
@@ -1,14 +1,14 @@
 {
     "General": {
         "Precision": "double",
-        "Dim": "2",
+        "Dim": "3",
         "IsTest": "false"
     },
     "SpatialResolution": {
-        "DegreeMin": "1",
-        "DegreeMax": "1",
-        "RefineSpaceMin": "2",
-        "RefineSpaceMax": "2"
+        "DegreeMin": "2",
+        "DegreeMax": "2",
+        "RefineSpaceMin": "1",
+        "RefineSpaceMax": "1"
     },
     "TemporalResolution": {
         "RefineTimeMin": "0",
@@ -21,12 +21,12 @@
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Dirichlet",
-        "Displacement": "-45.0",
+        "Displacement": "100.0",
         "Traction":	"0.0" 
     },
     "Output": {
         "OutputDirectory": "output/bar/",
-        "OutputName": "test_bc",
-        "WriteOutput": "true"
+        "OutputName": "test",
+        "WriteOutput": "false"
     }
 }

--- a/applications/structure/bar/input.json
+++ b/applications/structure/bar/input.json
@@ -5,8 +5,8 @@
         "IsTest": "false"
     },
     "SpatialResolution": {
-        "DegreeMin": "2",
-        "DegreeMax": "2",
+        "DegreeMin": "4",
+        "DegreeMax": "4",
         "RefineSpaceMin": "1",
         "RefineSpaceMax": "1"
     },
@@ -21,7 +21,7 @@
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Dirichlet",
-        "Displacement": "100.0",
+        "Displacement": "20.0",
         "Traction":	"0.0" 
     },
     "Output": {

--- a/applications/structure/bar/input.json
+++ b/applications/structure/bar/input.json
@@ -7,8 +7,8 @@
     "SpatialResolution": {
         "DegreeMin": "1",
         "DegreeMax": "1",
-        "RefineSpaceMin": "4",
-        "RefineSpaceMax": "4"
+        "RefineSpaceMin": "2",
+        "RefineSpaceMax": "2"
     },
     "TemporalResolution": {
         "RefineTimeMin": "0",
@@ -21,12 +21,12 @@
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Dirichlet",
-        "Displacement": "20.0",
+        "Displacement": "-45.0",
         "Traction":	"0.0" 
     },
     "Output": {
         "OutputDirectory": "output/bar/",
-        "OutputName": "test",
-        "WriteOutput": "false"
+        "OutputName": "test_bc",
+        "WriteOutput": "true"
     }
 }

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -159,9 +159,7 @@ private:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = 1;
 
-    this->param.load_increment            = 0.1;
-    this->param.adjust_load_increment     = true;
-    this->param.desired_newton_iterations = 20;
+    this->param.load_increment = 0.1;
 
     this->param.newton_solver_data                     = Newton::SolverData(1e3, 1.e-10, 1.e-6);
     this->param.solver                                 = Solver::FGMRES;

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -167,9 +167,11 @@ private:
     this->param.preconditioner                         = Preconditioner::Multigrid;
     this->param.update_preconditioner                  = true;
     this->param.update_preconditioner_every_time_steps = 1;
-    this->param.update_preconditioner_every_newton_iterations = 10;
-    this->param.multigrid_data.type                           = MultigridType::hpMG;
-    this->param.multigrid_data.coarse_problem.solver          = MultigridCoarseGridSolver::CG;
+    this->param.update_preconditioner_every_newton_iterations =
+      this->param.newton_solver_data.max_iter;
+    this->param.update_preconditioner_once_newton_converged = true;
+    this->param.multigrid_data.type                         = MultigridType::hpMG;
+    this->param.multigrid_data.coarse_problem.solver        = MultigridCoarseGridSolver::CG;
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
   }

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -150,7 +150,7 @@ private:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = 1;
 
-    this->param.load_increment = 0.01;
+    this->param.load_increment = 0.1;
 
     this->param.newton_solver_data                     = Newton::SolverData(1e3, 1.e-10, 1.e-6);
     this->param.solver                                 = Solver::CG;
@@ -158,9 +158,11 @@ private:
     this->param.preconditioner                         = Preconditioner::Multigrid;
     this->param.update_preconditioner                  = true;
     this->param.update_preconditioner_every_time_steps = 1;
-    this->param.update_preconditioner_every_newton_iterations = 1;
-    this->param.multigrid_data.type                           = MultigridType::hpMG;
-    this->param.multigrid_data.coarse_problem.solver          = MultigridCoarseGridSolver::CG;
+    this->param.update_preconditioner_every_newton_iterations =
+      this->param.newton_solver_data.max_iter;
+    this->param.update_preconditioner_once_newton_converged = true;
+    this->param.multigrid_data.type                         = MultigridType::hpMG;
+    this->param.multigrid_data.coarse_problem.solver        = MultigridCoarseGridSolver::CG;
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
   }

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -150,9 +150,7 @@ private:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = 1;
 
-    this->param.load_increment            = 0.01;
-    this->param.adjust_load_increment     = false; // true;
-    this->param.desired_newton_iterations = 10;
+    this->param.load_increment = 0.01;
 
     this->param.newton_solver_data                     = Newton::SolverData(1e3, 1.e-10, 1.e-6);
     this->param.solver                                 = Solver::CG;

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -331,9 +331,11 @@ private:
     this->param.preconditioner      = Preconditioner::Multigrid;
     this->param.multigrid_data.type = MultigridType::phMG;
 
-    this->param.update_preconditioner                         = true;
-    this->param.update_preconditioner_every_time_steps        = 1;
-    this->param.update_preconditioner_every_newton_iterations = 10;
+    this->param.update_preconditioner                  = true;
+    this->param.update_preconditioner_every_time_steps = 1;
+    this->param.update_preconditioner_every_newton_iterations =
+      this->param.newton_solver_data.max_iter;
+    this->param.update_preconditioner_once_newton_converged = true;
   }
 
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -263,8 +263,8 @@ OperatorCoupled<dim, Number>::solve_nonlinear_problem(BlockVectorType &  dst,
 
   // Solve nonlinear problem
   Newton::UpdateData update;
-  update.do_update             = update_preconditioner;
-  update.threshold_newton_iter = this->param.update_preconditioner_coupled_every_newton_iter;
+  update.do_update                = update_preconditioner;
+  update.update_every_newton_iter = this->param.update_preconditioner_coupled_every_newton_iter;
 
   auto const iter = newton_solver->solve(dst, update);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -287,8 +287,8 @@ OperatorPressureCorrection<dim, Number>::solve_nonlinear_momentum_equation(
 
   // Solve nonlinear problem
   Newton::UpdateData update;
-  update.do_update             = update_preconditioner;
-  update.threshold_newton_iter = this->param.update_preconditioner_momentum_every_newton_iter;
+  update.do_update                = update_preconditioner;
+  update.update_every_newton_iter = this->param.update_preconditioner_momentum_every_newton_iter;
 
   std::tuple<unsigned int, unsigned int> iter = momentum_newton_solver->solve(dst, update);
 

--- a/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
+++ b/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
@@ -46,8 +46,7 @@ public:
     : solver_data(solver_data_in),
       nonlinear_operator(nonlinear_operator_in),
       linear_operator(linear_operator_in),
-      linear_solver(linear_solver_in),
-      linear_iterations_last(0)
+      linear_solver(linear_solver_in)
   {
   }
 
@@ -84,7 +83,7 @@ public:
         update.do_update and (newton_iterations % update.update_every_newton_iter == 0);
 
       // solve linear problem
-      linear_iterations_last = linear_solver.solve(increment, residual, update_now);
+      unsigned int const n_iter_linear = linear_solver.solve(increment, residual, update_now);
 
       // damped Newton scheme
       double             omega         = 1.0; // damping factor (begin with 1)
@@ -121,7 +120,7 @@ public:
 
       // increment iteration counter
       ++newton_iterations;
-      linear_iterations += linear_iterations_last;
+      linear_iterations += n_iter_linear;
     }
 
     AssertThrow(norm_r <= this->solver_data.abs_tol || norm_r / norm_r_0 <= solver_data.rel_tol,
@@ -150,8 +149,6 @@ private:
   NonlinearOperator & nonlinear_operator;
   LinearOperator &    linear_operator;
   LinearSolver &      linear_solver;
-
-  unsigned int linear_iterations_last;
 };
 
 } // namespace Newton

--- a/include/exadg/solvers_and_preconditioners/newton/newton_solver_data.h
+++ b/include/exadg/solvers_and_preconditioners/newton/newton_solver_data.h
@@ -58,16 +58,13 @@ struct SolverData
 
 struct UpdateData
 {
-  UpdateData()
-    : do_update(true),
-      threshold_newton_iter(1),
-      threshold_linear_iter(std::numeric_limits<unsigned int>::max())
+  UpdateData() : do_update(true), update_every_newton_iter(1), update_once_converged(false)
   {
   }
 
   bool         do_update;
-  unsigned int threshold_newton_iter;
-  unsigned int threshold_linear_iter;
+  unsigned int update_every_newton_iter;
+  bool         update_once_converged;
 };
 } // namespace Newton
 } // namespace ExaDG

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -772,8 +772,9 @@ Operator<dim, Number>::solve_nonlinear(VectorType &       sol,
 
   // call Newton solver
   Newton::UpdateData update;
-  update.do_update             = update_preconditioner;
-  update.threshold_newton_iter = param.update_preconditioner_every_newton_iterations;
+  update.do_update                = update_preconditioner;
+  update.update_every_newton_iter = param.update_preconditioner_every_newton_iterations;
+  update.update_once_converged    = param.update_preconditioner_once_newton_converged;
 
   // solve nonlinear problem
   auto const iter = newton_solver->solve(sol, update);

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -58,7 +58,7 @@ template<int dim, typename Number>
 bool
 NonLinearOperator<dim, Number>::valid_deformation(VectorType const & displacement) const
 {
-  std::vector<Number> dst(1, 0.0);
+  Number dst = 0.0;
 
   // dst has to remain zero for a valid deformation state
   this->matrix_free->cell_loop(&This::cell_loop_valid_deformation,
@@ -70,7 +70,7 @@ NonLinearOperator<dim, Number>::valid_deformation(VectorType const & displacemen
   // sum over all MPI processes
   Number valid = 0.0;
   valid        = dealii::Utilities::MPI::sum(
-    dst.at(0), this->matrix_free->get_dof_handler(this->get_dof_index()).get_communicator());
+    dst, this->matrix_free->get_dof_handler(this->get_dof_index()).get_communicator());
 
   return (valid == 0.0);
 }
@@ -298,7 +298,7 @@ template<int dim, typename Number>
 void
 NonLinearOperator<dim, Number>::cell_loop_valid_deformation(
   dealii::MatrixFree<dim, Number> const & matrix_free,
-  std::vector<Number> &                   dst,
+  Number &                                dst,
   VectorType const &                      src,
   Range const &                           range) const
 {
@@ -326,8 +326,8 @@ NonLinearOperator<dim, Number>::cell_loop_valid_deformation(
       for(unsigned int v = 0; v < det_F.size(); ++v)
       {
         // if deformation is invalid, add a positive value to dst
-        if(det_F[v] < 0.0)
-          dst.at(0) += 1.0;
+        if(det_F[v] <= 0.0)
+          dst += 1.0;
       }
     }
   }

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -81,7 +81,7 @@ void
 NonLinearOperator<dim, Number>::set_solution_linearization(VectorType const & vector) const
 {
   // Only update linearized operator if deformation state is valid. It is better to continue
-  // with an old deformation state than within an invalid one.
+  // with an old deformation state in the linearized operator than with an invalid one.
   if(valid_deformation(vector))
   {
     displacement_lin = vector;
@@ -314,8 +314,6 @@ NonLinearOperator<dim, Number>::cell_loop_valid_deformation(
 
     integrator.evaluate(dealii::EvaluationFlags::gradients);
 
-    std::shared_ptr<Material<dim, Number>> material = this->material_handler.get_material();
-
     // loop over all quadrature points
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
@@ -327,7 +325,7 @@ NonLinearOperator<dim, Number>::cell_loop_valid_deformation(
       scalar const det_F = determinant(F);
       for(unsigned int v = 0; v < det_F.size(); ++v)
       {
-        // if deformation is invalid, add something to dst
+        // if deformation is invalid, add a positive value to dst
         if(det_F[v] < 0.0)
           dst.at(0) += 1.0;
       }

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -55,11 +55,38 @@ NonLinearOperator<dim, Number>::evaluate_nonlinear(VectorType & dst, VectorType 
 }
 
 template<int dim, typename Number>
+bool
+NonLinearOperator<dim, Number>::valid_deformation(VectorType const & displacement) const
+{
+  std::vector<Number> dst(1, 0.0);
+
+  // dst has to remain zero for a valid deformation state
+  this->matrix_free->cell_loop(&This::cell_loop_valid_deformation,
+                               this,
+                               dst,
+                               displacement,
+                               false /* no zeroing of dst vector */);
+
+  // sum over all MPI processes
+  Number valid = 0.0;
+  valid        = dealii::Utilities::MPI::sum(
+    dst.at(0), this->matrix_free->get_dof_handler(this->get_dof_index()).get_communicator());
+
+  return (valid == 0.0);
+}
+
+
+template<int dim, typename Number>
 void
 NonLinearOperator<dim, Number>::set_solution_linearization(VectorType const & vector) const
 {
-  displacement_lin = vector;
-  displacement_lin.update_ghost_values();
+  // Only update linearized operator if deformation state is valid. It is better to continue
+  // with an old deformation state than within an invalid one.
+  if(valid_deformation(vector))
+  {
+    displacement_lin = vector;
+    displacement_lin.update_ghost_values();
+  }
 }
 
 template<int dim, typename Number>
@@ -264,6 +291,47 @@ NonLinearOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) co
       integrator.submit_value(this->scaling_factor_mass * this->operator_data.density *
                                 integrator.get_value(q),
                               q);
+  }
+}
+
+template<int dim, typename Number>
+void
+NonLinearOperator<dim, Number>::cell_loop_valid_deformation(
+  dealii::MatrixFree<dim, Number> const & matrix_free,
+  std::vector<Number> &                   dst,
+  VectorType const &                      src,
+  Range const &                           range) const
+{
+  IntegratorCell integrator(matrix_free,
+                            this->operator_data.dof_index,
+                            this->operator_data.quad_index);
+
+  for(auto cell = range.first; cell < range.second; ++cell)
+  {
+    reinit_cell_nonlinear(integrator, cell);
+
+    integrator.read_dof_values_plain(src);
+
+    integrator.evaluate(dealii::EvaluationFlags::gradients);
+
+    std::shared_ptr<Material<dim, Number>> material = this->material_handler.get_material();
+
+    // loop over all quadrature points
+    for(unsigned int q = 0; q < integrator.n_q_points; ++q)
+    {
+      // material displacement gradient
+      tensor const Grad_d = integrator.get_gradient(q);
+
+      // material deformation gradient
+      tensor const F     = get_F<dim, Number>(Grad_d);
+      scalar const det_F = determinant(F);
+      for(unsigned int v = 0; v < det_F.size(); ++v)
+      {
+        // if deformation is invalid, add something to dst
+        if(det_F[v] < 0.0)
+          dst.at(0) += 1.0;
+      }
+    }
   }
 }
 

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -179,7 +179,7 @@ private:
 
   void
   cell_loop_valid_deformation(dealii::MatrixFree<dim, Number> const & matrix_free,
-                              std::vector<Number> &                   dst,
+                              Number &                                dst,
                               VectorType const &                      src,
                               Range const &                           range) const;
 

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -59,6 +59,12 @@ public:
   evaluate_nonlinear(VectorType & dst, VectorType const & src) const;
 
   /*
+   * Returns true if deformation state is valid.
+   */
+  bool
+  valid_deformation(VectorType const & displacement) const;
+
+  /*
    * Linearized operator:
    */
   void
@@ -170,6 +176,13 @@ private:
    */
   void
   do_cell_integral(IntegratorCell & integrator) const override;
+
+  void
+  cell_loop_valid_deformation(dealii::MatrixFree<dim, Number> const & matrix_free,
+                              std::vector<Number> &                   dst,
+                              VectorType const &                      src,
+                              Range const &                           range) const;
+
 
   mutable std::shared_ptr<IntegratorCell> integrator_lin;
   mutable VectorType                      displacement_lin;

--- a/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
+++ b/include/exadg/structure/time_integration/driver_quasi_static_problems.cpp
@@ -168,7 +168,8 @@ DriverQuasiStatic<dim, Number>::do_solve()
         // reduce load increment by factor of 2
         load_increment *= 0.5;
         pcout << std::endl
-              << "Could not solve non-linear problem. Reduce load increment to " << load_increment
+              << "  Could not solve non-linear problem. Reduce load increment to " << load_increment
+              << "." << std::endl
               << std::flush;
       }
     }

--- a/include/exadg/structure/time_integration/driver_quasi_static_problems.h
+++ b/include/exadg/structure/time_integration/driver_quasi_static_problems.h
@@ -84,7 +84,7 @@ private:
   output_solver_info_header(double const load_factor);
 
   std::tuple<unsigned int, unsigned int>
-  solve_step(double const load_factor);
+  solve_step(double const load_factor, bool const update_preconditioner);
 
   void
   postprocessing() const;
@@ -104,6 +104,15 @@ private:
   // vectors
   VectorType solution;
   VectorType rhs_vector;
+
+  // We need to store a vector in order to extrapolate the solution to the next
+  // load step and obtain an accurate initial guess for the Newton solver.
+  VectorType displacement_increment;
+
+  // For the purpose of extrapolating the displacements, we also need to store the
+  // load_increment of the last load step (in case we adjust the load increments
+  // dynamically during the simulation).
+  double last_load_increment;
 
   unsigned int step_number;
 

--- a/include/exadg/structure/time_integration/driver_quasi_static_problems.h
+++ b/include/exadg/structure/time_integration/driver_quasi_static_problems.h
@@ -110,8 +110,7 @@ private:
   VectorType displacement_increment;
 
   // For the purpose of extrapolating the displacements, we also need to store the
-  // load_increment of the last load step (in case we adjust the load increments
-  // dynamically during the simulation).
+  // load_increment of the last load step.
   double last_load_increment;
 
   unsigned int step_number;

--- a/include/exadg/structure/user_interface/parameters.cpp
+++ b/include/exadg/structure/user_interface/parameters.cpp
@@ -68,6 +68,7 @@ Parameters::Parameters()
     update_preconditioner(false),
     update_preconditioner_every_time_steps(1),
     update_preconditioner_every_newton_iterations(10),
+    update_preconditioner_once_newton_converged(false),
     multigrid_data(MultigridData())
 {
 }

--- a/include/exadg/structure/user_interface/parameters.cpp
+++ b/include/exadg/structure/user_interface/parameters.cpp
@@ -55,8 +55,6 @@ Parameters::Parameters()
 
     // quasi-static solver
     load_increment(1.0),
-    adjust_load_increment(false),
-    desired_newton_iterations(10),
 
     // SPATIAL DISCRETIZATION
     grid(GridData()),
@@ -161,8 +159,6 @@ Parameters::print_parameters_temporal_discretization(dealii::ConditionalOStream 
   if(problem_type == ProblemType::QuasiStatic)
   {
     print_parameter(pcout, "load_increment", load_increment);
-    print_parameter(pcout, "Adjust load increment", adjust_load_increment);
-    print_parameter(pcout, "Desired Newton iterations", desired_newton_iterations);
   }
 
   if(problem_type == ProblemType::Unsteady)

--- a/include/exadg/structure/user_interface/parameters.h
+++ b/include/exadg/structure/user_interface/parameters.h
@@ -160,14 +160,6 @@ public:
   // choose a value in [0,1] where 1 = maximum load (Neumann or Dirichlet)
   double load_increment;
 
-  // adjust load increment adaptively depending on the number of iterations needed to
-  // solve the system of equations
-  bool adjust_load_increment;
-
-  // in case of adaptively adjusting the load increment: specify a desired number of
-  // Newton iterations according to which the load increment will be adjusted
-  unsigned int desired_newton_iterations;
-
   /**************************************************************************************/
   /*                                                                                    */
   /*                              SPATIAL DISCRETIZATION                                */

--- a/include/exadg/structure/user_interface/parameters.h
+++ b/include/exadg/structure/user_interface/parameters.h
@@ -190,12 +190,21 @@ public:
   // description: see enum declaration
   Preconditioner preconditioner;
 
-  // only relevant for nonlinear problems
+  // only relevant for nonlinear problems: update of preconditioner
+
+  // Should the preconditioner be updated at all (set to false to never update the
+  // preconditioner)?
   bool update_preconditioner;
-  // ... every time steps (or load steps for QuasiStatic problems)
+  // If the above option is set to true, one can specify in more detail when to update
+  // the preconditioner exactly:
+  // - every ... time steps (or load steps for QuasiStatic problems)
   unsigned int update_preconditioner_every_time_steps;
-  // ... every Newton iterations
+  // and within a time step or load step:
+  // - every ... Newton iterations (first update is invoked in the first Newton iteration)
   unsigned int update_preconditioner_every_newton_iterations;
+  // - or once the Newton solver converged successfully (this option is currently used
+  // in order to avoid invalid deformation states in non-converged Newton iterations)
+  bool update_preconditioner_once_newton_converged;
 
   // description: see declaration of MultigridData
   MultigridData multigrid_data;


### PR DESCRIPTION
It helps to extrapolate the displacements in order to avoid invalid deformation states in the Newton solver, causing the solution to abort when initializing the Chebyshev smoother for the linearized problem.

The option `adjust_load_increment` does not seem to work in a robust manner. This topic should be addressed independently of this PR. The implementation has probably not sufficiently been tested, e.g. `++re_try_counter;` could not have any effect in the current implement when written in the try-block after the call to the solver.

It is important to check the validity of the deformation state (det_F > 0) for all geometric multigrid levels, and then only update the linearized operator and preconditioners/smoothers in case the deformation is valid.

The implementation of the Newton solver and linear solvers should be generalized such that one can independently call the update of the linearized operator/preconditioner and call the solver for the linearized problem. However, I would suggest to do this in a follow-up PR in order to concentrate on the `Structure` module in the present PR.

I also adjusted the application structure/bar. The Newton tolerances with 1.e-10 appear to be too tight for some problems, which is why I increased them to 1.e-8.