### PR TITLE
[WIP] Add google test for unittests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,9 +272,10 @@ DEAL_II_SETUP_TARGET(exadg)
 
 ENABLE_TESTING()
 
+INCLUDE(UnitTestingFramework.cmake)
+
 ADD_SUBDIRECTORY(applications)
 ADD_SUBDIRECTORY(prototypes)
-ADD_SUBDIRECTORY(tests)
 
 ADD_SUBDIRECTORY(doc/doxygen)
 

--- a/UnitTestingFramework.cmake
+++ b/UnitTestingFramework.cmake
@@ -1,5 +1,5 @@
 #########################################################################
-# 
+#
 #                 #######               ######  #######
 #                 ##                    ##   ## ##
 #                 #####   ##  ## #####  ##   ## ## ####
@@ -25,10 +25,26 @@
 #
 #########################################################################
 
-include(GoogleTest)
+OPTION(EXADG_WITH_GOOGLETEST "Use GoogleTest for unit testing" ON)
+IF(EXADG_WITH_GOOGLETEST)
+  MESSAGE(STATUS "Unit tests with GoogleTest: enabled")
 
-ADD_SUBDIRECTORY(operators_gtest)
-ADD_SUBDIRECTORY(solvers_and_preconditioners_gtest)
+  ADD_CUSTOM_TARGET(unittests)
+  ADD_DEPENDENCIES(exadg unittests)
 
-ADD_SUBDIRECTORY(solvers_and_preconditioners)
-ADD_SUBDIRECTORY(utilities)
+  IF(TARGET gtest)
+    MESSAGE(FATAL_ERROR "A target <gtest> has already been included by a TPL." "This is not supported.")
+  ENDIF()
+
+  INCLUDE(FetchContent)
+  FETCHCONTENT_DECLARE(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG release-1.12.0
+      )
+  FETCHCONTENT_MAKEAVAILABLE(googletest)
+
+  ADD_SUBDIRECTORY(tests)
+ELSE()
+  MESSAGE(STATUS "Unit tests with GoogleTest: disabled")
+ENDIF()

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -41,7 +41,8 @@ MomentumOperator<dim, Number>::initialize(
     this->viscous_kernel = std::make_shared<Operators::ViscousKernel<dim, Number>>();
     this->viscous_kernel->reinit(matrix_free,
                                  operator_data.viscous_kernel_data,
-                                 operator_data.dof_index);
+                                 operator_data.dof_index,
+                                 operator_data.quad_index);
   }
 
   if(operator_data.unsteady_problem)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -63,7 +63,8 @@ public:
   void
   reinit(dealii::MatrixFree<dim, Number> const & matrix_free,
          ViscousKernelData const &               data,
-         unsigned int const                      dof_index)
+         unsigned int const                      dof_index,
+         unsigned int const                      quad_index)
   {
     this->data = data;
 
@@ -77,7 +78,7 @@ public:
     if(data.viscosity_is_variable)
     {
       // allocate vectors for variable coefficients and initialize with constant viscosity
-      viscosity_coefficients.initialize(matrix_free, degree, data.viscosity);
+      viscosity_coefficients.initialize(matrix_free, quad_index, data.viscosity);
     }
   }
 
@@ -495,7 +496,7 @@ private:
 
   mutable scalar tau;
 
-  VariableCoefficients<dim, Number> viscosity_coefficients;
+  VariableCoefficients<dealii::VectorizedArray<Number>> viscosity_coefficients;
 };
 
 } // namespace Operators

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -404,7 +404,10 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   viscous_kernel_data.viscosity_is_variable        = param.use_turbulence_model;
   viscous_kernel_data.variable_normal_vector       = param.neumann_with_variable_normal_vector;
   viscous_kernel = std::make_shared<Operators::ViscousKernel<dim, Number>>();
-  viscous_kernel->reinit(*matrix_free, viscous_kernel_data, get_dof_index_velocity());
+  viscous_kernel->reinit(*matrix_free,
+                         viscous_kernel_data,
+                         get_dof_index_velocity(),
+                         get_quad_index_velocity_linearized());
 
   dealii::AffineConstraints<Number> constraint_dummy;
   constraint_dummy.close();

--- a/include/exadg/operators/variable_coefficients.h
+++ b/include/exadg/operators/variable_coefficients.h
@@ -21,6 +21,8 @@
 #ifndef INCLUDE_EXADG_OPERATORS_VARIABLE_COEFFICIENTS_H_
 #define INCLUDE_EXADG_OPERATORS_VARIABLE_COEFFICIENTS_H_
 
+#include <deal.II/matrix_free/matrix_free.h>
+
 namespace ExaDG
 {
 template<typename coefficient_t>

--- a/include/exadg/operators/variable_coefficients.h
+++ b/include/exadg/operators/variable_coefficients.h
@@ -23,117 +23,107 @@
 
 namespace ExaDG
 {
-template<int dim, typename Number>
+template<typename coefficient_t>
 class VariableCoefficientsCells
 {
-private:
-  typedef dealii::VectorizedArray<Number> scalar;
-
 public:
+  template<int dim, typename Number>
   void
   initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
-             unsigned int const                      degree,
-             Number const &                          constant_coefficient)
+             unsigned int const                      quad_index,
+             coefficient_t const &                   constant_coefficient)
   {
-    unsigned int const points_per_cell = dealii::Utilities::pow(degree + 1, dim);
+    reinit(matrix_free, quad_index);
 
-    coefficients_cell.reinit(matrix_free.n_cell_batches(), points_per_cell);
-    coefficients_cell.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
+    fill(constant_coefficient);
   }
 
-  scalar
+  coefficient_t
   get_coefficient(unsigned int const cell, unsigned int const q) const
   {
     return coefficients_cell[cell][q];
   }
 
   void
-  set_coefficient(unsigned int const cell, unsigned int const q, scalar const & value)
+  set_coefficient(unsigned int const cell, unsigned int const q, coefficient_t const & value)
   {
     coefficients_cell[cell][q] = value;
   }
 
 private:
-  // variable coefficients
-  dealii::Table<2, scalar> coefficients_cell;
-};
-
-template<int dim, typename Number>
-class VariableCoefficients
-{
-private:
-  typedef dealii::VectorizedArray<Number> scalar;
-
-public:
+  template<int dim, typename Number>
   void
-  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
-             unsigned int const                      degree,
-             Number const &                          constant_coefficient)
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free, unsigned int const quad_index)
   {
-    unsigned int const points_per_cell = dealii::Utilities::pow(degree + 1, dim);
-    unsigned int const points_per_face = dealii::Utilities::pow(degree + 1, dim - 1);
-
-    // cells
-    coefficients_cell.reinit(matrix_free.n_cell_batches(), points_per_cell);
-
-    coefficients_cell.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
-
-    // face-based loops
-    coefficients_face.reinit(matrix_free.n_inner_face_batches() +
-                               matrix_free.n_boundary_face_batches(),
-                             points_per_face);
-
-    coefficients_face.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
-
-    coefficients_face_neighbor.reinit(matrix_free.n_inner_face_batches(), points_per_face);
-
-    coefficients_face_neighbor.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
-
-    // TODO cell-based face loops
-    //    coefficients_face_cell_based.reinit(matrix_free.n_cell_batches()*2*dim,
-    //        points_per_face);
-    //
-    //    coefficients_face_cell_based.fill(dealii::make_vectorized_array<Number>(constant_coefficient));
+    coefficients_cell.reinit(matrix_free.n_cell_batches(), matrix_free.get_n_q_points(quad_index));
   }
 
-  scalar
+  void
+  fill(coefficient_t const & constant_coefficient)
+  {
+    coefficients_cell.fill(constant_coefficient);
+  }
+
+  // variable coefficients
+  dealii::Table<2, coefficient_t> coefficients_cell;
+};
+
+template<typename coefficient_t>
+class VariableCoefficients
+{
+public:
+  template<int dim, typename Number>
+  void
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free,
+             unsigned int const                      quad_index,
+             coefficient_t const &                   constant_coefficient)
+  {
+    reinit(matrix_free, quad_index);
+
+    fill(constant_coefficient);
+  }
+
+  coefficient_t
   get_coefficient_cell(unsigned int const cell, unsigned int const q) const
   {
     return coefficients_cell[cell][q];
   }
 
   void
-  set_coefficient_cell(unsigned int const cell, unsigned int const q, scalar const & value)
+  set_coefficient_cell(unsigned int const cell, unsigned int const q, coefficient_t const & value)
   {
     coefficients_cell[cell][q] = value;
   }
 
-  scalar
+  coefficient_t
   get_coefficient_face(unsigned int const face, unsigned int const q) const
   {
     return coefficients_face[face][q];
   }
 
   void
-  set_coefficient_face(unsigned int const face, unsigned int const q, scalar const & value)
+  set_coefficient_face(unsigned int const face, unsigned int const q, coefficient_t const & value)
   {
     coefficients_face[face][q] = value;
   }
 
-  scalar
+  coefficient_t
   get_coefficient_face_neighbor(unsigned int const face, unsigned int const q) const
   {
     return coefficients_face_neighbor[face][q];
   }
 
   void
-  set_coefficient_face_neighbor(unsigned int const face, unsigned int const q, scalar const & value)
+  set_coefficient_face_neighbor(unsigned int const    face,
+                                unsigned int const    q,
+                                coefficient_t const & value)
   {
     coefficients_face_neighbor[face][q] = value;
   }
 
   // TODO
-  //  scalar
+  //
+  //  coefficient_t
   //  get_coefficient_cell_based(unsigned int const face,
   //                             unsigned int const q) const
   //  {
@@ -141,26 +131,56 @@ public:
   //  }
   //
   //  void
-  //  set_coefficient_cell_based(unsigned int const face,
-  //                             unsigned int const q,
-  //                             scalar const &     value)
+  //  set_coefficient_cell_based(unsigned int const    face,
+  //                             unsigned int const    q,
+  //                             coefficient_t const & value)
   //  {
   //    coefficients_face_cell_based[face][q] = value;
   //  }
 
 private:
+  template<int dim, typename Number>
+  void
+  reinit(dealii::MatrixFree<dim, Number> const & matrix_free, unsigned int const quad_index)
+  {
+    coefficients_cell.reinit(matrix_free.n_cell_batches(), matrix_free.get_n_q_points(quad_index));
+
+    coefficients_face.reinit(matrix_free.n_inner_face_batches() +
+                               matrix_free.n_boundary_face_batches(),
+                             matrix_free.get_n_q_points_face(quad_index));
+
+    coefficients_face_neighbor.reinit(matrix_free.n_inner_face_batches(),
+                                      matrix_free.get_n_q_points_face(quad_index));
+
+    // TODO
+    // // cell-based face loops
+    // coefficients_face_cell_based.reinit(matrix_free.n_cell_batches()*2*dim,
+    // matrix_free.get_n_q_points_face(quad_index));
+  }
+
+  void
+  fill(coefficient_t const & constant_coefficient)
+  {
+    coefficients_cell.fill(constant_coefficient);
+    coefficients_face.fill(constant_coefficient);
+    coefficients_face_neighbor.fill(constant_coefficient);
+
+    // TODO
+    // coefficients_face_cell_based.fill(constant_coefficient);
+  }
+
   // variable coefficients
 
   // cell
-  dealii::Table<2, scalar> coefficients_cell;
+  dealii::Table<2, coefficient_t> coefficients_cell;
 
   // face-based loops
-  dealii::Table<2, scalar> coefficients_face;
-  dealii::Table<2, scalar> coefficients_face_neighbor;
+  dealii::Table<2, coefficient_t> coefficients_face;
+  dealii::Table<2, coefficient_t> coefficients_face_neighbor;
 
   // TODO
   //  // cell-based face loops
-  //  dealii::Table<2, scalar> coefficients_face_cell_based;
+  //  dealii::Table<2, coefficient_t> coefficients_face_cell_based;
 };
 
 } // namespace ExaDG

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -29,7 +29,6 @@ namespace Structure
 template<int dim, typename Number>
 StVenantKirchhoff<dim, Number>::StVenantKirchhoff(
   dealii::MatrixFree<dim, Number> const & matrix_free,
-  unsigned int const                      n_q_points_1d,
   unsigned int const                      dof_index,
   unsigned int const                      quad_index,
   StVenantKirchhoffData<dim> const &      data)
@@ -46,9 +45,9 @@ StVenantKirchhoff<dim, Number>::StVenantKirchhoff(
   if(E_is_variable)
   {
     // allocate vectors for variable coefficients and initialize with constant values
-    f0_coefficients.initialize(matrix_free, n_q_points_1d, get_f0_factor() * E);
-    f1_coefficients.initialize(matrix_free, n_q_points_1d, get_f1_factor() * E);
-    f2_coefficients.initialize(matrix_free, n_q_points_1d, get_f2_factor() * E);
+    f0_coefficients.initialize(matrix_free, quad_index, get_f0_factor() * E);
+    f1_coefficients.initialize(matrix_free, quad_index, get_f1_factor() * E);
+    f2_coefficients.initialize(matrix_free, quad_index, get_f2_factor() * E);
 
     VectorType dummy;
     matrix_free.cell_loop(&StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients,

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.h
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.h
@@ -64,7 +64,6 @@ public:
   typedef CellIntegrator<dim, dim, Number>                   IntegratorCell;
 
   StVenantKirchhoff(dealii::MatrixFree<dim, Number> const & matrix_free,
-                    unsigned int const                      n_q_points_1d,
                     unsigned int const                      dof_index,
                     unsigned int const                      quad_index,
                     StVenantKirchhoffData<dim> const &      data);
@@ -105,10 +104,10 @@ private:
   mutable dealii::VectorizedArray<Number> f2;
 
   // cache coefficients for spatially varying material parameters
-  bool                                           E_is_variable;
-  mutable VariableCoefficientsCells<dim, Number> f0_coefficients;
-  mutable VariableCoefficientsCells<dim, Number> f1_coefficients;
-  mutable VariableCoefficientsCells<dim, Number> f2_coefficients;
+  bool                                                               E_is_variable;
+  mutable VariableCoefficientsCells<dealii::VectorizedArray<Number>> f0_coefficients;
+  mutable VariableCoefficientsCells<dealii::VectorizedArray<Number>> f1_coefficients;
+  mutable VariableCoefficientsCells<dealii::VectorizedArray<Number>> f2_coefficients;
 };
 } // namespace Structure
 } // namespace ExaDG

--- a/include/exadg/structure/material/material_handler.h
+++ b/include/exadg/structure/material/material_handler.h
@@ -47,7 +47,6 @@ public:
 
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
-             unsigned int const                        n_q_points_1d,
              unsigned int const                        dof_index,
              unsigned int const                        quad_index,
              std::shared_ptr<MaterialDescriptor const> material_descriptor)
@@ -72,10 +71,8 @@ public:
         {
           std::shared_ptr<StVenantKirchhoffData<dim>> data_svk =
             std::static_pointer_cast<StVenantKirchhoffData<dim>>(data);
-          material_map.insert(
-            Pair(id,
-                 new StVenantKirchhoff<dim, Number>(
-                   matrix_free, n_q_points_1d, dof_index, quad_index, *data_svk)));
+          material_map.insert(Pair(
+            id, new StVenantKirchhoff<dim, Number>(matrix_free, dof_index, quad_index, *data_svk)));
           break;
         }
         default:

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -299,7 +299,6 @@ Operator<dim, Number>::setup_operators()
   }
   operator_data.bc                  = boundary_descriptor;
   operator_data.material_descriptor = material_descriptor;
-  operator_data.n_q_points_1d       = param.degree + 1;
   operator_data.unsteady            = (param.problem_type == ProblemType::Unsteady);
   operator_data.density             = param.density;
   if(param.large_deformation)

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -82,8 +82,10 @@ ElasticityOperatorBase<dim, Number>::initialize(
 
   this->integrator_flags = this->get_integrator_flags(data.unsteady);
 
-  material_handler.initialize(
-    matrix_free, data.n_q_points_1d, data.dof_index, data.quad_index, data.material_descriptor);
+  material_handler.initialize(matrix_free,
+                              data.dof_index,
+                              data.quad_index,
+                              data.material_descriptor);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -39,7 +39,6 @@ struct OperatorData : public OperatorBaseData
       pull_back_traction(false),
       unsteady(false),
       density(1.0),
-      n_q_points_1d(2),
       quad_index_gauss_lobatto(0)
   {
   }
@@ -57,10 +56,6 @@ struct OperatorData : public OperatorBaseData
 
   // density
   double density;
-
-  // for a material law with spatially varying coefficients, the number of 1D
-  // quadrature points is needed
-  unsigned int n_q_points_1d;
 
   // for DirichletCached boundary conditions, another quadrature rule
   // is needed to set the constrained DoFs.

--- a/tests/operators_gtest/CMakeLists.txt
+++ b/tests/operators_gtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 #########################################################################
-# 
+#
 #                 #######               ######  #######
 #                 ##                    ##   ## ##
 #                 #####   ##  ## #####  ##   ## ## ####
@@ -25,10 +25,14 @@
 #
 #########################################################################
 
-include(GoogleTest)
+TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
 
-ADD_SUBDIRECTORY(operators_gtest)
-ADD_SUBDIRECTORY(solvers_and_preconditioners_gtest)
+ADD_EXECUTABLE(
+    ${TARGET_NAME}
+    variable_coefficients.cc
+)
 
-ADD_SUBDIRECTORY(solvers_and_preconditioners)
-ADD_SUBDIRECTORY(utilities)
+DEAL_II_SETUP_TARGET(${TARGET_NAME})
+TARGET_LINK_LIBRARIES(${TARGET_NAME} exadg GTest::gtest_main)
+
+GTEST_DISCOVER_TESTS(${TARGET_NAME})

--- a/tests/operators_gtest/variable_coefficients.cc
+++ b/tests/operators_gtest/variable_coefficients.cc
@@ -1,0 +1,168 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+#include <gtest/gtest.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/grid/grid_generator.h>
+#include <exadg/operators/variable_coefficients.h>
+
+namespace
+{
+unsigned int const dim = 3;
+using Number           = double;
+
+Number
+extract(dealii::VectorizedArray<Number> const & scalar_in, unsigned int const v)
+{
+  return scalar_in[v];
+}
+
+dealii::Tensor<2, dim, Number>
+extract(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & dyadic_in,
+        unsigned int const                                              v)
+{
+  dealii::Tensor<2, dim, Number> dyadic;
+  for(unsigned int d1 = 0; d1 < dim; ++d1)
+    for(unsigned int d2 = 0; d2 < dim; ++d2)
+      dyadic[d1][d2] = dyadic_in[d1][d2][v];
+  return dyadic;
+}
+
+template<typename coefficient_t>
+class VariableCoefficientsTest : public ::testing::Test
+{
+private:
+  static unsigned int const degree               = 2;
+  static unsigned int const n_global_refinements = 1;
+
+protected:
+  void
+  SetUp() override
+  {
+    dealii::Triangulation<dim> triangulation;
+    dealii::GridGenerator::hyper_cube(triangulation);
+    triangulation.refine_global(n_global_refinements);
+
+    dealii::FE_DGQ<dim> const fe(degree);
+
+    dealii::DoFHandler<dim> dof_handler(triangulation);
+    dof_handler.distribute_dofs(fe);
+
+    dealii::AffineConstraints<Number> affine_constraints;
+    affine_constraints.close();
+
+    dealii::MatrixFree<dim, Number>::AdditionalData additional_data;
+    additional_data.mapping_update_flags                = dealii::update_JxW_values;
+    additional_data.mapping_update_flags_inner_faces    = dealii::update_JxW_values;
+    additional_data.mapping_update_flags_boundary_faces = dealii::update_JxW_values;
+
+    matrix_free.reinit(dealii::MappingQ<dim>(degree),
+                       dof_handler,
+                       affine_constraints,
+                       dealii::QGauss<1>(degree + 1),
+                       additional_data);
+
+    n_cell_batches = matrix_free.n_cell_batches();
+    n_face_batches = matrix_free.n_inner_face_batches() + matrix_free.n_boundary_face_batches();
+    n_inner_face_batches = matrix_free.n_inner_face_batches();
+
+    n_q_points_cell = matrix_free.get_n_q_points(0);
+    n_q_points_face = matrix_free.get_n_q_points_face(0);
+
+    vectorization_length = dealii::VectorizedArray<double>::size();
+
+    coefficients.initialize(matrix_free, 0, coefficient_t{});
+  }
+
+  dealii::MatrixFree<dim, Number>            matrix_free;
+  ExaDG::VariableCoefficients<coefficient_t> coefficients;
+
+  unsigned int n_cell_batches;
+  unsigned int n_face_batches;
+  unsigned int n_inner_face_batches;
+
+  unsigned int n_q_points_cell;
+  unsigned int n_q_points_face;
+
+  unsigned int vectorization_length;
+};
+
+using coefficient_types =
+  ::testing::Types<dealii::VectorizedArray<Number>,
+                   dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>,
+                   dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>>;
+TYPED_TEST_SUITE(VariableCoefficientsTest, coefficient_types);
+
+TYPED_TEST(VariableCoefficientsTest, InitializesWithConstant)
+{
+  TypeParam coefficient;
+
+  // Create a nice scalar coefficient
+  if constexpr(std::is_same_v<TypeParam, dealii::VectorizedArray<Number>>)
+  {
+    coefficient = 3.14159;
+  }
+  // Create a nice dyadic coefficient
+  else if constexpr(std::is_same_v<TypeParam,
+                                   dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>>)
+  {
+    coefficient[0][0]       = 1.41421;
+    coefficient[0][dim - 1] = 1.73205;
+  }
+  // Create a nice symmetric dyadic coefficient
+  else if constexpr(std::is_same_v<
+                      TypeParam,
+                      dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>>)
+  {
+    coefficient = 2.71828 * dealii::unit_symmetric_tensor<dim, dealii::VectorizedArray<Number>>();
+  }
+
+  // Call initialize to reinit (resize) and fill with coefficient
+  this->coefficients.initialize(this->matrix_free, 0, coefficient);
+
+  // Check cells
+  for(unsigned int cell = 0; cell < this->n_cell_batches; ++cell)
+    for(unsigned int q = 0; q < this->n_q_points_cell; ++q)
+    {
+      auto coeff_cell = this->coefficients.get_coefficient_cell(cell, q);
+      for(unsigned int v = 0; v < this->vectorization_length; ++v)
+        EXPECT_EQ(extract(coefficient, v), extract(coeff_cell, v));
+    }
+
+  // Check faces
+  for(unsigned int face = 0; face < this->n_face_batches; ++face)
+    for(unsigned int q = 0; q < this->n_q_points_face; ++q)
+    {
+      auto const coeff_face = this->coefficients.get_coefficient_face(face, q);
+      for(unsigned int v = 0; v < this->vectorization_length; ++v)
+        EXPECT_EQ(extract(coefficient, v), extract(coeff_face, v));
+    }
+
+  // Check neighbor faces
+  for(unsigned int face = 0; face < this->n_inner_face_batches; ++face)
+    for(unsigned int q = 0; q < this->n_q_points_face; ++q)
+    {
+      auto const coeff_face_neighbor = this->coefficients.get_coefficient_face_neighbor(face, q);
+      for(unsigned int v = 0; v < this->vectorization_length; ++v)
+        EXPECT_EQ(extract(coefficient, v), extract(coeff_face_neighbor, v));
+    }
+}
+} // namespace

--- a/tests/solvers_and_preconditioners_gtest/CMakeLists.txt
+++ b/tests/solvers_and_preconditioners_gtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 #########################################################################
-# 
+#
 #                 #######               ######  #######
 #                 ##                    ##   ## ##
 #                 #####   ##  ## #####  ##   ## ## ####
@@ -25,10 +25,14 @@
 #
 #########################################################################
 
-include(GoogleTest)
+TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
 
-ADD_SUBDIRECTORY(operators_gtest)
-ADD_SUBDIRECTORY(solvers_and_preconditioners_gtest)
+ADD_EXECUTABLE(
+    ${TARGET_NAME}
+    elementwise_gmres.cc
+)
 
-ADD_SUBDIRECTORY(solvers_and_preconditioners)
-ADD_SUBDIRECTORY(utilities)
+DEAL_II_SETUP_TARGET(${TARGET_NAME})
+TARGET_LINK_LIBRARIES(${TARGET_NAME} exadg GTest::gtest_main)
+
+GTEST_DISCOVER_TESTS(${TARGET_NAME})

--- a/tests/solvers_and_preconditioners_gtest/elementwise_gmres.cc
+++ b/tests/solvers_and_preconditioners_gtest/elementwise_gmres.cc
@@ -1,0 +1,235 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+#include <gtest/gtest.h>
+
+#include "./test_utilities.h"
+
+#include <exadg/solvers_and_preconditioners/preconditioners/elementwise_preconditioners.h>
+#include <exadg/solvers_and_preconditioners/solvers/elementwise_krylov_solvers.h>
+
+namespace
+{
+template<typename Number>
+class ElementwiseGMRESTest : public ::testing::Test
+{
+protected:
+  double const tol = 1.0e-14;
+
+  using Matrix = TestUtilities::MyMatrix<Number>;
+  using Vector = TestUtilities::MyVector<Number>;
+
+  using Preconditioner = ExaDG::Elementwise::PreconditionerIdentity<Number>;
+  using Solver         = ExaDG::Elementwise::SolverGMRES<Number, Matrix, Preconditioner>;
+
+  using ::testing::Test::SetUp; // silence -Woverloaded-virtual warning
+  void
+  SetUp(unsigned int system_size)
+  {
+    gmres_solver   = std::make_unique<Solver>(system_size, ExaDG::SolverData(100, tol, tol, 30));
+    preconditioner = std::make_unique<Preconditioner>(system_size);
+  }
+
+  static Vector
+  calculate_residual(unsigned int const system_size, Matrix const & A, Vector & x, Vector & b)
+  {
+    Vector residual(system_size);
+    A.vmult(residual.ptr(), x.ptr());
+    residual.sadd(-1.0, b.ptr());
+
+    return residual;
+  }
+
+  std::unique_ptr<Solver>         gmres_solver;
+  std::unique_ptr<Preconditioner> preconditioner;
+};
+
+/*
+ * Tests using double type
+ */
+using ElementwiseGMRESTestDouble = ElementwiseGMRESTest<double>;
+
+TEST_F(ElementwiseGMRESTestDouble, SolvesSmallSystem)
+{
+  unsigned int const system_size = 3;
+  SetUp(system_size);
+
+  Vector b(system_size);
+  b.set_value(1.0, 0);
+  b.set_value(4.0, 1);
+  b.set_value(6.0, 2);
+
+  Vector x(system_size);
+  x.init();
+
+  Matrix A(system_size);
+  A.set_value(1.0, 0, 0);
+  A.set_value(2.0, 0, 1);
+  A.set_value(3.0, 0, 2);
+  A.set_value(2.0, 1, 0);
+  A.set_value(3.0, 1, 1);
+  A.set_value(1.0, 1, 2);
+  A.set_value(3.0, 2, 0);
+  A.set_value(1.0, 2, 1);
+  A.set_value(2.0, 2, 2);
+
+  Vector res_initial = calculate_residual(system_size, A, x, b);
+  gmres_solver->solve(&A, x.ptr(), b.ptr(), preconditioner.get());
+  Vector res_final = calculate_residual(system_size, A, x, b);
+
+  EXPECT_NEAR(7.3e+00, res_initial.l2_norm(), 1.0e-01);
+  EXPECT_NEAR(3.6e-15, res_final.l2_norm(), 1.0e-16);
+}
+
+TEST_F(ElementwiseGMRESTestDouble, SolverLargeSystem)
+{
+  unsigned int const system_size = 10000;
+  SetUp(system_size);
+
+  Vector b(system_size);
+  for(unsigned int i = 0; i < system_size; ++i)
+    b.set_value(1.0, i);
+
+  Vector x(system_size);
+  x.init();
+
+  Matrix A(system_size);
+  for(unsigned int i = 0; i < system_size; ++i)
+  {
+    A.set_value(2.0, i, i);
+    if(i > 1)
+    {
+      A.set_value(-1.0, i - 1, i);
+      A.set_value(-1.0, i, i - i);
+    }
+  }
+
+  Vector res_initial = calculate_residual(system_size, A, x, b);
+  gmres_solver->solve(&A, x.ptr(), b.ptr(), preconditioner.get());
+  Vector res_final = calculate_residual(system_size, A, x, b);
+
+  EXPECT_NEAR(1.0e+02, res_initial.l2_norm(), 1.0e+01);
+  EXPECT_NEAR(5.9e-13, res_final.l2_norm(), tol);
+}
+
+/*
+ * Tests using dealii::VectorizedArray<double> type
+ */
+using ElementwiseGMRESTestVectorizedDouble = ElementwiseGMRESTest<dealii::VectorizedArray<double>>;
+
+TEST_F(ElementwiseGMRESTestVectorizedDouble, ConvergesFromExactSolution)
+{
+  unsigned int const system_size = 3;
+  SetUp(system_size);
+
+  Vector b(system_size);
+  b.set_value(1.0, 0);
+  b.set_value(2.0, 1);
+  b.set_value(3.0, 2);
+
+  Vector x(system_size);
+  x.init();
+  x.set_value(1.0, 0);
+  x.set_value(1.0, 1);
+  x.set_value(1.0, 2);
+
+  Matrix A(system_size);
+  A.set_value(1.0, 0, 0);
+  A.set_value(2.0, 1, 1);
+  A.set_value(3.0, 2, 2);
+
+  gmres_solver->solve(&A, x.ptr(), b.ptr(), preconditioner.get());
+  Vector res = calculate_residual(system_size, A, x, b);
+
+  dealii::VectorizedArray<double> const l2_norm = res.l2_norm();
+
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
+    EXPECT_LT(l2_norm[v], 1.0e-12);
+}
+
+TEST_F(ElementwiseGMRESTestVectorizedDouble, ConvergesFromZero)
+{
+  unsigned int const system_size = 3;
+  SetUp(system_size);
+
+  Vector b(system_size);
+  b.set_value(1.0, 0);
+  b.set_value(4.0, 1);
+  b.set_value(6.0, 2);
+
+  Vector x(system_size);
+  x.init();
+
+  Matrix A(system_size);
+  A.set_value(1.0, 0, 0);
+  A.set_value(2.0, 0, 1);
+  A.set_value(3.0, 0, 2);
+  A.set_value(2.0, 1, 0);
+  A.set_value(3.0, 1, 1);
+  A.set_value(1.0, 1, 2);
+  A.set_value(3.0, 2, 0);
+  A.set_value(1.0, 2, 1);
+  A.set_value(2.0, 2, 2);
+
+  gmres_solver->solve(&A, x.ptr(), b.ptr(), preconditioner.get());
+  Vector res = calculate_residual(system_size, A, x, b);
+
+  dealii::VectorizedArray<double> l2_norm = res.l2_norm();
+
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
+    EXPECT_LT(l2_norm[v], 1.0e-12);
+}
+
+TEST_F(ElementwiseGMRESTestVectorizedDouble, SolvesDifferentEquations)
+{
+  unsigned int const system_size = 3;
+  SetUp(system_size);
+
+  Vector b(system_size);
+  b.set_value(1.0, 0);
+  b.set_value(2.0, 1);
+  b.set_value(3.0, 2);
+
+  Vector x(system_size);
+  x.init();
+  x.set_value(1.0, 0);
+  x.set_value(1.0, 1);
+
+  dealii::VectorizedArray<double> inhom_array(1.0);
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
+    if(v > 1)
+      inhom_array[v] = 0.0;
+
+  x.set_value(inhom_array, 2);
+
+  Matrix A(system_size);
+  A.set_value(1.0, 0, 0);
+  A.set_value(2.0, 1, 1);
+  A.set_value(3.0, 2, 2);
+
+  gmres_solver->solve(&A, x.ptr(), b.ptr(), preconditioner.get());
+  Vector res = calculate_residual(system_size, A, x, b);
+
+  dealii::VectorizedArray<double> l2_norm = res.l2_norm();
+
+  for(unsigned int v = 0; v < dealii::VectorizedArray<double>::size(); ++v)
+    EXPECT_LT(l2_norm[v], 1.0e-12);
+}
+} // namespace

--- a/tests/solvers_and_preconditioners_gtest/test_utilities.h
+++ b/tests/solvers_and_preconditioners_gtest/test_utilities.h
@@ -1,0 +1,144 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_TESTS_HELPER_LINEAR_ALGEBRA_H
+#define EXADG_TESTS_HELPER_LINEAR_ALGEBRA_H
+
+#include <deal.II/base/aligned_vector.h>
+
+namespace TestUtilities
+{
+template<typename value_type>
+class MyVector
+{
+public:
+  MyVector(unsigned int const size) : M(size)
+  {
+    data.resize(M);
+  }
+
+  value_type *
+  ptr()
+  {
+    return &data[0];
+  }
+
+  void
+  init()
+  {
+    for(unsigned int i = 0; i < M; ++i)
+      data[i] = value_type();
+  }
+
+  void
+  set_value(value_type const value, unsigned int const i)
+  {
+    AssertThrow(i < M, dealii::ExcMessage("Index exceeds matrix dimensions."));
+
+    data[i] = value;
+  }
+
+  void
+  sadd(value_type factor, value_type * src)
+  {
+    for(unsigned int i = 0; i < M; ++i)
+      data[i] += factor * src[i];
+  }
+
+  value_type
+  l2_norm()
+  {
+    value_type l2_norm = value_type();
+
+    for(unsigned int i = 0; i < M; ++i)
+      l2_norm += data[i] * data[i];
+
+    l2_norm = std::sqrt(l2_norm);
+
+    return l2_norm;
+  }
+
+private:
+  // number of rows and columns of matrix
+  unsigned int const                M;
+  dealii::AlignedVector<value_type> data;
+};
+
+
+/*
+ * Own implementation of matrix class.
+ */
+template<typename value_type>
+class MyMatrix
+{
+public:
+  // Constructor.
+  MyMatrix(unsigned int const size) : M(size)
+  {
+    data.resize(M * M);
+  }
+
+  void
+  vmult(value_type * dst, value_type * src) const
+  {
+    for(unsigned int i = 0; i < M; ++i)
+    {
+      dst[i] = value_type();
+      for(unsigned int j = 0; j < M; ++j)
+        dst[i] += data[i * M + j] * src[j];
+    }
+  }
+
+  void
+  precondition(value_type * dst, value_type * src) const
+  {
+    // no preconditioner
+    for(unsigned int i = 0; i < M; ++i)
+    {
+      dst[i] = src[i]; // /data[i*M+i];
+    }
+  }
+
+  void
+  init()
+  {
+    for(unsigned int i = 0; i < M; ++i)
+      for(unsigned int j = 0; j < M; ++j)
+        data[i * M + j] = value_type(0.0);
+  }
+
+  void
+  set_value(value_type const value, unsigned int const i, unsigned int const j)
+  {
+    AssertThrow(i < M && j < M, dealii::ExcMessage("Index exceeds matrix dimensions."));
+
+    data[i * M + j] = value;
+  }
+
+private:
+  // number of rows and columns of matrix
+  unsigned int const                M;
+  dealii::AlignedVector<value_type> data;
+};
+
+} // namespace TestUtilities
+
+#endif // EXADG_TESTS_HELPER_LINEAR_ALGEBRA_H


### PR DESCRIPTION
With this PR, I'd like to introduce Googletest for writing unit tests in ExaDG.

The discussion on whether Googletest is desired is planned to take place in #359. This PR should be an example of what it may look like if we do.

To make the case for Googletest, I have written two test suites with it. 

1. An exact transfer of the test cases for `Elementwise::SolverGMRES` which we already had. Aside from reducing the number of lines, especially duplicated lines, I found that the tests would also run considerably faster with the new framework. The time required for this test suite dropped from about 17 seconds to no more than 10 seconds on my local machine.

2. A typed-test suite for the newly implemented generalized `VariableCoefficients` class (#353). A typed-test in this context means that multiple tests are created automatically for templated types. In this case, I tested `VariableCoefficients` with three different coefficient types.

Part of #359 
Follows #353 