### PR TITLE
dont store mean velocity calculator data as const reference

### DIFF
--- a/include/exadg/incompressible_navier_stokes/postprocessor/mean_velocity_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/mean_velocity_calculator.h
@@ -160,7 +160,7 @@ private:
                                    VectorType const &                            src,
                                    std::pair<unsigned int, unsigned int> const & cell_range) const;
 
-  MeanVelocityCalculatorData<dim> const & data;
+  MeanVelocityCalculatorData<dim> const   data;
   dealii::MatrixFree<dim, Number> const & matrix_free;
   unsigned int                            dof_index, quad_index;
   bool                                    area_has_been_initialized, volume_has_been_initialized;


### PR DESCRIPTION
Classes should always store a copy of `data` and not a `const` reference.