### PR TITLE
add missing include

### DIFF
--- a/include/exadg/grid/calculate_characteristic_element_length.h
+++ b/include/exadg/grid/calculate_characteristic_element_length.h
@@ -23,6 +23,7 @@
 #define INCLUDE_FUNCTIONALITIES_CALCULATE_CHARACTERISTIC_ELEMENT_LENGTH_H_
 
 // deal.II
+#include <deal.II/base/mpi.h>
 #include <deal.II/grid/tria.h>
 
 namespace ExaDG


### PR DESCRIPTION
This include is needed for ```dealii::Utilities::MPI::max(-min_cell_diameter, mpi_comm)```