### PR TITLE
Make FDA benchmark work out of the box

### DIFF
--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -461,7 +461,7 @@ private:
     }
 
     dealii::GridTools::collect_periodic_faces(
-      *this->grid->triangulation, 0 + 10, 1 + 10, 2, this->grid_pre->periodic_faces);
+      *this->grid_pre->triangulation, 0 + 10, 1 + 10, 2, this->grid_pre->periodic_faces);
     this->grid_pre->triangulation->add_periodicity(this->grid_pre->periodic_faces);
 
     // perform global refinements

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
@@ -141,16 +141,19 @@ public:
     }
 
     // evaluation of results along lines
-    if(line_plot_calculator_statistics->time_control_statistics.time_control.needs_evaluation(
-         time, time_step_number))
+    if(line_plot_calculator_statistics)
     {
-      line_plot_calculator_statistics->evaluate(velocity, pressure);
-    }
+      if(line_plot_calculator_statistics->time_control_statistics.time_control.needs_evaluation(
+           time, time_step_number))
+      {
+        line_plot_calculator_statistics->evaluate(velocity, pressure);
+      }
 
-    if(line_plot_calculator_statistics->time_control_statistics.write_preliminary_results(
-         time, time_step_number))
-    {
-      line_plot_calculator_statistics->write_output();
+      if(line_plot_calculator_statistics->time_control_statistics.write_preliminary_results(
+           time, time_step_number))
+      {
+        line_plot_calculator_statistics->write_output();
+      }
     }
   }
 


### PR DESCRIPTION
I currently investigated the precursor setup in ExaDG. For this I loked at the FDA benchmark and the backward facing step. Both applications did not work out of the box. 

* For the FDA benchmark, the wrong triangulation is used to set periodicity.
* For both benchmarks, evaluating e.g. the line plot data fails since the shared pointer for the calculator is only created if it is needed but is accessed in any case. 