### PR TITLE
shift coarse-grid Chebyshev smoother object to MGCoarseChebyshev

### DIFF
--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -163,7 +163,7 @@ MultigridPreconditioner<dim, Number>::update()
   // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
   // functionality implemented in the base class.
   this->update_smoothers();
-  this->update_coarse_solver(data.operator_is_singular);
+  this->update_coarse_solver();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -150,12 +150,14 @@ MultigridPreconditioner<dim, Number>::update()
       });
   }
 
-  // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
-  // functionality implemented in the base class.
-  this->update_smoothers();
-
-  // singular operators do not occur for this operator
-  this->update_coarse_solver(false /* operator_is_singular */);
+  // In case the operators have been updated, we also need to update the smoothers and the coarse
+  // grid solver. This is generic functionality implemented in the base class.
+  if(mesh_is_moving or data.unsteady_problem or
+     (mg_operator_type == MultigridOperatorType::ReactionConvectionDiffusion))
+  {
+    this->update_smoothers();
+    this->update_coarse_solver();
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -117,9 +117,7 @@ MultigridPreconditionerProjection<dim, Number>::update()
   // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
   // functionality implemented in the base class.
   this->update_smoothers();
-
-  // singular operators do not occur for this operator
-  this->update_coarse_solver(false /* operator_is_singular */);
+  this->update_coarse_solver();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -79,9 +79,7 @@ MultigridPreconditioner<dim, Number, n_components>::update()
     // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
     // functionality implemented in the base class.
     this->update_smoothers();
-
-    // singular operators do not occur for this operator
-    this->update_coarse_solver(data.operator_is_singular);
+    this->update_coarse_solver();
   }
 }
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -156,15 +156,19 @@ protected:
   void
   update_matrix_free_objects();
 
-  /*
-   * This function updates the smoother for all multigrid levels.
+  /**
+   * This function updates the smoother for all smoothing levels.
    * The prerequisite to call this function is that the multigrid operators have been updated.
    */
   void
   update_smoothers();
 
-  virtual void
-  update_coarse_solver(bool const operator_is_singular);
+  /**
+   * This function updates the coarse-grid solver.
+   * The prerequisite to call this function is that the coarse-grid operator has been updated.
+   */
+  void
+  update_coarse_solver();
 
   /*
    * Dof-handlers and constraints.
@@ -320,11 +324,6 @@ private:
    */
   void
   initialize_coarse_solver(bool const operator_is_singular);
-
-  void
-  initialize_chebyshev_smoother_coarse_grid(Operator &         matrix,
-                                            SolverData const & solver_data,
-                                            bool const         operator_is_singular);
 
   /*
    * Initialization of actual multigrid algorithm.

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -124,9 +124,7 @@ MultigridPreconditioner<dim, Number>::update()
   if(nonlinear or data.unsteady)
   {
     this->update_smoothers();
-
-    // singular operators do not occur for this operator
-    this->update_coarse_solver(false /* operator_is_singular */);
+    this->update_coarse_solver();
   }
 }
 


### PR DESCRIPTION
As a consequence, the number of smoother objects in `MultigridPreconditionerBase` can be reduced by one and is now consistent to the number of actual smoothing levels. So far, `smoothers[0]` was somewhat unclear and only used in case of a Chebyshev coarse-grid solver. The logic should now be clearer and more explicit.