### PR TITLE
Make access to MultigridPreconditionerBase::n_levels safe

### DIFF
--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -327,7 +327,7 @@ void
 MultigridPreconditioner<dim, Number>::update_smoothers()
 {
   // Skip coarsest level
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
+  for(unsigned int level = 1; level <= this->get_number_of_levels() - 1; ++level)
     this->update_smoother(level);
 }
 

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -281,11 +281,14 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::set_velocity(VectorTypeMG const & velocity)
 {
+  unsigned int const fine_level   = this->get_number_of_levels() - 1;
+  unsigned int const coarse_level = 0;
+
   // copy velocity to finest level
-  this->get_operator(this->fine_level)->set_velocity_copy(velocity);
+  this->get_operator(fine_level)->set_velocity_copy(velocity);
 
   // interpolate velocity from fine to coarse level
-  for(unsigned int level = this->fine_level; level > this->coarse_level; --level)
+  for(unsigned int level = fine_level; level > coarse_level; --level)
   {
     auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
     auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
@@ -298,17 +301,15 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::update_operators_after_grid_motion()
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
-  {
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
     this->get_operator(level)->update_after_grid_motion();
-  }
 }
 
 template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::set_time(double const & time)
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
     this->get_operator(level)->set_time(time);
 }
 
@@ -317,7 +318,7 @@ void
 MultigridPreconditioner<dim, Number>::set_scaling_factor_mass_operator(
   double const & scaling_factor)
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
     this->get_operator(level)->set_scaling_factor_mass_operator(scaling_factor);
 }
 
@@ -326,7 +327,7 @@ void
 MultigridPreconditioner<dim, Number>::update_smoothers()
 {
   // Skip coarsest level
-  for(unsigned int level = this->coarse_level + 1; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
     this->update_smoother(level);
 }
 

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -215,11 +215,14 @@ void
 MultigridPreconditioner<dim, Number>::set_vector_linearization(
   VectorTypeMG const & vector_linearization)
 {
+  unsigned int const fine_level   = this->get_number_of_levels() - 1;
+  unsigned int const coarse_level = 0;
+
   // copy velocity to finest level
-  this->get_operator(this->fine_level)->set_velocity_copy(vector_linearization);
+  this->get_operator(fine_level)->set_velocity_copy(vector_linearization);
 
   // interpolate velocity from fine to coarse level
-  for(unsigned int level = this->fine_level; level > this->coarse_level; --level)
+  for(unsigned int level = fine_level; level > coarse_level; --level)
   {
     auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
     auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
@@ -232,7 +235,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::set_time(double const & time)
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
   {
     get_operator(level)->set_time(time);
   }
@@ -242,7 +245,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::update_operators_after_grid_motion()
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
   {
     get_operator(level)->update_after_grid_motion();
   }
@@ -253,7 +256,7 @@ void
 MultigridPreconditioner<dim, Number>::set_scaling_factor_mass_operator(
   double const & scaling_factor_mass)
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
   {
     get_operator(level)->set_scaling_factor_mass_operator(scaling_factor_mass);
   }

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -180,15 +180,18 @@ MultigridPreconditionerProjection<dim, Number>::update_operators()
     velocity_multigrid_type_ptr  = &velocity_multigrid_type_copy;
   }
 
+  unsigned int const fine_level   = this->get_number_of_levels() - 1;
+  unsigned int const coarse_level = 0;
+
   // update operator on fine level
-  this->get_operator(this->fine_level)->update(*velocity_multigrid_type_ptr, time_step_size);
+  this->get_operator(fine_level)->update(*velocity_multigrid_type_ptr, time_step_size);
 
   // we store only two vectors since the velocity is no longer needed after having updated the
   // operators
   VectorTypeMG velocity_fine_level = *velocity_multigrid_type_ptr;
   VectorTypeMG velocity_coarse_level;
 
-  for(unsigned int level = this->fine_level; level > this->coarse_level; --level)
+  for(unsigned int level = fine_level; level > coarse_level; --level)
   {
     // interpolate velocity from fine to coarse level
     this->get_operator(level - 1)->initialize_dof_vector(velocity_coarse_level);

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -148,7 +148,7 @@ template<int dim, typename Number, int n_components>
 void
 MultigridPreconditioner<dim, Number, n_components>::update_operators_after_mesh_movement()
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
   {
     get_operator(level)->update_penalty_parameter();
   }

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -659,7 +659,8 @@ MultigridPreconditionerBase<dim, Number>::initialize_smoothers()
 {
   this->smoothers.resize(0, get_number_of_levels() - 1);
 
-  // skip the coarsest level
+  // level l = 0 is the coarse problem where we do not have a smoother,
+  // so we skip the coarsest level
   for(unsigned int level = 1; level <= get_number_of_levels() - 1; level++)
     this->initialize_smoother(*this->operators[level], level);
 }
@@ -781,7 +782,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::update_smoothers()
 {
-  // level l = 0 is the coarse-grid problem where we do not have a smoother,
+  // level l = 0 is the coarse problem where we do not have a smoother,
   // so we skip the coarsest level
   for(unsigned int level = 1; level <= get_number_of_levels() - 1; ++level)
   {

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -205,6 +205,15 @@ protected:
     dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>> & constrained_dofs,
     unsigned int const                                                  dof_index);
 
+  /**
+   * Returns the number of levels.
+   *
+   * The number of levels includes the coarse level and the finer smoothing levels, i.e.
+   * n_levels = 1 if the multigrid preconditioner is a coarse-grid solve on the coarse level only.
+   */
+  unsigned int
+  get_number_of_levels() const;
+
   dealii::MGLevelObject<std::shared_ptr<dealii::DoFHandler<dim> const>> dof_handlers;
   dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>>     constrained_dofs;
   dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>> constraints;
@@ -217,19 +226,13 @@ protected:
 
   std::vector<MGDoFHandlerIdentifier> p_levels;
   std::vector<MGLevelInfo>            level_info;
-  unsigned int                        n_levels;
-  unsigned int                        coarse_level;
-  unsigned int                        fine_level;
 
 private:
-  /*
-   * Multigrid levels (i.e. coarsening strategy, h-/p-/hp-/ph-MG).
+  /**
+   * Initializes multigrid levels according to coarsening strategy (h-/p-/hp-/ph-MG).
    */
   void
   initialize_levels(unsigned int const degree, bool const is_dg);
-
-  void
-  check_levels(std::vector<MGLevelInfo> const & level_info);
 
   unsigned int
   get_number_of_h_levels() const;

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -79,7 +79,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::set_time(double const & time)
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
   {
     if(nonlinear)
       get_operator_nonlinear(level)->set_time(time);
@@ -93,7 +93,7 @@ void
 MultigridPreconditioner<dim, Number>::set_scaling_factor_mass_operator(
   double const & scaling_factor_mass)
 {
-  for(unsigned int level = this->coarse_level; level <= this->fine_level; ++level)
+  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
   {
     if(nonlinear)
       get_operator_nonlinear(level)->set_scaling_factor_mass_operator(scaling_factor_mass);
@@ -178,11 +178,14 @@ void
 MultigridPreconditioner<dim, Number>::set_solution_linearization(
   VectorTypeMG const & vector_linearization)
 {
+  unsigned int const fine_level   = this->get_number_of_levels() - 1;
+  unsigned int const coarse_level = 0;
+
   // copy velocity to finest level
-  this->get_operator_nonlinear(this->fine_level)->set_solution_linearization(vector_linearization);
+  this->get_operator_nonlinear(fine_level)->set_solution_linearization(vector_linearization);
 
   // interpolate velocity from fine to coarse level
-  for(unsigned int level = this->fine_level; level > this->coarse_level; --level)
+  for(unsigned int level = fine_level; level > coarse_level; --level)
   {
     auto & vector_fine_level =
       this->get_operator_nonlinear(level - 0)->get_solution_linearization();


### PR DESCRIPTION
Currently, one could access the integer variables `coarse_level, fine_level, n_levels` before setup/initialization.

I suggest to remove all those member variables and only use the member function `get_number_of_levels()` instead. This function asserts that `level_info.size()>0`, which would give an error when called in an uninitialized state.