### PR TITLE
introduce update() functions for base classes of multigrid smoother and coarse solver

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -32,6 +32,7 @@
 #include <exadg/grid/grid.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/multigrid_operator_base.h>
+#include <exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h>
 #include <exadg/solvers_and_preconditioners/multigrid/levels_hybrid_multigrid.h>
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h>
@@ -308,12 +309,6 @@ private:
   initialize_smoother(Operator & matrix, unsigned int level);
 
   /*
-   * Update functions that have to be implemented by derived classes.
-   */
-  virtual void
-  update_smoother(unsigned int level);
-
-  /*
    * Coarse grid solver.
    */
   void
@@ -342,7 +337,7 @@ private:
 
   dealii::MGLevelObject<std::shared_ptr<Smoother>> smoothers;
 
-  std::shared_ptr<dealii::MGCoarseGridBase<VectorTypeMG>> coarse_grid_solver;
+  std::shared_ptr<CoarseGridSolverBase<Operator>> coarse_grid_solver;
 
   std::shared_ptr<MultigridAlgorithm<VectorTypeMG, Operator, Smoother>> multigrid_algorithm;
 };

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
@@ -90,7 +90,7 @@ public:
   }
 
   void
-  update()
+  update() final
   {
     if(preconditioner != nullptr)
       preconditioner->update();

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
@@ -106,7 +106,7 @@ public:
   }
 
   void
-  update()
+  update() final
   {
     AssertThrow(underlying_operator != nullptr,
                 dealii::ExcMessage("Pointer underlying_operator is uninitialized."));

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
@@ -92,7 +92,7 @@ public:
   }
 
   void
-  update()
+  update() final
   {
     if(preconditioner != nullptr)
       preconditioner->update();

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
@@ -95,7 +95,7 @@ public:
   }
 
   void
-  update()
+  update() final
   {
     if(preconditioner != nullptr)
       preconditioner->update();

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h
@@ -37,6 +37,9 @@ public:
 
   virtual void
   step(VectorType & dst, VectorType const & src) const = 0;
+
+  virtual void
+  update() = 0;
 };
 
 } // namespace ExaDG


### PR DESCRIPTION
The refactoring from previous PRs, e.g. #477, now allows to further simplify the implementation in `MultigridPreconditionerBase`.