### PR TITLE
implement Chebyshev smoother in a more encapsulated way

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
@@ -211,7 +211,7 @@ struct SmootherData
   // Chebyshev smmother: sets the smoothing range (range of eigenvalues to be smoothed)
   double smoothing_range;
 
-  // number of CG iterations for estimation of eigenvalues
+  // Chebyshev smmother: number of CG iterations for estimation of eigenvalues
   unsigned int iterations_eigenvalue_estimation;
 };
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -710,23 +710,6 @@ MultigridPreconditionerBase<dim, Number>::initialize_smoother(Operator &   mg_op
   {
     case MultigridSmoother::Chebyshev:
     {
-      // TODO
-      //      if(data.smoother_data.preconditioner == PreconditionerSmoother::PointJacobi)
-      //      {
-      //        smoothers[level] = std::make_shared<
-      //          ChebyshevSmoother<Operator, VectorTypeMG,
-      //          dealii::DiagonalMatrix<VectorTypeMG>>>();
-      //        initialize_chebyshev_smoother_point_jacobi(mg_operator, level);
-      //      }
-      //      else if(data.smoother_data.preconditioner == PreconditionerSmoother::BlockJacobi)
-      //      {
-      //        smoothers[level] = std::make_shared<
-      //          ChebyshevSmoother<Operator, VectorTypeMG, BlockJacobiPreconditioner<Operator>>>();
-      //        initialize_chebyshev_smoother_block_jacobi(mg_operator, level);
-      //      }
-      //      else
-      //        AssertThrow(false, dealii::ExcNotImplemented());
-
       typedef ChebyshevSmoother<Operator, VectorTypeMG> Chebyshev;
       smoothers[level] = std::make_shared<Chebyshev>();
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -313,12 +313,6 @@ private:
   virtual void
   update_smoother(unsigned int level);
 
-  void
-  initialize_chebyshev_smoother_point_jacobi(Operator & matrix, unsigned int const level);
-
-  void
-  initialize_chebyshev_smoother_block_jacobi(Operator & matrix, unsigned int const level);
-
   /*
    * Coarse grid solver.
    */

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
@@ -69,7 +69,7 @@ public:
   };
 
   void
-  initialize(Operator & operator_in, AdditionalData const & additional_data_in)
+  initialize(Operator const & operator_in, AdditionalData const & additional_data_in)
   {
     underlying_operator = &operator_in;
     data                = additional_data_in;
@@ -118,8 +118,8 @@ public:
   }
 
 private:
-  Operator *     underlying_operator;
-  AdditionalData data;
+  Operator const * underlying_operator;
+  AdditionalData   data;
 
   PreconditionerBase<typename Operator::value_type> * preconditioner;
 };

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
@@ -64,6 +64,7 @@ public:
     // sets the smoothing range (range of eigenvalues to be smoothed)
     double smoothing_range;
 
+    // degree of Chebyshev smoother
     unsigned int degree;
 
     // number of CG iterations for estimation of eigenvalues

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
@@ -26,42 +26,143 @@
 #include <deal.II/lac/precondition.h>
 
 // ExaDG
+#include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
 
 namespace ExaDG
 {
-template<typename Operator, typename VectorType, typename PreconditionerType>
+template<typename Operator, typename VectorType>
 class ChebyshevSmoother : public SmootherBase<VectorType>
 {
 public:
-  typedef
-    typename dealii::PreconditionChebyshev<Operator, VectorType, PreconditionerType>::AdditionalData
-      AdditionalData;
+  typedef dealii::PreconditionChebyshev<Operator, VectorType, dealii::DiagonalMatrix<VectorType>>
+    ChebyshevPointJacobi;
+  typedef dealii::PreconditionChebyshev<Operator, VectorType, BlockJacobiPreconditioner<Operator>>
+    ChebyshevBlockJacobi;
 
-  ChebyshevSmoother()
+  ChebyshevSmoother() : underlying_operator(nullptr)
   {
   }
+
+  struct AdditionalData
+  {
+    /**
+     * Constructor.
+     */
+    AdditionalData()
+      : preconditioner(PreconditionerSmoother::PointJacobi),
+        smoothing_range(20),
+        degree(5),
+        iterations_eigenvalue_estimation(20)
+    {
+    }
+
+    // preconditioner
+    PreconditionerSmoother preconditioner;
+
+    // sets the smoothing range (range of eigenvalues to be smoothed)
+    double smoothing_range;
+
+    unsigned int degree;
+
+    // number of CG iterations for estimation of eigenvalues
+    unsigned int iterations_eigenvalue_estimation;
+  };
 
   void
   vmult(VectorType & dst, VectorType const & src) const final
   {
-    smoother_object.vmult(dst, src);
+    if(data.preconditioner == PreconditionerSmoother::PointJacobi)
+    {
+      smoother_point_jacobi->vmult(dst, src);
+    }
+    else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
+    {
+      smoother_block_jacobi->vmult(dst, src);
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcNotImplemented());
+    }
   }
 
   void
   step(VectorType & dst, VectorType const & src) const final
   {
-    smoother_object.step(dst, src);
+    if(data.preconditioner == PreconditionerSmoother::PointJacobi)
+    {
+      smoother_point_jacobi->step(dst, src);
+    }
+    else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
+    {
+      smoother_block_jacobi->step(dst, src);
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcNotImplemented());
+    }
   }
 
   void
-  initialize(Operator const & matrix, AdditionalData const & additional_data)
+  update()
   {
-    smoother_object.initialize(matrix, additional_data);
+    AssertThrow(underlying_operator != nullptr,
+                dealii::ExcMessage("Pointer underlying_operator is uninitialized."));
+
+    initialize(*underlying_operator, data);
+  }
+
+  void
+  initialize(Operator const & operator_in, AdditionalData const & additional_data)
+  {
+    underlying_operator = &operator_in;
+    data                = additional_data;
+
+    if(data.preconditioner == PreconditionerSmoother::PointJacobi)
+    {
+      typename ChebyshevPointJacobi::AdditionalData additional_data_dealii;
+
+      std::shared_ptr<dealii::DiagonalMatrix<VectorType>> jacobi_preconditioner =
+        std::make_shared<dealii::DiagonalMatrix<VectorType>>();
+      VectorType & diagonal_vector = jacobi_preconditioner->get_vector();
+
+      underlying_operator->initialize_dof_vector(diagonal_vector);
+      underlying_operator->calculate_inverse_diagonal(diagonal_vector);
+
+      additional_data_dealii.preconditioner      = jacobi_preconditioner;
+      additional_data_dealii.smoothing_range     = data.smoothing_range;
+      additional_data_dealii.degree              = data.degree;
+      additional_data_dealii.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
+
+      smoother_point_jacobi = std::make_shared<ChebyshevPointJacobi>();
+      smoother_point_jacobi->initialize(*underlying_operator, additional_data_dealii);
+    }
+    else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
+    {
+      typename ChebyshevBlockJacobi::AdditionalData additional_data_dealii;
+
+      additional_data_dealii.preconditioner =
+        std::make_shared<BlockJacobiPreconditioner<Operator>>(*underlying_operator);
+      additional_data_dealii.smoothing_range     = data.smoothing_range;
+      additional_data_dealii.degree              = data.degree;
+      additional_data_dealii.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
+
+      smoother_block_jacobi = std::make_shared<ChebyshevBlockJacobi>();
+      smoother_block_jacobi->initialize(*underlying_operator, additional_data_dealii);
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcNotImplemented());
+    }
   }
 
 private:
-  dealii::PreconditionChebyshev<Operator, VectorType, PreconditionerType> smoother_object;
+  Operator const * underlying_operator;
+  AdditionalData   data;
+
+  std::shared_ptr<ChebyshevPointJacobi> smoother_point_jacobi;
+  std::shared_ptr<ChebyshevBlockJacobi> smoother_block_jacobi;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
@@ -69,7 +69,7 @@ public:
   };
 
   void
-  initialize(Operator & operator_in, AdditionalData const & additional_data_in)
+  initialize(Operator const & operator_in, AdditionalData const & additional_data_in)
   {
     underlying_operator = &operator_in;
 
@@ -122,7 +122,7 @@ public:
   }
 
 private:
-  Operator * underlying_operator;
+  Operator const * underlying_operator;
 
   AdditionalData data;
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
@@ -71,7 +71,7 @@ public:
   };
 
   void
-  initialize(Operator & operator_in, AdditionalData const & additional_data_in)
+  initialize(Operator const & operator_in, AdditionalData const & additional_data_in)
   {
     underlying_operator = &operator_in;
 
@@ -163,7 +163,7 @@ public:
   }
 
 private:
-  Operator * underlying_operator;
+  Operator const * underlying_operator;
 
   AdditionalData data;
 


### PR DESCRIPTION
The problem with the previous implementation was that `dealii::PreconditionChebyshev` is templated regarding the preconditioner. However, not all such preconditioner have a common base class in ExaDG. This implies if-else branches on the level of data types / constructors, which was currently realized in `MultigridPreconditionerBase`. However, this somewhat "pollutes" the multigrid preconditioner class that should have a higher astraction level. Hence, it makes in my opinion more sense to implement such "wrapping functionality" within `ExaDG::ChebyshevSmoother`. Moreover, the circumstance that `ExaDG::MGCoarseChebyshev` currently supports only point-Jacobi preconditioning is now realized more naturally, with the `Assert` appearing in the respective class `ExaDG::MGCoarseChebyshev` (which one potentially wants to extend to block-Jacobi in the future).

With the present changes, the `ChebyshevSmoother` follows closely the design of other smoothers in `ExaDG`.

Note that `const`-correctness has been improved along the way for other smoothers in ExaDG.
