### PR TITLE
Change interface of linear solvers

### DIFF
--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -847,7 +847,9 @@ Operator<dim, Number>::solve(VectorType &       sol,
 {
   update_conv_diff_operator(time, scaling_factor, velocity);
 
-  unsigned int const iterations = iterative_solver->solve(sol, rhs, update_preconditioner);
+  iterative_solver->update_preconditioner(update_preconditioner);
+
+  unsigned int const iterations = iterative_solver->solve(sol, rhs);
 
   return iterations;
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -181,7 +181,9 @@ OperatorCoupled<dim, Number>::solve_linear_stokes_problem(BlockVectorType &     
   // Update linear operator
   linear_operator.update(time, scaling_factor_mass);
 
-  return linear_solver->solve(dst, src, update_preconditioner);
+  linear_solver->update_preconditioner(update_preconditioner);
+
+  return linear_solver->solve(dst, src);
 }
 
 template<int dim, typename Number>
@@ -1050,10 +1052,9 @@ OperatorCoupled<dim, Number>::apply_preconditioner_velocity_block(VectorType &  
 
       // iteratively solve momentum equation up to given tolerance
       dst = 0.0;
-      // Note that update of preconditioner is set to false here since the preconditioner has
-      // already been updated in the member function update() if desired.
-      unsigned int const iterations =
-        solver_velocity_block->solve(dst, src, /* update_preconditioner = */ false);
+      // Note that the preconditioner is not updated here since it has
+      // already been updated in the function update_block_preconditioner().
+      unsigned int const iterations = solver_velocity_block->solve(dst, src);
 
       // output
       bool const print_iterations = false;
@@ -1176,9 +1177,9 @@ OperatorCoupled<dim, Number>::apply_inverse_negative_laplace_operator(VectorType
     }
 
     dst = 0.0;
-    // Note that update of preconditioner is set to false here since the preconditioner has
+    // Note that the preconditioner is not updated here since it has
     // already been updated in the function update_block_preconditioner().
-    solver_pressure_block->solve(dst, *pointer_to_src, /* update_preconditioner = */ false);
+    solver_pressure_block->solve(dst, *pointer_to_src);
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -754,7 +754,9 @@ OperatorDualSplitting<dim, Number>::solve_viscous(VectorType &       dst,
   // Update operator
   this->momentum_operator.set_scaling_factor_mass_operator(factor);
 
-  unsigned int n_iter = helmholtz_solver->solve(dst, src, update_preconditioner);
+  helmholtz_solver->update_preconditioner(update_preconditioner);
+
+  unsigned int n_iter = helmholtz_solver->solve(dst, src);
 
   return n_iter;
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -256,7 +256,9 @@ OperatorPressureCorrection<dim, Number>::solve_linear_momentum_equation(
   // in this because because this function is only called if the convective term is not considered
   // in the momentum_operator (Stokes eq. or explicit treatment of convective term).
 
-  auto linear_iterations = momentum_linear_solver->solve(solution, rhs, update_preconditioner);
+  momentum_linear_solver->update_preconditioner(update_preconditioner);
+
+  auto linear_iterations = momentum_linear_solver->solve(solution, rhs);
 
   return linear_iterations;
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -284,8 +284,11 @@ OperatorProjectionMethods<dim, Number>::do_solve_pressure(VectorType &       dst
   //    = std::dynamic_pointer_cast<MultigridPoisson>(preconditioner_pressure_poisson);
   //  unsigned int n_iter = mg_preconditioner->solve(dst,src);
 
+  // update preconditioner
+  this->pressure_poisson_solver->update_preconditioner(update_preconditioner);
+
   // call pressure Poisson solver
-  unsigned int n_iter = this->pressure_poisson_solver->solve(dst, src, update_preconditioner);
+  unsigned int n_iter = this->pressure_poisson_solver->solve(dst, src);
 
   return n_iter;
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1279,7 +1279,7 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
                                                                                    solver_data);
 
   // solve Poisson problem
-  poisson_solver.solve(dst, rhs, /* update preconditioner = */ false);
+  poisson_solver.solve(dst, rhs);
 }
 
 template<int dim, typename Number>
@@ -1310,11 +1310,11 @@ SpatialOperatorBase<dim, Number>::apply_inverse_mass_operator(VectorType &      
     if(&dst == &src)
     {
       temp = src;
-      return mass_solver->solve(dst, temp, false);
+      return mass_solver->solve(dst, temp);
     }
     else
     {
-      return mass_solver->solve(dst, src, false);
+      return mass_solver->solve(dst, src);
     }
   }
   else
@@ -1713,7 +1713,9 @@ SpatialOperatorBase<dim, Number>::solve_projection(VectorType &       dst,
   Assert(projection_solver.get() != 0,
          dealii::ExcMessage("Projection solver has not been initialized."));
 
-  unsigned int n_iter = projection_solver->solve(dst, src, update_preconditioner);
+  projection_solver->update_preconditioner(update_preconditioner);
+
+  unsigned int n_iter = projection_solver->solve(dst, src);
 
   return n_iter;
 }

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -543,8 +543,7 @@ OperatorBase<dim, Number, n_components>::apply_inverse_block_diagonal(VectorType
   {
     // Solve elementwise block Jacobi problems iteratively using an elementwise solver vectorized
     // over several elements.
-    bool update_preconditioner = false;
-    elementwise_solver->solve(dst, src, update_preconditioner);
+    elementwise_solver->solve(dst, src);
   }
   else // matrix-based
   {

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -476,8 +476,7 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
     laplace_operator.set_constrained_values(rhs_mutable, time);
   }
 
-  unsigned int iterations =
-    iterative_solver->solve(sol, rhs_mutable, /* update_preconditioner = */ false);
+  unsigned int iterations = iterative_solver->solve(sol, rhs_mutable);
 
   // This step should actually be optional: The constrained degrees of freedom of the
   // rhs vector contain the Dirichlet boundary values and the linear operator contains

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -329,7 +329,7 @@ public:
       }
 
       // Note that the preconditioner has already been updated
-      solver->solve(dst, src, false);
+      solver->solve(dst, src);
     }
   }
 

--- a/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
+++ b/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
@@ -131,9 +131,6 @@ public:
                   "Newton solver failed to solve nonlinear problem to given tolerance. "
                   "Maximum number of iterations exceeded!"));
 
-    // update linear operator and preconditioner once converged
-    // TODO: we currently re-solve the linear problem, which is actually un-necessary work
-    // given that we only want to update the operator/preconditioner
     if(update.do_update and update.update_once_converged)
     {
       // update linear operator (set linearization point)

--- a/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
+++ b/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
@@ -75,15 +75,18 @@ public:
       // multiply by -1.0 since the linearized problem is "linear_operator * increment = - residual"
       residual *= -1.0;
 
-      // set linearization point
+      // update linear operator (set linearization point)
       linear_operator.set_solution_linearization(solution);
 
       // determine whether to update the operator/preconditioner of the linearized problem
       bool const update_now =
         update.do_update and (newton_iterations % update.update_every_newton_iter == 0);
 
+      // update the preconditioner
+      linear_solver.update_preconditioner(update_now);
+
       // solve linear problem
-      unsigned int const n_iter_linear = linear_solver.solve(increment, residual, update_now);
+      unsigned int const n_iter_linear = linear_solver.solve(increment, residual);
 
       // damped Newton scheme
       double             omega         = 1.0; // damping factor (begin with 1)
@@ -133,12 +136,10 @@ public:
     // given that we only want to update the operator/preconditioner
     if(update.do_update and update.update_once_converged)
     {
-      increment = 0.0;
-      nonlinear_operator.evaluate_residual(residual, solution);
-      residual *= -1.0;
-      // set linearization point
+      // update linear operator (set linearization point)
       linear_operator.set_solution_linearization(solution);
-      linear_solver.solve(increment, residual, true /*update*/);
+      // update preconditioner
+      linear_solver.update_preconditioner(true);
     }
 
     return std::tuple<unsigned int, unsigned int>(newton_iterations, linear_iterations);

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -45,11 +45,14 @@ public:
   }
 
   virtual unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const = 0;
+  solve(VectorType & dst, VectorType const & rhs) const = 0;
 
   virtual ~SolverBase()
   {
   }
+
+  virtual void
+  update_preconditioner(bool const update_preconditioner) const = 0;
 
   template<typename Control>
   void
@@ -116,8 +119,17 @@ public:
   {
   }
 
+  void
+  update_preconditioner(bool const update_preconditioner) const override
+  {
+    if(solver_data.use_preconditioner and update_preconditioner)
+    {
+      preconditioner.update();
+    }
+  }
+
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
+  solve(VectorType & dst, VectorType const & rhs) const override
   {
     dealii::Timer timer;
 
@@ -133,11 +145,6 @@ public:
     }
     else
     {
-      if(update_preconditioner == true)
-      {
-        preconditioner.update();
-      }
-
       solver.solve(underlying_operator, dst, rhs, preconditioner);
     }
 
@@ -225,8 +232,17 @@ public:
   {
   }
 
+  void
+  update_preconditioner(bool const update_preconditioner) const override
+  {
+    if(solver_data.use_preconditioner and update_preconditioner)
+    {
+      preconditioner.update();
+    }
+  }
+
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
+  solve(VectorType & dst, VectorType const & rhs) const override
   {
     dealii::Timer timer;
 
@@ -254,11 +270,6 @@ public:
     }
     else
     {
-      if(update_preconditioner == true)
-      {
-        preconditioner.update();
-      }
-
       solver.solve(this->underlying_operator, dst, rhs, this->preconditioner);
     }
 
@@ -326,8 +337,17 @@ public:
   {
   }
 
+  void
+  update_preconditioner(bool const update_preconditioner) const override
+  {
+    if(solver_data.use_preconditioner and update_preconditioner)
+    {
+      preconditioner.update();
+    }
+  }
+
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
+  solve(VectorType & dst, VectorType const & rhs) const override
   {
     dealii::Timer timer;
 
@@ -347,11 +367,6 @@ public:
     }
     else
     {
-      if(update_preconditioner == true)
-      {
-        preconditioner.update();
-      }
-
       solver.solve(underlying_operator, dst, rhs, preconditioner);
     }
 

--- a/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
@@ -75,8 +75,16 @@ public:
   {
   }
 
+  void
+  update_preconditioner(bool const update_preconditioner) const override
+  {
+    (void)update_preconditioner;
+    AssertThrow(
+      false, dealii::ExcMessage("Should not arrive here. This function has not been implemented."));
+  }
+
   unsigned int
-  solve(VectorType & dst, VectorType const & src, bool const /* update_preconditioner */) const
+  solve(VectorType & dst, VectorType const & src) const override
   {
     dst = 0;
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -669,7 +669,7 @@ Operator<dim, Number>::compute_initial_acceleration(VectorType &       accelerat
   }
 
   // invert mass operator to get acceleration
-  mass_solver->solve(acceleration, rhs, false);
+  mass_solver->solve(acceleration, rhs);
 }
 
 template<int dim, typename Number>
@@ -830,7 +830,7 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   elasticity_operator_linear.set_constrained_values(rhs_mutable, time);
 
   // solve linear system of equations
-  unsigned int const iterations = linear_solver->solve(sol, rhs_mutable, false);
+  unsigned int const iterations = linear_solver->solve(sol, rhs_mutable);
 
   // This step should actually be optional: The constrained degrees of freedom of the
   // rhs vector contain the Dirichlet boundary values and the linear operator contains


### PR DESCRIPTION
As suggested in #301, the interface of the linear solvers should be adjusted in order to have more flexibility.

In particular, the update of the preconditioner should be separated from the call `linear_solver->solve()`.

closes #308