### PR TITLE
redesign SpatialOperator::move_grid_and_update_dependent_data_structures()

### DIFF
--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -188,7 +188,7 @@ Driver<dim, Number>::ale_update() const
     get_dynamic_mapping<dim, Number>(application->get_grid(), grid_motion);
   matrix_free->update_mapping(*mapping);
 
-  pde_operator->update_after_grid_motion();
+  pde_operator->update_spatial_operators_after_grid_motion();
   std::shared_ptr<TimeIntBDF<dim, Number>> time_int_bdf =
     std::dynamic_pointer_cast<TimeIntBDF<dim, Number>>(time_integrator);
   time_int_bdf->ale_update();

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -105,12 +105,6 @@ private:
   initialize_transfer_operators() override;
 
   /*
-   *  This function updates the operators on all levels
-   */
-  void
-  update_operators();
-
-  /*
    * This function updates the velocity field for all levels.
    * In order to update mg_matrices[level] this function has to be called.
    */
@@ -118,11 +112,11 @@ private:
   set_velocity(VectorTypeMG const & velocity);
 
   /*
-   * This function performs the updates that are necessary after the mesh has been moved
+   * This function performs the updates that are necessary after the grid has been moved
    * and after matrix_free has been updated.
    */
   void
-  update_operators_after_mesh_movement();
+  update_operators_after_grid_motion();
 
   /*
    *  This function sets the current the time.

--- a/include/exadg/convection_diffusion/spatial_discretization/interface.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/interface.h
@@ -109,7 +109,11 @@ public:
 
   // needed for ALE-type problems
   virtual void
-  move_grid_and_update_dependent_data_structures(double const & time) = 0;
+  update_matrix_free_after_grid_motion() = 0;
+
+  // needed for ALE-type problems
+  virtual void
+  update_spatial_operators_after_grid_motion() = 0;
 
   // needed for ALE-type problems
   virtual void

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -829,7 +829,6 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::move_grid(double const & time) const
 {
-  // Driver::ale_update() is responsible for the preconditioner update
   grid_motion->update(
     time,
     false /* print_solver_info */,
@@ -838,27 +837,14 @@ Operator<dim, Number>::move_grid(double const & time) const
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::move_grid_and_update_dependent_data_structures(double const & time)
+Operator<dim, Number>::update_matrix_free_after_grid_motion()
 {
-  // Driver::ale_update() is responsible for the preconditioner update
-  grid_motion->update(
-    time,
-    false /* print_solver_info */,
-    dealii::numbers::invalid_unsigned_int /* time_step_number used for preconditioner update */);
   matrix_free->update_mapping(*get_mapping());
-  update_after_grid_motion();
 }
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::fill_grid_coordinates_vector(VectorType & vector) const
-{
-  grid_motion->fill_grid_coordinates_vector(vector, this->get_dof_handler_velocity());
-}
-
-template<int dim, typename Number>
-void
-Operator<dim, Number>::update_after_grid_motion()
+Operator<dim, Number>::update_spatial_operators_after_grid_motion()
 {
   // update SIPG penalty parameter of diffusive operator which depends on the deformation
   // of elements
@@ -866,6 +852,13 @@ Operator<dim, Number>::update_after_grid_motion()
   {
     diffusive_kernel->calculate_penalty_parameter(*matrix_free, get_dof_index());
   }
+}
+
+template<int dim, typename Number>
+void
+Operator<dim, Number>::fill_grid_coordinates_vector(VectorType & vector) const
+{
+  grid_motion->fill_grid_coordinates_vector(vector, this->get_dof_handler_velocity());
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -202,22 +202,22 @@ public:
   move_grid(double const & time) const final;
 
   /*
-   * Moves the grid and updates dependent data structures for ALE-type problems.
+   * Updates MatrixFree after grid has been moved.
    */
   void
-  move_grid_and_update_dependent_data_structures(double const & time) final;
+  update_matrix_free_after_grid_motion() final;
+
+  /*
+   * Updates spatial operators after grid has been moved.
+   */
+  void
+  update_spatial_operators_after_grid_motion() final;
 
   /*
    * Fills a dof-vector with grid coordinates for ALE-type problems.
    */
   void
   fill_grid_coordinates_vector(VectorType & vector) const final;
-
-  /*
-   * Updates operators after grid has been moved.
-   */
-  void
-  update_after_grid_motion();
 
   /*
    * This function solves the linear system of equations in case of implicit time integration or

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -557,7 +557,9 @@ TimeIntBDF<dim, Number>::postprocessing() const
   if(this->param.ale_formulation and this->get_time_step_number() == 1 and
      not this->param.restarted_simulation)
   {
-    pde_operator->move_grid_and_update_dependent_data_structures(this->get_time());
+    pde_operator->move_grid(this->get_time());
+    pde_operator->update_matrix_free_after_grid_motion();
+    pde_operator->update_spatial_operators_after_grid_motion();
   }
 
   postprocessor->do_postprocessing(solution[0], this->get_time(), this->get_time_step_number());

--- a/include/exadg/fluid_structure_interaction/single_field_solvers/fluid.h
+++ b/include/exadg/fluid_structure_interaction/single_field_solvers/fluid.h
@@ -271,7 +271,7 @@ SolverFluid<dim, Number>::solve_ale(
   timer_tree->insert({"ALE", "Update matrix-free"}, sub_timer.wall_time());
 
   sub_timer.restart();
-  pde_operator->update_after_grid_motion();
+  pde_operator->update_spatial_operators_after_grid_motion();
   timer_tree->insert({"ALE", "Update operator"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -519,9 +519,9 @@ Driver<dim, Number>::ale_update() const
   timer_tree.insert({"Flow + transport", "ALE", "Update matrix-free"}, sub_timer.wall_time());
 
   sub_timer.restart();
-  fluid_operator->update_after_grid_motion();
+  fluid_operator->update_spatial_operators_after_grid_motion();
   for(unsigned int i = 0; i < application->get_n_scalars(); ++i)
-    scalar_operator[i]->update_after_grid_motion();
+    scalar_operator[i]->update_spatial_operators_after_grid_motion();
   timer_tree.insert({"Flow + transport", "ALE", "Update all operators"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -234,7 +234,7 @@ Driver<dim, Number>::ale_update() const
   timer_tree.insert({"Incompressible flow", "ALE", "Update matrix-free"}, sub_timer.wall_time());
 
   sub_timer.restart();
-  pde_operator->update_after_grid_motion();
+  pde_operator->update_spatial_operators_after_grid_motion();
   timer_tree.insert({"Incompressible flow", "ALE", "Update operator"}, sub_timer.wall_time());
 
   sub_timer.restart();

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -89,12 +89,6 @@ private:
   initialize_operator(unsigned int const level) override;
 
   /*
-   * This function updates the multigrid operators for all levels
-   */
-  void
-  update_operators();
-
-  /*
    * This function updates vector_linearization.
    * In order to update operators[level] this function has to be called.
    */
@@ -111,11 +105,11 @@ private:
   set_time(double const & time);
 
   /*
-   * This function performs the updates that are necessary after the mesh has been moved
+   * This function performs the updates that are necessary after the grid has been moved
    * and after matrix_free has been updated.
    */
   void
-  update_operators_after_mesh_movement();
+  update_operators_after_grid_motion();
 
   /*
    * This function updates scaling_factor_time_derivative_term. In order to update the

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -171,7 +171,7 @@ MultigridPreconditionerProjection<dim, Number>::update_operators()
     velocity_multigrid_type_ptr  = &velocity_multigrid_type_copy;
   }
 
-  // update operator
+  // update operator on fine level
   this->get_operator(this->fine_level)->update(*velocity_multigrid_type_ptr, time_step_size);
 
   // we store only two vectors since the velocity is no longer needed after having updated the

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -66,9 +66,9 @@ OperatorProjectionMethods<dim, Number>::setup(
 
 template<int dim, typename Number>
 void
-OperatorProjectionMethods<dim, Number>::update_after_grid_motion()
+OperatorProjectionMethods<dim, Number>::update_spatial_operators_after_grid_motion()
 {
-  Base::update_after_grid_motion();
+  Base::update_spatial_operators_after_grid_motion();
 
   // update SIPG penalty parameter of Laplace operator which depends on the deformation
   // of elements

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -68,7 +68,7 @@ public:
         std::string const &                              dof_index_temperature = "") override;
 
   void
-  update_after_grid_motion() override;
+  update_spatial_operators_after_grid_motion() override;
 
   /*
    * This function evaluates the rhs-contribution of the viscous term and adds the result to the

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1497,7 +1497,6 @@ template<int dim, typename Number>
 void
 SpatialOperatorBase<dim, Number>::move_grid(double const & time) const
 {
-  // Driver::ale_update() is responsible for the preconditioner update
   grid_motion->update(
     time,
     false /* print_solver_info */,
@@ -1506,28 +1505,14 @@ SpatialOperatorBase<dim, Number>::move_grid(double const & time) const
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::move_grid_and_update_dependent_data_structures(
-  double const & time)
+SpatialOperatorBase<dim, Number>::update_matrix_free_after_grid_motion()
 {
-  // Driver::ale_update() is responsible for the preconditioner update
-  grid_motion->update(
-    time,
-    false /* print_solver_info */,
-    dealii::numbers::invalid_unsigned_int /* time_step_number used for preconditioner update */);
   matrix_free->update_mapping(*get_mapping());
-  update_after_grid_motion();
 }
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::fill_grid_coordinates_vector(VectorType & vector) const
-{
-  grid_motion->fill_grid_coordinates_vector(vector, get_dof_handler_u());
-}
-
-template<int dim, typename Number>
-void
-SpatialOperatorBase<dim, Number>::update_after_grid_motion()
+SpatialOperatorBase<dim, Number>::update_spatial_operators_after_grid_motion()
 {
   if(param.turbulence_model_data.is_active)
   {
@@ -1543,6 +1528,13 @@ SpatialOperatorBase<dim, Number>::update_after_grid_motion()
   }
 
   // note that the update of div-div and continuity penalty terms is done separately
+}
+
+template<int dim, typename Number>
+void
+SpatialOperatorBase<dim, Number>::fill_grid_coordinates_vector(VectorType & vector) const
+{
+  grid_motion->fill_grid_coordinates_vector(vector, get_dof_handler_u());
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -388,22 +388,22 @@ public:
   move_grid(double const & time) const;
 
   /*
-   * Moves the grid and updates dependent data structures for ALE-type problems.
+   * Updates MatrixFree after grid has been moved.
    */
   void
-  move_grid_and_update_dependent_data_structures(double const & time);
+  update_matrix_free_after_grid_motion();
+
+  /*
+   * Updates operators after grid has been moved.
+   */
+  virtual void
+  update_spatial_operators_after_grid_motion();
 
   /*
    * Fills a dof-vector with grid coordinates for ALE-type problems.
    */
   void
   fill_grid_coordinates_vector(VectorType & vector) const;
-
-  /*
-   * Updates operators after grid has been moved.
-   */
-  virtual void
-  update_after_grid_motion();
 
   /*
    * Sets the grid velocity.

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -460,7 +460,9 @@ TimeIntBDF<dim, Number>::postprocessing() const
   if(this->param.ale_formulation and this->get_time_step_number() == 1 and
      not this->param.restarted_simulation)
   {
-    operator_base->move_grid_and_update_dependent_data_structures(this->get_time());
+    operator_base->move_grid(this->get_time());
+    operator_base->update_matrix_free_after_grid_motion();
+    operator_base->update_spatial_operators_after_grid_motion();
   }
 
   // We need to distribute the dofs before computing the error since

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -163,7 +163,11 @@ TimeIntBDFDualSplitting<dim, Number>::initialize_velocity_dbc()
 {
   // fill vector velocity_dbc: The first entry [0] is already needed if start_with_low_order == true
   if(this->param.ale_formulation)
-    pde_operator->move_grid_and_update_dependent_data_structures(this->get_time());
+  {
+    pde_operator->move_grid(this->get_time());
+    pde_operator->update_matrix_free_after_grid_motion();
+    pde_operator->update_spatial_operators_after_grid_motion();
+  }
   pde_operator->interpolate_velocity_dirichlet_bc(velocity_dbc[0], this->get_time());
   // ... and previous times if start_with_low_order == false
   if(this->start_with_low_order == false)
@@ -172,7 +176,11 @@ TimeIntBDFDualSplitting<dim, Number>::initialize_velocity_dbc()
     {
       double const time = this->get_time() - double(i) * this->get_time_step_size();
       if(this->param.ale_formulation)
-        pde_operator->move_grid_and_update_dependent_data_structures(time);
+      {
+        pde_operator->move_grid(time);
+        pde_operator->update_matrix_free_after_grid_motion();
+        pde_operator->update_spatial_operators_after_grid_motion();
+      }
       pde_operator->interpolate_velocity_dirichlet_bc(velocity_dbc[i], time);
     }
   }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -179,7 +179,11 @@ TimeIntBDFPressureCorrection<dim, Number>::initialize_pressure_on_boundary()
     {
       double const time = this->get_time() - double(i) * this->get_time_step_size();
       if(this->param.ale_formulation)
-        pde_operator->move_grid_and_update_dependent_data_structures(time);
+      {
+        pde_operator->move_grid(time);
+        pde_operator->update_matrix_free_after_grid_motion();
+        pde_operator->update_spatial_operators_after_grid_motion();
+      }
 
       pde_operator->interpolate_pressure_dirichlet_bc(pressure_dbc[i], time);
     }


### PR DESCRIPTION
This PR is an attempt to make the usage of ALE in time integrators and multigrid preconditioners more intuitive / easier to understand.

This PR originated from PR #404 and is one step towards realizing what is described in comment https://github.com/exadg/exadg/pull/404#discussion_r1177448382.