### PR TITLE
expose data needed for pressure time derivatives

### DIFF
--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -81,6 +81,14 @@ public:
                               std::vector<double> &             times) const;
 
   void
+  get_pressures_and_times(std::vector<VectorType const *> & pressures,
+                          std::vector<double> &             times) const;
+
+  void
+  get_pressures_and_times_np(std::vector<VectorType const *> & pressures,
+                             std::vector<double> &             times) const;
+
+  void
   ale_update();
 
   void
@@ -132,6 +140,19 @@ protected:
   std::shared_ptr<HelpersALE<Number> const> helpers_ale;
 
 private:
+  void
+  get_quantities_and_times(
+    std::vector<VectorType const *> &                             quantities,
+    std::vector<double> &                                         times,
+    std::function<VectorType const *(unsigned int const)> const & get_quantity) const;
+
+  void
+  get_quantities_and_times_np(
+    std::vector<VectorType const *> &                             quantities,
+    std::vector<double> &                                         times,
+    std::function<VectorType const *(unsigned int const)> const & get_quantity,
+    std::function<VectorType const *()> const &                   get_quantity_np) const;
+
   void
   initialize_vec_convective_term();
 

--- a/include/exadg/time_integration/time_int_bdf_base.cpp
+++ b/include/exadg/time_integration/time_int_bdf_base.cpp
@@ -140,6 +140,14 @@ TimeIntBDFBase::get_previous_time(int const i /* t_{n-i} */) const
   return t;
 }
 
+unsigned int
+TimeIntBDFBase::get_current_order() const
+{
+  if(start_with_low_order == true and time_step_number <= order)
+    return this->time_step_number;
+  return order;
+}
+
 double
 TimeIntBDFBase::get_time_step_size() const
 {

--- a/include/exadg/time_integration/time_int_bdf_base.h
+++ b/include/exadg/time_integration/time_int_bdf_base.h
@@ -97,6 +97,12 @@ public:
 
 protected:
   /*
+   * Get current order of time integrator
+   */
+  unsigned int
+  get_current_order() const;
+
+  /*
    * Do one time step including different updates before and after the actual solution of the
    * current time step.
    */

--- a/tests/time_integration/bdf_time_derivative_01.cc
+++ b/tests/time_integration/bdf_time_derivative_01.cc
@@ -1,0 +1,93 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#include <iostream>
+#include <numeric>
+
+#include <deal.II/lac/la_vector.h>
+
+#include <exadg/time_integration/bdf_constants.h>
+
+// Check compute_bdf_time_derivative() from quantities and times
+
+using namespace ExaDG;
+using VectorType = dealii::LinearAlgebra::Vector<double>;
+
+VectorType
+get_vector_with_value(double const value)
+{
+  VectorType vec(1);
+  vec[0] = value;
+  return vec;
+}
+
+void
+test(unsigned int const order, double const target_slope)
+{
+  std::cout << "Check derivative of slope " << target_slope << std::endl;
+
+  // construct quantites and times
+  std::vector<VectorType> quantities_np_values(order + 1);
+  std::vector<double>     times_np(order + 1);
+
+  // current time
+  times_np[0] = 10.0;
+
+  // start value
+  quantities_np_values[0] = get_vector_with_value(100.0);
+
+  double const dt = 1.0;
+  for(unsigned int i = 1; i < order + 1; ++i)
+  {
+    times_np[i] = times_np[i - 1] - dt;
+
+    quantities_np_values[i] =
+      get_vector_with_value(-target_slope * dt + quantities_np_values[i - 1][0]);
+  }
+
+  // transfrom to vector of pointers
+  std::vector<VectorType const *> quantities_np(quantities_np_values.size());
+  std::transform(quantities_np_values.begin(),
+                 quantities_np_values.end(),
+                 quantities_np.begin(),
+                 [](VectorType const & t) { return &t; });
+
+  // compute temporal derivative
+  VectorType derivative(1);
+  derivative[0] = -99.0;
+  compute_bdf_time_derivative(derivative, quantities_np, times_np);
+
+  // check if computed slope equals target slope
+  assert(std::abs(derivative[0] - target_slope) < 1e-12);
+  std::cout << "OK" << std::endl;
+}
+
+int
+main()
+{
+  for(unsigned int order = 1; order <= 4; ++order)
+  {
+    std::cout << "Order " << order << std::endl;
+    test(order, 0.0);
+    test(order, -1.0);
+  }
+  return 0;
+}

--- a/tests/time_integration/bdf_time_derivative_01.output
+++ b/tests/time_integration/bdf_time_derivative_01.output
@@ -1,0 +1,20 @@
+Order 1
+Check derivative of slope 0
+OK
+Check derivative of slope -1
+OK
+Order 2
+Check derivative of slope 0
+OK
+Check derivative of slope -1
+OK
+Order 3
+Check derivative of slope 0
+OK
+Check derivative of slope -1
+OK
+Order 4
+Check derivative of slope 0
+OK
+Check derivative of slope -1
+OK


### PR DESCRIPTION
I want to compute pressure time derivatives of the INSE from outside. To be able to do so some getters are required and `compute_bdf_time_derivative` has to be able to work on vectors of pointers.

Motivation: This is needed for aero-acoustic source term computation.