### PR TITLE
implement normal-flux calculation for scalar-transport / Poisson type problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ SET(TARGET_SRC
      include/exadg/postprocessor/time_control_statistics.cpp
      include/exadg/postprocessor/error_calculation.cpp
      include/exadg/postprocessor/mean_scalar_calculation.cpp
+     include/exadg/postprocessor/normal_flux_calculation.cpp
      include/exadg/postprocessor/lift_and_drag_calculation.cpp
      include/exadg/postprocessor/pressure_difference_calculation.cpp
      include/exadg/postprocessor/kinetic_energy_spectrum.cpp

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -103,7 +103,7 @@ private:
     this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
@@ -113,8 +113,8 @@ private:
     pp_data.output_data.write_higher_order          = true;
     pp_data.output_data.degree                      = this->param.degree;
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -308,7 +308,7 @@ private:
     this->field_functions->right_hand_side.reset(new RightHandSide<dim>());
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
@@ -321,8 +321,8 @@ private:
     pp_data.error_data.time_control_data.is_active = true;
     pp_data.error_data.analytical_solution.reset(new Solution<dim>());
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }

--- a/applications/poisson/overset_grids/application.h
+++ b/applications/poisson/overset_grids/application.h
@@ -113,7 +113,7 @@ public:
       new dealii::Functions::ConstantFunction<dim>(1.0, n_components));
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
@@ -123,8 +123,8 @@ public:
     pp_data.output_data.write_higher_order          = true;
     pp_data.output_data.degree                      = this->param.degree;
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }
@@ -219,7 +219,7 @@ private:
       new dealii::Functions::ConstantFunction<dim>(1.0, n_components));
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
@@ -229,8 +229,8 @@ private:
     pp_data.output_data.write_higher_order          = true;
     pp_data.output_data.degree                      = this->param.degree;
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -320,6 +320,13 @@ private:
     pp_data.error_data.analytical_solution.reset(new Solution<dim>());
     pp_data.error_data.calculate_relative_errors = true;
 
+    // these lines show exemplarily how to use the NormalFluxCalculator
+    pp_data.normal_flux_data.evaluate = false;
+    pp_data.normal_flux_data.boundary_ids.insert(0);
+    pp_data.normal_flux_data.boundary_ids.insert(1);
+    pp_data.normal_flux_data.directory = this->output_parameters.directory;
+    pp_data.normal_flux_data.filename  = this->output_parameters.filename;
+
     std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
     pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -303,7 +303,7 @@ private:
     this->field_functions->right_hand_side.reset(new RightHandSide<dim>());
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
@@ -320,8 +320,8 @@ private:
     pp_data.error_data.analytical_solution.reset(new Solution<dim>());
     pp_data.error_data.calculate_relative_errors = true;
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -98,7 +98,7 @@ private:
     this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
@@ -112,8 +112,8 @@ private:
     pp_data.error_data.analytical_solution.reset(
       new dealii::Functions::SlitSingularityFunction<dim>());
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }

--- a/applications/poisson/template/application.h
+++ b/applications/poisson/template/application.h
@@ -90,13 +90,13 @@ private:
     this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -134,13 +134,13 @@ private:
     this->field_functions->right_hand_side.reset(new dealii::Functions::ZeroFunction<dim>(1));
   }
 
-  std::shared_ptr<PostProcessorBase<dim, Number>>
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() final
   {
     PostProcessorData<dim> pp_data;
 
-    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
-    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+    std::shared_ptr<PostProcessorBase<dim, n_components, Number>> pp;
+    pp.reset(new PostProcessor<dim, n_components, Number>(pp_data, this->mpi_comm));
 
     return pp;
   }

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -104,7 +104,7 @@ Driver<dim, Number>::setup()
   {
     // initialize postprocessor
     postprocessor = application->create_postprocessor();
-    postprocessor->setup(*pde_operator, *mapping);
+    postprocessor->setup(*pde_operator);
 
     // initialize time integrator or driver for steady problems
     if(application->get_parameters().problem_type == ProblemType::Unsteady)

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor.cpp
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor.cpp
@@ -38,12 +38,15 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data
 
 template<int dim, typename Number>
 void
-PostProcessor<dim, Number>::setup(Operator<dim, Number> const & pde_operator,
-                                  dealii::Mapping<dim> const &  mapping)
+PostProcessor<dim, Number>::setup(Operator<dim, Number> const & pde_operator)
 {
-  error_calculator.setup(pde_operator.get_dof_handler(), mapping, pp_data.error_data);
+  error_calculator.setup(pde_operator.get_dof_handler(),
+                         *pde_operator.get_mapping(),
+                         pp_data.error_data);
 
-  output_generator.setup(pde_operator.get_dof_handler(), mapping, pp_data.output_data);
+  output_generator.setup(pde_operator.get_dof_handler(),
+                         *pde_operator.get_mapping(),
+                         pp_data.output_data);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor.h
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor.h
@@ -59,7 +59,7 @@ public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
   void
-  setup(Operator<dim, Number> const & pde_operator, dealii::Mapping<dim> const & mapping) override;
+  setup(Operator<dim, Number> const & pde_operator) override;
 
   void
   do_postprocessing(VectorType const &     solution,

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor_base.h
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor_base.h
@@ -67,7 +67,7 @@ public:
   }
 
   virtual void
-  setup(Operator<dim, Number> const & pde_operator, dealii::Mapping<dim> const & mapping) = 0;
+  setup(Operator<dim, Number> const & pde_operator) = 0;
 };
 
 } // namespace ConvDiff

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -381,6 +381,14 @@ Operator<dim, Number>::get_quad_index_overintegration() const
 }
 
 template<int dim, typename Number>
+std::shared_ptr<dealii::Mapping<dim> const>
+Operator<dim, Number>::get_mapping() const
+{
+  return get_dynamic_mapping<dim, Number>(grid, grid_motion);
+}
+
+
+template<int dim, typename Number>
 void
 Operator<dim, Number>::setup_solver(double const scaling_factor_mass, VectorType const * velocity)
 {
@@ -473,7 +481,7 @@ Operator<dim, Number>::initialize_preconditioner()
                                   &dof_handler.get_triangulation(),
                                   grid->coarse_triangulations,
                                   dof_handler.get_fe(),
-                                  get_dynamic_mapping<dim, Number>(grid, grid_motion),
+                                  get_mapping(),
                                   combined_operator,
                                   param.mg_operator_type,
                                   param.ale_formulation,
@@ -814,7 +822,7 @@ void
 Operator<dim, Number>::move_grid_and_update_dependent_data_structures(double const & time)
 {
   grid_motion->update(time, false);
-  matrix_free->update_mapping(*get_dynamic_mapping<dim, Number>(grid, grid_motion));
+  matrix_free->update_mapping(*get_mapping());
   update_after_grid_motion();
 }
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -286,6 +286,9 @@ public:
   unsigned int
   get_quad_index() const;
 
+  std::shared_ptr<dealii::Mapping<dim> const>
+  get_mapping() const;
+
 private:
   /*
    * Calculates maximum velocity (required for global CFL criterion).

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -140,7 +140,9 @@ Driver<dim, Number>::setup()
   if(application->get_parameters().use_cell_based_face_loops)
     Categorization::do_cell_based_loops(*application->get_grid()->triangulation,
                                         matrix_free_data->data);
-  matrix_free->reinit(*application->get_grid()->mapping,
+  std::shared_ptr<dealii::Mapping<dim> const> mapping =
+    get_dynamic_mapping<dim, Number>(application->get_grid(), grid_motion);
+  matrix_free->reinit(*mapping,
                       matrix_free_data->get_dof_handler_vector(),
                       matrix_free_data->get_constraint_vector(),
                       matrix_free_data->get_quadrature_vector(),
@@ -182,9 +184,7 @@ Driver<dim, Number>::setup()
   for(unsigned int i = 0; i < n_scalars; ++i)
   {
     scalar_postprocessor[i] = application->create_postprocessor_scalar(i);
-    std::shared_ptr<dealii::Mapping<dim> const> mapping =
-      get_dynamic_mapping<dim, Number>(application->get_grid(), grid_motion);
-    scalar_postprocessor[i]->setup(*scalar_operator[i], *mapping);
+    scalar_postprocessor[i]->setup(*scalar_operator[i]);
   }
 
   // setup time integrator before calling setup_solvers

--- a/include/exadg/poisson/postprocessor/postprocessor.cpp
+++ b/include/exadg/poisson/postprocessor/postprocessor.cpp
@@ -48,6 +48,16 @@ PostProcessor<dim, n_components, Number>::setup(
   output_generator.setup(pde_operator.get_dof_handler(),
                          *pde_operator.get_mapping(),
                          pp_data.output_data);
+
+  if(pp_data.normal_flux_data.evaluate)
+  {
+    normal_flux_calculator =
+      std::make_shared<NormalFluxCalculator<dim, Number>>(pde_operator.get_matrix_free(),
+                                                          pde_operator.get_dof_index(),
+                                                          pde_operator.get_quad_index(),
+                                                          pp_data.normal_flux_data,
+                                                          mpi_comm);
+  }
 }
 
 template<int dim, int n_components, typename Number>
@@ -61,6 +71,11 @@ PostProcessor<dim, n_components, Number>::do_postprocessing(VectorType const &  
 
   if(output_generator.time_control.needs_evaluation(time, time_step_number))
     output_generator.evaluate(solution, time, Utilities::is_unsteady_timestep(time_step_number));
+
+  if(pp_data.normal_flux_data.evaluate)
+    normal_flux_calculator->evaluate(solution,
+                                     time,
+                                     Utilities::is_unsteady_timestep(time_step_number));
 }
 
 template class PostProcessor<2, 1, float>;

--- a/include/exadg/poisson/postprocessor/postprocessor.h
+++ b/include/exadg/poisson/postprocessor/postprocessor.h
@@ -46,11 +46,11 @@ struct PostProcessorData
   ErrorCalculationData<dim> error_data;
 };
 
-template<int dim, typename Number>
-class PostProcessor : public PostProcessorBase<dim, Number>
+template<int dim, int n_components, typename Number>
+class PostProcessor : public PostProcessorBase<dim, n_components, Number>
 {
 protected:
-  typedef PostProcessorBase<dim, Number> Base;
+  typedef PostProcessorBase<dim, n_components, Number> Base;
 
   typedef typename Base::VectorType VectorType;
 
@@ -58,7 +58,7 @@ public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
   void
-  setup(dealii::DoFHandler<dim> const & dof_handler, dealii::Mapping<dim> const & mapping) override;
+  setup(Operator<dim, n_components, Number> const & pde_operator) override;
 
   void
   do_postprocessing(VectorType const &     solution,

--- a/include/exadg/poisson/postprocessor/postprocessor.h
+++ b/include/exadg/poisson/postprocessor/postprocessor.h
@@ -28,6 +28,7 @@
 // ExaDG
 #include <exadg/poisson/postprocessor/postprocessor_base.h>
 #include <exadg/postprocessor/error_calculation.h>
+#include <exadg/postprocessor/normal_flux_calculation.h>
 #include <exadg/postprocessor/output_data_base.h>
 #include <exadg/postprocessor/output_generator_scalar.h>
 
@@ -44,6 +45,7 @@ struct PostProcessorData
 
   OutputDataBase            output_data;
   ErrorCalculationData<dim> error_data;
+  NormalFluxCalculatorData  normal_flux_data;
 };
 
 template<int dim, int n_components, typename Number>
@@ -73,6 +75,8 @@ private:
 
   OutputGenerator<dim, Number> output_generator;
   ErrorCalculator<dim, Number> error_calculator;
+
+  std::shared_ptr<NormalFluxCalculator<dim, Number>> normal_flux_calculator;
 };
 
 } // namespace Poisson

--- a/include/exadg/poisson/postprocessor/postprocessor_base.h
+++ b/include/exadg/poisson/postprocessor/postprocessor_base.h
@@ -33,6 +33,9 @@ namespace ExaDG
 {
 namespace Poisson
 {
+template<int dim, int n_components, typename Number>
+class Operator;
+
 template<typename Number>
 class PostProcessorInterface
 {
@@ -49,7 +52,7 @@ public:
                     types::time_step const time_step_number = numbers::steady_timestep) = 0;
 };
 
-template<int dim, typename Number>
+template<int dim, int n_components, typename Number>
 class PostProcessorBase : public PostProcessorInterface<Number>
 {
 protected:
@@ -61,7 +64,7 @@ public:
   }
 
   virtual void
-  setup(dealii::DoFHandler<dim, dim> const & dof_handler, dealii::Mapping<dim> const & mapping) = 0;
+  setup(Operator<dim, n_components, Number> const & pde_operator) = 0;
 };
 
 } // namespace Poisson

--- a/include/exadg/poisson/solver_poisson.h
+++ b/include/exadg/poisson/solver_poisson.h
@@ -68,12 +68,12 @@ public:
       pde_operator->setup_solver();
 
       postprocessor = application->create_postprocessor();
-      postprocessor->setup(pde_operator->get_dof_handler(), *application->get_grid()->mapping);
+      postprocessor->setup(*pde_operator);
     }
   }
 
-  std::shared_ptr<Operator<dim, n_components, Number>> pde_operator;
-  std::shared_ptr<PostProcessorBase<dim, Number>>      postprocessor;
+  std::shared_ptr<Operator<dim, n_components, Number>>          pde_operator;
+  std::shared_ptr<PostProcessorBase<dim, n_components, Number>> postprocessor;
 
 private:
   std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -492,6 +492,13 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
 }
 
 template<int dim, int n_components, typename Number>
+dealii::MatrixFree<dim, Number> const &
+Operator<dim, n_components, Number>::get_matrix_free() const
+{
+  return *matrix_free;
+}
+
+template<int dim, int n_components, typename Number>
 dealii::DoFHandler<dim> const &
 Operator<dim, n_components, Number>::get_dof_handler() const
 {

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -639,6 +639,13 @@ Operator<dim, n_components, Number>::get_timings() const
   return iterative_solver->get_timings();
 }
 
+template<int dim, int n_components, typename Number>
+std::shared_ptr<dealii::Mapping<dim> const>
+Operator<dim, n_components, Number>::get_mapping() const
+{
+  return grid->mapping;
+}
+
 template class Operator<2, 1, float>;
 template class Operator<2, 1, double>;
 template class Operator<2, 2, float>;

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -85,6 +85,13 @@ public:
   unsigned int
   solve(VectorType & sol, VectorType const & rhs, double const time) const;
 
+  /*
+   * Setters and getters.
+   */
+
+  dealii::MatrixFree<dim, Number> const &
+  get_matrix_free() const;
+
   dealii::DoFHandler<dim> const &
   get_dof_handler() const;
 
@@ -139,6 +146,9 @@ public:
   unsigned int
   get_dof_index() const;
 
+  unsigned int
+  get_quad_index() const;
+
 private:
   std::string
   get_dof_name() const;
@@ -148,9 +158,6 @@ private:
 
   std::string
   get_quad_gauss_lobatto_name() const;
-
-  unsigned int
-  get_quad_index() const;
 
   unsigned int
   get_quad_index_gauss_lobatto() const;

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -104,6 +104,9 @@ public:
   std::shared_ptr<TimerTree>
   get_timings() const;
 
+  std::shared_ptr<dealii::Mapping<dim> const>
+  get_mapping() const;
+
 #ifdef DEAL_II_WITH_TRILINOS
   void
   init_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix,

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -124,7 +124,7 @@ public:
     set_field_functions();
   }
 
-  virtual std::shared_ptr<Poisson::PostProcessorBase<dim, Number>>
+  virtual std::shared_ptr<Poisson::PostProcessorBase<dim, n_components, Number>>
   create_postprocessor() = 0;
 
   Parameters const &

--- a/include/exadg/postprocessor/normal_flux_calculation.cpp
+++ b/include/exadg/postprocessor/normal_flux_calculation.cpp
@@ -1,0 +1,114 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#include <exadg/postprocessor/normal_flux_calculation.h>
+
+namespace ExaDG
+{
+template<int dim, typename Number>
+NormalFluxCalculator<dim, Number>::NormalFluxCalculator(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_in,
+  unsigned int const                      quad_index_in,
+  MPI_Comm const &                        mpi_comm_in)
+  : matrix_free(matrix_free_in),
+    dof_index(dof_index_in),
+    quad_index(quad_index_in),
+    mpi_comm(mpi_comm_in)
+{
+}
+
+template<int dim, typename Number>
+Number
+NormalFluxCalculator<dim, Number>::evaluate(VectorType const &                             solution,
+                                            std::map<dealii::types::boundary_id, Number> & flux)
+{
+  // zero mean scalars since we sum into these variables
+  for(auto & iterator : flux)
+  {
+    iterator.second = 0.0;
+  }
+
+  FaceIntegratorScalar integrator(matrix_free, true, dof_index, quad_index);
+
+  std::map<dealii::types::boundary_id, Number> area(flux);
+
+  for(unsigned int face = matrix_free.n_inner_face_batches();
+      face < (matrix_free.n_inner_face_batches() + matrix_free.n_boundary_face_batches());
+      face++)
+  {
+    typename std::map<dealii::types::boundary_id, Number>::iterator it;
+    dealii::types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
+
+    it = flux.find(boundary_id);
+    if(it != flux.end())
+    {
+      integrator.reinit(face);
+      integrator.read_dof_values(solution);
+      integrator.evaluate(dealii::EvaluationFlags::gradients);
+
+      scalar flux_face = dealii::make_vectorized_array<Number>(0.0);
+
+      for(unsigned int q = 0; q < integrator.n_q_points; ++q)
+      {
+        flux_face +=
+          integrator.JxW(q) * integrator.get_gradient(q) * integrator.get_normal_vector(q);
+      }
+
+      // sum over all entries of dealii::VectorizedArray
+      for(unsigned int n = 0; n < matrix_free.n_active_entries_per_face_batch(face); ++n)
+      {
+        flux.at(boundary_id) += flux_face[n];
+      }
+    }
+  }
+
+  // map -> vector
+  std::vector<double> flux_vector(flux.size());
+  auto                iterator = flux.begin();
+  for(unsigned int counter = 0; counter < flux.size(); ++counter)
+  {
+    flux_vector[counter] = (iterator++)->second;
+  }
+
+  // sum over MPI processes
+  dealii::Utilities::MPI::sum(
+    dealii::ArrayView<double const>(&(*flux_vector.begin()), flux_vector.size()),
+    mpi_comm,
+    dealii::ArrayView<double>(&(*flux_vector.begin()), flux_vector.size()));
+
+  // vector -> map
+  iterator = flux.begin();
+  for(unsigned int counter = 0; counter < flux.size(); ++counter)
+  {
+    (iterator++)->second = flux_vector[counter];
+  }
+
+  return 0;
+}
+
+template class NormalFluxCalculator<2, float>;
+template class NormalFluxCalculator<2, double>;
+
+template class NormalFluxCalculator<3, float>;
+template class NormalFluxCalculator<3, double>;
+
+} // namespace ExaDG

--- a/include/exadg/postprocessor/normal_flux_calculation.cpp
+++ b/include/exadg/postprocessor/normal_flux_calculation.cpp
@@ -41,7 +41,7 @@ Number
 NormalFluxCalculator<dim, Number>::evaluate(VectorType const &                             solution,
                                             std::map<dealii::types::boundary_id, Number> & flux)
 {
-  // zero mean scalars since we sum into these variables
+  // zero values since we sum into these variables
   for(auto & iterator : flux)
   {
     iterator.second = 0.0;

--- a/include/exadg/postprocessor/normal_flux_calculation.cpp
+++ b/include/exadg/postprocessor/normal_flux_calculation.cpp
@@ -38,11 +38,10 @@ NormalFluxCalculator<dim, Number>::NormalFluxCalculator(
   : matrix_free(matrix_free_in),
     dof_index(dof_index_in),
     quad_index(quad_index_in),
+    data(data_in),
     clear_files(true),
     mpi_comm(mpi_comm_in)
 {
-  data = data_in;
-
   for(auto it : data.boundary_ids)
     flux.insert(typename std::pair<dealii::types::boundary_id, double>(it, 0.0));
 
@@ -56,8 +55,6 @@ NormalFluxCalculator<dim, Number>::evaluate(VectorType const & solution,
                                             double const       time,
                                             bool const         unsteady)
 {
-  std::cout << "Evaluate_normal_flux" << std::endl;
-
   // zero values since we sum into these variables
   for(auto & iterator : flux)
   {
@@ -66,16 +63,13 @@ NormalFluxCalculator<dim, Number>::evaluate(VectorType const & solution,
 
   FaceIntegratorScalar integrator(matrix_free, true, dof_index, quad_index);
 
-  std::map<dealii::types::boundary_id, double> area(flux);
-
   for(unsigned int face = matrix_free.n_inner_face_batches();
       face < (matrix_free.n_inner_face_batches() + matrix_free.n_boundary_face_batches());
       face++)
   {
-    typename std::map<dealii::types::boundary_id, double>::iterator it;
     dealii::types::boundary_id boundary_id = matrix_free.get_boundary_id(face);
 
-    it = flux.find(boundary_id);
+    auto it = flux.find(boundary_id);
     if(it != flux.end())
     {
       integrator.reinit(face);

--- a/include/exadg/postprocessor/normal_flux_calculation.cpp
+++ b/include/exadg/postprocessor/normal_flux_calculation.cpp
@@ -37,7 +37,7 @@ NormalFluxCalculator<dim, Number>::NormalFluxCalculator(
 }
 
 template<int dim, typename Number>
-Number
+void
 NormalFluxCalculator<dim, Number>::evaluate(VectorType const &                             solution,
                                             std::map<dealii::types::boundary_id, Number> & flux)
 {
@@ -101,8 +101,6 @@ NormalFluxCalculator<dim, Number>::evaluate(VectorType const &                  
   {
     (iterator++)->second = flux_vector[counter];
   }
-
-  return 0;
 }
 
 template class NormalFluxCalculator<2, float>;

--- a/include/exadg/postprocessor/normal_flux_calculation.h
+++ b/include/exadg/postprocessor/normal_flux_calculation.h
@@ -40,7 +40,7 @@ public:
                        unsigned int                            quad_index_in,
                        MPI_Comm const &                        mpi_comm_in);
 
-  Number
+  void
   evaluate(VectorType const & solution, std::map<dealii::types::boundary_id, Number> & flux);
 
 private:

--- a/include/exadg/postprocessor/normal_flux_calculation.h
+++ b/include/exadg/postprocessor/normal_flux_calculation.h
@@ -21,10 +21,25 @@
 #ifndef INCLUDE_EXADG_POSTPROCESSOR_NORMAL_FLUX_CALCULATION_H
 #define INCLUDE_EXADG_POSTPROCESSOR_NORMAL_FLUX_CALCULATION_H
 
+// ExaDG
 #include <exadg/matrix_free/integrators.h>
 
 namespace ExaDG
 {
+struct NormalFluxCalculatorData
+{
+  NormalFluxCalculatorData() : evaluate(false)
+  {
+  }
+
+  bool                                 evaluate;
+  std::set<dealii::types::boundary_id> boundary_ids;
+
+  // specify where to write output files
+  std::string directory;
+  std::string filename;
+};
+
 template<int dim, typename Number>
 class NormalFluxCalculator
 {
@@ -38,14 +53,21 @@ public:
   NormalFluxCalculator(dealii::MatrixFree<dim, Number> const & matrix_free_in,
                        unsigned int                            dof_index_in,
                        unsigned int                            quad_index_in,
+                       NormalFluxCalculatorData const &        data,
                        MPI_Comm const &                        mpi_comm_in);
 
   void
-  evaluate(VectorType const & solution, std::map<dealii::types::boundary_id, Number> & flux);
+  evaluate(VectorType const & solution, double const time, bool const unsteady);
 
 private:
   dealii::MatrixFree<dim, Number> const & matrix_free;
   unsigned int                            dof_index, quad_index;
+
+  NormalFluxCalculatorData data;
+
+  bool clear_files;
+
+  std::map<dealii::types::boundary_id, double> flux;
 
   MPI_Comm const mpi_comm;
 };

--- a/include/exadg/postprocessor/normal_flux_calculation.h
+++ b/include/exadg/postprocessor/normal_flux_calculation.h
@@ -1,0 +1,57 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+#ifndef INCLUDE_EXADG_POSTPROCESSOR_NORMAL_FLUX_CALCULATION_H
+#define INCLUDE_EXADG_POSTPROCESSOR_NORMAL_FLUX_CALCULATION_H
+
+#include <exadg/matrix_free/integrators.h>
+
+namespace ExaDG
+{
+template<int dim, typename Number>
+class NormalFluxCalculator
+{
+public:
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+
+  typedef FaceIntegrator<dim, 1, Number> FaceIntegratorScalar;
+
+  typedef dealii::VectorizedArray<Number> scalar;
+
+  NormalFluxCalculator(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                       unsigned int                            dof_index_in,
+                       unsigned int                            quad_index_in,
+                       MPI_Comm const &                        mpi_comm_in);
+
+  Number
+  evaluate(VectorType const & solution, std::map<dealii::types::boundary_id, Number> & flux);
+
+private:
+  dealii::MatrixFree<dim, Number> const & matrix_free;
+  unsigned int                            dof_index, quad_index;
+
+  MPI_Comm const mpi_comm;
+};
+
+} // namespace ExaDG
+
+
+
+#endif // INCLUDE_EXADG_POSTPROCESSOR_NORMAL_FLUX_CALCULATION_H


### PR DESCRIPTION
Postprocessing routine integrating `grad(u)*normal` over boundary faces of a given boundary ID. A map of boundary IDs can be specified in order to be able to compute the flux separately for different parts of the boundary.

Adding the postprocessing routine in a Poisson application works like this:
```C++
create_postprocessor() final
{
   ...

    pp_data.normal_flux_data.evaluate = true;
    // insert e.g. boundary IDs 0 and 1
    pp_data.normal_flux_data.boundary_ids.insert(0);
    pp_data.normal_flux_data.boundary_ids.insert(1);
    ...
    pp_data.normal_flux_data.directory = this->output_parameters.directory; // just an example
    pp_data.normal_flux_data.filename  = this->output_parameters.filename; // just an example

    ...
}
```

The output looks like this:

```bash
Time t              Flux (bid = 0)      Flux (bid = 1)
0.000000000000e+00  9.992007221626e-16  -1.110223024625e-16
```

More boundary IDs would appear as additional columns. Additional time steps as additional rows. The time is printed in order to be able to use this module for general unsteady problems, e.g. for the `ConvDiff` module. For the steady Poisson problem, time is of course meaningless.

@gilrrei @c-p-schmidt would you like to have a look at this PR and provide feedback?
