### PR TITLE
fix names in .json

### DIFF
--- a/applications/fluid_structure_interaction/bending_wall/input.json
+++ b/applications/fluid_structure_interaction/bending_wall/input.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "FSI" : {
-        "Method": "IQN-ILS",
+        "Method": "IQN_ILS",
         "AbsTol": "1.e-12",
         "RelTol": "1.e-3",
         "OmegaInit": "0.1",

--- a/applications/fluid_structure_interaction/cylinder_with_flag/input.json
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/input.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "FSI" : {
-        "Method": "IQN-ILS",
+        "Method": "IQN_ILS",
         "AbsTol": "1.e-8",
         "RelTol": "1.e-3", 
         "OmegaInit": "0.3",

--- a/applications/fluid_structure_interaction/pressure_wave/input.json
+++ b/applications/fluid_structure_interaction/pressure_wave/input.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "FSI" : {
-        "Method": "IQN-ILS",
+        "Method": "IQN_ILS",
         "AbsTol": "1.e-9",
         "RelTol": "1.e-3",
         "OmegaInit": "0.3",


### PR DESCRIPTION
While introducing the enum parameter handler I missed changing the names of acceleration methods in .json files.