### PR TITLE
Enable OperatorBase::rhs()/evaluate() for is_dg=false or evaluate_face_integrals=false

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -325,11 +325,11 @@ template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::rhs_add(VectorType & rhs) const
 {
-  VectorType tmp;
-  tmp.reinit(rhs, false);
-
   if(evaluate_face_integrals())
   {
+    VectorType tmp;
+    tmp.reinit(rhs, false);
+
     matrix_free->loop(&This::cell_loop_empty,
                       &This::face_loop_empty,
                       &This::boundary_face_loop_inhom_operator,

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -392,12 +392,19 @@ OperatorBase<dim, Number, n_components>::evaluate_add(VectorType &       dst,
   }
   else
   {
-    matrix_free->loop(&This::cell_loop,
-                      &This::face_loop_empty,
-                      &This::boundary_face_loop_inhom_operator,
-                      this,
-                      dst,
-                      src);
+    if(evaluate_face_integrals())
+    {
+      matrix_free->loop(&This::cell_loop,
+                        &This::face_loop_empty,
+                        &This::boundary_face_loop_inhom_operator,
+                        this,
+                        dst,
+                        src);
+    }
+    else
+    {
+      matrix_free->cell_loop(&This::cell_loop, this, dst, src);
+    }
   }
 }
 


### PR DESCRIPTION
`OperatorBase::rhs()` and `OperatorBase::evaluate()` currently assume `is_dg = true` and `evaluate_face_integrals() = true`. Since no asserts are placed in the code, this can be considered a bug in the present code version.

The problem occurred for example when solving scalar transport using the `CombinedOperator` but treating convection explicitly and omitting the diffusive term. Then, `CombinedOperator` should only evaluate cell integrals for the mass operator. However, the code currently runs into the face integrals due to shortcomings / incomplete functionality in `OperatorBase::rhs()` and `OperatorBase::evaluate()`.

For the implementation in `OperatorBase`, we have to distinguish 4 cases:
- DG with face integrals
- DG without face integrals
- CG with boundary face integrals
- CG without boundary face integrals

Some explanations for review:
- (Boundary) face integrals occur for CG disretizations only in the form of inhomogeneous boundary conditions. Hence, the function `OperatorBase::apply()` (homogeneous operator) does not distinguish between the two cases for CG (because `apply()` == homogeneous operator only).
- `OperatorBase::rhs()` (inhomogeneous operator) only considers inhomogeneous boundary face integrals. Therefore, there is no need to distinguish between DG and CG. The distinction between CG/DG happens somewhat deeper in `OperatorBase::boundary_face_loop_inhom_operator()`.
- `OperatorBase::evaluate()` (homogeneous+inhomogeneous operator) needs a 4th case as compared to `OperatorBase::apply()` because there is also the case of CG with boundary face integrals. In fact, for the case `evaluate_face_integrals()==false`, one could combine the CG and DG branches because only a cell loop remains, which is the same for CG/DG. However, for better readability and consistency with the other functions in `OperatorBase`, I think it is advantageous to show the 4 cases explicitly.