### PR TITLE
Provide configure script and installation description for HDF5

### DIFF
--- a/scripts/config_hdf5.sh
+++ b/scripts/config_hdf5.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2021 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+
+./configure --prefix=$WORKING_DIRECTORY/hdf5/install/ --enable-unsupported --enable-symbols=yes --disable-threadsafe --disable-cxx --enable-hl --without-szlib --enable-parallel --enable-shared CC=mpicc

--- a/scripts/config_hdf5.sh
+++ b/scripts/config_hdf5.sh
@@ -27,4 +27,14 @@
 #########################################################################
 
 
-./configure --prefix=$WORKING_DIRECTORY/hdf5/install/ --enable-unsupported --enable-symbols=yes --disable-threadsafe --disable-cxx --enable-hl --without-szlib --enable-parallel --enable-shared CC=mpicc
+./configure \
+  --prefix=$WORKING_DIRECTORY/hdf5/install/ \
+  --enable-unsupported \
+  --enable-symbols=yes \
+  --disable-threadsafe \
+  --disable-cxx \
+  --enable-hl \
+  --without-szlib \
+  --enable-parallel \
+  --enable-shared \
+  CC=mpicc


### PR DESCRIPTION
closes #410 

Together with the configure script introduced here, let us discuss the installation description for HDF5 in the wiki https://github.com/exadg/exadg/wiki/Installation during this PR. @jh66637 I did not understand whether `sudo apt install ...` and the variant with `.configure ...` are two different alternatives or not. In particular, I did not know what exactly you mean by `download hdf5`. Could you explain this?