### PR TITLE
Fix volume/surface calculation for simplices in IP

### DIFF
--- a/include/exadg/operators/interior_penalty_parameter.h
+++ b/include/exadg/operators/interior_penalty_parameter.h
@@ -62,7 +62,8 @@ calculate_penalty_parameter(
   dealii::FEValues<dim> fe_values(mapping, fe, quadrature, dealii::update_JxW_values);
 
   auto const face_quadrature =
-    reference_cells[0].template get_gauss_type_quadrature<dim - 1>(degree + 1);
+    reference_cells[0].face_reference_cell(0).template get_gauss_type_quadrature<dim - 1>(degree +
+                                                                                          1);
   dealii::FEFaceValues<dim> fe_face_values(mapping, fe, face_quadrature, dealii::update_JxW_values);
 
   for(unsigned int i = 0; i < n_cells; ++i)

--- a/include/exadg/operators/interior_penalty_parameter.h
+++ b/include/exadg/operators/interior_penalty_parameter.h
@@ -54,10 +54,15 @@ calculate_penalty_parameter(
   dealii::FiniteElement<dim> const & fe      = matrix_free.get_dof_handler(dof_index).get_fe();
   unsigned int const                 degree  = fe.degree;
 
-  dealii::QGauss<dim>   quadrature(degree + 1);
+  auto const reference_cells =
+    matrix_free.get_dof_handler(dof_index).get_triangulation().get_reference_cells();
+  AssertThrow(reference_cells.size() == 1, dealii::ExcMessage("No mixed meshes allowed."));
+
+  auto const quadrature = reference_cells[0].template get_gauss_type_quadrature<dim>(degree + 1);
   dealii::FEValues<dim> fe_values(mapping, fe, quadrature, dealii::update_JxW_values);
 
-  dealii::QGauss<dim - 1>   face_quadrature(degree + 1);
+  auto const face_quadrature =
+    reference_cells[0].template get_gauss_type_quadrature<dim - 1>(degree + 1);
   dealii::FEFaceValues<dim> fe_face_values(mapping, fe, face_quadrature, dealii::update_JxW_values);
 
   for(unsigned int i = 0; i < n_cells; ++i)


### PR DESCRIPTION
Closes #334.

The calculation of the surface and the volume for simplices was wrong, because of the wrong quadrature rule. This PR fixes this.