### PR TITLE
use <> for include

### DIFF
--- a/include/exadg/utilities/throughput_parameters.h
+++ b/include/exadg/utilities/throughput_parameters.h
@@ -31,7 +31,7 @@
 #include <deal.II/base/parameter_handler.h>
 
 // ExaDG
-#include "print_solver_results.h"
+#include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
 {


### PR DESCRIPTION
As mentioned in https://github.com/exadg/exadg/pull/382#discussion_r1214043857 `<>` should be used for consistency.