### PR TITLE
Generalize pointwise output generator for any VectorType and update to deal.II

### DIFF
--- a/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.cpp
@@ -56,7 +56,7 @@ template struct PointwiseOutputData<3>;
 
 template<int dim, typename Number>
 PointwiseOutputGenerator<dim, Number>::PointwiseOutputGenerator(MPI_Comm const & comm)
-  : PointwiseOutputGeneratorBase<dim, Number>(comm)
+  : PointwiseOutputGeneratorBase<dim, VectorType>(comm)
 {
 }
 
@@ -67,8 +67,9 @@ PointwiseOutputGenerator<dim, Number>::setup(
   dealii::Mapping<dim> const &     mapping_in,
   PointwiseOutputData<dim> const & pointwise_output_data_in)
 {
-  this->setup_base(dof_handler_in, mapping_in, pointwise_output_data_in);
+  this->setup_base(dof_handler_in.get_triangulation(), mapping_in, pointwise_output_data_in);
 
+  dof_handler           = &dof_handler_in;
   pointwise_output_data = pointwise_output_data_in;
 
   if(pointwise_output_data.write_rho)
@@ -86,7 +87,7 @@ PointwiseOutputGenerator<dim, Number>::do_evaluate(VectorType const & solution)
   if(pointwise_output_data.write_rho || pointwise_output_data.write_rho_u ||
      pointwise_output_data.write_rho_E)
   {
-    auto const values = this->template compute_point_values<dim + 2>(solution);
+    auto const values = this->template compute_point_values<dim + 2>(solution, *dof_handler);
     if(pointwise_output_data.write_rho)
       this->write_quantity("Rho", values, 0);
     if(pointwise_output_data.write_rho_u)

--- a/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.h
@@ -22,6 +22,8 @@
 #ifndef INCLUDE_EXADG_COMPRESSIBLE_NAVIER_STOKES_POSTPROCESSOR_POINTWISE_OUTPUT_GENERATOR_H_
 #define INCLUDE_EXADG_COMPRESSIBLE_NAVIER_STOKES_POSTPROCESSOR_POINTWISE_OUTPUT_GENERATOR_H_
 
+#include <deal.II/lac/la_parallel_vector.h>
+
 #include <exadg/postprocessor/pointwise_output_generator_base.h>
 
 namespace ExaDG
@@ -42,10 +44,11 @@ struct PointwiseOutputData : public PointwiseOutputDataBase<dim>
 };
 
 template<int dim, typename Number>
-class PointwiseOutputGenerator : public PointwiseOutputGeneratorBase<dim, Number>
+class PointwiseOutputGenerator
+  : public PointwiseOutputGeneratorBase<dim, dealii::LinearAlgebra::distributed::Vector<Number>>
 {
 public:
-  using VectorType = typename PointwiseOutputGeneratorBase<dim, Number>::VectorType;
+  using VectorType = dealii::LinearAlgebra::distributed::Vector<Number>;
 
   PointwiseOutputGenerator(MPI_Comm const & comm);
 
@@ -58,7 +61,8 @@ private:
   void
   do_evaluate(VectorType const & solution) final;
 
-  PointwiseOutputData<dim> pointwise_output_data;
+  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
+  PointwiseOutputData<dim>                            pointwise_output_data;
 };
 
 } // namespace CompNS


### PR DESCRIPTION
I extended the class to be able to use it with ```BlockVectors```. For scalar blocks, the output data type changes in ```deal.II```, so I added a function overload for ```write_quantity()```