### PR TITLE
Implement imposition of hanging node constraints and periodic boundaries for CG discretizations

### DIFF
--- a/include/exadg/grid/grid_utilities.h
+++ b/include/exadg/grid/grid_utilities.h
@@ -129,45 +129,6 @@ transform_periodic_face_pairs_to_dof_cell_iterator(
 }
 
 /**
- * This function can be seen as some form of "copy constructor" for periodic face pairs,
- * transforming the template argument of dealii::GridTools::PeriodicFacePair from
- * DoFHandler::cell_iterator to Triangulation::cell_iterator.
- */
-template<int dim>
-std::vector<dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
-transform_periodic_face_pairs_to_tria_cell_iterator(
-  std::vector<
-    dealii::GridTools::PeriodicFacePair<typename dealii::DoFHandler<dim>::cell_iterator>> const &
-    periodic_faces)
-{
-  typedef typename std::vector<
-    dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
-    PeriodicFacesTria;
-
-  PeriodicFacesTria periodic_faces_tria;
-
-  for(auto it : periodic_faces)
-  {
-    dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>
-      face_pair_tria;
-
-    // works "automatically" from DoFHandler::cell_iterator to Triangulation::cell_iterator
-    face_pair_tria.cell[0] = typename dealii::Triangulation<dim>::cell_iterator(it.cell[0]);
-    face_pair_tria.cell[1] = typename dealii::Triangulation<dim>::cell_iterator(it.cell[1]);
-
-    face_pair_tria.face_idx[0] = it.face_idx[0];
-    face_pair_tria.face_idx[1] = it.face_idx[1];
-
-    face_pair_tria.orientation = it.orientation;
-    face_pair_tria.matrix      = it.matrix;
-
-    periodic_faces_tria.push_back(face_pair_tria);
-  }
-
-  return periodic_faces_tria;
-}
-
-/**
  * This function creates a triangulation based on a lambda function and refinement parameters for
  * global and local mesh refinements. This function is used to create the fine triangulation on the
  * one hand and the coarse triangulations required for global-coarsening multigrid on the other

--- a/include/exadg/grid/grid_utilities.h
+++ b/include/exadg/grid/grid_utilities.h
@@ -91,6 +91,86 @@ get_mesh_smoothing(bool const use_local_smoothing_multigrid, ElementType const &
 }
 
 /**
+ * This function can be seen as some form of "copy constructor" for periodic face pairs,
+ * transforming the template argument of dealii::GridTools::PeriodicFacePair from
+ * Triangulation::cell_iterator to DoFHandler::cell_iterator.
+ */
+template<int dim>
+std::vector<dealii::GridTools::PeriodicFacePair<typename dealii::DoFHandler<dim>::cell_iterator>>
+transform_periodic_face_pairs_to_dof_cell_iterator(
+  std::vector<dealii::GridTools::PeriodicFacePair<
+    typename dealii::Triangulation<dim>::cell_iterator>> const & periodic_faces,
+  dealii::Triangulation<dim> const &                             triangulation,
+  dealii::DoFHandler<dim> const &                                dof_handler)
+{
+  typedef typename std::vector<
+    dealii::GridTools::PeriodicFacePair<typename dealii::DoFHandler<dim>::cell_iterator>>
+    PeriodicFacesDoF;
+
+  PeriodicFacesDoF periodic_faces_dof;
+
+  for(auto it : periodic_faces)
+  {
+    dealii::GridTools::PeriodicFacePair<typename dealii::DoFHandler<dim>::cell_iterator>
+      face_pair_dof_hander;
+
+    face_pair_dof_hander.cell[0] = typename dealii::DoFHandler<dim>::cell_iterator(
+      &triangulation, it.cell[0]->level(), it.cell[0]->index(), &dof_handler);
+    face_pair_dof_hander.cell[1] = typename dealii::DoFHandler<dim>::cell_iterator(
+      &triangulation, it.cell[1]->level(), it.cell[1]->index(), &dof_handler);
+
+    face_pair_dof_hander.face_idx[0] = it.face_idx[0];
+    face_pair_dof_hander.face_idx[1] = it.face_idx[1];
+
+    face_pair_dof_hander.orientation = it.orientation;
+    face_pair_dof_hander.matrix      = it.matrix;
+
+    periodic_faces_dof.push_back(face_pair_dof_hander);
+  }
+
+  return periodic_faces_dof;
+}
+
+/**
+ * This function can be seen as some form of "copy constructor" for periodic face pairs,
+ * transforming the template argument of dealii::GridTools::PeriodicFacePair from
+ * DoFHandler::cell_iterator to Triangulation::cell_iterator.
+ */
+template<int dim>
+std::vector<dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
+transform_periodic_face_pairs_to_tria_cell_iterator(
+  std::vector<
+    dealii::GridTools::PeriodicFacePair<typename dealii::DoFHandler<dim>::cell_iterator>> const &
+    periodic_faces)
+{
+  typedef typename std::vector<
+    dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
+    PeriodicFacesTria;
+
+  PeriodicFacesTria periodic_faces_tria;
+
+  for(auto it : periodic_faces)
+  {
+    dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>
+      face_pair_tria;
+
+    // works "automatically" from DoFHandler::cell_iterator to Triangulation::cell_iterator
+    face_pair_tria.cell[0] = typename dealii::Triangulation<dim>::cell_iterator(it.cell[0]);
+    face_pair_tria.cell[1] = typename dealii::Triangulation<dim>::cell_iterator(it.cell[1]);
+
+    face_pair_tria.face_idx[0] = it.face_idx[0];
+    face_pair_tria.face_idx[1] = it.face_idx[1];
+
+    face_pair_tria.orientation = it.orientation;
+    face_pair_tria.matrix      = it.matrix;
+
+    periodic_faces_tria.push_back(face_pair_tria);
+  }
+
+  return periodic_faces_tria;
+}
+
+/**
  * This function creates a triangulation based on a lambda function and refinement parameters for
  * global and local mesh refinements. This function is used to create the fine triangulation on the
  * one hand and the coarse triangulations required for global-coarsening multigrid on the other

--- a/include/exadg/grid/grid_utilities.h
+++ b/include/exadg/grid/grid_utilities.h
@@ -100,7 +100,6 @@ std::vector<dealii::GridTools::PeriodicFacePair<typename dealii::DoFHandler<dim>
 transform_periodic_face_pairs_to_dof_cell_iterator(
   std::vector<dealii::GridTools::PeriodicFacePair<
     typename dealii::Triangulation<dim>::cell_iterator>> const & periodic_faces,
-  dealii::Triangulation<dim> const &                             triangulation,
   dealii::DoFHandler<dim> const &                                dof_handler)
 {
   typedef typename std::vector<
@@ -114,10 +113,8 @@ transform_periodic_face_pairs_to_dof_cell_iterator(
     dealii::GridTools::PeriodicFacePair<typename dealii::DoFHandler<dim>::cell_iterator>
       face_pair_dof_hander;
 
-    face_pair_dof_hander.cell[0] = typename dealii::DoFHandler<dim>::cell_iterator(
-      &triangulation, it.cell[0]->level(), it.cell[0]->index(), &dof_handler);
-    face_pair_dof_hander.cell[1] = typename dealii::DoFHandler<dim>::cell_iterator(
-      &triangulation, it.cell[1]->level(), it.cell[1]->index(), &dof_handler);
+    face_pair_dof_hander.cell[0] = it.cell[0]->as_dof_handler_iterator(dof_handler);
+    face_pair_dof_hander.cell[1] = it.cell[1]->as_dof_handler_iterator(dof_handler);
 
     face_pair_dof_hander.face_idx[0] = it.face_idx[0];
     face_pair_dof_hander.face_idx[1] = it.face_idx[1];

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -147,6 +147,7 @@ Operator<dim, n_components, Number>::distribute_dofs()
     if(this->grid->triangulation->has_hanging_nodes())
       dealii::DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints);
 
+    // constraints from periodic boundary conditions
     if(not(this->grid->periodic_faces.empty()))
     {
       auto periodic_faces_dof = GridUtilities::transform_periodic_face_pairs_to_dof_cell_iterator(

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -138,6 +138,10 @@ Operator<dim, n_components, Number>::distribute_dofs()
   {
     affine_constraints.clear();
 
+    dealii::IndexSet locally_relevant_dofs;
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    affine_constraints.reinit(locally_relevant_dofs);
+
     // hanging nodes (needs to be done before imposing periodicity constraints and boundary
     // conditions)
     if(this->grid->triangulation->has_hanging_nodes())
@@ -146,7 +150,7 @@ Operator<dim, n_components, Number>::distribute_dofs()
     if(not(this->grid->periodic_faces.empty()))
     {
       auto periodic_faces_dof = GridUtilities::transform_periodic_face_pairs_to_dof_cell_iterator(
-        this->grid->periodic_faces, *this->grid->triangulation, dof_handler);
+        this->grid->periodic_faces, dof_handler);
 
       dealii::DoFTools::make_periodicity_constraints<dim, dim, Number>(periodic_faces_dof,
                                                                        affine_constraints);

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -372,7 +372,8 @@ private:
   std::shared_ptr<dealii::FiniteElement<dim>> fe;
   dealii::DoFHandler<dim>                     dof_handler;
   dealii::AffineConstraints<Number>           affine_constraints;
-  // constraints for mass operator (i.e., do not apply any constraints)
+  // constraints for mass operator (we use a separate AffineConstraints object, because we do not
+  // apply constraints from Dirichlet boundary conditions here)
   dealii::AffineConstraints<Number> constraints_mass;
 
   std::string const dof_index                = "dof";


### PR DESCRIPTION
closes #385

Note: The present PR can be considered a "bugfix", because we didn't assert before that hanging nodes and periodic boundaries were actually not working correctly with continuous Galerkin discretizations. 

The two utility functions could be relevant for the deal.II library. Does deal.II already provide such functionality @peterrum @kronbichler? I could not find it.

thanks to @bergbauer for your help how to construct a `DoF::cell_iterator` from a `Tria::cell_iterator`. The deal.II docu (https://www.dealii.org/developer/doxygen/deal.II/classDoFCellAccessor.html#a3fdfeda1dae3c8c79aab8f8693d773f4) is quite hard to understand in my opinion.

To test the periodic boundary condition implementation, I circumvented the `GridUtilities::create_triangulation()` functionality for global-coarsening (see problem described in issue #387), and used local-smoothing multigrid instead, by constructing the fine triangulation and related periodic face pairs explicitly in application.h (for the poisson/sine app). The numerical solution was wrong with the old code version, i.e. it was not periodic, and also iteration counts reduced drastically (from 33.2 to 5.9 for the example I have chosen) with the new implementation.

Note that this PR only addresses the setup of the AffineConstraints objects. Not all operators will work correctly with the changes of this PR (because of `read_dof_values_plain()` used at some places in the code, see issue #383).