### PR TITLE
Multigrid: Use more generic loop over levels

### DIFF
--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -119,8 +119,8 @@ MultigridPreconditioner<dim, Number>::update()
   this->for_all_levels([&](unsigned int const level) {
     // the velocity field of the convective term is a function of the time
     this->get_operator(level)->set_time(pde_operator->get_time());
-    // in case of adaptive time stepping, the scaling factor of the derivative term changes over
-    // time
+    // in case of adaptive time stepping, the scaling factor of the time derivative term changes
+    // over time
     this->get_operator(level)->set_scaling_factor_mass_operator(
       pde_operator->get_scaling_factor_mass_operator());
   });
@@ -146,20 +146,18 @@ MultigridPreconditioner<dim, Number>::update()
       vector_multigrid_type_ptr  = &vector_multigrid_type_copy;
     }
 
-    unsigned int const fine_level   = this->get_number_of_levels() - 1;
-    unsigned int const coarse_level = 0;
-
     // copy velocity to finest level
-    this->get_operator(fine_level)->set_velocity_copy(*vector_multigrid_type_ptr);
+    this->get_operator(this->get_number_of_levels() - 1)
+      ->set_velocity_copy(*vector_multigrid_type_ptr);
 
     // interpolate velocity from fine to coarse level
-    for(unsigned int level = fine_level; level > coarse_level; --level)
-    {
-      auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
-      auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
-      transfers_velocity->interpolate(level, vector_coarse_level, vector_fine_level);
-      this->get_operator(level - 1)->set_velocity_copy(vector_coarse_level);
-    }
+    this->transfer_from_fine_to_coarse_levels(
+      [&](unsigned int const fine_level, unsigned int const coarse_level) {
+        auto & vector_fine_level   = this->get_operator(fine_level)->get_velocity();
+        auto   vector_coarse_level = this->get_operator(coarse_level)->get_velocity();
+        transfers_velocity->interpolate(fine_level, vector_coarse_level, vector_fine_level);
+        this->get_operator(coarse_level)->set_velocity_copy(vector_coarse_level);
+      });
   }
 
   // Once the operators are updated, the update of smoothers and the coarse grid solver is generic

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -105,21 +105,32 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::update()
 {
+  // Update matrix-free objects and operators
   if(mesh_is_moving)
   {
     this->initialize_mapping();
 
-    this->update_matrix_free();
+    this->update_matrix_free_objects();
 
-    update_operators_after_grid_motion();
+    this->for_all_levels(
+      [&](unsigned int const level) { this->get_operator(level)->update_after_grid_motion(); });
   }
 
-  set_time(pde_operator->get_time());
-  set_scaling_factor_mass_operator(pde_operator->get_scaling_factor_mass_operator());
+  this->for_all_levels([&](unsigned int const level) {
+    // the velocity field of the convective term is a function of the time
+    this->get_operator(level)->set_time(pde_operator->get_time());
+    // in case of adaptive time stepping, the scaling factor of the derivative term changes over
+    // time
+    this->get_operator(level)->set_scaling_factor_mass_operator(
+      pde_operator->get_scaling_factor_mass_operator());
+  });
 
   if(data.convective_problem and
      data.convective_kernel_data.velocity_type == TypeVelocityField::DoFVector)
   {
+    // If necessary, interpolate fine level velocity field to coarser levels and set velocity for
+    // all operators
+
     VectorType const & velocity = pde_operator->get_velocity();
 
     // convert Number --> MultigridNumber, e.g., double --> float, but only if necessary
@@ -135,14 +146,25 @@ MultigridPreconditioner<dim, Number>::update()
       vector_multigrid_type_ptr  = &vector_multigrid_type_copy;
     }
 
-    set_velocity(*vector_multigrid_type_ptr);
+    unsigned int const fine_level   = this->get_number_of_levels() - 1;
+    unsigned int const coarse_level = 0;
+
+    // copy velocity to finest level
+    this->get_operator(fine_level)->set_velocity_copy(*vector_multigrid_type_ptr);
+
+    // interpolate velocity from fine to coarse level
+    for(unsigned int level = fine_level; level > coarse_level; --level)
+    {
+      auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
+      auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
+      transfers_velocity->interpolate(level, vector_coarse_level, vector_fine_level);
+      this->get_operator(level - 1)->set_velocity_copy(vector_coarse_level);
+    }
   }
 
   // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
-  // functionality implemented in the base class
-
-  update_smoothers();
-
+  // functionality implemented in the base class.
+  this->update_smoothers();
   this->update_coarse_solver(data.operator_is_singular);
 }
 
@@ -275,60 +297,6 @@ MultigridPreconditioner<dim, Number>::initialize_transfer_operators()
                                            constrained_dofs_velocity,
                                            dof_index);
   }
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::set_velocity(VectorTypeMG const & velocity)
-{
-  unsigned int const fine_level   = this->get_number_of_levels() - 1;
-  unsigned int const coarse_level = 0;
-
-  // copy velocity to finest level
-  this->get_operator(fine_level)->set_velocity_copy(velocity);
-
-  // interpolate velocity from fine to coarse level
-  for(unsigned int level = fine_level; level > coarse_level; --level)
-  {
-    auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
-    auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
-    transfers_velocity->interpolate(level, vector_coarse_level, vector_fine_level);
-    this->get_operator(level - 1)->set_velocity_copy(vector_coarse_level);
-  }
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::update_operators_after_grid_motion()
-{
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
-    this->get_operator(level)->update_after_grid_motion();
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::set_time(double const & time)
-{
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
-    this->get_operator(level)->set_time(time);
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::set_scaling_factor_mass_operator(
-  double const & scaling_factor)
-{
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
-    this->get_operator(level)->set_scaling_factor_mass_operator(scaling_factor);
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::update_smoothers()
-{
-  // Skip coarsest level
-  for(unsigned int level = 1; level <= this->get_number_of_levels() - 1; ++level)
-    this->update_smoother(level);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -60,7 +60,7 @@ public:
 
   virtual ~MultigridPreconditioner(){};
 
-  /*
+  /**
    *  This function initializes the multigrid preconditioner.
    */
   void
@@ -75,71 +75,30 @@ public:
              Map_DBC const &                             dirichlet_bc,
              Map_DBC_ComponentMask const &               dirichlet_bc_component_mask);
 
-  /*
+  /**
    *  This function updates the multigrid preconditioner.
    */
   void
-  update() override;
+  update() final;
 
 private:
   void
   fill_matrix_free_data(MatrixFreeData<dim, MultigridNumber> & matrix_free_data,
                         unsigned int const                     level,
-                        unsigned int const                     h_level) override;
+                        unsigned int const                     h_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) override;
+  initialize_operator(unsigned int const level) final;
 
   void
   initialize_dof_handler_and_constraints(
     bool const                         operator_is_singular,
     dealii::FiniteElement<dim> const & fe,
     Map_DBC const &                    dirichlet_bc,
-    Map_DBC_ComponentMask const &      dirichlet_bc_component_mask) override;
+    Map_DBC_ComponentMask const &      dirichlet_bc_component_mask) final;
 
   void
-  initialize_transfer_operators() override;
-
-  /*
-   * This function updates the velocity field for all levels.
-   * In order to update mg_matrices[level] this function has to be called.
-   */
-  void
-  set_velocity(VectorTypeMG const & velocity);
-
-  /*
-   * This function performs the updates that are necessary after the grid has been moved
-   * and after matrix_free has been updated.
-   */
-  void
-  update_operators_after_grid_motion();
-
-  /*
-   *  This function sets the current the time.
-   *  In order to update operators[level] this function has to be called.
-   *  (This is due to the fact that the velocity field of the convective term
-   *  is a function of the time.)
-   */
-  void
-  set_time(double const & time);
-
-  /*
-   *  This function updates the scaling factor of the mass operator.
-   *  In order to update operators[level] this function has to be called.
-   *  This is necessary if adaptive time stepping is used where
-   *  the scaling factor of the derivative term is variable.
-   */
-  void
-  set_scaling_factor_mass_operator(double const & scaling_factor);
-
-  /*
-   *  This function updates the smoother for all levels of the multigrid
-   *  algorithm.
-   *  The prerequisite to call this function is that operators[level] have
-   *  been updated.
-   */
-  void
-  update_smoothers();
+  initialize_transfer_operators() final;
 
   std::shared_ptr<PDEOperatorMG>
   get_operator(unsigned int level) const;

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -94,19 +94,29 @@ template<int dim, typename Number>
 void
 MultigridPreconditioner<dim, Number>::update()
 {
+  // Update matrix-free objects and operators
   if(mesh_is_moving)
   {
     this->initialize_mapping();
 
-    this->update_matrix_free();
+    this->update_matrix_free_objects();
 
-    update_operators_after_grid_motion();
+    this->for_all_levels(
+      [&](unsigned int const level) { this->get_operator(level)->update_after_grid_motion(); });
   }
 
   if(data.unsteady_problem)
   {
-    set_time(pde_operator->get_time());
-    set_scaling_factor_mass_operator(pde_operator->get_scaling_factor_mass_operator());
+    this->for_all_levels([&](unsigned int const level) {
+      // The operator also depends on the time. This is due to the fact that the linearized
+      // convective term does not only depend on the linearized velocity field but also on Dirichlet
+      // boundary data which itself depends on the current time.
+      this->get_operator(level)->set_time(pde_operator->get_time());
+      // In case of adaptive time stepping, the scaling factor of the time derivative term changes
+      // over time.
+      this->get_operator(level)->set_scaling_factor_mass_operator(
+        pde_operator->get_scaling_factor_mass_operator());
+    });
   }
 
   if(mg_operator_type == MultigridOperatorType::ReactionConvectionDiffusion)
@@ -126,12 +136,24 @@ MultigridPreconditioner<dim, Number>::update()
       vector_multigrid_type_ptr  = &vector_multigrid_type_copy;
     }
 
-    set_vector_linearization(*vector_multigrid_type_ptr);
+    unsigned int const fine_level   = this->get_number_of_levels() - 1;
+    unsigned int const coarse_level = 0;
+
+    // copy velocity to finest level
+    this->get_operator(fine_level)->set_velocity_copy(*vector_multigrid_type_ptr);
+
+    // interpolate velocity from fine to coarse level
+    for(unsigned int level = fine_level; level > coarse_level; --level)
+    {
+      auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
+      auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
+      this->transfers->interpolate(level, vector_coarse_level, vector_fine_level);
+      this->get_operator(level - 1)->set_velocity_copy(vector_coarse_level);
+    }
   }
 
   // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
-  // functionality implemented in the base class
-
+  // functionality implemented in the base class.
   this->update_smoothers();
 
   // singular operators do not occur for this operator
@@ -208,58 +230,6 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
   std::shared_ptr<MGOperator> mg_operator(new MGOperator(pde_operator_level));
 
   return mg_operator;
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::set_vector_linearization(
-  VectorTypeMG const & vector_linearization)
-{
-  unsigned int const fine_level   = this->get_number_of_levels() - 1;
-  unsigned int const coarse_level = 0;
-
-  // copy velocity to finest level
-  this->get_operator(fine_level)->set_velocity_copy(vector_linearization);
-
-  // interpolate velocity from fine to coarse level
-  for(unsigned int level = fine_level; level > coarse_level; --level)
-  {
-    auto & vector_fine_level   = this->get_operator(level - 0)->get_velocity();
-    auto   vector_coarse_level = this->get_operator(level - 1)->get_velocity();
-    this->transfers->interpolate(level, vector_coarse_level, vector_fine_level);
-    this->get_operator(level - 1)->set_velocity_copy(vector_coarse_level);
-  }
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::set_time(double const & time)
-{
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
-  {
-    get_operator(level)->set_time(time);
-  }
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::update_operators_after_grid_motion()
-{
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
-  {
-    get_operator(level)->update_after_grid_motion();
-  }
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditioner<dim, Number>::set_scaling_factor_mass_operator(
-  double const & scaling_factor_mass)
-{
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; ++level)
-  {
-    get_operator(level)->set_scaling_factor_mass_operator(scaling_factor_mass);
-  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -73,47 +73,16 @@ public:
    * This function updates the multigrid preconditioner.
    */
   void
-  update() override;
+  update() final;
 
 private:
   void
   fill_matrix_free_data(MatrixFreeData<dim, MultigridNumber> & matrix_free_data,
                         unsigned int const                     level,
-                        unsigned int const                     h_level) override;
+                        unsigned int const                     h_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) override;
-
-  /*
-   * This function updates vector_linearization.
-   * In order to update operators[level] this function has to be called.
-   */
-  void
-  set_vector_linearization(VectorTypeMG const & vector_linearization);
-
-  /*
-   * This function updates the evaluation time. In order to update the operators this function
-   * has to be called. (This is due to the fact that the linearized convective term does not only
-   * depend on the linearized velocity field but also on Dirichlet boundary data which itself
-   * depends on the current time.)
-   */
-  void
-  set_time(double const & time);
-
-  /*
-   * This function performs the updates that are necessary after the grid has been moved
-   * and after matrix_free has been updated.
-   */
-  void
-  update_operators_after_grid_motion();
-
-  /*
-   * This function updates scaling_factor_time_derivative_term. In order to update the
-   * operators this function has to be called. This is necessary if adaptive time stepping
-   * is used where the scaling factor of the mass operator is variable.
-   */
-  void
-  set_scaling_factor_mass_operator(double const & scaling_factor_mass);
+  initialize_operator(unsigned int const level) final;
 
   std::shared_ptr<PDEOperatorMG>
   get_operator(unsigned int level);

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -70,11 +70,54 @@ MultigridPreconditionerProjection<dim, Number>::update()
   {
     this->initialize_mapping();
 
-    this->update_matrix_free();
+    this->update_matrix_free_objects();
   }
 
-  update_operators();
+  // update operators for all levels
+  double const time_step_size = pde_operator->get_time_step_size();
 
+  VectorType const & velocity = pde_operator->get_velocity();
+
+  // convert Number --> MultigridNumber, e.g., double --> float, but only if necessary
+  VectorTypeMG         velocity_multigrid_type_copy;
+  VectorTypeMG const * velocity_multigrid_type_ptr;
+  if(std::is_same<MultigridNumber, Number>::value)
+  {
+    velocity_multigrid_type_ptr = reinterpret_cast<VectorTypeMG const *>(&velocity);
+  }
+  else
+  {
+    velocity_multigrid_type_copy = velocity;
+    velocity_multigrid_type_ptr  = &velocity_multigrid_type_copy;
+  }
+
+  unsigned int const fine_level   = this->get_number_of_levels() - 1;
+  unsigned int const coarse_level = 0;
+
+  // update operator on fine level
+  this->get_operator(fine_level)->update(*velocity_multigrid_type_ptr, time_step_size);
+
+  // we store only two vectors since the velocity is no longer needed after having updated the
+  // operators
+  VectorTypeMG velocity_fine_level = *velocity_multigrid_type_ptr;
+  VectorTypeMG velocity_coarse_level;
+
+  for(unsigned int level = fine_level; level > coarse_level; --level)
+  {
+    // interpolate velocity from fine to coarse level
+    this->get_operator(level - 1)->initialize_dof_vector(velocity_coarse_level);
+    this->transfers->interpolate(level, velocity_coarse_level, velocity_fine_level);
+
+    // update operator
+    this->get_operator(level - 1)->update(velocity_coarse_level, time_step_size);
+
+    // current coarse level becomes the fine level in the next iteration
+    this->get_operator(level - 1)->initialize_dof_vector(velocity_fine_level);
+    velocity_fine_level.copy_locally_owned_data_from(velocity_coarse_level);
+  }
+
+  // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
+  // functionality implemented in the base class.
   this->update_smoothers();
 
   // singular operators do not occur for this operator
@@ -157,53 +200,6 @@ MultigridPreconditionerProjection<dim, Number>::initialize_operator(unsigned int
   std::shared_ptr<MGOperator> mg_operator(new MGOperator(pde_operator_level));
 
   return mg_operator;
-}
-
-template<int dim, typename Number>
-void
-MultigridPreconditionerProjection<dim, Number>::update_operators()
-{
-  double const time_step_size = pde_operator->get_time_step_size();
-
-  VectorType const & velocity = pde_operator->get_velocity();
-
-  // convert Number --> MultigridNumber, e.g., double --> float, but only if necessary
-  VectorTypeMG         velocity_multigrid_type_copy;
-  VectorTypeMG const * velocity_multigrid_type_ptr;
-  if(std::is_same<MultigridNumber, Number>::value)
-  {
-    velocity_multigrid_type_ptr = reinterpret_cast<VectorTypeMG const *>(&velocity);
-  }
-  else
-  {
-    velocity_multigrid_type_copy = velocity;
-    velocity_multigrid_type_ptr  = &velocity_multigrid_type_copy;
-  }
-
-  unsigned int const fine_level   = this->get_number_of_levels() - 1;
-  unsigned int const coarse_level = 0;
-
-  // update operator on fine level
-  this->get_operator(fine_level)->update(*velocity_multigrid_type_ptr, time_step_size);
-
-  // we store only two vectors since the velocity is no longer needed after having updated the
-  // operators
-  VectorTypeMG velocity_fine_level = *velocity_multigrid_type_ptr;
-  VectorTypeMG velocity_coarse_level;
-
-  for(unsigned int level = fine_level; level > coarse_level; --level)
-  {
-    // interpolate velocity from fine to coarse level
-    this->get_operator(level - 1)->initialize_dof_vector(velocity_coarse_level);
-    this->transfers->interpolate(level, velocity_coarse_level, velocity_fine_level);
-
-    // update operator
-    this->get_operator(level - 1)->update(velocity_coarse_level, time_step_size);
-
-    // current coarse level becomes the fine level in the next iteration
-    this->get_operator(level - 1)->initialize_dof_vector(velocity_fine_level);
-    velocity_fine_level.copy_locally_owned_data_from(velocity_coarse_level);
-  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
@@ -72,22 +72,16 @@ public:
    * This function updates the multigrid preconditioner.
    */
   void
-  update() override;
+  update() final;
 
 private:
   void
   fill_matrix_free_data(MatrixFreeData<dim, MultigridNumber> & matrix_free_data,
                         unsigned int const                     level,
-                        unsigned int const                     h_level) override;
+                        unsigned int const                     h_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) override;
-
-  /*
-   * This function updates the multigrid operators for all levels
-   */
-  void
-  update_operators();
+  initialize_operator(unsigned int const level) final;
 
   std::shared_ptr<PDEOperatorMG>
   get_operator(unsigned int level);

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -70,23 +70,16 @@ public:
              Map_DBC_ComponentMask const &               dirichlet_bc_component_mask);
 
   void
-  update() override;
+  update() final;
 
 private:
   void
   fill_matrix_free_data(MatrixFreeData<dim, MultigridNumber> & matrix_free_data,
                         unsigned int const                     level,
-                        unsigned int const                     h_level) override;
+                        unsigned int const                     h_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) override;
-
-  /*
-   * This function performs the updates that are necessary after the mesh has been moved
-   * and after matrix_free has been updated.
-   */
-  void
-  update_operators_after_mesh_movement();
+  initialize_operator(unsigned int const level) final;
 
   std::shared_ptr<Laplace>
   get_operator(unsigned int level);

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -83,7 +83,7 @@ MultigridPreconditionerBase<dim, Number>::initialize(
                                                dirichlet_bc,
                                                dirichlet_bc_component_mask);
 
-  this->initialize_matrix_free();
+  this->initialize_matrix_free_objects();
 
   this->initialize_operators();
 
@@ -603,7 +603,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
 
 template<int dim, typename Number>
 void
-MultigridPreconditionerBase<dim, Number>::initialize_matrix_free()
+MultigridPreconditionerBase<dim, Number>::initialize_matrix_free_objects()
 {
   matrix_free_data_objects.resize(0, get_number_of_levels() - 1);
   matrix_free_objects.resize(0, get_number_of_levels() - 1);
@@ -628,7 +628,7 @@ MultigridPreconditionerBase<dim, Number>::initialize_matrix_free()
 
 template<int dim, typename Number>
 void
-MultigridPreconditionerBase<dim, Number>::update_matrix_free()
+MultigridPreconditionerBase<dim, Number>::update_matrix_free_objects()
 {
   for_all_levels([&](unsigned int const level) {
     matrix_free_objects[level]->update_mapping(get_mapping(level_info[level].h_level()));

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -397,9 +397,8 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
   if(multigrid_variant == MultigridVariant::GlobalCoarsening)
   {
     // setup dof-handler and constrained dofs for all multigrid levels
-    for(unsigned int i = 0; i < get_number_of_levels(); i++)
-    {
-      auto const & level = level_info[i];
+    for_all_levels([&](unsigned int const l) {
+      auto const & level = level_info[l];
 
       std::shared_ptr<dealii::DoFHandler<dim>> dof_handler;
       if(level.h_level() == get_number_of_h_levels() - 1)
@@ -448,7 +447,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
         AssertThrow(false, dealii::ExcMessage("Only hypercube or simplex elements are supported."));
       }
 
-      dof_handlers[i] = dof_handler;
+      dof_handlers[l] = dof_handler;
 
       auto affine_constraints_own = new dealii::AffineConstraints<MultigridNumber>();
 
@@ -506,8 +505,8 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
 
       affine_constraints_own->close();
 
-      constraints[i].reset(affine_constraints_own);
-    }
+      constraints[l].reset(affine_constraints_own);
+    });
   }
   else if(multigrid_variant == MultigridVariant::LocalSmoothing)
   {
@@ -574,16 +573,15 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
       map_constrained_dofs[level] = std::shared_ptr<dealii::MGConstrainedDoFs>(constrained_dofs);
     }
 
-    // populate dof-handler and constrained dofs to all hp-levels with the same degree
-    for(unsigned int level = 0; level <= get_number_of_levels() - 1; level++)
-    {
+    // populate dof-handler and constrained dofs of a certain p-levels to all multigrid levels with
+    // the same FE / DoFHandler
+    for_all_levels([&](unsigned int const level) {
       auto p_level            = level_info[level].dof_handler_id();
       dof_handlers[level]     = map_dofhandlers[p_level];
       constrained_dofs[level] = map_constrained_dofs[p_level];
-    }
+    });
 
-    for(unsigned int level = 0; level <= get_number_of_levels() - 1; level++)
-    {
+    for_all_levels([&](unsigned int const level) {
       auto affine_constraints_own = new dealii::AffineConstraints<MultigridNumber>;
 
       ConstraintUtil::add_constraints<dim>(level_info[level].is_dg(),
@@ -595,7 +593,7 @@ MultigridPreconditionerBase<dim, Number>::do_initialize_dof_handler_and_constrai
                                            level_info[level].h_level());
 
       constraints[level].reset(affine_constraints_own);
-    }
+    });
   }
   else
   {
@@ -610,8 +608,7 @@ MultigridPreconditionerBase<dim, Number>::initialize_matrix_free()
   matrix_free_data_objects.resize(0, get_number_of_levels() - 1);
   matrix_free_objects.resize(0, get_number_of_levels() - 1);
 
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; level++)
-  {
+  for_all_levels([&](unsigned int const level) {
     unsigned int const h_level = (multigrid_variant == MultigridVariant::GlobalCoarsening) ?
                                    dealii::numbers::invalid_unsigned_int :
                                    level_info[level].h_level();
@@ -626,15 +623,16 @@ MultigridPreconditionerBase<dim, Number>::initialize_matrix_free()
                                        matrix_free_data_objects[level]->get_constraint_vector(),
                                        matrix_free_data_objects[level]->get_quadrature_vector(),
                                        matrix_free_data_objects[level]->data);
-  }
+  });
 }
 
 template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::update_matrix_free()
 {
-  for(unsigned int level = 0; level <= this->get_number_of_levels() - 1; level++)
+  for_all_levels([&](unsigned int const level) {
     matrix_free_objects[level]->update_mapping(get_mapping(level_info[level].h_level()));
+  });
 }
 
 template<int dim, typename Number>
@@ -643,9 +641,8 @@ MultigridPreconditionerBase<dim, Number>::initialize_operators()
 {
   this->operators.resize(0, this->get_number_of_levels() - 1);
 
-  // create and setup operator on each level
-  for(unsigned int level = 0; level <= get_number_of_levels() - 1; level++)
-    operators[level] = this->initialize_operator(level);
+  for_all_levels(
+    [&](unsigned int const level) { operators[level] = this->initialize_operator(level); });
 }
 
 template<int dim, typename Number>
@@ -669,10 +666,8 @@ MultigridPreconditionerBase<dim, Number>::initialize_smoothers()
 {
   this->smoothers.resize(0, get_number_of_levels() - 1);
 
-  // level l = 0 is the coarse problem where we do not have a smoother,
-  // so we skip the coarsest level
-  for(unsigned int level = 1; level <= get_number_of_levels() - 1; level++)
-    this->initialize_smoother(*this->operators[level], level);
+  for_all_smoothing_levels(
+    [&](unsigned int const level) { this->initialize_smoother(*this->operators[level], level); });
 }
 
 template<int dim, typename Number>
@@ -717,10 +712,6 @@ void
 MultigridPreconditionerBase<dim, Number>::initialize_smoother(Operator &   mg_operator,
                                                               unsigned int level)
 {
-  AssertThrow(level > 0 and level < this->get_number_of_levels(),
-              dealii::ExcMessage(
-                "Multigrid level is invalid when initializing multigrid smoother!"));
-
   switch(data.smoother_data.smoother)
   {
     case MultigridSmoother::Chebyshev:
@@ -792,12 +783,7 @@ template<int dim, typename Number>
 void
 MultigridPreconditionerBase<dim, Number>::update_smoothers()
 {
-  // level l = 0 is the coarse problem where we do not have a smoother,
-  // so we skip the coarsest level
-  for(unsigned int level = 1; level <= get_number_of_levels() - 1; ++level)
-  {
-    this->update_smoother(level);
-  }
+  for_all_smoothing_levels([&](unsigned int const level) { this->update_smoother(level); });
 }
 
 template<int dim, typename Number>

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -227,7 +227,7 @@ protected:
   }
 
   /**
-   * This is a generic function allowing to loop over all multigrid levels (including the coarsest
+   * This is a generic function allowing to loop over all smoothing levels (excluding the coarsest
    * level). The operation to be performed on each level is passed as a lambda with argument level.
    */
   void

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -147,14 +147,14 @@ protected:
    * This function initializes the matrix-free objects for all multigrid levels.
    */
   virtual void
-  initialize_matrix_free();
+  initialize_matrix_free_objects();
 
   /*
    * This function updates the matrix-free objects for all multigrid levels, which
    * is necessary if the domain changes over time.
    */
   void
-  update_matrix_free();
+  update_matrix_free_objects();
 
   /*
    * This function updates the smoother for all multigrid levels.

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -163,12 +163,6 @@ protected:
   void
   update_smoothers();
 
-  /*
-   * Update functions that have to be called/implemented by derived classes.
-   */
-  virtual void
-  update_smoother(unsigned int level);
-
   virtual void
   update_coarse_solver(bool const operator_is_singular);
 
@@ -239,6 +233,20 @@ protected:
       function_on_level(level);
   }
 
+  /**
+   * This is a generic function allowing to successively transfer information from the fine level to
+   * all coarser multigrid levels. The operation to be performed for a transfer between two
+   * successive levels is passed as a lambda with fine_level as the first argument and coarse_level
+   * as the second argument.
+   */
+  void
+  transfer_from_fine_to_coarse_levels(
+    std::function<void(unsigned int const, unsigned int const)> const & levelwise_transfer)
+  {
+    for(unsigned int fine_level = this->get_number_of_levels() - 1; fine_level > 0; --fine_level)
+      levelwise_transfer(fine_level, fine_level - 1);
+  }
+
   dealii::MGLevelObject<std::shared_ptr<dealii::DoFHandler<dim> const>> dof_handlers;
   dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>>     constrained_dofs;
   dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>> constraints;
@@ -297,6 +305,12 @@ private:
 
   void
   initialize_smoother(Operator & matrix, unsigned int level);
+
+  /*
+   * Update functions that have to be implemented by derived classes.
+   */
+  virtual void
+  update_smoother(unsigned int level);
 
   void
   initialize_chebyshev_smoother_point_jacobi(Operator & matrix, unsigned int const level);

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -215,6 +215,30 @@ protected:
   unsigned int
   get_number_of_levels() const;
 
+  /**
+   * This is a generic function allowing to loop over all multigrid levels (including the coarsest
+   * level). The operation to be performed on each level is passed as a lambda with argument level.
+   */
+  void
+  for_all_levels(std::function<void(unsigned int const)> const & function_on_level)
+  {
+    for(unsigned int level = 0; level < this->get_number_of_levels(); ++level)
+      function_on_level(level);
+  }
+
+  /**
+   * This is a generic function allowing to loop over all multigrid levels (including the coarsest
+   * level). The operation to be performed on each level is passed as a lambda with argument level.
+   */
+  void
+  for_all_smoothing_levels(std::function<void(unsigned int const)> const & function_on_level)
+  {
+    // level l = 0 is the coarse problem where we do not have a smoother,
+    // so we skip the coarsest level
+    for(unsigned int level = 1; level < this->get_number_of_levels(); ++level)
+      function_on_level(level);
+  }
+
   dealii::MGLevelObject<std::shared_ptr<dealii::DoFHandler<dim> const>> dof_handlers;
   dealii::MGLevelObject<std::shared_ptr<dealii::MGConstrainedDoFs>>     constrained_dofs;
   dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>> constraints;

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -103,23 +103,20 @@ MultigridPreconditioner<dim, Number>::update()
       vector_multigrid_type_ptr  = &vector_multigrid_type_copy;
     }
 
-    unsigned int const fine_level   = this->get_number_of_levels() - 1;
-    unsigned int const coarse_level = 0;
-
     // copy velocity to finest level
-    this->get_operator_nonlinear(fine_level)
+    this->get_operator_nonlinear(this->get_number_of_levels() - 1)
       ->set_solution_linearization(*vector_multigrid_type_ptr);
 
     // interpolate velocity from fine to coarse level
-    for(unsigned int level = fine_level; level > coarse_level; --level)
-    {
-      auto & vector_fine_level =
-        this->get_operator_nonlinear(level - 0)->get_solution_linearization();
-      auto vector_coarse_level =
-        this->get_operator_nonlinear(level - 1)->get_solution_linearization();
-      this->transfers->interpolate(level, vector_coarse_level, vector_fine_level);
-      this->get_operator_nonlinear(level - 1)->set_solution_linearization(vector_coarse_level);
-    }
+    this->transfer_from_fine_to_coarse_levels(
+      [&](unsigned int const fine_level, unsigned int const coarse_level) {
+        auto & vector_fine_level =
+          this->get_operator_nonlinear(fine_level)->get_solution_linearization();
+        auto vector_coarse_level =
+          this->get_operator_nonlinear(coarse_level)->get_solution_linearization();
+        this->transfers->interpolate(fine_level, vector_coarse_level, vector_fine_level);
+        this->get_operator_nonlinear(coarse_level)->set_solution_linearization(vector_coarse_level);
+      });
   }
 
   // In case that the operators have been updated, we also need to update the smoothers and the

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -75,13 +75,16 @@ public:
    * This function updates the multigrid preconditioner.
    */
   void
-  update() override;
+  update() final;
 
 private:
   void
   fill_matrix_free_data(MatrixFreeData<dim, MultigridNumber> & matrix_free_data,
                         unsigned int const                     level,
-                        unsigned int const                     h_level) override;
+                        unsigned int const                     h_level) final;
+
+  std::shared_ptr<MGOperatorBase>
+  initialize_operator(unsigned int const level) final;
 
   /*
    * This function updates the multigrid operators for all levels
@@ -89,27 +92,11 @@ private:
   void
   update_operators();
 
-  void
-  set_time(double const & time);
-
-  void
-  set_scaling_factor_mass_operator(double const & scaling_factor_mass);
-
-  /*
-   * This function updates solution_linearization.
-   * In order to update operators[level] this function has to be called.
-   */
-  void
-  set_solution_linearization(VectorTypeMG const & vector_linearization);
-
   std::shared_ptr<PDEOperatorNonlinearMG>
   get_operator_nonlinear(unsigned int level);
 
   std::shared_ptr<PDEOperatorLinearMG>
   get_operator_linear(unsigned int level);
-
-  std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) override;
 
 private:
   OperatorData<dim> data;


### PR DESCRIPTION
This PR introduces generic loops over all multigrid levels and the smoothing levels, where the operation to be performed on a particular level is provided by a lambda with `unsigned int level` as argument.

This code can especially be used in derived multigrid classes, where the for-loop over the multigrid levels is written out explicitly many times, which is error prone (see for example https://github.com/exadg/exadg/pull/448/commits/b0d63fffe82ddc9dff2a54a1d4861b88db2ecbe5).

I consider the many member functions in derived multigrid preconditioner classes as needless complexity, which I therefore removed in the present PR.