### PR TITLE
remove function IncNS::Parameters::linear_problem_has_to_be_solved()

### DIFF
--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
@@ -174,7 +174,7 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
     std::get<0>(iterations.second) += std::get<0>(iter);
     std::get<1>(iterations.second) += std::get<1>(iter);
   }
-  else
+  else // linear problem
   {
     // calculate rhs vector
     pde_operator->rhs_stokes_problem(rhs_vector, time);
@@ -227,7 +227,7 @@ DriverSteadyProblems<dim, Number>::print_iterations() const
     else
       iterations_avg[2] = iterations_avg[1];
   }
-  else
+  else // linear problem
   {
     names = {"Coupled system"};
     iterations_avg.resize(1);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -262,7 +262,7 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
                                   timer.wall_time());
     }
   }
-  else
+  else // linear problem
   {
     BlockVectorType rhs_vector;
     pde_operator->initialize_block_vector_velocity_pressure(rhs_vector);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -385,7 +385,33 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
     ((this->time_step_number - 1) % this->param.update_preconditioner_momentum_every_time_steps ==
      0);
 
-  if(this->param.linear_problem_has_to_be_solved())
+  if(this->param.nonlinear_problem_has_to_be_solved())
+  {
+    AssertThrow(this->param.nonlinear_problem_has_to_be_solved(),
+                dealii::ExcMessage("Logical error."));
+
+    // solve non-linear system of equations
+    auto const iter = pde_operator->solve_nonlinear_momentum_equation(
+      velocity_np,
+      rhs,
+      this->get_next_time(),
+      update_preconditioner,
+      this->get_scaling_factor_time_derivative_term());
+
+    iterations_momentum.first += 1;
+    std::get<0>(iterations_momentum.second) += std::get<0>(iter);
+    std::get<1>(iterations_momentum.second) += std::get<1>(iter);
+
+    if(this->print_solver_info() and not(this->is_test))
+    {
+      this->pcout << std::endl << "Solve momentum step:";
+      print_solver_info_nonlinear(this->pcout,
+                                  std::get<0>(iter),
+                                  std::get<1>(iter),
+                                  timer.wall_time());
+    }
+  }
+  else
   {
     if(this->param.viscous_problem())
     {
@@ -412,32 +438,6 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
         this->pcout << std::endl << "Explicit momentum step:";
         print_wall_time(this->pcout, timer.wall_time());
       }
-    }
-  }
-  else // nonlinear problem
-  {
-    AssertThrow(this->param.nonlinear_problem_has_to_be_solved(),
-                dealii::ExcMessage("Logical error."));
-
-    // solve non-linear system of equations
-    auto const iter = pde_operator->solve_nonlinear_momentum_equation(
-      velocity_np,
-      rhs,
-      this->get_next_time(),
-      update_preconditioner,
-      this->get_scaling_factor_time_derivative_term());
-
-    iterations_momentum.first += 1;
-    std::get<0>(iterations_momentum.second) += std::get<0>(iter);
-    std::get<1>(iterations_momentum.second) += std::get<1>(iter);
-
-    if(this->print_solver_info() and not(this->is_test))
-    {
-      this->pcout << std::endl << "Solve momentum step:";
-      print_solver_info_nonlinear(this->pcout,
-                                  std::get<0>(iter),
-                                  std::get<1>(iter),
-                                  timer.wall_time());
     }
   }
 
@@ -518,11 +518,11 @@ TimeIntBDFPressureCorrection<dim, Number>::rhs_momentum(VectorType & rhs)
 
   /*
    *  Right-hand side viscous term:
-   *  If a linear system of equations has to be solved,
+   *  If there is no nonlinearity, we solve a linear system of equations, where
    *  inhomogeneous parts of boundary face integrals of the viscous operator
    *  have to be shifted to the right-hand side of the equation.
    */
-  if(this->param.viscous_problem() and this->param.linear_problem_has_to_be_solved())
+  if(this->param.viscous_problem() && not(this->param.nonlinear_problem_has_to_be_solved()))
   {
     pde_operator->rhs_add_viscous_term(rhs, this->get_next_time());
   }
@@ -999,19 +999,7 @@ TimeIntBDFPressureCorrection<dim, Number>::print_iterations() const
   std::vector<std::string> names;
   std::vector<double>      iterations_avg;
 
-  if(this->param.linear_problem_has_to_be_solved())
-  {
-    names = {"Momentum step", "Pressure step", "Projection step"};
-
-    iterations_avg.resize(3);
-    iterations_avg[0] = (double)std::get<1>(iterations_momentum.second) /
-                        std::max(1., (double)iterations_momentum.first);
-    iterations_avg[1] =
-      (double)iterations_pressure.second / std::max(1., (double)iterations_pressure.first);
-    iterations_avg[2] =
-      (double)iterations_projection.second / std::max(1., (double)iterations_projection.first);
-  }
-  else // nonlinear system of equations in momentum step
+  if(this->param.nonlinear_problem_has_to_be_solved())
   {
     names = {"Momentum (nonlinear)",
              "Momentum (linear accumulated)",
@@ -1031,6 +1019,18 @@ TimeIntBDFPressureCorrection<dim, Number>::print_iterations() const
     iterations_avg[3] =
       (double)iterations_pressure.second / std::max(1., (double)iterations_pressure.first);
     iterations_avg[4] =
+      (double)iterations_projection.second / std::max(1., (double)iterations_projection.first);
+  }
+  else
+  {
+    names = {"Momentum step", "Pressure step", "Projection step"};
+
+    iterations_avg.resize(3);
+    iterations_avg[0] = (double)std::get<1>(iterations_momentum.second) /
+                        std::max(1., (double)iterations_momentum.first);
+    iterations_avg[1] =
+      (double)iterations_pressure.second / std::max(1., (double)iterations_pressure.first);
+    iterations_avg[2] =
       (double)iterations_projection.second / std::max(1., (double)iterations_projection.first);
   }
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -387,9 +387,6 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
 
   if(this->param.nonlinear_problem_has_to_be_solved())
   {
-    AssertThrow(this->param.nonlinear_problem_has_to_be_solved(),
-                dealii::ExcMessage("Logical error."));
-
     // solve non-linear system of equations
     auto const iter = pde_operator->solve_nonlinear_momentum_equation(
       velocity_np,
@@ -411,7 +408,7 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
                                   timer.wall_time());
     }
   }
-  else
+  else // linear problem
   {
     if(this->param.viscous_problem())
     {
@@ -1021,7 +1018,7 @@ TimeIntBDFPressureCorrection<dim, Number>::print_iterations() const
     iterations_avg[4] =
       (double)iterations_projection.second / std::max(1., (double)iterations_projection.first);
   }
-  else
+  else // linear problem
   {
     names = {"Momentum step", "Pressure step", "Projection step"};
 

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -636,12 +636,6 @@ Parameters::nonlinear_problem_has_to_be_solved() const
 }
 
 bool
-Parameters::linear_problem_has_to_be_solved() const
-{
-  return not nonlinear_problem_has_to_be_solved();
-}
-
-bool
 Parameters::involves_h_multigrid() const
 {
   bool use_global_coarsening = false;

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -70,9 +70,6 @@ public:
   nonlinear_problem_has_to_be_solved() const;
 
   bool
-  linear_problem_has_to_be_solved() const;
-
-  bool
   involves_h_multigrid() const;
 
   unsigned int


### PR DESCRIPTION
The changes of this PR might appear somewhat unnecessary, so let me explain them in detail:

The name `IncNS::Parameters::linear_problem_has_to_be_solved()` is actually hard to understand in the context of `IncNS` (with monolithic vs. splitting-type solvers), because the name is actually meant in the sense of "no nonlinear problem". Moreover, what is the meaning of this function in case of splitting methods (pressure-correction, dual splitting), where we always have a linear problem to solve (pressure Poisson equation)? 

For this reason, I believe it is better to remove this function entirely. Since the function is mostly used in if-else constructions, we do not even need the negation `not nonlinear_problem_has_to_be_solved()` in the code, but can instead simply change the order of the `if` and `else` branch.

@richardschu This is code you are currently working on. I would therefore suggest you as a reviewer.