### PR TITLE
Pass in references to functions instead of shared_ptr

### DIFF
--- a/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
@@ -164,7 +164,7 @@ inline DEAL_II_ALWAYS_INLINE //
   if(boundary_type == BoundaryType::Dirichlet)
   {
     auto bc = boundary_descriptor.dirichlet_bc.find(boundary_id)->second;
-    auto g  = FunctionEvaluator<rank, dim, Number>::value(bc, q_point, time);
+    auto g  = FunctionEvaluator<rank, dim, Number>::value(*bc, q_point, time);
 
     value_p = -value_m + dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>(2.0 * g);
   }
@@ -205,7 +205,7 @@ inline DEAL_II_ALWAYS_INLINE //
   else if(boundary_type == BoundaryType::Neumann)
   {
     auto bc = boundary_descriptor.neumann_bc.find(boundary_id)->second;
-    auto h  = FunctionEvaluator<rank, dim, Number>::value(bc, q_point, time);
+    auto h  = FunctionEvaluator<rank, dim, Number>::value(*bc, q_point, time);
 
     grad_P_normal =
       -grad_M_normal + dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>(2.0 * h);
@@ -351,9 +351,11 @@ public:
     vector u        = momentum.get_value(q) / rho;
 
     scalar rhs_density =
-      FunctionEvaluator<0, dim, Number>::value(data.rhs_rho, q_points, eval_time);
-    vector rhs_momentum = FunctionEvaluator<1, dim, Number>::value(data.rhs_u, q_points, eval_time);
-    scalar rhs_energy   = FunctionEvaluator<0, dim, Number>::value(data.rhs_E, q_points, eval_time);
+      FunctionEvaluator<0, dim, Number>::value(*(data.rhs_rho), q_points, eval_time);
+    vector rhs_momentum =
+      FunctionEvaluator<1, dim, Number>::value(*(data.rhs_u), q_points, eval_time);
+    scalar rhs_energy =
+      FunctionEvaluator<0, dim, Number>::value(*(data.rhs_E), q_points, eval_time);
 
     return std::make_tuple(rhs_density, rhs_momentum, rhs_momentum * u + rhs_energy);
   }

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
@@ -313,7 +313,7 @@ public:
     {
       dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
-      vector velocity = FunctionEvaluator<1, dim, Number>::value(data.velocity, q_points, time);
+      vector velocity = FunctionEvaluator<1, dim, Number>::value(*(data.velocity), q_points, time);
 
       scalar normal_velocity = velocity * normal_m;
 
@@ -390,7 +390,7 @@ public:
     {
       dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
-      velocity = FunctionEvaluator<1, dim, Number>::value(data.velocity, q_points, time);
+      velocity = FunctionEvaluator<1, dim, Number>::value(*(data.velocity), q_points, time);
     }
     else if(data.velocity_type == TypeVelocityField::DoFVector)
     {
@@ -480,7 +480,7 @@ public:
 
     if(data.velocity_type == TypeVelocityField::Function)
     {
-      velocity = FunctionEvaluator<1, dim, Number>::value(data.velocity,
+      velocity = FunctionEvaluator<1, dim, Number>::value(*(data.velocity),
                                                           integrator.quadrature_point(q),
                                                           time);
     }
@@ -507,7 +507,7 @@ public:
 
     if(data.velocity_type == TypeVelocityField::Function)
     {
-      velocity = FunctionEvaluator<1, dim, Number>::value(data.velocity,
+      velocity = FunctionEvaluator<1, dim, Number>::value(*(data.velocity),
                                                           integrator.quadrature_point(q),
                                                           time);
     }

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/weak_boundary_conditions.h
@@ -94,7 +94,7 @@ inline DEAL_II_ALWAYS_INLINE //
       auto bc       = boundary_descriptor->dirichlet_bc.find(boundary_id)->second;
       auto q_points = integrator.quadrature_point(q);
 
-      g = FunctionEvaluator<0, dim, Number>::value(bc, q_points, time);
+      g = FunctionEvaluator<0, dim, Number>::value(*bc, q_points, time);
 
       value_p = -value_m + 2.0 * g;
     }
@@ -197,7 +197,7 @@ inline DEAL_II_ALWAYS_INLINE //
       auto bc       = boundary_descriptor->neumann_bc.find(boundary_id)->second;
       auto q_points = integrator.quadrature_point(q);
 
-      auto h = FunctionEvaluator<0, dim, Number>::value(bc, q_points, time);
+      auto h = FunctionEvaluator<0, dim, Number>::value(*bc, q_points, time);
 
       normal_gradient_p = -normal_gradient_m + 2.0 * h;
     }

--- a/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
@@ -82,7 +82,7 @@ private:
       for(unsigned int q = 0; q < integrator.n_q_points; ++q)
       {
         integrator.submit_value(
-          FunctionEvaluator<1, dim, Number>::value(function, integrator.quadrature_point(q), time),
+          FunctionEvaluator<1, dim, Number>::value(*function, integrator.quadrature_point(q), time),
           q);
       }
 

--- a/include/exadg/functions_and_boundary_conditions/evaluate_functions.h
+++ b/include/exadg/functions_and_boundary_conditions/evaluate_functions.h
@@ -40,7 +40,7 @@ struct FunctionEvaluator
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>> const                function,
+    value(dealii::Function<dim> &                                     function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -55,10 +55,10 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<rank, dim>> const function,
-          unsigned int const                               face,
-          unsigned int const                               q,
-          unsigned int const                               quad_index)
+    value(FunctionCached<rank, dim> const & function,
+          unsigned int const                face,
+          unsigned int const                q,
+          unsigned int const                quad_index)
   {
     (void)function;
     (void)face;
@@ -72,12 +72,12 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>> const                    function,
+    value(FunctionWithNormal<dim> &                                       function_with_normal,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const &     q_points,
           dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normals,
           double const &                                                  time)
   {
-    (void)function;
+    (void)function_with_normal;
     (void)q_points;
     (void)normals;
     (void)time;
@@ -89,7 +89,7 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<rank, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<dealii::Function<dim>> const                function,
+    value_symmetric(dealii::Function<dim> &                                     function,
                     dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
                     double const &                                              time)
   {
@@ -104,10 +104,10 @@ struct FunctionEvaluator
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<rank, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<FunctionCached<rank, dim>> const function,
-                    unsigned int const                               face,
-                    unsigned int const                               q,
-                    unsigned int const                               quad_index)
+    value_symmetric(FunctionCached<rank, dim> const & function,
+                    unsigned int const                face,
+                    unsigned int const                q,
+                    unsigned int const                quad_index)
   {
     (void)function;
     (void)face;
@@ -125,7 +125,7 @@ struct FunctionEvaluator<0, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<0, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>> const                function,
+    value(dealii::Function<dim> &                                     function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -137,8 +137,8 @@ struct FunctionEvaluator<0, dim, Number>
       for(unsigned int d = 0; d < dim; ++d)
         q_point[d] = q_points[d][v];
 
-      function->set_time(time);
-      value[v] = function->value(q_point);
+      function.set_time(time);
+      value[v] = function.value(q_point);
     }
 
     return value;
@@ -146,15 +146,15 @@ struct FunctionEvaluator<0, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<0, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<0, dim>> const function,
-          unsigned int const                            face,
-          unsigned int const                            q,
-          unsigned int const                            quad_index)
+    value(FunctionCached<0, dim> const & function,
+          unsigned int const             face,
+          unsigned int const             q,
+          unsigned int const             quad_index)
   {
     dealii::VectorizedArray<Number> value = dealii::make_vectorized_array<Number>(0.0);
 
     for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
-      value[v] = function->tensor_value(face, q, v, quad_index);
+      value[v] = function.tensor_value(face, q, v, quad_index);
 
     return value;
   }
@@ -165,7 +165,7 @@ struct FunctionEvaluator<1, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>> const                function,
+    value(dealii::Function<dim> &                                     function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -179,8 +179,8 @@ struct FunctionEvaluator<1, dim, Number>
         for(unsigned int i = 0; i < dim; ++i)
           q_point[i] = q_points[i][v];
 
-        function->set_time(time);
-        value[d][v] = function->value(q_point, d);
+        function.set_time(time);
+        value[d][v] = function.value(q_point, d);
       }
     }
 
@@ -189,10 +189,10 @@ struct FunctionEvaluator<1, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<1, dim>> const function,
-          unsigned int const                            face,
-          unsigned int const                            q,
-          unsigned int const                            quad_index)
+    value(FunctionCached<1, dim> const & function,
+          unsigned int const             face,
+          unsigned int const             q,
+          unsigned int const             quad_index)
   {
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value;
 
@@ -200,7 +200,7 @@ struct FunctionEvaluator<1, dim, Number>
       tensor_array;
 
     for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
-      tensor_array[v] = function->tensor_value(face, q, v, quad_index);
+      tensor_array[v] = function.tensor_value(face, q, v, quad_index);
 
     for(unsigned int d = 0; d < dim; ++d)
     {
@@ -213,13 +213,11 @@ struct FunctionEvaluator<1, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>> const                    function,
+    value(FunctionWithNormal<dim> &                                       function_with_normal,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const &     q_points,
           dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> const & normals,
           double const &                                                  time)
   {
-    auto function_with_normal = std::dynamic_pointer_cast<FunctionWithNormal<dim>>(function);
-
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> value;
 
     for(unsigned int d = 0; d < dim; ++d)
@@ -233,9 +231,9 @@ struct FunctionEvaluator<1, dim, Number>
           q_point[i] = q_points[i][v];
           normal[i]  = normals[i][v];
         }
-        function_with_normal->set_time(time);
-        function_with_normal->set_normal_vector(normal);
-        value[d][v] = function_with_normal->value(q_point, d);
+        function_with_normal.set_time(time);
+        function_with_normal.set_normal_vector(normal);
+        value[d][v] = function_with_normal.value(q_point, d);
       }
     }
 
@@ -248,7 +246,7 @@ struct FunctionEvaluator<2, dim, Number>
 {
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<dealii::Function<dim>> const                function,
+    value(dealii::Function<dim> &                                     function,
           dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
           double const &                                              time)
   {
@@ -265,12 +263,12 @@ struct FunctionEvaluator<2, dim, Number>
           for(unsigned int i = 0; i < dim; ++i)
             q_point[i] = q_points[i][v];
 
-          function->set_time(time);
+          function.set_time(time);
 
           auto const unrolled_index =
             dealii::Tensor<2, dim>::component_to_unrolled_index(dealii::TableIndices<2>(d1, d2));
 
-          value[d1][d2][v] = function->value(q_point, unrolled_index);
+          value[d1][d2][v] = function.value(q_point, unrolled_index);
         }
       }
     }
@@ -280,10 +278,10 @@ struct FunctionEvaluator<2, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-    value(std::shared_ptr<FunctionCached<2, dim>> const function,
-          unsigned int const                            face,
-          unsigned int const                            q,
-          unsigned int const                            quad_index)
+    value(FunctionCached<2, dim> const & function,
+          unsigned int const             face,
+          unsigned int const             q,
+          unsigned int const             quad_index)
   {
     dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> value;
 
@@ -291,7 +289,7 @@ struct FunctionEvaluator<2, dim, Number>
       tensor_array;
 
     for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
-      tensor_array[v] = function->tensor_value(face, q, v, quad_index);
+      tensor_array[v] = function.tensor_value(face, q, v, quad_index);
 
     for(unsigned int d1 = 0; d1 < dim; ++d1)
     {
@@ -307,7 +305,7 @@ struct FunctionEvaluator<2, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<dealii::Function<dim>> const                function,
+    value_symmetric(dealii::Function<dim> &                                     function,
                     dealii::Point<dim, dealii::VectorizedArray<Number>> const & q_points,
                     double const &                                              time)
   {
@@ -324,12 +322,12 @@ struct FunctionEvaluator<2, dim, Number>
           for(unsigned int i = 0; i < dim; ++i)
             q_point[i] = q_points[i][v];
 
-          function->set_time(time);
+          function.set_time(time);
 
           auto const unrolled_index = dealii::SymmetricTensor<2, dim>::component_to_unrolled_index(
             dealii::TableIndices<2>(d1, d2));
 
-          value[d1][d2][v] = function->value(q_point, unrolled_index);
+          value[d1][d2][v] = function.value(q_point, unrolled_index);
         }
       }
     }
@@ -339,10 +337,10 @@ struct FunctionEvaluator<2, dim, Number>
 
   static inline DEAL_II_ALWAYS_INLINE //
     dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
-    value_symmetric(std::shared_ptr<FunctionCached<2, dim>> const function,
-                    unsigned int const                            face,
-                    unsigned int const                            q,
-                    unsigned int const                            quad_index)
+    value_symmetric(FunctionCached<2, dim> const & function,
+                    unsigned int const             face,
+                    unsigned int const             q,
+                    unsigned int const             quad_index)
   {
     dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> value;
 
@@ -350,7 +348,7 @@ struct FunctionEvaluator<2, dim, Number>
       tensor_array;
 
     for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
-      tensor_array[v] = function->tensor_value(face, q, v, quad_index);
+      tensor_array[v] = function.tensor_value(face, q, v, quad_index);
 
     for(unsigned int d1 = 0; d1 < dim; ++d1)
     {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -289,7 +289,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_body_forces_boundary_
 
         // evaluate right-hand side
         vector rhs =
-          FunctionEvaluator<1, dim, Number>::value(this->field_functions->right_hand_side,
+          FunctionEvaluator<1, dim, Number>::value(*(this->field_functions->right_hand_side),
                                                    q_points,
                                                    this->evaluation_time);
 
@@ -543,7 +543,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_body_force_term_add_bounda
 
         // evaluate right-hand side
         vector rhs =
-          FunctionEvaluator<1, dim, Number>::value(this->field_functions->right_hand_side,
+          FunctionEvaluator<1, dim, Number>::value(*(this->field_functions->right_hand_side),
                                                    q_points,
                                                    this->evaluation_time);
 
@@ -835,14 +835,14 @@ OperatorDualSplitting<dim, Number>::local_interpolate_velocity_dirichlet_bc_boun
           auto bc = this->boundary_descriptor->velocity->dirichlet_bc.find(boundary_id)->second;
           auto q_points = integrator.quadrature_point(q);
 
-          g = FunctionEvaluator<1, dim, Number>::value(bc, q_points, this->evaluation_time);
+          g = FunctionEvaluator<1, dim, Number>::value(*bc, q_points, this->evaluation_time);
         }
         else if(boundary_type == BoundaryTypeU::DirichletCached)
         {
           auto bc =
             this->boundary_descriptor->velocity->dirichlet_cached_bc.find(boundary_id)->second;
 
-          g = FunctionEvaluator<1, dim, Number>::value(bc, face, q, quad_index);
+          g = FunctionEvaluator<1, dim, Number>::value(*bc, face, q, quad_index);
         }
         else
         {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -512,7 +512,7 @@ OperatorPressureCorrection<dim, Number>::local_interpolate_pressure_dirichlet_bc
         auto bc       = this->boundary_descriptor->pressure->dirichlet_bc.find(boundary_id)->second;
         auto q_points = integrator.quadrature_point(q);
 
-        scalar g = FunctionEvaluator<0, dim, Number>::value(bc, q_points, this->evaluation_time);
+        scalar g = FunctionEvaluator<0, dim, Number>::value(*bc, q_points, this->evaluation_time);
         integrator.submit_dof_value(g, index);
       }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/rhs_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/rhs_operator.h
@@ -81,12 +81,13 @@ public:
   {
     dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
-    vector f = FunctionEvaluator<1, dim, Number>::value(data.f, q_points, time);
+    vector f = FunctionEvaluator<1, dim, Number>::value(*(data.f), q_points, time);
 
     if(data.boussinesq_term)
     {
-      vector g = FunctionEvaluator<1, dim, Number>::value(data.gravitational_force, q_points, time);
-      scalar T = integrator_temperature.get_value(q);
+      vector g =
+        FunctionEvaluator<1, dim, Number>::value(*(data.gravitational_force), q_points, time);
+      scalar T     = integrator_temperature.get_value(q);
       scalar T_ref = data.reference_temperature;
       // solve only for the dynamic pressure variations
       if(data.boussinesq_dynamic_part_only)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
@@ -466,7 +466,7 @@ inline DEAL_II_ALWAYS_INLINE //
       {
         auto normals_m = integrator.get_normal_vector(q);
         h              = FunctionEvaluator<1, dim, Number>::value(
-          *(std::static_pointer_cast<FunctionWithNormal<dim>>(bc)), q_points, normals_m, time);
+          *(std::dynamic_pointer_cast<FunctionWithNormal<dim>>(bc)), q_points, normals_m, time);
       }
 
       normal_gradient_p = -normal_gradient_m + 2.0 * h;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
@@ -89,12 +89,12 @@ inline DEAL_II_ALWAYS_INLINE //
         auto bc       = boundary_descriptor->dirichlet_bc.find(boundary_id)->second;
         auto q_points = integrator.quadrature_point(q);
 
-        g = FunctionEvaluator<1, dim, Number>::value(bc, q_points, time);
+        g = FunctionEvaluator<1, dim, Number>::value(*bc, q_points, time);
       }
       else if(boundary_type == BoundaryTypeU::DirichletCached)
       {
         auto bc = boundary_descriptor->dirichlet_cached_bc.find(boundary_id)->second;
-        g       = FunctionEvaluator<1, dim, Number>::value(bc,
+        g       = FunctionEvaluator<1, dim, Number>::value(*bc,
                                                      integrator.get_current_cell_index(),
                                                      q,
                                                      integrator.get_quadrature_index());
@@ -169,12 +169,12 @@ inline DEAL_II_ALWAYS_INLINE //
       auto bc       = boundary_descriptor->dirichlet_bc.find(boundary_id)->second;
       auto q_points = integrator.quadrature_point(q);
 
-      g = FunctionEvaluator<1, dim, Number>::value(bc, q_points, time);
+      g = FunctionEvaluator<1, dim, Number>::value(*bc, q_points, time);
     }
     else if(boundary_type == BoundaryTypeU::DirichletCached)
     {
       auto bc = boundary_descriptor->dirichlet_cached_bc.find(boundary_id)->second;
-      g       = FunctionEvaluator<1, dim, Number>::value(bc,
+      g       = FunctionEvaluator<1, dim, Number>::value(*bc,
                                                    integrator.get_current_cell_index(),
                                                    q,
                                                    integrator.get_quadrature_index());
@@ -332,7 +332,7 @@ inline DEAL_II_ALWAYS_INLINE //
       auto q_points = integrator.quadrature_point(q);
 
       dealii::VectorizedArray<Number> g =
-        FunctionEvaluator<0, dim, Number>::value(bc, q_points, time);
+        FunctionEvaluator<0, dim, Number>::value(*bc, q_points, time);
 
       value_p = -value_m + 2.0 * inverse_scaling_factor * g;
     }
@@ -460,12 +460,13 @@ inline DEAL_II_ALWAYS_INLINE //
       dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> h;
       if(variable_normal_vector == false)
       {
-        h = FunctionEvaluator<1, dim, Number>::value(bc, q_points, time);
+        h = FunctionEvaluator<1, dim, Number>::value(*bc, q_points, time);
       }
       else
       {
         auto normals_m = integrator.get_normal_vector(q);
-        h              = FunctionEvaluator<1, dim, Number>::value(bc, q_points, normals_m, time);
+        h              = FunctionEvaluator<1, dim, Number>::value(
+          *(std::dynamic_pointer_cast<FunctionWithNormal<dim>>(bc)), q_points, normals_m, time);
       }
 
       normal_gradient_p = -normal_gradient_m + 2.0 * h;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
@@ -466,7 +466,7 @@ inline DEAL_II_ALWAYS_INLINE //
       {
         auto normals_m = integrator.get_normal_vector(q);
         h              = FunctionEvaluator<1, dim, Number>::value(
-          *(std::dynamic_pointer_cast<FunctionWithNormal<dim>>(bc)), q_points, normals_m, time);
+          *(std::static_pointer_cast<FunctionWithNormal<dim>>(bc)), q_points, normals_m, time);
       }
 
       normal_gradient_p = -normal_gradient_m + 2.0 * h;

--- a/include/exadg/operators/rhs_operator.h
+++ b/include/exadg/operators/rhs_operator.h
@@ -79,7 +79,7 @@ public:
   {
     dealii::Point<dim, scalar> q_points = integrator.quadrature_point(q);
 
-    return FunctionEvaluator<rank, dim, Number>::value(data.f, q_points, time);
+    return FunctionEvaluator<rank, dim, Number>::value(*(data.f), q_points, time);
   }
 
 private:

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -455,7 +455,7 @@ LaplaceOperator<dim, Number, n_components>::set_constrained_values(VectorType & 
           {
             auto bc = operator_data.bc->dirichlet_cached_bc.find(boundary_id)->second;
 
-            g = FunctionEvaluator<rank, dim, Number>::value(bc, face, q, quad_index);
+            g = FunctionEvaluator<rank, dim, Number>::value(*bc, face, q, quad_index);
           }
           else
           {

--- a/include/exadg/poisson/spatial_discretization/weak_boundary_conditions.h
+++ b/include/exadg/poisson/spatial_discretization/weak_boundary_conditions.h
@@ -94,12 +94,12 @@ inline DEAL_II_ALWAYS_INLINE //
         auto bc       = boundary_descriptor->dirichlet_bc.find(boundary_id)->second;
         auto q_points = integrator.quadrature_point(q);
 
-        g = FunctionEvaluator<rank, dim, Number>::value(bc, q_points, time);
+        g = FunctionEvaluator<rank, dim, Number>::value(*bc, q_points, time);
       }
       else if(boundary_type == BoundaryType::DirichletCached)
       {
         auto bc = boundary_descriptor->dirichlet_cached_bc.find(boundary_id)->second;
-        g       = FunctionEvaluator<rank, dim, Number>::value(bc,
+        g       = FunctionEvaluator<rank, dim, Number>::value(*bc,
                                                         integrator.get_current_cell_index(),
                                                         q,
                                                         integrator.get_quadrature_index());
@@ -210,7 +210,7 @@ inline DEAL_II_ALWAYS_INLINE //
       auto bc       = boundary_descriptor->neumann_bc.find(boundary_id)->second;
       auto q_points = integrator.quadrature_point(q);
 
-      auto h = FunctionEvaluator<rank, dim, Number>::value(bc, q_points, time);
+      auto h = FunctionEvaluator<rank, dim, Number>::value(*bc, q_points, time);
 
       normal_gradient_p =
         -normal_gradient_m + dealii::Tensor<rank, dim, dealii::VectorizedArray<Number>>(2.0 * h);
@@ -253,7 +253,7 @@ inline DEAL_II_ALWAYS_INLINE //
     auto bc       = boundary_descriptor->neumann_bc.find(boundary_id)->second;
     auto q_points = integrator.quadrature_point(q);
 
-    normal_gradient = FunctionEvaluator<rank, dim, Number>::value(bc, q_points, time);
+    normal_gradient = FunctionEvaluator<rank, dim, Number>::value(*bc, q_points, time);
   }
   else
   {

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -119,7 +119,7 @@ StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients(
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
       dealii::VectorizedArray<Number> E_vec =
-        FunctionEvaluator<0, dim, Number>::value(data.E_function,
+        FunctionEvaluator<0, dim, Number>::value(*(data.E_function),
                                                  integrator.quadrature_point(q),
                                                  0.0 /*time*/);
 

--- a/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
@@ -87,7 +87,7 @@ BodyForceOperator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const 
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
       auto q_points = integrator.quadrature_point(q);
-      auto b        = FunctionEvaluator<1, dim, Number>::value(data.function, q_points, time);
+      auto b        = FunctionEvaluator<1, dim, Number>::value(*(data.function), q_points, time);
 
       if(data.pull_back_body_force)
       {

--- a/include/exadg/structure/spatial_discretization/operators/boundary_conditions.h
+++ b/include/exadg/structure/spatial_discretization/operators/boundary_conditions.h
@@ -49,13 +49,13 @@ inline DEAL_II_ALWAYS_INLINE //
     auto bc       = boundary_descriptor->neumann_bc.find(boundary_id)->second;
     auto q_points = integrator.quadrature_point(q);
 
-    traction = FunctionEvaluator<1, dim, Number>::value(bc, q_points, time);
+    traction = FunctionEvaluator<1, dim, Number>::value(*bc, q_points, time);
   }
   else if(boundary_type == BoundaryType::NeumannCached)
   {
     auto bc = boundary_descriptor->neumann_cached_bc.find(boundary_id)->second;
 
-    traction = FunctionEvaluator<1, dim, Number>::value(bc,
+    traction = FunctionEvaluator<1, dim, Number>::value(*bc,
                                                         integrator.get_current_cell_index(),
                                                         q,
                                                         integrator.get_quadrature_index());

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -175,7 +175,7 @@ ElasticityOperatorBase<dim, Number>::set_constrained_values(VectorType & dst,
           {
             auto bc = operator_data.bc->dirichlet_cached_bc.find(boundary_id)->second;
 
-            g = FunctionEvaluator<1, dim, Number>::value(bc, face, q, quad_index);
+            g = FunctionEvaluator<1, dim, Number>::value(*bc, face, q, quad_index);
           }
           else
           {

--- a/include/exadg/time_integration/time_step_calculation.h
+++ b/include/exadg/time_integration/time_step_calculation.h
@@ -200,7 +200,7 @@ calculate_time_step_cfl_local(dealii::MatrixFree<dim, value_type> const &  data,
       dealii::Point<dim, dealii::VectorizedArray<value_type>> q_point = fe_eval.quadrature_point(q);
 
       dealii::Tensor<1, dim, dealii::VectorizedArray<value_type>> u_x =
-        FunctionEvaluator<1, dim, value_type>::value(velocity, q_point, time);
+        FunctionEvaluator<1, dim, value_type>::value(*velocity, q_point, time);
       dealii::Tensor<2, dim, dealii::VectorizedArray<value_type>> invJ =
         fe_eval.inverse_jacobian(q);
       invJ                                                              = transpose(invJ);


### PR DESCRIPTION
Refactoring/clean code.

Closes #439, see issue description.