### PR TITLE
flow past sphere: add missing parameter

### DIFF
--- a/applications/incompressible_navier_stokes/flow_past_sphere/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/application.h
@@ -138,6 +138,8 @@ public:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = this->param.degree_u;
     this->param.degree_p                = DegreePressure::MixedOrder;
+    // we need to create coarse triangulations since we use global coarsening multigrid
+    this->param.grid.create_coarse_triangulations = true;
 
     // convective term
     if(this->param.formulation_convective_term == FormulationConvectiveTerm::DivergenceFormulation)


### PR DESCRIPTION
Test fails if run out of the box, due to ```*hMG``` without ```param.grid.create_coarse_triangulations```

Resolves #303 

Thanks to @necioglu @nfehn @peterrum 