### PR TITLE
enable AMG preconditioner for Poisson module

### DIFF
--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -35,6 +35,7 @@
 #include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h>
 #include <exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h>
 #include <exadg/solvers_and_preconditioners/utilities/check_multigrid.h>
 #include <exadg/solvers_and_preconditioners/utilities/petsc_operation.h>
@@ -317,6 +318,11 @@ Operator<dim, n_components, Number>::setup_solver()
   else if(param.preconditioner == Poisson::Preconditioner::BlockJacobi)
   {
     preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator);
+  }
+  else if(param.preconditioner == Poisson::Preconditioner::AMG)
+  {
+    preconditioner = std::make_shared<PreconditionerAMG<Laplace, Number>>(
+      laplace_operator, param.multigrid_data.coarse_problem.amg_data);
   }
   else if(param.preconditioner == Poisson::Preconditioner::Multigrid)
   {

--- a/include/exadg/poisson/user_interface/enum_types.cpp
+++ b/include/exadg/poisson/user_interface/enum_types.cpp
@@ -108,6 +108,9 @@ enum_to_string(Preconditioner const enum_type)
     case Preconditioner::BlockJacobi:
       string_type = "BlockJacobi";
       break;
+    case Preconditioner::AMG:
+      string_type = "AMG";
+      break;
     case Preconditioner::Multigrid:
       string_type = "Multigrid";
       break;

--- a/include/exadg/poisson/user_interface/enum_types.h
+++ b/include/exadg/poisson/user_interface/enum_types.h
@@ -73,6 +73,7 @@ enum class Preconditioner
   None,
   PointJacobi,
   BlockJacobi,
+  AMG,
   Multigrid
 };
 


### PR DESCRIPTION
Allows to use AMG directly as a preconditioner for Poisson (most releveant for continuous Galerkin with degree `k=1` and a coarse mesh). Whenever there is geometric coarsening possible (e.g. Discontinuous Galerkin, degree `k>1`, global mesh refinements (in ExaDG/deal.II)), geometric `Multigrid` with coarse-grid solver `AMG` is the recommended default setting.

closes #337

@gilrrei @c-p-schmidt FYI