### PR TITLE
rename Poisson::SolverPoisson to Poisson::Solver

### DIFF
--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -579,7 +579,7 @@ private:
     param.spatial_discretization = SpatialDiscretization::CG;
 
     // SOLVER
-    param.solver         = Poisson::Solver::FGMRES;
+    param.solver         = Poisson::LinearSolver::FGMRES;
     param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
     param.preconditioner = Preconditioner::Multigrid;
 

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -601,7 +601,7 @@ private:
     param.degree                 = this->param.mapping_degree;
 
     // SOLVER
-    param.solver         = Poisson::Solver::FGMRES;
+    param.solver         = Poisson::LinearSolver::FGMRES;
     param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
     param.preconditioner = Preconditioner::Multigrid;
 

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -468,7 +468,7 @@ private:
     param.degree                 = this->param.mapping_degree;
 
     // SOLVER
-    param.solver         = Poisson::Solver::FGMRES;
+    param.solver         = Poisson::LinearSolver::FGMRES;
     param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
     param.preconditioner = Preconditioner::Multigrid;
 

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -464,7 +464,7 @@ private:
     param.degree                 = this->param.mapping_degree;
 
     // SOLVER
-    param.solver         = Poisson::Solver::FGMRES;
+    param.solver         = Poisson::LinearSolver::FGMRES;
     param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
     param.preconditioner = Preconditioner::Multigrid;
 

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -51,7 +51,7 @@ private:
     this->param.IP_factor               = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = Poisson::Solver::CG;
+    this->param.solver                      = Poisson::LinearSolver::CG;
     this->param.solver_data.abs_tol         = 1.e-20;
     this->param.solver_data.rel_tol         = 1.e-10;
     this->param.solver_data.max_iter        = 1e4;

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -550,7 +550,7 @@ private:
     this->poisson_param.IP_factor              = 1.0e0;
 
     // SOLVER
-    this->poisson_param.solver                    = Poisson::Solver::CG;
+    this->poisson_param.solver                    = Poisson::LinearSolver::CG;
     this->poisson_param.solver_data.abs_tol       = 1.e-20;
     this->poisson_param.solver_data.rel_tol       = 1.e-10;
     this->poisson_param.solver_data.max_iter      = 1e4;

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -209,7 +209,7 @@ private:
     this->param.IP_factor               = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = Poisson::Solver::CG;
+    this->param.solver                      = LinearSolver::CG;
     this->param.solver_data.abs_tol         = 1.e-20;
     this->param.solver_data.rel_tol         = 1.e-10;
     this->param.solver_data.max_iter        = 1e4;

--- a/applications/poisson/overset_grids/application.h
+++ b/applications/poisson/overset_grids/application.h
@@ -53,7 +53,7 @@ public:
     p.IP_factor               = 1.0e0;
 
     // SOLVER
-    p.solver                      = Solver::CG;
+    p.solver                      = LinearSolver::CG;
     p.solver_data.abs_tol         = 1.e-20;
     p.solver_data.rel_tol         = 1.e-10;
     p.solver_data.max_iter        = 1e4;
@@ -173,7 +173,7 @@ private:
     p.IP_factor               = 1.0e0;
 
     // SOLVER
-    p.solver                      = Solver::CG;
+    p.solver                      = LinearSolver::CG;
     p.solver_data.abs_tol         = 1.e-20;
     p.solver_data.rel_tol         = 1.e-10;
     p.solver_data.max_iter        = 1e4;

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -152,7 +152,7 @@ private:
     this->param.IP_factor              = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = Solver::CG;
+    this->param.solver                      = LinearSolver::CG;
     this->param.solver_data.abs_tol         = 1.e-20;
     this->param.solver_data.rel_tol         = 1.e-10;
     this->param.solver_data.max_iter        = 1e4;

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -52,7 +52,7 @@ private:
     this->param.IP_factor               = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = Poisson::Solver::CG;
+    this->param.solver                      = LinearSolver::CG;
     this->param.solver_data.abs_tol         = 1.e-20;
     this->param.solver_data.rel_tol         = 1.e-10;
     this->param.solver_data.max_iter        = 1e4;

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -70,7 +70,7 @@ private:
     this->param.IP_factor               = 1.0e0;
 
     // SOLVER
-    this->param.solver         = Poisson::Solver::CG;
+    this->param.solver         = LinearSolver::CG;
     this->param.preconditioner = Preconditioner::None;
   }
 

--- a/include/exadg/poisson/driver.cpp
+++ b/include/exadg/poisson/driver.cpp
@@ -50,7 +50,7 @@ Driver<dim, Number>::Driver(MPI_Comm const &                                 com
 {
   print_general_info<Number>(pcout, mpi_comm, is_test);
 
-  poisson = std::make_shared<SolverPoisson<dim, 1, Number>>();
+  poisson = std::make_shared<Solver<dim, 1, Number>>();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -103,7 +103,7 @@ private:
   // application
   std::shared_ptr<ApplicationBase<dim, 1, Number>> application;
 
-  std::shared_ptr<SolverPoisson<dim, 1, Number>> poisson;
+  std::shared_ptr<Solver<dim, 1, Number>> poisson;
 
   // number of iterations
   mutable unsigned int iterations;

--- a/include/exadg/poisson/overset_grids/driver.cpp
+++ b/include/exadg/poisson/overset_grids/driver.cpp
@@ -39,8 +39,8 @@ DriverOversetGrids<dim, n_components, Number>::DriverOversetGrids(
 {
   print_general_info<Number>(pcout, mpi_comm, false /* is_test */);
 
-  poisson1 = std::make_shared<SolverPoisson<dim, n_components, Number>>();
-  poisson2 = std::make_shared<SolverPoisson<dim, n_components, Number>>();
+  poisson1 = std::make_shared<Solver<dim, n_components, Number>>();
+  poisson2 = std::make_shared<Solver<dim, n_components, Number>>();
 }
 
 template<int dim, int n_components, typename Number>

--- a/include/exadg/poisson/overset_grids/driver.h
+++ b/include/exadg/poisson/overset_grids/driver.h
@@ -57,7 +57,7 @@ private:
   std::shared_ptr<ApplicationOversetGridsBase<dim, n_components, Number>> application;
 
   // Poisson solvers
-  std::shared_ptr<SolverPoisson<dim, n_components, Number>> poisson1, poisson2;
+  std::shared_ptr<Solver<dim, n_components, Number>> poisson1, poisson2;
 
   // interface coupling
   std::shared_ptr<InterfaceCoupling<rank, dim, Number>> first_to_second, second_to_first;

--- a/include/exadg/poisson/solver_poisson.h
+++ b/include/exadg/poisson/solver_poisson.h
@@ -32,7 +32,7 @@ namespace ExaDG
 namespace Poisson
 {
 template<int dim, int n_components, typename Number>
-class SolverPoisson
+class Solver
 {
 public:
   void

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -401,7 +401,7 @@ Operator<dim, n_components, Number>::setup_solver()
     AssertThrow(false, dealii::ExcMessage("Specified preconditioner is not implemented!"));
   }
 
-  if(param.solver == Poisson::Solver::CG)
+  if(param.solver == LinearSolver::CG)
   {
     // initialize solver_data
     Krylov::SolverDataCG solver_data;
@@ -418,7 +418,7 @@ Operator<dim, n_components, Number>::setup_solver()
       std::make_shared<Krylov::SolverCG<Laplace, PreconditionerBase<Number>, VectorType>>(
         laplace_operator, *preconditioner, solver_data);
   }
-  else if(param.solver == Solver::FGMRES)
+  else if(param.solver == LinearSolver::FGMRES)
   {
     // initialize solver_data
     Krylov::SolverDataFGMRES solver_data;

--- a/include/exadg/poisson/user_interface/enum_types.h
+++ b/include/exadg/poisson/user_interface/enum_types.h
@@ -51,7 +51,7 @@ enum class SpatialDiscretization
 /*
  *   Solver for linear system of equations
  */
-enum class Solver
+enum class LinearSolver
 {
   Undefined,
   CG,

--- a/include/exadg/poisson/user_interface/parameters.cpp
+++ b/include/exadg/poisson/user_interface/parameters.cpp
@@ -41,7 +41,7 @@ Parameters::Parameters()
     IP_factor(1.0),
 
     // SOLVER
-    solver(Solver::Undefined),
+    solver(LinearSolver::Undefined),
     solver_data(SolverData(1e4, 1.e-20, 1.e-12)),
     compute_performance_metrics(false),
     preconditioner(Preconditioner::Undefined),
@@ -64,7 +64,7 @@ Parameters::check() const
   AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
 
   // SOLVER
-  AssertThrow(solver != Solver::Undefined, dealii::ExcMessage("parameter must be defined."));
+  AssertThrow(solver != LinearSolver::Undefined, dealii::ExcMessage("parameter must be defined."));
   AssertThrow(preconditioner != Preconditioner::Undefined,
               dealii::ExcMessage("parameter must be defined."));
 }

--- a/include/exadg/poisson/user_interface/parameters.h
+++ b/include/exadg/poisson/user_interface/parameters.h
@@ -100,7 +100,7 @@ public:
   /**************************************************************************************/
 
   // description: see enum declaration
-  Solver solver;
+  LinearSolver solver;
 
   // solver data
   SolverData solver_data;


### PR DESCRIPTION
I have just seen the naming `Poisson::SolverPoisson`, which I find irritating and which I want to resolve by the present PR.