### PR TITLE
Bug fix test outputs

### DIFF
--- a/applications/compressible_navier_stokes/couette/tests/couette.output
+++ b/applications/compressible_navier_stokes/couette/tests/couette.output
@@ -50,8 +50,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/compressible_navier_stokes/euler_vortex/tests/euler_vortex.output
+++ b/applications/compressible_navier_stokes/euler_vortex/tests/euler_vortex.output
@@ -49,8 +49,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            7

--- a/applications/compressible_navier_stokes/manufactured_solution/tests/manufactured.output
+++ b/applications/compressible_navier_stokes/manufactured_solution/tests/manufactured.output
@@ -49,8 +49,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            6

--- a/applications/compressible_navier_stokes/shear_flow/tests/shear_flow.output
+++ b/applications/compressible_navier_stokes/shear_flow/tests/shear_flow.output
@@ -50,8 +50,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            6

--- a/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
+++ b/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
@@ -47,8 +47,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -171,8 +171,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -295,8 +295,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -419,8 +419,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -543,8 +543,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
+++ b/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
@@ -46,8 +46,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        4
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/deforming_hill/tests/convective_explicit_time_int.output
+++ b/applications/convection_diffusion/deforming_hill/tests/convective_explicit_time_int.output
@@ -46,8 +46,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
@@ -48,8 +48,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/convection_diffusion/sine_wave/tests/explicit_time_int.output
+++ b/applications/convection_diffusion/sine_wave/tests/explicit_time_int.output
@@ -49,8 +49,8 @@ Temporal discretization:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            1

--- a/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
+++ b/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
@@ -38,8 +38,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            2
@@ -209,8 +209,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -380,8 +380,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            4
@@ -551,8 +551,8 @@ Physical quantities:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        1
   Subdivisions hypercube:                    1
   Mapping degree:                            5

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
@@ -62,8 +62,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
@@ -60,8 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -60,8 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -60,8 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -60,8 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -60,8 +60,8 @@ Temporal discretization:
 
 Spatial discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        0
   Subdivisions hypercube:                    1
   Mapping degree:                            2

--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -26,8 +26,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            1
@@ -122,8 +122,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            2
@@ -218,8 +218,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -314,8 +314,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            4
@@ -410,8 +410,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            5
@@ -506,8 +506,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            6
@@ -602,8 +602,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            7
@@ -698,8 +698,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            8
@@ -794,8 +794,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            9
@@ -890,8 +890,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            10
@@ -986,8 +986,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            11
@@ -1082,8 +1082,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            12
@@ -1178,8 +1178,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            13
@@ -1274,8 +1274,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            14
@@ -1370,8 +1370,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        3
   Subdivisions hypercube:                    1
   Mapping degree:                            15

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -26,8 +26,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -122,8 +122,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -218,8 +218,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -314,8 +314,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -410,8 +410,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -506,8 +506,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -602,8 +602,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -26,8 +26,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -122,8 +122,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -218,8 +218,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -314,8 +314,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -410,8 +410,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -506,8 +506,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3
@@ -602,8 +602,8 @@ Mathematical model:
 
 Spatial Discretization:
   Triangulation type:                        Distributed
-  Element type                               Hypercube
-  Create coarse triangulations               false
+  Element type:                              Hypercube
+  Create coarse triangulations:              false
   Global refinements:                        2
   Subdivisions hypercube:                    1
   Mapping degree:                            3


### PR DESCRIPTION
Fix the mistake introduced in #310: Add the missing `:` in all test files. 

Note: 2 test files (2d.ouput and 3d.output) were already fixed in #305.