### PR TITLE
fix writing Rho_E in pointwise output of CNSE

### DIFF
--- a/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.cpp
@@ -93,7 +93,7 @@ PointwiseOutputGenerator<dim, Number>::do_evaluate(VectorType const & solution)
     if(pointwise_output_data.write_rho_u)
       this->write_quantity("Rho_U", values, 1);
     if(pointwise_output_data.write_rho_E)
-      this->write_quantity("Rho_E", values, dim + 2);
+      this->write_quantity("Rho_E", values, dim + 1);
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/exadg/exadg/issues/493

The index at which to access Rho_E was wrong.