### PR TITLE
expose quadrature index of pressure

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -139,12 +139,12 @@ public:
   unsigned int
   get_quad_index_velocity_linear() const;
 
+  unsigned int
+  get_quad_index_pressure() const;
+
 protected:
   unsigned int
   get_dof_index_velocity_scalar() const;
-
-  unsigned int
-  get_quad_index_pressure() const;
 
   unsigned int
   get_quad_index_velocity_nonlinear() const;


### PR DESCRIPTION
I want to use the quadrature index of the pressure outside the INSE module. Therefore, I would like to make it public.