### PR TITLE
Make functions pointers const in the FunctionEvaluator methods

### DIFF
--- a/include/exadg/functions_and_boundary_conditions/evaluate_functions.h
+++ b/include/exadg/functions_and_boundary_conditions/evaluate_functions.h
@@ -40,7 +40,7 @@ struct FunctionEvaluator
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>>                      function,
+    value(std::shared_ptr<dealii::Function<dim>> const                function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -55,10 +55,10 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<rank, dim>> function,
-          unsigned int const                         face,
-          unsigned int const                         q,
-          unsigned int const                         quad_index)
+    value(std::shared_ptr<FunctionCached<rank, dim>> const function,
+          unsigned int const                               face,
+          unsigned int const                               q,
+          unsigned int const                               quad_index)
   {
     (void)function;
     (void)face;
@@ -72,7 +72,7 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>>                          function,
+    value(std::shared_ptr<dealii::Function<dim>> const                    function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const &     q_points,
           dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normals,
           double const &                                                  time)
@@ -89,7 +89,7 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<rank, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<dealii::Function<dim>>                      function,
+    value_symmetric(std::shared_ptr<dealii::Function<dim>> const                function,
                     dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
                     double const &                                              time)
   {
@@ -104,10 +104,10 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<rank, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<FunctionCached<rank, dim>> function,
-                    unsigned int const                         face,
-                    unsigned int const                         q,
-                    unsigned int const                         quad_index)
+    value_symmetric(std::shared_ptr<FunctionCached<rank, dim>> const function,
+                    unsigned int const                               face,
+                    unsigned int const                               q,
+                    unsigned int const                               quad_index)
   {
     (void)function;
     (void)face;
@@ -125,7 +125,7 @@ struct FunctionEvaluator<0, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<0, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>>                      function,
+    value(std::shared_ptr<dealii::Function<dim>> const                function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -146,10 +146,10 @@ struct FunctionEvaluator<0, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<0, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<0, dim>> function,
-          unsigned int const                      face,
-          unsigned int const                      q,
-          unsigned int const                      quad_index)
+    value(std::shared_ptr<FunctionCached<0, dim>> const function,
+          unsigned int const                            face,
+          unsigned int const                            q,
+          unsigned int const                            quad_index)
   {
     dealii::VectorizedArray<Number> value = dealii::make_vectorized_array<Number>(0.0);
 
@@ -165,7 +165,7 @@ struct FunctionEvaluator<1, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>>                      function,
+    value(std::shared_ptr<dealii::Function<dim>> const                function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -189,10 +189,10 @@ struct FunctionEvaluator<1, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<1, dim>> function,
-          unsigned int const                      face,
-          unsigned int const                      q,
-          unsigned int const                      quad_index)
+    value(std::shared_ptr<FunctionCached<1, dim>> const function,
+          unsigned int const                            face,
+          unsigned int const                            q,
+          unsigned int const                            quad_index)
   {
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value;
 
@@ -213,7 +213,7 @@ struct FunctionEvaluator<1, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>>                          function,
+    value(std::shared_ptr<dealii::Function<dim>> const                    function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const &     q_points,
           dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normals,
           double const &                                                  time)
@@ -248,7 +248,7 @@ struct FunctionEvaluator<2, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>>                      function,
+    value(std::shared_ptr<dealii::Function<dim>> const                function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -280,10 +280,10 @@ struct FunctionEvaluator<2, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<2, dim>> function,
-          unsigned int const                      face,
-          unsigned int const                      q,
-          unsigned int const                      quad_index)
+    value(std::shared_ptr<FunctionCached<2, dim>> const function,
+          unsigned int const                            face,
+          unsigned int const                            q,
+          unsigned int const                            quad_index)
   {
     dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> value;
 
@@ -307,7 +307,7 @@ struct FunctionEvaluator<2, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<dealii::Function<dim>>                      function,
+    value_symmetric(std::shared_ptr<dealii::Function<dim>> const                function,
                     dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
                     double const &                                              time)
   {
@@ -339,10 +339,10 @@ struct FunctionEvaluator<2, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<FunctionCached<2, dim>> function,
-                    unsigned int const                      face,
-                    unsigned int const                      q,
-                    unsigned int const                      quad_index)
+    value_symmetric(std::shared_ptr<FunctionCached<2, dim>> const function,
+                    unsigned int const                            face,
+                    unsigned int const                            q,
+                    unsigned int const                            quad_index)
   {
     dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> value;
 


### PR DESCRIPTION
The pointers were not marked `const` for no reason at all. So I'd like to add the the `const` qualifier here.