### PR TITLE
always use construct_multigrid_hierarchy for LocalSmoothing-MG

### DIFF
--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -95,7 +95,7 @@ public:
     param.print(pcout, "List of parameters:");
 
     // grid
-    grid = std::make_shared<Grid<dim>>(param.grid, false /* involves_h_multigrid */, mpi_comm);
+    grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
 

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -91,7 +91,7 @@ public:
     param.print(pcout, "List of parameters:");
 
     // grid
-    grid = std::make_shared<Grid<dim>>(param.grid, param.involves_h_multigrid(), mpi_comm);
+    grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
 

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -104,7 +104,7 @@ public:
     param.print(pcout, "List of parameters for structure:");
 
     // grid
-    grid = std::make_shared<Grid<dim>>(param.grid, param.involves_h_multigrid(), mpi_comm);
+    grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
 
@@ -249,7 +249,7 @@ public:
                 dealii::ExcMessage("Invalid parameter in context of fluid-structure interaction."));
 
     // grid
-    grid = std::make_shared<Grid<dim>>(param.grid, param.involves_h_multigrid(), mpi_comm);
+    grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
 

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -47,7 +47,7 @@ public:
   /**
    * Constructor.
    */
-  Grid(GridData const & data, bool const involves_h_multigrid, MPI_Comm const & mpi_comm);
+  Grid(GridData const & data, MPI_Comm const & mpi_comm);
 
   /**
    * dealii::Triangulation.

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -102,7 +102,7 @@ public:
     param.print(pcout, "List of parameters:");
 
     // grid
-    grid = std::make_shared<Grid<dim>>(param.grid, param.involves_h_multigrid(), mpi_comm);
+    grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
 
@@ -329,8 +329,7 @@ public:
                 dealii::ExcMessage("start_with_low_order has to be true for two-domain solver."));
 
     // grid
-    grid_pre =
-      std::make_shared<Grid<dim>>(param_pre.grid, param_pre.involves_h_multigrid(), this->mpi_comm);
+    grid_pre = std::make_shared<Grid<dim>>(param_pre.grid, this->mpi_comm);
     create_grid_precursor();
     print_grid_info(this->pcout, *grid_pre);
 

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -106,7 +106,7 @@ public:
     param.print(pcout, "List of parameters:");
 
     // grid
-    grid = std::make_shared<Grid<dim>>(param.grid, param.involves_h_multigrid(), mpi_comm);
+    grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
   }

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -74,7 +74,7 @@ public:
     param.print(pcout, "List of parameters:");
 
     // grid
-    grid = std::make_shared<Grid<dim>>(param.grid, param.involves_h_multigrid(), mpi_comm);
+    grid = std::make_shared<Grid<dim>>(param.grid, mpi_comm);
     create_grid();
     print_grid_info(pcout, *grid);
 


### PR DESCRIPTION
closes #339.

Reverts some of the changes from #331 (where I have been overly optimistic in getting rid of `construct_multigrid_hierarchy`). Overall, all the PRs related to this topic are a sign that dealii's `distribute_mg_dofs()` is a design hard to use in a modular/flexible code.