### PR TITLE
enable running FDA benchmark without precursor

### DIFF
--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -789,8 +789,6 @@ private:
 
 } // namespace ExaDG
 
-#include <exadg/incompressible_navier_stokes/user_interface/implement_get_application.h>
-
 #include <exadg/incompressible_navier_stokes/user_interface/implement_get_application_precursor.h>
 
 #endif /* APPLICATIONS_INCOMPRESSIBLE_NAVIER_STOKES_TEST_CASES_TURBULENT_CHANNEL_H_ */

--- a/include/exadg/incompressible_navier_stokes/solver_precursor.h
+++ b/include/exadg/incompressible_navier_stokes/solver_precursor.h
@@ -48,6 +48,9 @@ create_input_file(std::string const & input_file)
   GeneralParameters general;
   general.add_parameters(prm);
 
+  ExaDG::ResolutionParameters resolution;
+  resolution.add_parameters(prm);
+
   // we have to assume a default dimension and default Number type
   // for the automatic generation of a default input file
   unsigned int const Dim = 2;
@@ -61,13 +64,19 @@ create_input_file(std::string const & input_file)
 
 template<int dim, typename Number>
 void
-run(std::string const & input_file, MPI_Comm const & mpi_comm, bool const is_test)
+run(std::string const & input_file,
+    unsigned int const  degree,
+    unsigned int const  refine_space,
+    MPI_Comm const &    mpi_comm,
+    bool const          is_test)
 {
   dealii::Timer timer;
   timer.restart();
 
   std::shared_ptr<IncNS::ApplicationBasePrecursor<dim, Number>> application =
     IncNS::get_application<dim, Number>(input_file, mpi_comm);
+
+  application->set_resolution_parameters_solver_precursor(degree, refine_space);
 
   std::shared_ptr<IncNS::DriverPrecursor<dim, Number>> driver =
     std::make_shared<IncNS::DriverPrecursor<dim, Number>>(mpi_comm, application, is_test);
@@ -115,24 +124,29 @@ main(int argc, char ** argv)
     }
   }
 
-  ExaDG::GeneralParameters general(input_file);
+  ExaDG::GeneralParameters    general(input_file);
+  ExaDG::ResolutionParameters resolution(input_file);
 
   // run the simulation
   if(general.dim == 2 and general.precision == "float")
   {
-    ExaDG::run<2, float>(input_file, mpi_comm, general.is_test);
+    ExaDG::run<2, float>(
+      input_file, resolution.degree, resolution.refine_space, mpi_comm, general.is_test);
   }
   else if(general.dim == 2 and general.precision == "double")
   {
-    ExaDG::run<2, double>(input_file, mpi_comm, general.is_test);
+    ExaDG::run<2, double>(
+      input_file, resolution.degree, resolution.refine_space, mpi_comm, general.is_test);
   }
   else if(general.dim == 3 and general.precision == "float")
   {
-    ExaDG::run<3, float>(input_file, mpi_comm, general.is_test);
+    ExaDG::run<3, float>(
+      input_file, resolution.degree, resolution.refine_space, mpi_comm, general.is_test);
   }
   else if(general.dim == 3 and general.precision == "double")
   {
-    ExaDG::run<3, double>(input_file, mpi_comm, general.is_test);
+    ExaDG::run<3, double>(
+      input_file, resolution.degree, resolution.refine_space, mpi_comm, general.is_test);
   }
   else
   {

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -287,21 +287,21 @@ public:
   {
   }
 
-  virtual void
-  add_parameters(dealii::ParameterHandler & prm) final
+  void
+  set_resolution_parameters_solver_precursor(unsigned int const degree,
+                                             unsigned int const refine_space)
   {
-    ApplicationBase<dim, Number>::add_parameters(prm);
+    this->param.degree_u             = degree;
+    this->param.grid.n_refine_global = refine_space;
 
-    resolution.add_parameters(prm);
+    this->param_pre.degree_u             = degree;
+    this->param_pre.grid.n_refine_global = refine_space;
   }
 
   void
   setup() final
   {
     this->parse_parameters();
-
-    // resolution parameters
-    set_resolution_parameters();
 
     // actual domain
     ApplicationBase<dim, Number>::setup();
@@ -401,16 +401,6 @@ protected:
   std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor_pre;
 
 private:
-  void
-  set_resolution_parameters()
-  {
-    this->param.degree_u             = resolution.degree;
-    this->param.grid.n_refine_global = resolution.refine_space;
-
-    this->param_pre.degree_u             = resolution.degree;
-    this->param_pre.grid.n_refine_global = resolution.refine_space;
-  }
-
   virtual void
   set_parameters_precursor() = 0;
 
@@ -422,8 +412,6 @@ private:
 
   virtual void
   set_field_functions_precursor() = 0;
-
-  ResolutionParameters resolution;
 };
 
 


### PR DESCRIPTION
This PR should fix the problem that `./incompressible_navier_stokes/fda_benchmark/solver` (the solver without precursor) is currently not running for the FDA benchmark.

Overall, the application design for precursor simulations (relying on inheritance) should be changed, since it is very hard to keep the overview of what is going on if one runs such an `Application` (deriving from `ApplicationBasePrecursor`, itself deriving from `ApplicationBase`) without precursor.