### PR TITLE
Incorporate non-hypercube elements and every triangulation type in categorazation.h

### DIFF
--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -132,8 +132,7 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops && this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
-      &this->dof_handlers[level]->get_triangulation());
+    auto tria = &this->dof_handlers[level]->get_triangulation();
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, h_level);
   }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -103,8 +103,7 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops && this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
-      &this->dof_handlers[level]->get_triangulation());
+    auto tria = &this->dof_handlers[level]->get_triangulation();
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, h_level);
   }
 

--- a/include/exadg/matrix_free/categorization.h
+++ b/include/exadg/matrix_free/categorization.h
@@ -50,9 +50,9 @@ do_cell_based_loops(dealii::Triangulation<dim> const & tria,
   else
     data.cell_vectorization_category.resize(tria.n_active_cells());
 
-  unsigned int const n_faces_per_cell = tria.get_reference_cells()[0].n_faces();
   AssertThrow(tria.get_reference_cells().size() == 1,
               dealii::ExcMessage("No mixed meshes allowed."));
+  unsigned int const n_faces_per_cell = tria.get_reference_cells()[0].n_faces();
 
   // ... setup scaling factor
   std::vector<unsigned int> factors(n_faces_per_cell);

--- a/include/exadg/matrix_free/categorization.h
+++ b/include/exadg/matrix_free/categorization.h
@@ -50,8 +50,12 @@ do_cell_based_loops(dealii::Triangulation<dim> const & tria,
   else
     data.cell_vectorization_category.resize(tria.n_active_cells());
 
+  unsigned int const n_faces_per_cell = tria.get_reference_cells()[0].n_faces();
+  AssertThrow(tria.get_reference_cells().size() == 1,
+              dealii::ExcMessage("No mixed meshes allowed."));
+
   // ... setup scaling factor
-  std::vector<unsigned int> factors(dim * 2);
+  std::vector<unsigned int> factors(n_faces_per_cell);
 
   std::map<unsigned int, unsigned int> bid_map;
   for(unsigned int i = 0; i < tria.get_boundary_ids().size(); i++)
@@ -60,13 +64,13 @@ do_cell_based_loops(dealii::Triangulation<dim> const & tria,
   {
     unsigned int bids   = tria.get_boundary_ids().size() + 1;
     int          offset = 1;
-    for(unsigned int i = 0; i < dim * 2; i++, offset = offset * bids)
+    for(unsigned int i = 0; i < n_faces_per_cell; i++, offset = offset * bids)
       factors[i] = offset;
   }
 
   auto to_category = [&](auto & cell) {
     unsigned int c_num = 0;
-    for(unsigned int i = 0; i < dim * 2; i++)
+    for(unsigned int i = 0; i < n_faces_per_cell; i++)
     {
       auto & face = *cell->face(i);
       if(face.at_boundary())

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -100,8 +100,7 @@ MultigridPreconditioner<dim, Number, n_components>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops && this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
-      &this->dof_handlers[level]->get_triangulation());
+    auto tria = &this->dof_handlers[level]->get_triangulation();
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, h_level);
   }
 


### PR DESCRIPTION
This PR closes #375 and replaces `dim*2` (which is equal to `n_faces` for hypercubes) by dealii's `n_faces` in categorization.h. 