### PR TITLE
Simplex output bugfix and add console output parameters

### DIFF
--- a/applications/compressible_navier_stokes/couette/tests/couette.output
+++ b/applications/compressible_navier_stokes/couette/tests/couette.output
@@ -50,6 +50,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/compressible_navier_stokes/euler_vortex/tests/euler_vortex.output
+++ b/applications/compressible_navier_stokes/euler_vortex/tests/euler_vortex.output
@@ -49,6 +49,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            7

--- a/applications/compressible_navier_stokes/manufactured_solution/tests/manufactured.output
+++ b/applications/compressible_navier_stokes/manufactured_solution/tests/manufactured.output
@@ -49,6 +49,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            6

--- a/applications/compressible_navier_stokes/shear_flow/tests/shear_flow.output
+++ b/applications/compressible_navier_stokes/shear_flow/tests/shear_flow.output
@@ -50,6 +50,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            6

--- a/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
+++ b/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
@@ -47,6 +47,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -169,6 +171,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -291,6 +295,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -413,6 +419,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -535,6 +543,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
+++ b/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
@@ -46,6 +46,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/deforming_hill/tests/convective_explicit_time_int.output
+++ b/applications/convection_diffusion/deforming_hill/tests/convective_explicit_time_int.output
@@ -46,6 +46,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
@@ -48,6 +48,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/sine_wave/tests/explicit_time_int.output
+++ b/applications/convection_diffusion/sine_wave/tests/explicit_time_int.output
@@ -49,6 +49,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
+++ b/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
@@ -38,6 +38,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            2
@@ -207,6 +209,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -376,6 +380,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            4
@@ -545,6 +551,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            5

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
@@ -62,6 +62,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
@@ -60,6 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -60,6 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -60,6 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -60,6 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -60,6 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -26,6 +26,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -120,6 +122,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            2
@@ -214,6 +218,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -308,6 +314,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            4
@@ -402,6 +410,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            5
@@ -496,6 +506,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            6
@@ -590,6 +602,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            7
@@ -684,6 +698,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            8
@@ -778,6 +794,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            9
@@ -872,6 +890,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            10
@@ -966,6 +986,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            11
@@ -1060,6 +1082,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            12
@@ -1154,6 +1178,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            13
@@ -1248,6 +1274,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            14
@@ -1342,6 +1370,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            15

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -26,6 +26,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -120,6 +122,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -214,6 +218,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -308,6 +314,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -402,6 +410,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -496,6 +506,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -590,6 +602,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -26,6 +26,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -120,6 +122,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -214,6 +218,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -308,6 +314,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -402,6 +410,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -496,6 +506,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -590,6 +602,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/structure/manufactured/tests/2d.output
+++ b/applications/structure/manufactured/tests/2d.output
@@ -45,6 +45,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -166,6 +168,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -287,6 +291,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -408,6 +414,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -529,6 +537,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -650,6 +660,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -771,6 +783,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -892,6 +906,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -1013,6 +1029,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/structure/manufactured/tests/3d.output
+++ b/applications/structure/manufactured/tests/3d.output
@@ -45,6 +45,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -166,6 +168,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -287,6 +291,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -408,6 +414,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -529,6 +537,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -650,6 +660,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -771,6 +783,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -892,6 +906,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -1013,6 +1029,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
+  Element type                               Hypercube
+  Create coarse triangulations               false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/include/exadg/grid/grid_data.h
+++ b/include/exadg/grid/grid_data.h
@@ -51,8 +51,9 @@ struct GridData
   {
     print_parameter(pcout, "Triangulation type", enum_to_string(triangulation_type));
 
-    // TODO: causes tests to fail introduce as a separate PR
-    // print_parameter(pcout, "Element type", enum_to_string(element_type));
+    print_parameter(pcout, "Element type", enum_to_string(element_type));
+
+    print_parameter(pcout, "Create coarse triangulations", create_coarse_triangulations);
 
     if(triangulation_type == TriangulationType::FullyDistributed)
       print_parameter(pcout,

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -162,8 +162,6 @@ Operator<dim, n_components, Number>::distribute_dofs()
     affine_constraints.close();
   }
 
-  unsigned int const ndofs_per_cell = dealii::Utilities::pow(param.degree + 1, dim);
-
   pcout << std::endl;
 
   if(param.spatial_discretization == SpatialDiscretization::DG)
@@ -178,7 +176,7 @@ Operator<dim, n_components, Number>::distribute_dofs()
     AssertThrow(false, dealii::ExcMessage("Not implemented."));
 
   print_parameter(pcout, "degree of 1D polynomials", param.degree);
-  print_parameter(pcout, "number of dofs per cell", ndofs_per_cell);
+  print_parameter(pcout, "number of dofs per cell", fe->n_dofs_per_cell());
   print_parameter(pcout, "number of dofs (total)", dof_handler.n_dofs());
 }
 


### PR DESCRIPTION
This PR closes #304 and adds the `GridData` parameters `ElementType` and `create_coarse_triangulations` to the console output. The tests are also changed accordingly.