### PR TITLE
fix failing Poisseuille test case

### DIFF
--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -207,17 +207,17 @@ private:
 
 
     // TEMPORAL DISCRETIZATION
-    this->param.solver_type                   = SolverType::Unsteady;
-    this->param.temporal_discretization       = TemporalDiscretization::BDFDualSplittingScheme;
-    this->param.treatment_of_convective_term  = TreatmentOfConvectiveTerm::Explicit;
-    this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
-    this->param.adaptive_time_stepping        = true;
-    this->param.max_velocity                  = max_velocity;
-    this->param.cfl                           = 2.0e-1;
+    this->param.solver_type                     = SolverType::Unsteady;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
+    this->param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
+    this->param.adaptive_time_stepping          = true;
+    this->param.max_velocity                    = max_velocity;
+    this->param.cfl                             = 2.0e-1;
     this->param.cfl_exponent_fe_degree_velocity = 1.5;
-    this->param.time_step_size                = 1.0e-1;
-    this->param.order_time_integrator         = 2;    // 1; // 2; // 3;
-    this->param.start_with_low_order          = true; // true; // false;
+    this->param.time_step_size                  = 1.0e-1;
+    this->param.order_time_integrator           = 2;    // 1; // 2; // 3;
+    this->param.start_with_low_order            = true; // true; // false;
 
     this->param.convergence_criterion_steady_problem =
       ConvergenceCriterionSteadyProblem::SolutionIncrement; // ResidualSteadyNavierStokes;

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -214,6 +214,7 @@ private:
     this->param.adaptive_time_stepping        = true;
     this->param.max_velocity                  = max_velocity;
     this->param.cfl                           = 2.0e-1;
+    this->param.cfl_exponent_fe_degree_velocity = 1.5;
     this->param.time_step_size                = 1.0e-1;
     this->param.order_time_integrator         = 2;    // 1; // 2; // 3;
     this->param.start_with_low_order          = true; // true; // false;

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -171,8 +171,8 @@ Setup BDF time integrator ...
 Calculation of time step size according to CFL condition:
 
   CFL:                                       2.0000e-01
-  Time step size (global):                   1.0000e-01
-  Time step size (adaptive):                 1.0000e-01
+  Time step size (global):                   1.4142e-01
+  Time step size (adaptive):                 1.4142e-01
 
 ... done!
 
@@ -190,110 +190,110 @@ Calculate error for pressure at time t = 0.0000e+00:
 
 ________________________________________________________________________________
 
- Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-01
+ Time step number = 1       t = 0.00000e+00 -> t + dt = 1.41421e-01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0001e+01:
-  Absolute error (L2-norm): 1.11167e-15
+Calculate error for velocity at time t = 1.0036e+01:
+  Absolute error (L2-norm): 1.26539e-15
 
-Calculate error for pressure at time t = 1.0001e+01:
-  Absolute error (L2-norm): 2.08187e-15
-
-________________________________________________________________________________
-
- Time step number = 101     t = 1.00011e+01 -> t + dt = 1.01011e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 2.0099e+01:
-  Absolute error (L2-norm): 1.44113e-15
-
-Calculate error for pressure at time t = 2.0099e+01:
-  Absolute error (L2-norm): 7.81642e-15
+Calculate error for pressure at time t = 1.0036e+01:
+  Absolute error (L2-norm): 1.44206e-14
 
 ________________________________________________________________________________
 
- Time step number = 202     t = 2.00991e+01 -> t + dt = 2.01991e+01
+ Time step number = 72      t = 1.00355e+01 -> t + dt = 1.01769e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 3.0097e+01:
-  Absolute error (L2-norm): 1.50997e-15
+Calculate error for velocity at time t = 2.0076e+01:
+  Absolute error (L2-norm): 1.18377e-15
 
-Calculate error for pressure at time t = 3.0097e+01:
-  Absolute error (L2-norm): 1.94719e-14
-
-________________________________________________________________________________
-
- Time step number = 302     t = 3.00972e+01 -> t + dt = 3.01972e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 4.0095e+01:
-  Absolute error (L2-norm): 1.46430e-15
-
-Calculate error for pressure at time t = 4.0095e+01:
-  Absolute error (L2-norm): 1.63110e-14
+Calculate error for pressure at time t = 2.0076e+01:
+  Absolute error (L2-norm): 2.27940e-15
 
 ________________________________________________________________________________
 
- Time step number = 402     t = 4.00954e+01 -> t + dt = 4.01953e+01
+ Time step number = 143     t = 2.00763e+01 -> t + dt = 2.02178e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 5.0094e+01:
-  Absolute error (L2-norm): 1.40536e-15
+Calculate error for velocity at time t = 3.0117e+01:
+  Absolute error (L2-norm): 1.14072e-15
 
-Calculate error for pressure at time t = 5.0094e+01:
-  Absolute error (L2-norm): 1.34416e-15
-
-________________________________________________________________________________
-
- Time step number = 502     t = 5.00935e+01 -> t + dt = 5.01935e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 6.0092e+01:
-  Absolute error (L2-norm): 1.22217e-15
-
-Calculate error for pressure at time t = 6.0092e+01:
-  Absolute error (L2-norm): 7.99678e-15
+Calculate error for pressure at time t = 3.0117e+01:
+  Absolute error (L2-norm): 1.27709e-14
 
 ________________________________________________________________________________
 
- Time step number = 602     t = 6.00915e+01 -> t + dt = 6.01915e+01
+ Time step number = 214     t = 3.01172e+01 -> t + dt = 3.02586e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 7.0090e+01:
-  Absolute error (L2-norm): 1.22241e-15
+Calculate error for velocity at time t = 4.0017e+01:
+  Absolute error (L2-norm): 1.23467e-15
 
-Calculate error for pressure at time t = 7.0090e+01:
-  Absolute error (L2-norm): 1.80128e-14
-
-________________________________________________________________________________
-
- Time step number = 702     t = 7.00895e+01 -> t + dt = 7.01895e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 8.0088e+01:
-  Absolute error (L2-norm): 1.31471e-15
-
-Calculate error for pressure at time t = 8.0088e+01:
-  Absolute error (L2-norm): 2.57096e-14
+Calculate error for pressure at time t = 4.0017e+01:
+  Absolute error (L2-norm): 2.05179e-14
 
 ________________________________________________________________________________
 
- Time step number = 802     t = 8.00876e+01 -> t + dt = 8.01876e+01
+ Time step number = 284     t = 4.00166e+01 -> t + dt = 4.01580e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 9.0086e+01:
-  Absolute error (L2-norm): 1.95871e-15
+Calculate error for velocity at time t = 5.0057e+01:
+  Absolute error (L2-norm): 1.35670e-15
 
-Calculate error for pressure at time t = 9.0086e+01:
-  Absolute error (L2-norm): 2.82074e-15
+Calculate error for pressure at time t = 5.0057e+01:
+  Absolute error (L2-norm): 1.01704e-14
 
 ________________________________________________________________________________
 
- Time step number = 902     t = 9.00857e+01 -> t + dt = 9.01856e+01
+ Time step number = 355     t = 5.00574e+01 -> t + dt = 5.01988e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0008e+02:
-  Absolute error (L2-norm): 1.39926e-15
+Calculate error for velocity at time t = 6.0098e+01:
+  Absolute error (L2-norm): 1.12516e-15
 
-Calculate error for pressure at time t = 1.0008e+02:
-  Absolute error (L2-norm): 4.64781e-15
+Calculate error for pressure at time t = 6.0098e+01:
+  Absolute error (L2-norm): 7.43169e-15
+
+________________________________________________________________________________
+
+ Time step number = 426     t = 6.00982e+01 -> t + dt = 6.02396e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 7.0139e+01:
+  Absolute error (L2-norm): 1.22333e-15
+
+Calculate error for pressure at time t = 7.0139e+01:
+  Absolute error (L2-norm): 5.71454e-15
+
+________________________________________________________________________________
+
+ Time step number = 497     t = 7.01390e+01 -> t + dt = 7.02804e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 8.0038e+01:
+  Absolute error (L2-norm): 1.23367e-15
+
+Calculate error for pressure at time t = 8.0038e+01:
+  Absolute error (L2-norm): 2.17933e-15
+
+________________________________________________________________________________
+
+ Time step number = 567     t = 8.00384e+01 -> t + dt = 8.01798e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 9.0079e+01:
+  Absolute error (L2-norm): 1.27886e-15
+
+Calculate error for pressure at time t = 9.0079e+01:
+  Absolute error (L2-norm): 1.08951e-14
+
+________________________________________________________________________________
+
+ Time step number = 638     t = 9.00792e+01 -> t + dt = 9.02207e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 1.0012e+02:
+  Absolute error (L2-norm): 1.28291e-15
+
+Calculate error for pressure at time t = 1.0012e+02:
+  Absolute error (L2-norm): 7.25196e-15

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -171,8 +171,8 @@ Setup BDF time integrator ...
 Calculation of time step size according to CFL condition:
 
   CFL:                                       2.0000e-01
-  Time step size (global):                   5.0000e-02
-  Time step size (adaptive):                 5.0000e-02
+  Time step size (global):                   7.0711e-02
+  Time step size (adaptive):                 7.0711e-02
 
 ... done!
 
@@ -190,110 +190,110 @@ Calculate error for pressure at time t = 0.0000e+00:
 
 ________________________________________________________________________________
 
- Time step number = 1       t = 0.00000e+00 -> t + dt = 5.00000e-02
+ Time step number = 1       t = 0.00000e+00 -> t + dt = 7.07107e-02
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0100e+01:
-  Absolute error (L2-norm): 1.02288e-15
+Calculate error for velocity at time t = 1.0127e+01:
+  Absolute error (L2-norm): 1.14394e-15
 
-Calculate error for pressure at time t = 1.0100e+01:
-  Absolute error (L2-norm): 5.30950e-15
-
-________________________________________________________________________________
-
- Time step number = 102     t = 1.01004e+01 -> t + dt = 1.02017e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 2.0026e+01:
-  Absolute error (L2-norm): 8.50818e-16
-
-Calculate error for pressure at time t = 2.0026e+01:
-  Absolute error (L2-norm): 9.32414e-15
+Calculate error for pressure at time t = 1.0127e+01:
+  Absolute error (L2-norm): 6.88115e-15
 
 ________________________________________________________________________________
 
- Time step number = 200     t = 2.00259e+01 -> t + dt = 2.01272e+01
+ Time step number = 73      t = 1.01269e+01 -> t + dt = 1.02701e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 3.0053e+01:
-  Absolute error (L2-norm): 8.77475e-16
+Calculate error for velocity at time t = 2.0010e+01:
+  Absolute error (L2-norm): 9.64108e-16
 
-Calculate error for pressure at time t = 3.0053e+01:
-  Absolute error (L2-norm): 2.17686e-14
-
-________________________________________________________________________________
-
- Time step number = 299     t = 3.00526e+01 -> t + dt = 3.01539e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 4.0079e+01:
-  Absolute error (L2-norm): 8.06029e-16
-
-Calculate error for pressure at time t = 4.0079e+01:
-  Absolute error (L2-norm): 2.17191e-14
+Calculate error for pressure at time t = 2.0010e+01:
+  Absolute error (L2-norm): 4.31363e-15
 
 ________________________________________________________________________________
 
- Time step number = 398     t = 4.00793e+01 -> t + dt = 4.01806e+01
+ Time step number = 142     t = 2.00104e+01 -> t + dt = 2.01537e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 5.0005e+01:
-  Absolute error (L2-norm): 8.99109e-16
+Calculate error for velocity at time t = 3.0037e+01:
+  Absolute error (L2-norm): 1.10713e-15
 
-Calculate error for pressure at time t = 5.0005e+01:
-  Absolute error (L2-norm): 9.06344e-15
-
-________________________________________________________________________________
-
- Time step number = 496     t = 5.00048e+01 -> t + dt = 5.01060e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 6.0031e+01:
-  Absolute error (L2-norm): 7.47949e-16
-
-Calculate error for pressure at time t = 6.0031e+01:
-  Absolute error (L2-norm): 3.79518e-15
+Calculate error for pressure at time t = 3.0037e+01:
+  Absolute error (L2-norm): 7.31908e-15
 
 ________________________________________________________________________________
 
- Time step number = 595     t = 6.00315e+01 -> t + dt = 6.01328e+01
+ Time step number = 212     t = 3.00372e+01 -> t + dt = 3.01805e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 7.0058e+01:
-  Absolute error (L2-norm): 7.16460e-16
+Calculate error for velocity at time t = 4.0064e+01:
+  Absolute error (L2-norm): 9.43704e-16
 
-Calculate error for pressure at time t = 7.0058e+01:
-  Absolute error (L2-norm): 2.17012e-15
-
-________________________________________________________________________________
-
- Time step number = 694     t = 7.00582e+01 -> t + dt = 7.01595e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 8.0085e+01:
-  Absolute error (L2-norm): 5.12294e-16
-
-Calculate error for pressure at time t = 8.0085e+01:
-  Absolute error (L2-norm): 7.97099e-15
+Calculate error for pressure at time t = 4.0064e+01:
+  Absolute error (L2-norm): 4.10667e-15
 
 ________________________________________________________________________________
 
- Time step number = 793     t = 8.00849e+01 -> t + dt = 8.01862e+01
+ Time step number = 282     t = 4.00640e+01 -> t + dt = 4.02073e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 9.0010e+01:
-  Absolute error (L2-norm): 5.28905e-16
+Calculate error for velocity at time t = 5.0091e+01:
+  Absolute error (L2-norm): 1.01834e-15
 
-Calculate error for pressure at time t = 9.0010e+01:
-  Absolute error (L2-norm): 2.27035e-14
+Calculate error for pressure at time t = 5.0091e+01:
+  Absolute error (L2-norm): 1.45269e-15
 
 ________________________________________________________________________________
 
- Time step number = 891     t = 9.00104e+01 -> t + dt = 9.01116e+01
+ Time step number = 352     t = 5.00908e+01 -> t + dt = 5.02341e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0004e+02:
-  Absolute error (L2-norm): 8.58488e-16
+Calculate error for velocity at time t = 6.0118e+01:
+  Absolute error (L2-norm): 7.41663e-16
 
-Calculate error for pressure at time t = 1.0004e+02:
-  Absolute error (L2-norm): 2.43275e-15
+Calculate error for pressure at time t = 6.0118e+01:
+  Absolute error (L2-norm): 1.43543e-14
+
+________________________________________________________________________________
+
+ Time step number = 422     t = 6.01176e+01 -> t + dt = 6.02609e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 7.0001e+01:
+  Absolute error (L2-norm): 9.08230e-16
+
+Calculate error for pressure at time t = 7.0001e+01:
+  Absolute error (L2-norm): 7.27625e-15
+
+________________________________________________________________________________
+
+ Time step number = 491     t = 7.00012e+01 -> t + dt = 7.01444e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 8.0028e+01:
+  Absolute error (L2-norm): 1.06426e-15
+
+Calculate error for pressure at time t = 8.0028e+01:
+  Absolute error (L2-norm): 6.74728e-15
+
+________________________________________________________________________________
+
+ Time step number = 561     t = 8.00280e+01 -> t + dt = 8.01712e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 9.0055e+01:
+  Absolute error (L2-norm): 1.06337e-15
+
+Calculate error for pressure at time t = 9.0055e+01:
+  Absolute error (L2-norm): 1.34551e-14
+
+________________________________________________________________________________
+
+ Time step number = 631     t = 9.00548e+01 -> t + dt = 9.01980e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 1.0008e+02:
+  Absolute error (L2-norm): 9.29354e-16
+
+Calculate error for pressure at time t = 1.0008e+02:
+  Absolute error (L2-norm): 4.45805e-16

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -171,8 +171,8 @@ Setup BDF time integrator ...
 Calculation of time step size according to CFL condition:
 
   CFL:                                       2.0000e-01
-  Time step size (global):                   1.0000e-01
-  Time step size (adaptive):                 1.0000e-01
+  Time step size (global):                   1.4142e-01
+  Time step size (adaptive):                 1.4142e-01
 
 ... done!
 
@@ -190,110 +190,110 @@ Calculate error for pressure at time t = 0.0000e+00:
 
 ________________________________________________________________________________
 
- Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-01
+ Time step number = 1       t = 0.00000e+00 -> t + dt = 1.41421e-01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0040e+01:
-  Absolute error (L2-norm): 1.69143e-01
+Calculate error for velocity at time t = 1.0059e+01:
+  Absolute error (L2-norm): 1.68241e-01
 
-Calculate error for pressure at time t = 1.0040e+01:
-  Absolute error (L2-norm): 5.75061e-10
-
-________________________________________________________________________________
-
- Time step number = 69      t = 1.00405e+01 -> t + dt = 1.01494e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 2.0046e+01:
-  Absolute error (L2-norm): 1.39798e-02
-
-Calculate error for pressure at time t = 2.0046e+01:
-  Absolute error (L2-norm): 3.32141e-11
+Calculate error for pressure at time t = 1.0059e+01:
+  Absolute error (L2-norm): 3.97849e-10
 
 ________________________________________________________________________________
 
- Time step number = 166     t = 2.00460e+01 -> t + dt = 2.01467e+01
+ Time step number = 50      t = 1.00588e+01 -> t + dt = 1.02128e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 3.0070e+01:
-  Absolute error (L2-norm): 1.15007e-03
+Calculate error for velocity at time t = 2.0123e+01:
+  Absolute error (L2-norm): 1.36953e-02
 
-Calculate error for pressure at time t = 3.0070e+01:
-  Absolute error (L2-norm): 2.20838e-12
-
-________________________________________________________________________________
-
- Time step number = 266     t = 3.00703e+01 -> t + dt = 3.01704e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 4.0071e+01:
-  Absolute error (L2-norm): 9.51614e-05
-
-Calculate error for pressure at time t = 4.0071e+01:
-  Absolute error (L2-norm): 1.50939e-13
+Calculate error for pressure at time t = 2.0123e+01:
+  Absolute error (L2-norm): 2.49567e-11
 
 ________________________________________________________________________________
 
- Time step number = 366     t = 4.00715e+01 -> t + dt = 4.01715e+01
+ Time step number = 119     t = 2.01231e+01 -> t + dt = 2.02654e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 5.0071e+01:
-  Absolute error (L2-norm): 7.87624e-06
+Calculate error for velocity at time t = 3.0047e+01:
+  Absolute error (L2-norm): 1.15467e-03
 
-Calculate error for pressure at time t = 5.0071e+01:
-  Absolute error (L2-norm): 9.73225e-15
-
-________________________________________________________________________________
-
- Time step number = 466     t = 5.00715e+01 -> t + dt = 5.01715e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 6.0071e+01:
-  Absolute error (L2-norm): 6.51895e-07
-
-Calculate error for pressure at time t = 6.0071e+01:
-  Absolute error (L2-norm): 2.09526e-15
+Calculate error for pressure at time t = 3.0047e+01:
+  Absolute error (L2-norm): 3.49131e-12
 
 ________________________________________________________________________________
 
- Time step number = 566     t = 6.00715e+01 -> t + dt = 6.01715e+01
+ Time step number = 189     t = 3.00467e+01 -> t + dt = 3.01882e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 7.0071e+01:
-  Absolute error (L2-norm): 5.39555e-08
+Calculate error for velocity at time t = 4.0089e+01:
+  Absolute error (L2-norm): 9.45165e-05
 
-Calculate error for pressure at time t = 7.0071e+01:
-  Absolute error (L2-norm): 1.50222e-15
-
-________________________________________________________________________________
-
- Time step number = 666     t = 7.00715e+01 -> t + dt = 7.01715e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 8.0071e+01:
-  Absolute error (L2-norm): 4.46575e-09
-
-Calculate error for pressure at time t = 8.0071e+01:
-  Absolute error (L2-norm): 3.54453e-15
+Calculate error for pressure at time t = 4.0089e+01:
+  Absolute error (L2-norm): 4.23032e-13
 
 ________________________________________________________________________________
 
- Time step number = 766     t = 8.00715e+01 -> t + dt = 8.01715e+01
+ Time step number = 260     t = 4.00890e+01 -> t + dt = 4.02304e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 9.0071e+01:
-  Absolute error (L2-norm): 3.69614e-10
+Calculate error for velocity at time t = 5.0130e+01:
+  Absolute error (L2-norm): 7.73955e-06
 
-Calculate error for pressure at time t = 9.0071e+01:
-  Absolute error (L2-norm): 1.63304e-15
+Calculate error for pressure at time t = 5.0130e+01:
+  Absolute error (L2-norm): 1.45998e-14
 
 ________________________________________________________________________________
 
- Time step number = 866     t = 9.00715e+01 -> t + dt = 9.01715e+01
+ Time step number = 331     t = 5.01298e+01 -> t + dt = 5.02712e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0007e+02:
-  Absolute error (L2-norm): 3.05838e-11
+Calculate error for velocity at time t = 6.0029e+01:
+  Absolute error (L2-norm): 6.56494e-07
 
-Calculate error for pressure at time t = 1.0007e+02:
-  Absolute error (L2-norm): 2.27412e-15
+Calculate error for pressure at time t = 6.0029e+01:
+  Absolute error (L2-norm): 4.04763e-15
+
+________________________________________________________________________________
+
+ Time step number = 401     t = 6.00292e+01 -> t + dt = 6.01706e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 7.0070e+01:
+  Absolute error (L2-norm): 5.37574e-08
+
+Calculate error for pressure at time t = 7.0070e+01:
+  Absolute error (L2-norm): 6.85418e-16
+
+________________________________________________________________________________
+
+ Time step number = 472     t = 7.00700e+01 -> t + dt = 7.02115e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 8.0111e+01:
+  Absolute error (L2-norm): 4.40196e-09
+
+Calculate error for pressure at time t = 8.0111e+01:
+  Absolute error (L2-norm): 8.60933e-16
+
+________________________________________________________________________________
+
+ Time step number = 543     t = 8.01109e+01 -> t + dt = 8.02523e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 9.0010e+01:
+  Absolute error (L2-norm): 3.73379e-10
+
+Calculate error for pressure at time t = 9.0010e+01:
+  Absolute error (L2-norm): 1.54894e-15
+
+________________________________________________________________________________
+
+ Time step number = 613     t = 9.00103e+01 -> t + dt = 9.01517e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 1.0005e+02:
+  Absolute error (L2-norm): 3.05662e-11
+
+Calculate error for pressure at time t = 1.0005e+02:
+  Absolute error (L2-norm): 8.73198e-16

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -171,8 +171,8 @@ Setup BDF time integrator ...
 Calculation of time step size according to CFL condition:
 
   CFL:                                       2.0000e-01
-  Time step size (global):                   1.0000e-01
-  Time step size (adaptive):                 1.0000e-01
+  Time step size (global):                   1.4142e-01
+  Time step size (adaptive):                 1.4142e-01
 
 ... done!
 
@@ -190,110 +190,110 @@ Calculate error for pressure at time t = 0.0000e+00:
 
 ________________________________________________________________________________
 
- Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-01
+ Time step number = 1       t = 0.00000e+00 -> t + dt = 1.41421e-01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0037e+01:
-  Absolute error (L2-norm): 1.69035e-01
+Calculate error for velocity at time t = 1.0056e+01:
+  Absolute error (L2-norm): 1.68135e-01
 
-Calculate error for pressure at time t = 1.0037e+01:
-  Absolute error (L2-norm): 1.33810e-09
-
-________________________________________________________________________________
-
- Time step number = 69      t = 1.00374e+01 -> t + dt = 1.01464e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 2.0043e+01:
-  Absolute error (L2-norm): 1.39526e-02
-
-Calculate error for pressure at time t = 2.0043e+01:
-  Absolute error (L2-norm): 5.53794e-11
+Calculate error for pressure at time t = 1.0056e+01:
+  Absolute error (L2-norm): 4.13674e-10
 
 ________________________________________________________________________________
 
- Time step number = 166     t = 2.00425e+01 -> t + dt = 2.01432e+01
+ Time step number = 50      t = 1.00557e+01 -> t + dt = 1.02097e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 3.0067e+01:
-  Absolute error (L2-norm): 1.14622e-03
+Calculate error for velocity at time t = 2.0119e+01:
+  Absolute error (L2-norm): 1.36693e-02
 
-Calculate error for pressure at time t = 3.0067e+01:
-  Absolute error (L2-norm): 2.77895e-12
-
-________________________________________________________________________________
-
- Time step number = 266     t = 3.00668e+01 -> t + dt = 3.01669e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 4.0068e+01:
-  Absolute error (L2-norm): 9.47099e-05
-
-Calculate error for pressure at time t = 4.0068e+01:
-  Absolute error (L2-norm): 3.40410e-13
+Calculate error for pressure at time t = 2.0119e+01:
+  Absolute error (L2-norm): 3.37113e-12
 
 ________________________________________________________________________________
 
- Time step number = 366     t = 4.00680e+01 -> t + dt = 4.01680e+01
+ Time step number = 119     t = 2.01194e+01 -> t + dt = 2.02617e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 5.0068e+01:
-  Absolute error (L2-norm): 7.82785e-06
+Calculate error for velocity at time t = 3.0043e+01:
+  Absolute error (L2-norm): 1.15089e-03
 
-Calculate error for pressure at time t = 5.0068e+01:
-  Absolute error (L2-norm): 2.31450e-14
-
-________________________________________________________________________________
-
- Time step number = 466     t = 5.00680e+01 -> t + dt = 5.01680e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 6.0068e+01:
-  Absolute error (L2-norm): 6.46979e-07
-
-Calculate error for pressure at time t = 6.0068e+01:
-  Absolute error (L2-norm): 2.81907e-15
+Calculate error for pressure at time t = 3.0043e+01:
+  Absolute error (L2-norm): 1.03113e-12
 
 ________________________________________________________________________________
 
- Time step number = 566     t = 6.00680e+01 -> t + dt = 6.01680e+01
+ Time step number = 189     t = 3.00429e+01 -> t + dt = 3.01844e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 7.0068e+01:
-  Absolute error (L2-norm): 5.34733e-08
+Calculate error for velocity at time t = 4.0085e+01:
+  Absolute error (L2-norm): 9.40746e-05
 
-Calculate error for pressure at time t = 7.0068e+01:
-  Absolute error (L2-norm): 8.52214e-15
-
-________________________________________________________________________________
-
- Time step number = 666     t = 7.00680e+01 -> t + dt = 7.01680e+01
-________________________________________________________________________________
-
-Calculate error for velocity at time t = 8.0068e+01:
-  Absolute error (L2-norm): 4.41960e-09
-
-Calculate error for pressure at time t = 8.0068e+01:
-  Absolute error (L2-norm): 2.71170e-15
+Calculate error for pressure at time t = 4.0085e+01:
+  Absolute error (L2-norm): 2.79389e-14
 
 ________________________________________________________________________________
 
- Time step number = 766     t = 8.00680e+01 -> t + dt = 8.01680e+01
+ Time step number = 260     t = 4.00852e+01 -> t + dt = 4.02266e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 9.0068e+01:
-  Absolute error (L2-norm): 3.65277e-10
+Calculate error for velocity at time t = 5.0126e+01:
+  Absolute error (L2-norm): 7.69248e-06
 
-Calculate error for pressure at time t = 9.0068e+01:
-  Absolute error (L2-norm): 1.06862e-15
+Calculate error for pressure at time t = 5.0126e+01:
+  Absolute error (L2-norm): 3.10408e-15
 
 ________________________________________________________________________________
 
- Time step number = 866     t = 9.00680e+01 -> t + dt = 9.01680e+01
+ Time step number = 331     t = 5.01260e+01 -> t + dt = 5.02674e+01
 ________________________________________________________________________________
 
-Calculate error for velocity at time t = 1.0007e+02:
-  Absolute error (L2-norm): 3.01793e-11
+Calculate error for velocity at time t = 6.0025e+01:
+  Absolute error (L2-norm): 6.51593e-07
 
-Calculate error for pressure at time t = 1.0007e+02:
-  Absolute error (L2-norm): 2.40767e-15
+Calculate error for pressure at time t = 6.0025e+01:
+  Absolute error (L2-norm): 8.03386e-16
+
+________________________________________________________________________________
+
+ Time step number = 401     t = 6.00254e+01 -> t + dt = 6.01668e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 7.0066e+01:
+  Absolute error (L2-norm): 5.32807e-08
+
+Calculate error for pressure at time t = 7.0066e+01:
+  Absolute error (L2-norm): 8.47126e-16
+
+________________________________________________________________________________
+
+ Time step number = 472     t = 7.00662e+01 -> t + dt = 7.02077e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 8.0107e+01:
+  Absolute error (L2-norm): 4.35676e-09
+
+Calculate error for pressure at time t = 8.0107e+01:
+  Absolute error (L2-norm): 5.92357e-15
+
+________________________________________________________________________________
+
+ Time step number = 543     t = 8.01071e+01 -> t + dt = 8.02485e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 9.0006e+01:
+  Absolute error (L2-norm): 3.69031e-10
+
+Calculate error for pressure at time t = 9.0006e+01:
+  Absolute error (L2-norm): 3.49310e-15
+
+________________________________________________________________________________
+
+ Time step number = 613     t = 9.00065e+01 -> t + dt = 9.01479e+01
+________________________________________________________________________________
+
+Calculate error for velocity at time t = 1.0005e+02:
+  Absolute error (L2-norm): 3.01731e-11
+
+Calculate error for pressure at time t = 1.0005e+02:
+  Absolute error (L2-norm): 4.39027e-15


### PR DESCRIPTION
closes #431 

I am not sure if changing the test output is a robust solution for the future, @kronbichler ?

I suspect the origin of the failing test in the calculation of the time step size (CFL condition) due to a slightly different velocity value.