### PR TITLE
Generalize variable coefficients to arbitrary types

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -41,7 +41,8 @@ MomentumOperator<dim, Number>::initialize(
     this->viscous_kernel = std::make_shared<Operators::ViscousKernel<dim, Number>>();
     this->viscous_kernel->reinit(matrix_free,
                                  operator_data.viscous_kernel_data,
-                                 operator_data.dof_index);
+                                 operator_data.dof_index,
+                                 operator_data.quad_index);
   }
 
   if(operator_data.unsteady_problem)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -63,7 +63,8 @@ public:
   void
   reinit(dealii::MatrixFree<dim, Number> const & matrix_free,
          ViscousKernelData const &               data,
-         unsigned int const                      dof_index)
+         unsigned int const                      dof_index,
+         unsigned int const                      quad_index)
   {
     this->data = data;
 
@@ -77,7 +78,7 @@ public:
     if(data.viscosity_is_variable)
     {
       // allocate vectors for variable coefficients and initialize with constant viscosity
-      viscosity_coefficients.initialize(matrix_free, degree, data.viscosity);
+      viscosity_coefficients.initialize(matrix_free, quad_index, data.viscosity);
     }
   }
 
@@ -495,7 +496,7 @@ private:
 
   mutable scalar tau;
 
-  VariableCoefficients<dim, Number> viscosity_coefficients;
+  VariableCoefficients<dealii::VectorizedArray<Number>> viscosity_coefficients;
 };
 
 } // namespace Operators

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -407,7 +407,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   viscous_kernel->reinit(*matrix_free,
                          viscous_kernel_data,
                          get_dof_index_velocity(),
-                         get_quad_index_velocity_linearized());
+                         get_quad_index_velocity_linear());
 
   dealii::AffineConstraints<Number> constraint_dummy;
   constraint_dummy.close();

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -404,7 +404,10 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   viscous_kernel_data.viscosity_is_variable        = param.use_turbulence_model;
   viscous_kernel_data.variable_normal_vector       = param.neumann_with_variable_normal_vector;
   viscous_kernel = std::make_shared<Operators::ViscousKernel<dim, Number>>();
-  viscous_kernel->reinit(*matrix_free, viscous_kernel_data, get_dof_index_velocity());
+  viscous_kernel->reinit(*matrix_free,
+                         viscous_kernel_data,
+                         get_dof_index_velocity(),
+                         get_quad_index_velocity_linearized());
 
   dealii::AffineConstraints<Number> constraint_dummy;
   constraint_dummy.close();

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -425,6 +425,13 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
     }
   }
 
+  bool const variable_viscosity = use_turbulence_model;
+  if(variable_viscosity and nonlinear_problem_has_to_be_solved())
+    AssertThrow(quad_rule_linearization == QuadratureRuleLinearization::Standard,
+                dealii::ExcMessage(
+                  "Only the standard integration rule is supported for variable viscosity. "
+                  "Variable viscosity with multiple integration rules is not yet implemented."));
+
   // HIGH-ORDER DUAL SPLITTING SCHEME
   if(temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
   {

--- a/include/exadg/operators/variable_coefficients.h
+++ b/include/exadg/operators/variable_coefficients.h
@@ -23,117 +23,111 @@
 
 namespace ExaDG
 {
-template<int dim, typename Number>
+template<typename coefficient_type>
 class VariableCoefficientsCells
 {
-private:
-  typedef dealii::VectorizedArray<Number> scalar;
-
 public:
+  template<int dim, typename Number>
   void
   initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
-             unsigned int const                      degree,
-             Number const &                          constant_coefficient)
+             unsigned int const                      quad_index,
+             coefficient_type const &                constant_coefficient)
   {
-    unsigned int const points_per_cell = dealii::Utilities::pow(degree + 1, dim);
+    reinit(matrix_free, quad_index);
 
-    coefficients_cell.reinit(matrix_free.n_cell_batches(), points_per_cell);
-    coefficients_cell.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
+    fill(constant_coefficient);
   }
 
-  scalar
+  coefficient_type
   get_coefficient(unsigned int const cell, unsigned int const q) const
   {
     return coefficients_cell[cell][q];
   }
 
   void
-  set_coefficient(unsigned int const cell, unsigned int const q, scalar const & value)
+  set_coefficient(unsigned int const cell, unsigned int const q, coefficient_type const & value)
   {
     coefficients_cell[cell][q] = value;
   }
 
 private:
-  // variable coefficients
-  dealii::Table<2, scalar> coefficients_cell;
-};
-
-template<int dim, typename Number>
-class VariableCoefficients
-{
-private:
-  typedef dealii::VectorizedArray<Number> scalar;
-
-public:
+  template<int dim, typename Number>
   void
-  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
-             unsigned int const                      degree,
-             Number const &                          constant_coefficient)
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free, unsigned int const quad_index)
   {
-    unsigned int const points_per_cell = dealii::Utilities::pow(degree + 1, dim);
-    unsigned int const points_per_face = dealii::Utilities::pow(degree + 1, dim - 1);
-
-    // cells
-    coefficients_cell.reinit(matrix_free.n_cell_batches(), points_per_cell);
-
-    coefficients_cell.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
-
-    // face-based loops
-    coefficients_face.reinit(matrix_free.n_inner_face_batches() +
-                               matrix_free.n_boundary_face_batches(),
-                             points_per_face);
-
-    coefficients_face.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
-
-    coefficients_face_neighbor.reinit(matrix_free.n_inner_face_batches(), points_per_face);
-
-    coefficients_face_neighbor.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
-
-    // TODO cell-based face loops
-    //    coefficients_face_cell_based.reinit(matrix_free.n_cell_batches()*2*dim,
-    //        points_per_face);
-    //
-    //    coefficients_face_cell_based.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
+    coefficients_cell.reinit(matrix_free.n_cell_batches(), matrix_free.get_n_q_points(quad_index));
   }
 
-  scalar
+  void
+  fill(coefficient_type const & constant_coefficient)
+  {
+    coefficients_cell.fill(constant_coefficient);
+  }
+
+  // variable coefficients
+  dealii::Table<2, coefficient_type> coefficients_cell;
+};
+
+template<typename coefficient_type>
+class VariableCoefficients
+{
+public:
+  template<int dim, typename Number>
+  void
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             unsigned int const                      quad_index,
+             coefficient_type const &                constant_coefficient)
+  {
+    reinit(matrix_free, quad_index);
+
+    fill(constant_coefficient);
+  }
+
+  coefficient_type
   get_coefficient_cell(unsigned int const cell, unsigned int const q) const
   {
     return coefficients_cell[cell][q];
   }
 
   void
-  set_coefficient_cell(unsigned int const cell, unsigned int const q, scalar const & value)
+  set_coefficient_cell(unsigned int const       cell,
+                       unsigned int const       q,
+                       coefficient_type const & value)
   {
     coefficients_cell[cell][q] = value;
   }
 
-  scalar
+  coefficient_type
   get_coefficient_face(unsigned int const face, unsigned int const q) const
   {
     return coefficients_face[face][q];
   }
 
   void
-  set_coefficient_face(unsigned int const face, unsigned int const q, scalar const & value)
+  set_coefficient_face(unsigned int const       face,
+                       unsigned int const       q,
+                       coefficient_type const & value)
   {
     coefficients_face[face][q] = value;
   }
 
-  scalar
+  coefficient_type
   get_coefficient_face_neighbor(unsigned int const face, unsigned int const q) const
   {
     return coefficients_face_neighbor[face][q];
   }
 
   void
-  set_coefficient_face_neighbor(unsigned int const face, unsigned int const q, scalar const & value)
+  set_coefficient_face_neighbor(unsigned int const       face,
+                                unsigned int const       q,
+                                coefficient_type const & value)
   {
     coefficients_face_neighbor[face][q] = value;
   }
 
   // TODO
-  //  scalar
+  //
+  //  coefficient_type
   //  get_coefficient_cell_based(unsigned int const face,
   //                             unsigned int const q) const
   //  {
@@ -141,26 +135,56 @@ public:
   //  }
   //
   //  void
-  //  set_coefficient_cell_based(unsigned int const face,
-  //                             unsigned int const q,
-  //                             scalar const &     value)
+  //  set_coefficient_cell_based(unsigned int const       face,
+  //                             unsigned int const       q,
+  //                             coefficient_type const & value)
   //  {
   //    coefficients_face_cell_based[face][q] = value;
   //  }
 
 private:
+  template<int dim, typename Number>
+  void
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free, unsigned int const quad_index)
+  {
+    coefficients_cell.reinit(matrix_free.n_cell_batches(), matrix_free.get_n_q_points(quad_index));
+
+    coefficients_face.reinit(matrix_free.n_inner_face_batches() +
+                               matrix_free.n_boundary_face_batches(),
+                             matrix_free.get_n_q_points_face(quad_index));
+
+    coefficients_face_neighbor.reinit(matrix_free.n_inner_face_batches(),
+                                      matrix_free.get_n_q_points_face(quad_index));
+
+    // TODO
+    // // cell-based face loops
+    // coefficients_face_cell_based.reinit(matrix_free.n_cell_batches()*2*dim,
+    // matrix_free.get_n_q_points_face(quad_index));
+  }
+
+  void
+  fill(coefficient_type const & constant_coefficient)
+  {
+    coefficients_cell.fill(constant_coefficient);
+    coefficients_face.fill(constant_coefficient);
+    coefficients_face_neighbor.fill(constant_coefficient);
+
+    // TODO
+    // coefficients_face_cell_based.fill(constant_coefficient);
+  }
+
   // variable coefficients
 
   // cell
-  dealii::Table<2, scalar> coefficients_cell;
+  dealii::Table<2, coefficient_type> coefficients_cell;
 
   // face-based loops
-  dealii::Table<2, scalar> coefficients_face;
-  dealii::Table<2, scalar> coefficients_face_neighbor;
+  dealii::Table<2, coefficient_type> coefficients_face;
+  dealii::Table<2, coefficient_type> coefficients_face_neighbor;
 
   // TODO
   //  // cell-based face loops
-  //  dealii::Table<2, scalar> coefficients_face_cell_based;
+  //  dealii::Table<2, coefficient_type> coefficients_face_cell_based;
 };
 
 } // namespace ExaDG

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -29,7 +29,6 @@ namespace Structure
 template<int dim, typename Number>
 StVenantKirchhoff<dim, Number>::StVenantKirchhoff(
   dealii::MatrixFree<dim, Number> const & matrix_free,
-  unsigned int const                      n_q_points_1d,
   unsigned int const                      dof_index,
   unsigned int const                      quad_index,
   StVenantKirchhoffData<dim> const &      data)
@@ -46,9 +45,9 @@ StVenantKirchhoff<dim, Number>::StVenantKirchhoff(
   if(E_is_variable)
   {
     // allocate vectors for variable coefficients and initialize with constant values
-    f0_coefficients.initialize(matrix_free, n_q_points_1d, get_f0_factor() * E);
-    f1_coefficients.initialize(matrix_free, n_q_points_1d, get_f1_factor() * E);
-    f2_coefficients.initialize(matrix_free, n_q_points_1d, get_f2_factor() * E);
+    f0_coefficients.initialize(matrix_free, quad_index, get_f0_factor() * E);
+    f1_coefficients.initialize(matrix_free, quad_index, get_f1_factor() * E);
+    f2_coefficients.initialize(matrix_free, quad_index, get_f2_factor() * E);
 
     VectorType dummy;
     matrix_free.cell_loop(&StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients,

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.h
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.h
@@ -64,7 +64,6 @@ public:
   typedef CellIntegrator<dim, dim, Number>                   IntegratorCell;
 
   StVenantKirchhoff(dealii::MatrixFree<dim, Number> const & matrix_free,
-                    unsigned int const                      n_q_points_1d,
                     unsigned int const                      dof_index,
                     unsigned int const                      quad_index,
                     StVenantKirchhoffData<dim> const &      data);
@@ -105,10 +104,10 @@ private:
   mutable dealii::VectorizedArray<Number> f2;
 
   // cache coefficients for spatially varying material parameters
-  bool                                           E_is_variable;
-  mutable VariableCoefficientsCells<dim, Number> f0_coefficients;
-  mutable VariableCoefficientsCells<dim, Number> f1_coefficients;
-  mutable VariableCoefficientsCells<dim, Number> f2_coefficients;
+  bool                                                               E_is_variable;
+  mutable VariableCoefficientsCells<dealii::VectorizedArray<Number>> f0_coefficients;
+  mutable VariableCoefficientsCells<dealii::VectorizedArray<Number>> f1_coefficients;
+  mutable VariableCoefficientsCells<dealii::VectorizedArray<Number>> f2_coefficients;
 };
 } // namespace Structure
 } // namespace ExaDG

--- a/include/exadg/structure/material/material_handler.h
+++ b/include/exadg/structure/material/material_handler.h
@@ -47,7 +47,6 @@ public:
 
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
-             unsigned int const                        n_q_points_1d,
              unsigned int const                        dof_index,
              unsigned int const                        quad_index,
              std::shared_ptr<MaterialDescriptor const> material_descriptor)
@@ -72,10 +71,8 @@ public:
         {
           std::shared_ptr<StVenantKirchhoffData<dim>> data_svk =
             std::static_pointer_cast<StVenantKirchhoffData<dim>>(data);
-          material_map.insert(
-            Pair(id,
-                 new StVenantKirchhoff<dim, Number>(
-                   matrix_free, n_q_points_1d, dof_index, quad_index, *data_svk)));
+          material_map.insert(Pair(
+            id, new StVenantKirchhoff<dim, Number>(matrix_free, dof_index, quad_index, *data_svk)));
           break;
         }
         default:

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -299,7 +299,6 @@ Operator<dim, Number>::setup_operators()
   }
   operator_data.bc                  = boundary_descriptor;
   operator_data.material_descriptor = material_descriptor;
-  operator_data.n_q_points_1d       = param.degree + 1;
   operator_data.unsteady            = (param.problem_type == ProblemType::Unsteady);
   operator_data.density             = param.density;
   if(param.large_deformation)

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -82,8 +82,10 @@ ElasticityOperatorBase<dim, Number>::initialize(
 
   this->integrator_flags = this->get_integrator_flags(data.unsteady);
 
-  material_handler.initialize(
-    matrix_free, data.n_q_points_1d, data.dof_index, data.quad_index, data.material_descriptor);
+  material_handler.initialize(matrix_free,
+                              data.dof_index,
+                              data.quad_index,
+                              data.material_descriptor);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -39,7 +39,6 @@ struct OperatorData : public OperatorBaseData
       pull_back_traction(false),
       unsteady(false),
       density(1.0),
-      n_q_points_1d(2),
       quad_index_gauss_lobatto(0)
   {
   }
@@ -57,10 +56,6 @@ struct OperatorData : public OperatorBaseData
 
   // density
   double density;
-
-  // for a material law with spatially varying coefficients, the number of 1D
-  // quadrature points is needed
-  unsigned int n_q_points_1d;
 
   // for DirichletCached boundary conditions, another quadrature rule
   // is needed to set the constrained DoFs.


### PR DESCRIPTION
Especially in problems with complex (multi-)physics, scalar as well as tensor-valued (generally rank 2) variable coefficients play a significant role. Currently, the `VariableCoefficients` class provides the basic implementation for scalar-valued coefficients as tables with cell and quadrature indices.

This PR:
- generalizes the `VariableCoefficients` class (and the related `VariableCoefficientsCell` class) to hold coefficients of arbitrary type like tensors of different ranks, hence closes #289,
- fixes the calculation of the number of quadrature points by getting the `quad_index` alongside the `MatrixFree` object and extracting the quadrature formula from it, hence closes #128.

Also:
- removes the `n_q_points_1d` variable piped through in the structure module, as it is not needed for the number of quadrature points,
- passes in the `quad_index` into the viscous kernel for the purpose of getting the number of quadrature points from the `MatrixFree` object inside the `VariableCoefficients` class, 
- does not touch or modify the `cell_based_face_loop` type of variable coefficients which was and still is marked `TODO`.

This PR constitutes one of the first steps towards widely enabling variable coefficients in ExaDG. I will try to bring in more issues and PRs soon on this topic.