### PR TITLE
Simplex support for incompressible Navier-Stokes

### DIFF
--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -195,6 +195,8 @@ private:
     this->param.grid.triangulation_type = TriangulationType::Distributed;
     this->param.grid.mapping_degree     = this->param.degree_u;
     this->param.degree_p                = DegreePressure::MixedOrder;
+    this->param.grid.element_type       = ElementType::Hypercube;
+    this->param.grid.multigrid          = MultigridVariant::LocalSmoothing;
 
     // convective term
     if(this->param.formulation_convective_term == FormulationConvectiveTerm::DivergenceFormulation)

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -331,7 +331,10 @@ private:
           unsigned int const                                       global_refinements,
           std::vector<unsigned int> const &                        vector_local_refinements) {
         (void)periodic_face_pairs;
-        create_coarse_grid<dim>(tria, this->grid->periodic_face_pairs, cylinder_type_string);
+        create_coarse_grid<dim>(tria,
+                                this->grid->periodic_face_pairs,
+                                cylinder_type_string,
+                                this->param.grid.element_type);
 
         if(vector_local_refinements.size() > 0)
           refine_local(tria, vector_local_refinements);

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
@@ -1019,12 +1019,12 @@ double const h_x_1 = D / nele_x_middle_middle;
 double const h_x_0 = (X_1 - X_0) / nele_x_left;
 
 void
-do_create_coarse_triangulation(dealii::Triangulation<2> &        tria,
-                               std::vector<unsigned int> const & repetitions,
-                               dealii::Point<2> const &          p1,
-                               dealii::Point<2> const &          p2,
-                               ElementType const &               element_type,
-                               bool const                        colorize = false)
+create_subdivided_hyper_rectangle(dealii::Triangulation<2> &        tria,
+                                  std::vector<unsigned int> const & repetitions,
+                                  dealii::Point<2> const &          p1,
+                                  dealii::Point<2> const &          p2,
+                                  ElementType const &               element_type,
+                                  bool const                        colorize = false)
 {
   if(element_type == ElementType::Hypercube)
   {
@@ -1053,7 +1053,7 @@ create_trapezoid(dealii::Triangulation<2> & tria,
 
   dealii::Point<2> x_1 = x_0 + dealii::Point<2>(length, height);
 
-  do_create_coarse_triangulation(tmp, ref, x_0, x_1, element_type, false);
+  create_subdivided_hyper_rectangle(tmp, ref, x_0, x_1, element_type, false);
 
   for(dealii::Triangulation<2>::vertex_iterator v = tmp.begin_vertex(); v != tmp.end_vertex(); ++v)
   {
@@ -1155,52 +1155,52 @@ do_create_coarse_triangulation(dealii::Triangulation<2> & triangulation,
   std::vector<unsigned int> ref_middle_left  = {nele_x_middle_left, nele_y_middle};
 
   // left part
-  do_create_coarse_triangulation(left_bottom,
-                                 ref_left_bottom,
-                                 dealii::Point<2>(X_0, Y_0),
-                                 dealii::Point<2>(X_1, Y_1),
-                                 element_type,
-                                 false);
+  create_subdivided_hyper_rectangle(left_bottom,
+                                    ref_left_bottom,
+                                    dealii::Point<2>(X_0, Y_0),
+                                    dealii::Point<2>(X_1, Y_1),
+                                    element_type,
+                                    false);
 
-  do_create_coarse_triangulation(left_middle,
-                                 ref_left_middle,
-                                 dealii::Point<2>(X_0, Y_1),
-                                 dealii::Point<2>(X_1, Y_2),
-                                 element_type,
-                                 false);
+  create_subdivided_hyper_rectangle(left_middle,
+                                    ref_left_middle,
+                                    dealii::Point<2>(X_0, Y_1),
+                                    dealii::Point<2>(X_1, Y_2),
+                                    element_type,
+                                    false);
 
-  do_create_coarse_triangulation(left_top,
-                                 ref_left_top,
-                                 dealii::Point<2>(X_0, Y_2),
-                                 dealii::Point<2>(X_1, H),
-                                 element_type,
-                                 false);
+  create_subdivided_hyper_rectangle(left_top,
+                                    ref_left_top,
+                                    dealii::Point<2>(X_0, Y_2),
+                                    dealii::Point<2>(X_1, H),
+                                    element_type,
+                                    false);
 
   // merge left triangulations
   dealii::GridGenerator::merge_triangulations(left_bottom, left_middle, tmp);
   dealii::GridGenerator::merge_triangulations(tmp, left_top, left);
 
   // right part
-  do_create_coarse_triangulation(right_bottom,
-                                 ref_right_bottom,
-                                 dealii::Point<2>(X_2, Y_0),
-                                 dealii::Point<2>(L, Y_1),
-                                 element_type,
-                                 false);
+  create_subdivided_hyper_rectangle(right_bottom,
+                                    ref_right_bottom,
+                                    dealii::Point<2>(X_2, Y_0),
+                                    dealii::Point<2>(L, Y_1),
+                                    element_type,
+                                    false);
 
-  do_create_coarse_triangulation(right_middle,
-                                 ref_right_middle,
-                                 dealii::Point<2>(X_2, Y_1),
-                                 dealii::Point<2>(L, Y_2),
-                                 element_type,
-                                 false);
+  create_subdivided_hyper_rectangle(right_middle,
+                                    ref_right_middle,
+                                    dealii::Point<2>(X_2, Y_1),
+                                    dealii::Point<2>(L, Y_2),
+                                    element_type,
+                                    false);
 
-  do_create_coarse_triangulation(right_top,
-                                 ref_right_top,
-                                 dealii::Point<2>(X_2, Y_2),
-                                 dealii::Point<2>(L, H),
-                                 element_type,
-                                 false);
+  create_subdivided_hyper_rectangle(right_top,
+                                    ref_right_top,
+                                    dealii::Point<2>(X_2, Y_2),
+                                    dealii::Point<2>(L, H),
+                                    element_type,
+                                    false);
 
   // merge right triangulations
   dealii::GridGenerator::merge_triangulations(right_bottom, right_middle, tmp);
@@ -1210,64 +1210,64 @@ do_create_coarse_triangulation(dealii::Triangulation<2> & triangulation,
   if(!adaptive_mesh_shift)
   {
     // create middle bottom part
-    do_create_coarse_triangulation(middle_bottom,
-                                   ref_middle_bottom,
-                                   dealii::Point<2>(X_0 + I_x, Y_0),
-                                   dealii::Point<2>(X_0 + I_x + D, Y_1),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_bottom,
+                                      ref_middle_bottom,
+                                      dealii::Point<2>(X_0 + I_x, Y_0),
+                                      dealii::Point<2>(X_0 + I_x + D, Y_1),
+                                      element_type,
+                                      false);
 
     // create middle top part
-    do_create_coarse_triangulation(middle_top,
-                                   ref_middle_top,
-                                   dealii::Point<2>(X_0 + I_x, Y_2),
-                                   dealii::Point<2>(X_0 + I_x + D, H),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_top,
+                                      ref_middle_top,
+                                      dealii::Point<2>(X_0 + I_x, Y_2),
+                                      dealii::Point<2>(X_0 + I_x + D, H),
+                                      element_type,
+                                      false);
 
     // create middle left part
-    do_create_coarse_triangulation(middle_left,
-                                   ref_middle_left,
-                                   dealii::Point<2>(X_1, Y_1),
-                                   dealii::Point<2>(X_0 + I_x, Y_2),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_left,
+                                      ref_middle_left,
+                                      dealii::Point<2>(X_1, Y_1),
+                                      dealii::Point<2>(X_0 + I_x, Y_2),
+                                      element_type,
+                                      false);
 
-    do_create_coarse_triangulation(middle_left_top,
-                                   ref_middle_top_left,
-                                   dealii::Point<2>(X_1, Y_2),
-                                   dealii::Point<2>(X_0 + I_x, H),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_left_top,
+                                      ref_middle_top_left,
+                                      dealii::Point<2>(X_1, Y_2),
+                                      dealii::Point<2>(X_0 + I_x, H),
+                                      element_type,
+                                      false);
 
-    do_create_coarse_triangulation(middle_left_bottom,
-                                   ref_middle_bottom_left,
-                                   dealii::Point<2>(X_1, Y_0),
-                                   dealii::Point<2>(X_0 + I_x, Y_1),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_left_bottom,
+                                      ref_middle_bottom_left,
+                                      dealii::Point<2>(X_1, Y_0),
+                                      dealii::Point<2>(X_0 + I_x, Y_1),
+                                      element_type,
+                                      false);
 
     // create middle right part
-    do_create_coarse_triangulation(middle_right,
-                                   ref_middle_right,
-                                   dealii::Point<2>(X_0 + I_x + D, Y_1),
-                                   dealii::Point<2>(X_2, Y_2),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_right,
+                                      ref_middle_right,
+                                      dealii::Point<2>(X_0 + I_x + D, Y_1),
+                                      dealii::Point<2>(X_2, Y_2),
+                                      element_type,
+                                      false);
 
-    do_create_coarse_triangulation(middle_right_top,
-                                   ref_middle_top_right,
-                                   dealii::Point<2>(X_0 + I_x + D, Y_2),
-                                   dealii::Point<2>(X_2, H),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_right_top,
+                                      ref_middle_top_right,
+                                      dealii::Point<2>(X_0 + I_x + D, Y_2),
+                                      dealii::Point<2>(X_2, H),
+                                      element_type,
+                                      false);
 
-    do_create_coarse_triangulation(middle_right_bottom,
-                                   ref_middle_bottom_right,
-                                   dealii::Point<2>(X_0 + I_x + D, Y_0),
-                                   dealii::Point<2>(X_2, Y_1),
-                                   element_type,
-                                   false);
+    create_subdivided_hyper_rectangle(middle_right_bottom,
+                                      ref_middle_bottom_right,
+                                      dealii::Point<2>(X_0 + I_x + D, Y_0),
+                                      dealii::Point<2>(X_2, Y_1),
+                                      element_type,
+                                      false);
   }
   else
   {

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
@@ -1493,9 +1493,11 @@ create_coarse_grid(dealii::Triangulation<dim> &                             tria
 {
   if(element_type == ElementType::Simplex)
   {
-    AssertThrow(dim == 2,
-                dealii::ExcMessage("You are trying to create a grid with 3D Simplices. For this "
-                                   "application this is currently supported."));
+    AssertThrow(
+      dim == 2,
+      dealii::ExcMessage(
+        "You are trying to create a grid with 3D Simplices. This is currently not supported "
+        "for this application."));
   }
 
   select_cylinder_type(cylinder_type_string);
@@ -1507,8 +1509,8 @@ create_coarse_grid(dealii::Triangulation<dim> &                             tria
       AssertThrow(
         element_type == ElementType::Hypercube,
         dealii::ExcMessage(
-          "You are trying to create a grid with simplex elements with a circular cylinder, which "
-          "is currently not supported."));
+          "You are trying to create a grid with simplex elements for the circular cylinder case, "
+          "which is currently not supported."));
 
       CircularCylinder::create_coarse_triangulation<dim>(triangulation, periodic_faces);
       break;

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
@@ -1122,9 +1122,15 @@ do_create_coarse_triangulation(dealii::Triangulation<2> & triangulation,
                                ElementType                element_type,
                                bool                       is_2d = true)
 {
-  dealii::Triangulation<2> left, left_bottom, left_middle, left_top, middle, middle_top,
-    middle_bottom, middle_left, middle_right, middle_left_top, middle_left_bottom, middle_right_top,
-    middle_right_bottom, right, right_bottom, right_middle, right_top, tmp;
+  dealii::Triangulation<2>::MeshSmoothing const mesh_smoothing = triangulation.get_mesh_smoothing();
+
+  dealii::Triangulation<2> left(mesh_smoothing), left_bottom(mesh_smoothing),
+    left_middle(mesh_smoothing), left_top(mesh_smoothing), middle(mesh_smoothing),
+    middle_top(mesh_smoothing), middle_bottom(mesh_smoothing), middle_left(mesh_smoothing),
+    middle_right(mesh_smoothing), middle_left_top(mesh_smoothing),
+    middle_left_bottom(mesh_smoothing), middle_right_top(mesh_smoothing),
+    middle_right_bottom(mesh_smoothing), right(mesh_smoothing), right_bottom(mesh_smoothing),
+    right_middle(mesh_smoothing), right_top(mesh_smoothing), tmp(mesh_smoothing);
 
   // left
   std::vector<unsigned int> ref_left_top    = {nele_x_left, nele_y_top};
@@ -1430,6 +1436,19 @@ void
 do_create_coarse_triangulation(dealii::Triangulation<3> & triangulation, ElementType element_type)
 {
   dealii::Triangulation<2> tria_2D;
+
+  if(triangulation.get_mesh_smoothing() == dealii::Triangulation<3>::none)
+  {
+    tria_2D.set_mesh_smoothing(dealii::Triangulation<2>::none);
+  }
+  else if(triangulation.get_mesh_smoothing() ==
+          dealii::Triangulation<3>::limit_level_difference_at_vertices)
+  {
+    tria_2D.set_mesh_smoothing(dealii::Triangulation<2>::limit_level_difference_at_vertices);
+  }
+  else
+    AssertThrow(false, dealii::ExcMessage("Invalid parameter mesh smoothing."));
+
   do_create_coarse_triangulation<2>(tria_2D, element_type, false);
 
   dealii::GridGenerator::extrude_triangulation(tria_2D, nele_z, H, triangulation);

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -155,11 +155,9 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
   }
   else
   {
-    AssertThrow(
-      false,
-      dealii::ExcMessage(
-        "Only pure hypercube or pure simplex meshes are implemented for "
-        "MomentumPreconditioner::Multigrid."));
+    AssertThrow(false,
+                dealii::ExcMessage("Only pure hypercube or pure simplex meshes are implemented for "
+                                   "MomentumPreconditioner::Multigrid."));
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -157,7 +157,7 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
   {
     AssertThrow(false,
                 dealii::ExcMessage("Only pure hypercube or pure simplex meshes are implemented for "
-                                   "MomentumPreconditioner::Multigrid."));
+                                   "IncNS::Multigrid."));
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -157,7 +157,7 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
   {
     AssertThrow(false,
                 dealii::ExcMessage("Only pure hypercube or pure simplex meshes are implemented for "
-                                   "IncNS::Multigrid."));
+                                   "IncNS::MultigridPreconditioner."));
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -142,8 +142,25 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 
   matrix_free_data.insert_dof_handler(&(*this->dof_handlers[level]), "std_dof_handler");
   matrix_free_data.insert_constraint(&(*this->constraints[level]), "std_dof_handler");
-  matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
-                                     "std_quadrature");
+  if(this->dof_handlers[level]->get_triangulation().all_reference_cells_are_hyper_cube())
+  {
+    matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
+                                       "std_quadrature");
+  }
+  else if(this->dof_handlers[level]->get_triangulation().all_reference_cells_are_simplex())
+  {
+    matrix_free_data.insert_quadrature(dealii::QGaussSimplex<dim>(this->level_info[level].degree() +
+                                                                  1),
+                                       "std_quadrature");
+  }
+  else
+  {
+    AssertThrow(
+      false,
+      dealii::ExcMessage(
+        "Only pure hypercube or pure simplex meshes are implemented for "
+        "MomentumPreconditioner::Multigrid."));
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -128,7 +128,7 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
   {
     AssertThrow(false,
                 dealii::ExcMessage("Only pure hypercube or pure simplex meshes are implemented for "
-                                   "ProjectionPreconditioner::Multigrid."));
+                                   "IncNS::Multigrid."));
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -113,8 +113,24 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
 
   matrix_free_data.insert_dof_handler(&(*this->dof_handlers[level]), "std_dof_handler");
   matrix_free_data.insert_constraint(&(*this->constraints[level]), "std_dof_handler");
-  matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
-                                     "std_quadrature");
+  if(this->dof_handlers[level]->get_triangulation().all_reference_cells_are_hyper_cube())
+  {
+    matrix_free_data.insert_quadrature(dealii::QGauss<1>(this->level_info[level].degree() + 1),
+                                       "std_quadrature");
+  }
+  else if(this->dof_handlers[level]->get_triangulation().all_reference_cells_are_simplex())
+  {
+    matrix_free_data.insert_quadrature(dealii::QGaussSimplex<dim>(this->level_info[level].degree() +
+                                                                  1),
+                                       "std_quadrature");
+  }
+  else
+  {
+    AssertThrow(
+      false,
+      dealii::ExcMessage(
+        "Only pure hypercube or pure simplex meshes are implemented for ProjectionPreconditioner::Multigrid."));
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -128,7 +128,7 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
   {
     AssertThrow(false,
                 dealii::ExcMessage("Only pure hypercube or pure simplex meshes are implemented for "
-                                   "IncNS::Multigrid."));
+                                   "IncNS::MultigridPreconditioner."));
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -128,7 +128,7 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
   {
     AssertThrow(false,
                 dealii::ExcMessage("Only pure hypercube or pure simplex meshes are implemented for "
-                                   "IncNS::MultigridPreconditioner."));
+                                   "IncNS::MultigridPreconditionerProjection."));
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -126,10 +126,9 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
   }
   else
   {
-    AssertThrow(
-      false,
-      dealii::ExcMessage(
-        "Only pure hypercube or pure simplex meshes are implemented for ProjectionPreconditioner::Multigrid."));
+    AssertThrow(false,
+                dealii::ExcMessage("Only pure hypercube or pure simplex meshes are implemented for "
+                                   "ProjectionPreconditioner::Multigrid."));
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -801,7 +801,10 @@ OperatorDualSplitting<dim, Number>::local_interpolate_velocity_dirichlet_bc_boun
   VectorType const &,
   Range const & face_range) const
 {
-  unsigned int const dof_index  = this->get_dof_index_velocity();
+  unsigned int const dof_index = this->get_dof_index_velocity();
+  AssertThrow(
+    matrix_free.get_dof_handler(dof_index).get_triangulation().all_reference_cells_are_hyper_cube(),
+    dealii::ExcMessage("This function is not supported for simplices."));
   unsigned int const quad_index = this->get_quad_index_velocity_gauss_lobatto();
 
   FaceIntegratorU integrator(matrix_free, true, dof_index, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -804,7 +804,7 @@ OperatorDualSplitting<dim, Number>::local_interpolate_velocity_dirichlet_bc_boun
   unsigned int const dof_index = this->get_dof_index_velocity();
   AssertThrow(
     matrix_free.get_dof_handler(dof_index).get_triangulation().all_reference_cells_are_hyper_cube(),
-    dealii::ExcMessage("This function is not supported for simplices."));
+    dealii::ExcMessage("This function is only implemented for hypercube elements."));
   unsigned int const quad_index = this->get_quad_index_velocity_gauss_lobatto();
 
   FaceIntegratorU integrator(matrix_free, true, dof_index, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -482,7 +482,10 @@ OperatorPressureCorrection<dim, Number>::local_interpolate_pressure_dirichlet_bc
   VectorType const &,
   Range const & face_range) const
 {
-  unsigned int const dof_index  = this->get_dof_index_pressure();
+  unsigned int const dof_index = this->get_dof_index_pressure();
+  AssertThrow(
+    matrix_free.get_dof_handler(dof_index).get_triangulation().all_reference_cells_are_hyper_cube(),
+    dealii::ExcMessage("This function is not supported for simplices."));
   unsigned int const quad_index = this->get_quad_index_pressure_gauss_lobatto();
 
   FaceIntegratorP integrator(matrix_free, true, dof_index, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -485,7 +485,7 @@ OperatorPressureCorrection<dim, Number>::local_interpolate_pressure_dirichlet_bc
   unsigned int const dof_index = this->get_dof_index_pressure();
   AssertThrow(
     matrix_free.get_dof_handler(dof_index).get_triangulation().all_reference_cells_are_hyper_cube(),
-    dealii::ExcMessage("This function is not supported for simplices."));
+    dealii::ExcMessage("This function is only implemented for hypercube elements."));
   unsigned int const quad_index = this->get_quad_index_pressure_gauss_lobatto();
 
   FaceIntegratorP integrator(matrix_free, true, dof_index, quad_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -285,7 +285,10 @@ SpatialOperatorBase<dim, Number>::distribute_dofs()
       fe_u_scalar = std::make_shared<dealii::FE_SimplexDGP<dim>>(param.degree_u);
     }
     else
-      AssertThrow(false, dealii::ExcMessage("FE not implemented."));
+      AssertThrow(
+        false,
+        dealii::ExcMessage(
+          "The specified finite element type is currently not implemented for ElementType::Simplex."));
   }
   else
     AssertThrow(false, dealii::ExcMessage("Only hypercube or simplex elements are supported."));

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -25,6 +25,7 @@
 // deal.II
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_raviart_thomas.h>
+#include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
@@ -165,7 +166,7 @@ public:
   dealii::FiniteElement<dim> const &
   get_fe_u() const;
 
-  dealii::FE_DGQ<dim> const &
+  dealii::FiniteElement<dim> const &
   get_fe_p() const;
 
   dealii::DoFHandler<dim> const &
@@ -486,8 +487,8 @@ private:
    * Basic finite element ingredients.
    */
   std::shared_ptr<dealii::FiniteElement<dim>> fe_u;
-  dealii::FE_DGQ<dim>                         fe_p;
-  dealii::FE_DGQ<dim>                         fe_u_scalar;
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_p;
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_u_scalar;
 
   dealii::DoFHandler<dim> dof_handler_u;
   dealii::DoFHandler<dim> dof_handler_p;

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -572,6 +572,13 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
           "The current implementation only calls a Newton solver, if we have an implicit convective problem. Treat nonlinear convective and viscous terms alike."));
     }
   }
+
+  // SIMPLEX ELEMENTS
+  if(grid.element_type == ElementType::Simplex)
+  {
+    AssertThrow(temporal_discretization == TemporalDiscretization::BDFCoupledSolution,
+                dealii::ExcMessage("Only BDFCoupledSolution is supported for simplex elements."));
+  }
 }
 
 bool

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -572,13 +572,6 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
           "The current implementation only calls a Newton solver, if we have an implicit convective problem. Treat nonlinear convective and viscous terms alike."));
     }
   }
-
-  // SIMPLEX ELEMENTS
-  if(grid.element_type == ElementType::Simplex)
-  {
-    AssertThrow(temporal_discretization == TemporalDiscretization::BDFCoupledSolution,
-                dealii::ExcMessage("Only BDFCoupledSolution is supported for simplex elements."));
-  }
 }
 
 bool


### PR DESCRIPTION
This PR introduces simplex elements to incompressible Navier-Stokes. As an application example, flow past cylinder (FPC) is chosen. The following is done:

- The spatial operator is adapted to work with simplices. The multigrid momentum and the multigrid projection preconditioners are also adjusted. ~~However, not all preconditiers work with simplices, for now. (see Asserts in `parameters.cpp`) The reason behind is that the inverse mass operator is not implemented for simplices in dealii. I will adress this in ExaDG in a seperate PR.~~ 
- Flow past cylinder is used as an example application working with simplices.
- For now, only BDFCoupled is supported, others are asserted.
- In the current master, the square test case of the FPC application doesn't work because of a mismatch in mesh smoothing.  This is addressed in this PR in `grid.h` of the FPC application.