### PR TITLE
Enable hanging nodes for continuous Galerkin discretizations

### DIFF
--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -67,6 +67,54 @@ private:
   double const end_time;
 };
 
+// TODO: only the time factor is different compared to the above function -> refactor and unify the
+// code
+template<int dim>
+class AccelerationDBC : public dealii::Function<dim>
+{
+public:
+  AccelerationDBC(double const displacement,
+                  bool const   quasistatic_solver,
+                  bool const   unsteady,
+                  double const end_time)
+    : dealii::Function<dim>(dim),
+      displacement(displacement),
+      quasistatic(quasistatic_solver),
+      unsteady(unsteady),
+      end_time(end_time)
+  {
+  }
+
+  double
+  value(dealii::Point<dim> const & p, unsigned int const c) const final
+  {
+    (void)p;
+
+    double factor = 1.0;
+    if(quasistatic)
+      factor *= this->get_time();
+
+    if(unsteady)
+    {
+      factor =
+        2 * std::pow(2.0 * dealii::numbers::PI / end_time, 2.0) *
+        (1.0 -
+         2.0 * std::pow(std::sin(this->get_time() * 2.0 * dealii::numbers::PI / end_time), 2.0));
+    }
+
+    if(c == 0)
+      return displacement * factor;
+    else
+      return 0.0;
+  }
+
+private:
+  double const displacement;
+  bool const   quasistatic;
+  bool const   unsteady;
+  double const end_time;
+};
+
 template<int dim>
 class VolumeForce : public dealii::Function<dim>
 {
@@ -387,6 +435,9 @@ private:
     }
     this->boundary_descriptor->dirichlet_bc.insert(
       pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
+    this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
+
     this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(1, mask_left));
 
     // right face: Dirichlet or Neumann BC
@@ -407,6 +458,9 @@ private:
       bool const unsteady = (this->param.problem_type == ProblemType::Unsteady);
       this->boundary_descriptor->dirichlet_bc.insert(
         pair(2, new DisplacementDBC<dim>(displacement, quasistatic_solver, unsteady, end_time)));
+      this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+        pair(2, new AccelerationDBC<dim>(displacement, quasistatic_solver, unsteady, end_time)));
+
       this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(2, mask_right));
     }
     else if(boundary_type == BoundaryType::Neumann)
@@ -437,6 +491,9 @@ private:
       {
         this->boundary_descriptor->dirichlet_bc.insert(
           pair(3, new dealii::Functions::ZeroFunction<dim>(dim)));
+        this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+          pair(3, new dealii::Functions::ZeroFunction<dim>(dim)));
+
         std::vector<bool> mask_y = {false, true};
         this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(3, mask_y));
       }
@@ -444,11 +501,17 @@ private:
       {
         this->boundary_descriptor->dirichlet_bc.insert(
           pair(3, new dealii::Functions::ZeroFunction<dim>(dim)));
+        this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+          pair(3, new dealii::Functions::ZeroFunction<dim>(dim)));
+
         std::vector<bool> mask_y = {false, true, false};
         this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(3, mask_y));
 
         this->boundary_descriptor->dirichlet_bc.insert(
           pair(4, new dealii::Functions::ZeroFunction<dim>(dim)));
+        this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+          pair(4, new dealii::Functions::ZeroFunction<dim>(dim)));
+
         std::vector<bool> mask_z = {false, false, true};
         this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(4, mask_z));
       }

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -268,6 +268,9 @@ private:
     // left side
     this->boundary_descriptor->dirichlet_bc.insert(
       pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
+    this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+      pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
+
     this->boundary_descriptor->dirichlet_bc_component_mask.insert(
       pair_mask(1, dealii::ComponentMask()));
 

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -240,6 +240,9 @@ private:
     std::vector<bool> mask_lower = {true, true, true}; // clamp boundary, i.e., fix all directions
     this->boundary_descriptor->dirichlet_bc.insert(
       pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
+    this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+      pair(0, new dealii::Functions::ZeroFunction<dim>(dim)));
+
     this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(0, mask_lower));
 
     // BC at the top (boundary_id = 1)
@@ -251,6 +254,10 @@ private:
       //      directions
       this->boundary_descriptor->dirichlet_bc.insert(
         pair(1, new DisplacementDBC<dim>(displacement, incremental_loading)));
+      // DisplacementDBC is a linearly increasing function, so the acceleration is zero.
+      this->boundary_descriptor->dirichlet_bc_initial_acceleration.insert(
+        pair(1, new dealii::Functions::ZeroFunction<dim>(dim)));
+
       this->boundary_descriptor->dirichlet_bc_component_mask.insert(pair_mask(1, mask_upper));
     }
     else if(boundary_type == BoundaryType::Neumann)

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
@@ -160,10 +160,10 @@ CombinedOperator<dim, Number>::set_scaling_factor_mass_operator(Number const & s
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_cell(IntegratorCell &   integrator,
-                                           unsigned int const cell) const
+CombinedOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                      unsigned int const cell) const
 {
-  Base::reinit_cell(integrator, cell);
+  (void)integrator;
 
   if(operator_data.convective_problem)
     convective_kernel->reinit_cell(cell);

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
@@ -171,12 +171,10 @@ CombinedOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integra
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
-                                           IntegratorFace &   integrator_p,
-                                           unsigned int const face) const
+CombinedOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                      IntegratorFace &   integrator_p,
+                                                      unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
-
   if(operator_data.convective_problem)
     convective_kernel->reinit_face(face);
   if(operator_data.diffusive_problem)
@@ -185,11 +183,9 @@ CombinedOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                    unsigned int const face) const
+CombinedOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                                               unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
-
   if(operator_data.convective_problem)
     convective_kernel->reinit_boundary_face(face);
   if(operator_data.diffusive_problem)
@@ -198,15 +194,13 @@ CombinedOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrato
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_face_cell_based(
+CombinedOperator<dim, Number>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
-
   if(operator_data.convective_problem)
     convective_kernel->reinit_face_cell_based(cell, face, boundary_id);
   if(operator_data.diffusive_problem)

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
@@ -160,8 +160,8 @@ CombinedOperator<dim, Number>::set_scaling_factor_mass_operator(Number const & s
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                      unsigned int const cell) const
+CombinedOperator<dim, Number>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                   unsigned int const cell) const
 {
   (void)integrator;
 
@@ -171,9 +171,9 @@ CombinedOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integra
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                      IntegratorFace &   integrator_p,
-                                                      unsigned int const face) const
+CombinedOperator<dim, Number>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                   IntegratorFace &   integrator_p,
+                                                   unsigned int const face) const
 {
   if(operator_data.convective_problem)
     convective_kernel->reinit_face(face);
@@ -183,8 +183,8 @@ CombinedOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integra
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                                               unsigned int const face) const
+CombinedOperator<dim, Number>::reinit_boundary_face_derived(IntegratorFace &   integrator_m,
+                                                            unsigned int const face) const
 {
   if(operator_data.convective_problem)
     convective_kernel->reinit_boundary_face(face);
@@ -194,7 +194,7 @@ CombinedOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace & 
 
 template<int dim, typename Number>
 void
-CombinedOperator<dim, Number>::reinit_face_cell_based_additional(
+CombinedOperator<dim, Number>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
@@ -109,19 +109,20 @@ private:
   reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
@@ -106,7 +106,7 @@ public:
 
 private:
   void
-  reinit_cell(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
   reinit_face(IntegratorFace &   integrator_m,

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
@@ -106,23 +106,22 @@ public:
 
 private:
   void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
@@ -70,40 +70,43 @@ ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integ
                                                         unsigned int const cell) const
 {
   (void)integrator;
+
   kernel->reinit_cell(cell);
 }
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
-                                             IntegratorFace &   integrator_p,
-                                             unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                        IntegratorFace &   integrator_p,
+                                                        unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
+  (void)integrator_m;
+  (void)integrator_p;
 
   kernel->reinit_face(face);
 }
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                      unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                                                 unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
+  (void)integrator_m;
 
   kernel->reinit_boundary_face(face);
 }
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_cell_based(
+ConvectiveOperator<dim, Number>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
+  (void)integrator_m;
+  (void)integrator_p;
 
   kernel->reinit_face_cell_based(cell, face, boundary_id);
 }

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
@@ -66,8 +66,8 @@ ConvectiveOperator<dim, Number>::get_velocity() const
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                        unsigned int const cell) const
+ConvectiveOperator<dim, Number>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                     unsigned int const cell) const
 {
   (void)integrator;
 
@@ -76,9 +76,9 @@ ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integ
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                        IntegratorFace &   integrator_p,
-                                                        unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                     IntegratorFace &   integrator_p,
+                                                     unsigned int const face) const
 {
   (void)integrator_m;
   (void)integrator_p;
@@ -88,8 +88,8 @@ ConvectiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integ
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                                                 unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_boundary_face_derived(IntegratorFace &   integrator_m,
+                                                              unsigned int const face) const
 {
   (void)integrator_m;
 
@@ -98,7 +98,7 @@ ConvectiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace 
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_cell_based_additional(
+ConvectiveOperator<dim, Number>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
@@ -66,11 +66,10 @@ ConvectiveOperator<dim, Number>::get_velocity() const
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_cell(IntegratorCell &   integrator,
-                                             unsigned int const cell) const
+ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                        unsigned int const cell) const
 {
-  Base::reinit_cell(integrator, cell);
-
+  (void)integrator;
   kernel->reinit_cell(cell);
 }
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
@@ -583,19 +583,20 @@ private:
   reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
@@ -580,7 +580,7 @@ public:
 
 private:
   void
-  reinit_cell(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
   reinit_face(IntegratorFace &   integrator_m,

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
@@ -580,23 +580,22 @@ public:
 
 private:
   void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.cpp
@@ -52,35 +52,36 @@ DiffusiveOperator<dim, Number>::update()
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
-                                            IntegratorFace &   integrator_p,
-                                            unsigned int const face) const
+DiffusiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                       IntegratorFace &   integrator_p,
+                                                       unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
+  (void)face;
 
   kernel->reinit_face(integrator_m, integrator_p, operator_data.dof_index);
 }
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                     unsigned int const face) const
+DiffusiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                                                unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
+  (void)face;
 
   kernel->reinit_boundary_face(integrator_m, operator_data.dof_index);
 }
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::reinit_face_cell_based(
+DiffusiveOperator<dim, Number>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
+  (void)cell;
+  (void)face;
 
   kernel->reinit_face_cell_based(boundary_id, integrator_m, integrator_p, operator_data.dof_index);
 }

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.cpp
@@ -52,9 +52,9 @@ DiffusiveOperator<dim, Number>::update()
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                       IntegratorFace &   integrator_p,
-                                                       unsigned int const face) const
+DiffusiveOperator<dim, Number>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                    IntegratorFace &   integrator_p,
+                                                    unsigned int const face) const
 {
   (void)face;
 
@@ -63,8 +63,8 @@ DiffusiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integr
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                                                unsigned int const face) const
+DiffusiveOperator<dim, Number>::reinit_boundary_face_derived(IntegratorFace &   integrator_m,
+                                                             unsigned int const face) const
 {
   (void)face;
 
@@ -73,7 +73,7 @@ DiffusiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &
 
 template<int dim, typename Number>
 void
-DiffusiveOperator<dim, Number>::reinit_face_cell_based_additional(
+DiffusiveOperator<dim, Number>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.h
@@ -252,20 +252,19 @@ public:
 
 private:
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/diffusive_operator.h
@@ -252,19 +252,20 @@ public:
 
 private:
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/grid/mapping_deformation_structure.h
+++ b/include/exadg/grid/mapping_deformation_structure.h
@@ -139,7 +139,7 @@ public:
       // calculate right-hand side vector
       VectorType rhs;
       pde_operator->initialize_dof_vector(rhs);
-      pde_operator->compute_rhs_linear(rhs, time);
+      pde_operator->rhs(rhs, time);
 
       auto const iter = pde_operator->solve_linear(
         displacement, rhs, 0.0 /* no mass term */, time, false /* do not update preconditioner */);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -358,8 +358,8 @@ ConvectiveOperator<dim, Number>::do_boundary_integral_nonlinear_operator(
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                        unsigned int const cell) const
+ConvectiveOperator<dim, Number>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                     unsigned int const cell) const
 {
   (void)integrator;
 
@@ -368,9 +368,9 @@ ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integ
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                        IntegratorFace &   integrator_p,
-                                                        unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                     IntegratorFace &   integrator_p,
+                                                     unsigned int const face) const
 {
   (void)integrator_m;
   (void)integrator_p;
@@ -380,8 +380,8 @@ ConvectiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integ
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                                                 unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_boundary_face_derived(IntegratorFace &   integrator_m,
+                                                              unsigned int const face) const
 {
   (void)integrator_m;
 
@@ -390,7 +390,7 @@ ConvectiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace 
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_cell_based_additional(
+ConvectiveOperator<dim, Number>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -368,35 +368,37 @@ ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integ
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
-                                             IntegratorFace &   integrator_p,
-                                             unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                        IntegratorFace &   integrator_p,
+                                                        unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
+  (void)integrator_m;
+  (void)integrator_p;
 
   kernel->reinit_face(face);
 }
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                      unsigned int const face) const
+ConvectiveOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                                                 unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
+  (void)integrator_m;
 
   kernel->reinit_boundary_face(face);
 }
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_face_cell_based(
+ConvectiveOperator<dim, Number>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
+  (void)integrator_m;
+  (void)integrator_p;
 
   kernel->reinit_face_cell_based(cell, face, boundary_id);
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -358,10 +358,10 @@ ConvectiveOperator<dim, Number>::do_boundary_integral_nonlinear_operator(
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::reinit_cell(IntegratorCell &   integrator,
-                                             unsigned int const cell) const
+ConvectiveOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                        unsigned int const cell) const
 {
-  Base::reinit_cell(integrator, cell);
+  (void)integrator;
 
   kernel->reinit_cell(cell);
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -961,21 +961,22 @@ private:
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   // linearized operator
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -957,7 +957,7 @@ private:
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_cell(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   // Note: this function can only be used for the linearized operator.
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -957,26 +957,25 @@ private:
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const final;
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   // Note: this function can only be used for the linearized operator.
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   // linearized operator
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -213,8 +213,8 @@ MomentumOperator<dim, Number>::evaluate_add(VectorType & dst, VectorType const &
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                      unsigned int const cell) const
+MomentumOperator<dim, Number>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                   unsigned int const cell) const
 {
   (void)integrator;
 
@@ -224,9 +224,9 @@ MomentumOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integra
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                      IntegratorFace &   integrator_p,
-                                                      unsigned int const face) const
+MomentumOperator<dim, Number>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                   IntegratorFace &   integrator_p,
+                                                   unsigned int const face) const
 {
   if(operator_data.convective_problem)
     convective_kernel->reinit_face(face);
@@ -237,8 +237,8 @@ MomentumOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integra
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                                               unsigned int const face) const
+MomentumOperator<dim, Number>::reinit_boundary_face_derived(IntegratorFace &   integrator_m,
+                                                            unsigned int const face) const
 {
   if(operator_data.convective_problem)
     convective_kernel->reinit_boundary_face(face);
@@ -249,7 +249,7 @@ MomentumOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace & 
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_face_cell_based_additional(
+MomentumOperator<dim, Number>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -224,12 +224,10 @@ MomentumOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integra
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
-                                           IntegratorFace &   integrator_p,
-                                           unsigned int const face) const
+MomentumOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                      IntegratorFace &   integrator_p,
+                                                      unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
-
   if(operator_data.convective_problem)
     convective_kernel->reinit_face(face);
 
@@ -239,11 +237,9 @@ MomentumOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                    unsigned int const face) const
+MomentumOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                                               unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
-
   if(operator_data.convective_problem)
     convective_kernel->reinit_boundary_face(face);
 
@@ -253,15 +249,13 @@ MomentumOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrato
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_face_cell_based(
+MomentumOperator<dim, Number>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
-
   if(operator_data.convective_problem)
     convective_kernel->reinit_face_cell_based(cell, face, boundary_id);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -213,10 +213,10 @@ MomentumOperator<dim, Number>::evaluate_add(VectorType & dst, VectorType const &
 
 template<int dim, typename Number>
 void
-MomentumOperator<dim, Number>::reinit_cell(IntegratorCell &   integrator,
-                                           unsigned int const cell) const
+MomentumOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                      unsigned int const cell) const
 {
-  Base::reinit_cell(integrator, cell);
+  (void)integrator;
 
   if(operator_data.convective_problem)
     convective_kernel->reinit_cell(cell);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
@@ -120,23 +120,22 @@ public:
 
 private:
   void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   // linearized operator
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
@@ -123,19 +123,20 @@ private:
   reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   // linearized operator
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
@@ -120,7 +120,7 @@ public:
 
 private:
   void
-  reinit_cell(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
   reinit_face(IntegratorFace &   integrator_m,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
@@ -145,10 +145,10 @@ ProjectionOperator<dim, Number>::update(VectorType const & velocity, double cons
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_cell(IntegratorCell &   integrator,
-                                             unsigned int const cell) const
+ProjectionOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                        unsigned int const cell) const
 {
-  Base::reinit_cell(integrator, cell);
+  (void)cell;
 
   if(operator_data.use_divergence_penalty)
     div_kernel->reinit_cell(integrator);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
@@ -145,8 +145,8 @@ ProjectionOperator<dim, Number>::update(VectorType const & velocity, double cons
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                        unsigned int const cell) const
+ProjectionOperator<dim, Number>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                     unsigned int const cell) const
 {
   (void)cell;
 
@@ -156,9 +156,9 @@ ProjectionOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integ
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                        IntegratorFace &   integrator_p,
-                                                        unsigned int const face) const
+ProjectionOperator<dim, Number>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                     IntegratorFace &   integrator_p,
+                                                     unsigned int const face) const
 {
   (void)face;
 
@@ -168,8 +168,8 @@ ProjectionOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integ
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                                                 unsigned int const face) const
+ProjectionOperator<dim, Number>::reinit_boundary_face_derived(IntegratorFace &   integrator_m,
+                                                              unsigned int const face) const
 {
   (void)face;
 
@@ -178,7 +178,7 @@ ProjectionOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace 
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_face_cell_based_additional(
+ProjectionOperator<dim, Number>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
@@ -156,11 +156,11 @@ ProjectionOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integ
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
-                                             IntegratorFace &   integrator_p,
-                                             unsigned int const face) const
+ProjectionOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                        IntegratorFace &   integrator_p,
+                                                        unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
+  (void)face;
 
   if(operator_data.use_continuity_penalty)
     conti_kernel->reinit_face(integrator_m, integrator_p);
@@ -168,24 +168,25 @@ ProjectionOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                      unsigned int const face) const
+ProjectionOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                                                 unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
+  (void)face;
 
   conti_kernel->reinit_boundary_face(integrator_m);
 }
 
 template<int dim, typename Number>
 void
-ProjectionOperator<dim, Number>::reinit_face_cell_based(
+ProjectionOperator<dim, Number>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
+  (void)cell;
+  (void)face;
 
   if(operator_data.use_continuity_penalty)
     conti_kernel->reinit_face_cell_based(boundary_id, integrator_m, integrator_p);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
@@ -115,7 +115,7 @@ public:
 
 private:
   void
-  reinit_cell(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
   reinit_face(IntegratorFace &   integrator_m,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
@@ -118,19 +118,20 @@ private:
   reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.h
@@ -115,23 +115,22 @@ public:
 
 private:
   void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const final;
 
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
@@ -38,35 +38,36 @@ ViscousOperator<dim, Number>::update()
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
-                                          IntegratorFace &   integrator_p,
-                                          unsigned int const face) const
+ViscousOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                     IntegratorFace &   integrator_p,
+                                                     unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
+  (void)face;
 
   kernel->reinit_face(integrator_m, integrator_p, operator_data.dof_index);
 }
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                   unsigned int const face) const
+ViscousOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                                              unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
+  (void)face;
 
   kernel->reinit_boundary_face(integrator_m, operator_data.dof_index);
 }
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::reinit_face_cell_based(
+ViscousOperator<dim, Number>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
+  (void)cell;
+  (void)face;
 
   kernel->reinit_face_cell_based(boundary_id, integrator_m, integrator_p, operator_data.dof_index);
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
@@ -38,9 +38,9 @@ ViscousOperator<dim, Number>::update()
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                     IntegratorFace &   integrator_p,
-                                                     unsigned int const face) const
+ViscousOperator<dim, Number>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                  IntegratorFace &   integrator_p,
+                                                  unsigned int const face) const
 {
   (void)face;
 
@@ -49,8 +49,8 @@ ViscousOperator<dim, Number>::reinit_face_additional(IntegratorFace &   integrat
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                                              unsigned int const face) const
+ViscousOperator<dim, Number>::reinit_boundary_face_derived(IntegratorFace &   integrator_m,
+                                                           unsigned int const face) const
 {
   (void)face;
 
@@ -59,7 +59,7 @@ ViscousOperator<dim, Number>::reinit_boundary_face_additional(IntegratorFace &  
 
 template<int dim, typename Number>
 void
-ViscousOperator<dim, Number>::reinit_face_cell_based_additional(
+ViscousOperator<dim, Number>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -571,20 +571,19 @@ public:
 
 private:
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -571,19 +571,20 @@ public:
 
 private:
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/operators/constraints.h
+++ b/include/exadg/operators/constraints.h
@@ -1,0 +1,67 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_OPERATORS_CONSTRAINTS_H_
+#define INCLUDE_EXADG_OPERATORS_CONSTRAINTS_H_
+
+// deal.II
+#include <deal.II/dofs/dof_tools.h>
+
+// ExaDG
+#include <exadg/grid/grid_utilities.h>
+
+namespace ExaDG
+{
+/**
+ * This function adds hanging-node and periodicity constraints. This function combines these two
+ * types of constraints since deal.II requires to add these constraints in a certain order.
+ */
+template<int dim, typename Number>
+void
+add_hanging_node_and_periodicity_constraints(dealii::AffineConstraints<Number> & affine_constraints,
+                                             Grid<dim> const &                   grid,
+                                             dealii::DoFHandler<dim> const &     dof_handler)
+{
+  dealii::IndexSet locally_relevant_dofs;
+  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  affine_constraints.reinit(locally_relevant_dofs);
+
+  // hanging nodes (needs to be done before imposing periodicity constraints
+  if(grid.triangulation->has_hanging_nodes())
+  {
+    dealii::DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints);
+  }
+
+  // constraints from periodic boundary conditions
+  if(not(grid.periodic_face_pairs.empty()))
+  {
+    auto periodic_faces_dof =
+      GridUtilities::transform_periodic_face_pairs_to_dof_cell_iterator(grid.periodic_face_pairs,
+                                                                        dof_handler);
+
+    dealii::DoFTools::make_periodicity_constraints<dim, dim, Number>(periodic_faces_dof,
+                                                                     affine_constraints);
+  }
+}
+
+} // namespace ExaDG
+
+#endif /* INCLUDE_EXADG_OPERATORS_CONSTRAINTS_H_ */

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -889,6 +889,19 @@ OperatorBase<dim, Number, n_components>::reinit_face(IntegratorFace &   integrat
 {
   integrator_m.reinit(face);
   integrator_p.reinit(face);
+
+  reinit_face_additional(integrator_m, integrator_p, face);
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                                IntegratorFace &   integrator_p,
+                                                                unsigned int const face) const
+{
+  (void)integrator_m;
+  (void)integrator_p;
+  (void)face;
 }
 
 template<int dim, typename Number, int n_components>
@@ -897,6 +910,18 @@ OperatorBase<dim, Number, n_components>::reinit_boundary_face(IntegratorFace &  
                                                               unsigned int const face) const
 {
   integrator_m.reinit(face);
+
+  reinit_boundary_face_additional(integrator_m, face);
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::reinit_boundary_face_additional(
+  IntegratorFace &   integrator_m,
+  unsigned int const face) const
+{
+  (void)integrator_m;
+  (void)face;
 }
 
 template<int dim, typename Number, int n_components>
@@ -1003,6 +1028,24 @@ OperatorBase<dim, Number, n_components>::reinit_face_cell_based(
   {
     integrator_p.reinit(cell, face);
   }
+
+  reinit_face_cell_based_additional(integrator_m, integrator_p, cell, face, boundary_id);
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::reinit_face_cell_based_additional(
+  IntegratorFace &                 integrator_m,
+  IntegratorFace &                 integrator_p,
+  unsigned int const               cell,
+  unsigned int const               face,
+  dealii::types::boundary_id const boundary_id) const
+{
+  (void)integrator_m;
+  (void)integrator_p;
+  (void)cell;
+  (void)face;
+  (void)boundary_id;
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -331,11 +331,11 @@ OperatorBase<dim, Number, n_components>::rhs_add(VectorType & rhs) const
 
   if(not is_dg)
   {
-    // Set constrained degrees of freedom according to Dirichlet boundary conditions. The rest of
-    // the vector contains zeros.
+    // Set constrained degrees of freedom according to inhomogeneous Dirichlet boundary conditions.
+    //  The rest of the vector contains zeros.
     VectorType temp1;
     matrix_free->initialize_dof_vector(temp1, data.dof_index);
-    set_constrained_values(temp1, time);
+    set_inhomogeneous_boundary_values(temp1, time);
 
     // Perform matrix-vector product using read_dof_values_plain() with temp1 as src-vector to
     // obtain the inhomogeneous action of the operator. Subsequently, we shift the resulting vector
@@ -923,15 +923,16 @@ OperatorBase<dim, Number, n_components>::do_boundary_integral_continuous(
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::set_constrained_values(VectorType & solution,
-                                                                double const time) const
+OperatorBase<dim, Number, n_components>::set_inhomogeneous_boundary_values(VectorType & solution,
+                                                                           double const time) const
 {
   (void)solution;
   (void)time;
 
-  AssertThrow(false,
-              dealii::ExcMessage(
-                "OperatorBase::set_constrained_values() has to be overwritten by derived class!"));
+  AssertThrow(
+    false,
+    dealii::ExcMessage(
+      "OperatorBase::set_inhomogeneous_boundary_values() has to be overwritten by derived class!"));
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -453,7 +453,7 @@ OperatorBase<dim, Number, n_components>::add_diagonal(VectorType & diagonal) con
         [&](auto & integrator) -> void {
           // TODO: this is currently done for every column, but would only be necessary
           // once per cell
-          this->reinit_cell_additional(integrator, integrator.get_current_cell_index());
+          this->reinit_cell_derived(integrator, integrator.get_current_cell_index());
 
           integrator.evaluate(integrator_flags.cell_evaluate);
 
@@ -867,13 +867,13 @@ OperatorBase<dim, Number, n_components>::reinit_cell(IntegratorCell &   integrat
 {
   integrator.reinit(cell);
 
-  reinit_cell_additional(integrator, cell);
+  reinit_cell_derived(integrator, cell);
 }
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                                unsigned int const cell) const
+OperatorBase<dim, Number, n_components>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                             unsigned int const cell) const
 {
   (void)integrator;
   (void)cell;
@@ -890,14 +890,14 @@ OperatorBase<dim, Number, n_components>::reinit_face(IntegratorFace &   integrat
   integrator_m.reinit(face);
   integrator_p.reinit(face);
 
-  reinit_face_additional(integrator_m, integrator_p, face);
+  reinit_face_derived(integrator_m, integrator_p, face);
 }
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                                IntegratorFace &   integrator_p,
-                                                                unsigned int const face) const
+OperatorBase<dim, Number, n_components>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                             IntegratorFace &   integrator_p,
+                                                             unsigned int const face) const
 {
   (void)integrator_m;
   (void)integrator_p;
@@ -911,14 +911,13 @@ OperatorBase<dim, Number, n_components>::reinit_boundary_face(IntegratorFace &  
 {
   integrator_m.reinit(face);
 
-  reinit_boundary_face_additional(integrator_m, face);
+  reinit_boundary_face_derived(integrator_m, face);
 }
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::reinit_boundary_face_additional(
-  IntegratorFace &   integrator_m,
-  unsigned int const face) const
+OperatorBase<dim, Number, n_components>::reinit_boundary_face_derived(IntegratorFace & integrator_m,
+                                                                      unsigned int const face) const
 {
   (void)integrator_m;
   (void)face;
@@ -1029,12 +1028,12 @@ OperatorBase<dim, Number, n_components>::reinit_face_cell_based(
     integrator_p.reinit(cell, face);
   }
 
-  reinit_face_cell_based_additional(integrator_m, integrator_p, cell, face, boundary_id);
+  reinit_face_cell_based_derived(integrator_m, integrator_p, cell, face, boundary_id);
 }
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::reinit_face_cell_based_additional(
+OperatorBase<dim, Number, n_components>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -1070,8 +1070,6 @@ OperatorBase<dim, Number, n_components>::cell_loop_full_operator(
 
     this->do_cell_integral(integrator);
 
-    // TODO: will this now write into "Dirichlet" degrees of freedom, which are not part of the
-    // constraints with dof_index_inhomogeneous anymore?
     integrator.integrate_scatter(integrator_flags.cell_integrate, dst);
   }
 }
@@ -2084,11 +2082,11 @@ OperatorBase<dim, Number, n_components>::boundary_face_loop_calculate_system_mat
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::set_constraint_diagonal(VectorType & diagonal) const
+OperatorBase<dim, Number, n_components>::set_constrained_dofs_to_one(VectorType & vector) const
 {
   // set (diagonal) entries to 1.0 for constrained dofs
   for(auto i : matrix_free->get_constrained_dofs(this->data.dof_index))
-    diagonal.local_element(i) = 1.0;
+    vector.local_element(i) = 1.0;
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -229,8 +229,10 @@ OperatorBase<dim, Number, n_components>::calculate_inverse_diagonal(VectorType &
   this->calculate_diagonal(diagonal);
 
   if(false)
+  {
     verify_calculation_of_diagonal(
       *this, diagonal, matrix_free->get_dof_handler(this->data.dof_index).get_communicator());
+  }
 
   invert_diagonal(diagonal);
 }
@@ -260,7 +262,7 @@ OperatorBase<dim, Number, n_components>::apply(VectorType & dst, VectorType cons
   {
     // Compute matrix-vector product. Constrained degrees of freedom in the src-vector will not be
     // used. The function read_dof_values() (or gather_evaluate()) uses the homogeneous boundary
-    // data passed to MatrixFree via AffineConstraints.
+    // data passed to MatrixFree via AffineConstraints with the standard "dof_index".
     matrix_free->cell_loop(&This::cell_loop, this, dst, src, true);
 
     // Constrained degree of freedom are not removed from the system of equations.
@@ -269,7 +271,9 @@ OperatorBase<dim, Number, n_components>::apply(VectorType & dst, VectorType cons
     // dst vector.
     for(unsigned int const constrained_index :
         matrix_free->get_constrained_dofs(this->data.dof_index))
+    {
       dst.local_element(constrained_index) = src.local_element(constrained_index);
+    }
   }
 }
 

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -451,9 +451,9 @@ OperatorBase<dim, Number, n_components>::add_diagonal(VectorType & diagonal) con
         *matrix_free,
         diagonal,
         [&](auto & integrator) -> void {
-          // TODO this line is currently needed as bugfix, but should be
-          // removed because reinit is now done twice
-          // this->reinit_cell(integrator, integrator.get_current_cell_index());
+          // TODO: this is currently done for every column, but would only be necessary
+          // once per cell
+          this->reinit_cell_additional(integrator, integrator.get_current_cell_index());
 
           integrator.evaluate(integrator_flags.cell_evaluate);
 
@@ -866,6 +866,19 @@ OperatorBase<dim, Number, n_components>::reinit_cell(IntegratorCell &   integrat
                                                      unsigned int const cell) const
 {
   integrator.reinit(cell);
+
+  reinit_cell_additional(integrator, cell);
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                                unsigned int const cell) const
+{
+  (void)integrator;
+  (void)cell;
+
+  // overwrite this function in derived classes if additional initialization is necessary
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -388,28 +388,21 @@ OperatorBase<dim, Number, n_components>::evaluate_add(VectorType &       dst,
     AssertThrow(data.dof_index_inhomogeneous != dealii::numbers::invalid_unsigned_int,
                 dealii::ExcMessage("dof_index_inhomogeneous is uninitialized."));
 
-    // Start with a zero destination vector.
-    VectorType tmp;
-    tmp.reinit(dst, false);
-
-    // Perform matrix-vector product using src_inhom (which contains inhomogeneous Dirichlet values)
-    // as src-vector to obtain the hom+inhom action of the operator.
+    // Perform matrix-vector product using a src-vector which contains inhomogeneous Dirichlet
+    // values to obtain the hom+inhom action of the operator.
     if(evaluate_face_integrals())
     {
       matrix_free->loop(&This::cell_loop_full_operator,
                         &This::face_loop_empty,
                         &This::boundary_face_loop_inhom_operator,
                         this,
-                        tmp,
+                        dst,
                         src);
     }
     else
     {
-      matrix_free->cell_loop(&This::cell_loop_full_operator, this, tmp, src);
+      matrix_free->cell_loop(&This::cell_loop_full_operator, this, dst, src);
     }
-
-    // This is the function of type evaluate_add().
-    dst += tmp;
   }
 }
 

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -878,7 +878,7 @@ OperatorBase<dim, Number, n_components>::reinit_cell_additional(IntegratorCell &
   (void)integrator;
   (void)cell;
 
-  // overwrite this function in derived classes if additional initialization is necessary
+  // override this function in derived classes if additional initialization is necessary
 }
 
 template<int dim, typename Number, int n_components>
@@ -973,7 +973,7 @@ OperatorBase<dim, Number, n_components>::do_boundary_integral_continuous(
   AssertThrow(
     false,
     dealii::ExcMessage(
-      "OperatorBase::do_boundary_integral_continuous() has to be overwritten by derived class!"));
+      "OperatorBase::do_boundary_integral_continuous() has to be overridden by derived class!"));
 }
 
 template<int dim, typename Number, int n_components>
@@ -986,7 +986,7 @@ OperatorBase<dim, Number, n_components>::set_inhomogeneous_boundary_values(
   AssertThrow(
     false,
     dealii::ExcMessage(
-      "OperatorBase::set_inhomogeneous_boundary_values() has to be overwritten by derived class!"));
+      "OperatorBase::set_inhomogeneous_boundary_values() has to be overridden by derived class!"));
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -206,9 +206,7 @@ template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::initialize_dof_vector(VectorType & vector) const
 {
-  unsigned int dof_index = get_dof_index();
-
-  this->matrix_free->initialize_dof_vector(vector, dof_index);
+  this->matrix_free->initialize_dof_vector(vector, this->data.dof_index);
 }
 
 template<int dim, typename Number, int n_components>
@@ -420,7 +418,7 @@ void
 OperatorBase<dim, Number, n_components>::calculate_diagonal(VectorType & diagonal) const
 {
   if(diagonal.size() == 0)
-    matrix_free->initialize_dof_vector(diagonal);
+    this->initialize_dof_vector(diagonal);
   diagonal = 0;
   add_diagonal(diagonal);
 }
@@ -455,7 +453,7 @@ OperatorBase<dim, Number, n_components>::add_diagonal(VectorType & diagonal) con
         [&](auto & integrator) -> void {
           // TODO this line is currently needed as bugfix, but should be
           // removed because reinit is now done twice
-          this->reinit_cell(integrator, integrator.get_current_cell_index());
+          // this->reinit_cell(integrator, integrator.get_current_cell_index());
 
           integrator.evaluate(integrator_flags.cell_evaluate);
 

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -383,6 +383,9 @@ OperatorBase<dim, Number, n_components>::evaluate_add(VectorType &       dst,
   }
   else
   {
+    AssertThrow(data.dof_index_inhomogeneous != dealii::numbers::invalid_unsigned_int,
+                dealii::ExcMessage("dof_index_inhomogeneous is uninitialized."));
+
     // Set constrained degrees of freedom according to inhomogeneous Dirichlet boundary conditions.
     //  The rest of the vector remains unchanged.
     // TODO: do this outside OperatorBase::evaluate_add()/rhs_add()

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -427,14 +427,19 @@ private:
                         IntegratorFace & integrator_2) const;
 
   /*
-   * This function calculates the inhomogeneous part of Dirichlet BCs for continuous Galerkin
-   * discretizations.
+   * This function calculates cell integrals for the full (= homogeneous + inhomogeneous) part,
+   * where inhomogeneous part may occur for continuous Galerkin discretizations due to inhomogeneous
+   * Dirichlet BCs. A prerequisite to call this function is to set inhomogeneous Dirichlet degrees
+   * of freedom appropriate in the DoF-vector src. In case the DoF-vector src is zero apart from the
+   * inhomogeneous Dirichlet degrees of freedom, this function calculates only the inhomogeneous
+   * part of the operator, because the homogeneous operator is zero in this case. For DG
+   * discretizations, this function is equivalent to cell_loop().
    */
   void
-  cell_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
-                           VectorType &                            dst,
-                           VectorType const &                      src,
-                           Range const &                           range) const;
+  cell_loop_full_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                          VectorType &                            dst,
+                          VectorType const &                      src,
+                          Range const &                           range) const;
 
   /*
    * This function loops over all cells and calculates cell integrals.

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -267,7 +267,7 @@ public:
    * reason, these functions are currently defined 'virtual' to provide the opportunity to override
    * and assert these functions in derived classes.
    *
-   * Unlike the function rhs(), this function does internally not call the function
+   * Unlike the function rhs(), this function does not internally call the function
    * set_inhomogeneous_boundary_values() prior to evaluation. Hence, one needs to explicitly call
    * the function set_inhomogeneous_boundary_values() in case of continuous Galerkin discretizations
    * with inhomogeneous Dirichlet boundary conditions before calling the present function.
@@ -472,8 +472,8 @@ private:
    * This function calculates cell integrals for the full (= homogeneous + inhomogeneous) part,
    * where inhomogeneous part may occur for continuous Galerkin discretizations due to inhomogeneous
    * Dirichlet BCs. A prerequisite to call this function is to set inhomogeneous Dirichlet degrees
-   * of freedom appropriate in the DoF-vector src. In case the DoF-vector src is zero apart from the
-   * inhomogeneous Dirichlet degrees of freedom, this function calculates only the inhomogeneous
+   * of freedom appropriately in the DoF-vector src. In case the DoF-vector src is zero apart from
+   * the inhomogeneous Dirichlet degrees of freedom, this function calculates only the inhomogeneous
    * part of the operator, because the homogeneous operator is zero in this case. For DG
    * discretizations, this function is equivalent to cell_loop().
    */

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -177,7 +177,7 @@ public:
   set_inhomogeneous_boundary_values(VectorType & solution, double const time) const;
 
   void
-  set_constrained_values_to_zero(VectorType & vector) const;
+  set_constrained_dofs_to_zero(VectorType & vector) const;
 
   void
   calculate_inverse_diagonal(VectorType & diagonal) const;

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -58,7 +58,7 @@ struct OperatorBaseData
 {
   OperatorBaseData()
     : dof_index(0),
-      dof_index_inhomogeneous(1),
+      dof_index_inhomogeneous(dealii::numbers::invalid_unsigned_int),
       quad_index(0),
       operator_is_singular(false),
       use_cell_based_loops(false),

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -617,10 +617,10 @@ private:
                                              Range const &                           range) const;
 
   /*
-   * This function sets entries in the diagonal corresponding to constraint DoFs to one.
+   * This function sets entries of the DoF-vector corresponding to constraint DoFs to one.
    */
   void
-  set_constraint_diagonal(VectorType & diagonal) const;
+  set_constrained_dofs_to_one(VectorType & vector) const;
 
   /*
    * Do we have to evaluate (boundary) face integrals for this operator? For example, operators

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -420,13 +420,14 @@ private:
                         IntegratorFace & integrator_2) const;
 
   /*
-   * This function applies Dirichlet BCs for continuous Galerkin discretizations.
+   * This function calculates the inhomogeneous part of Dirichlet BCs for continuous Galerkin
+   * discretizations.
    */
   void
-  cell_loop_dbc(dealii::MatrixFree<dim, Number> const & matrix_free,
-                VectorType &                            dst,
-                VectorType const &                      src,
-                Range const &                           range) const;
+  cell_loop_inhom_operator(dealii::MatrixFree<dim, Number> const & matrix_free,
+                           VectorType &                            dst,
+                           VectorType const &                      src,
+                           Range const &                           range) const;
 
   /*
    * This function loops over all cells and calculates cell integrals.

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -58,6 +58,7 @@ struct OperatorBaseData
 {
   OperatorBaseData()
     : dof_index(0),
+      dof_index_inhomogeneous(1),
       quad_index(0),
       operator_is_singular(false),
       use_cell_based_loops(false),
@@ -69,6 +70,12 @@ struct OperatorBaseData
   }
 
   unsigned int dof_index;
+
+  // In addition to the dof_index in OperatorBaseData, we need a separate dof index to evaluate
+  // inhomogeneous boundary data correctly. This dof index corresponds to an AffineConstraints
+  // object that only applies periodicity and hanging node constraints.
+  unsigned int dof_index_inhomogeneous;
+
   unsigned int quad_index;
 
   // Solution of linear systems of equations and preconditioning

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -167,7 +167,7 @@ public:
   initialize_dof_vector(VectorType & vector) const;
 
   virtual void
-  set_constrained_values(VectorType & solution, double const time) const;
+  set_inhomogeneous_boundary_values(VectorType & solution, double const time) const;
 
   void
   set_constrained_values_to_zero(VectorType & vector) const;

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -327,25 +327,28 @@ protected:
          dealii::AffineConstraints<Number> const & constraints,
          OperatorBaseData const &                  data);
 
-  /*
-   * These methods have to be overwritten by derived classes because these functions are
-   * operator-specific and define how the operator looks like.
-   */
-private:
   void
   reinit_cell(IntegratorCell & integrator, unsigned int const cell) const;
 
-  virtual void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const;
-
-protected:
-  virtual void
+  void
   reinit_face(IntegratorFace &   integrator_m,
               IntegratorFace &   integrator_p,
               unsigned int const face) const;
 
-  virtual void
+  void
   reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const;
+
+  void
+  reinit_face_cell_based(IntegratorFace &                 integrator_m,
+                         IntegratorFace &                 integrator_p,
+                         unsigned int const               cell,
+                         unsigned int const               face,
+                         dealii::types::boundary_id const boundary_id) const;
+
+  /*
+   * These methods have to be overwritten by derived classes because these functions are
+   * operator-specific and define how the operator looks like.
+   */
 
   // standard integration procedure with separate loops for cell and face integrals
   virtual void
@@ -370,14 +373,6 @@ protected:
 
   virtual void
   do_face_ext_integral(IntegratorFace & integrator_m, IntegratorFace & integrator_p) const;
-
-  // cell-based computation of both cell and face integrals
-  virtual void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const;
 
   // This function is currently only needed due to limitations of deal.II which do
   // currently not allow to access neighboring data in case of cell-based face loops.
@@ -437,6 +432,24 @@ protected:
   mutable std::shared_ptr<ELEMENTWISE_SOLVER>         elementwise_solver;
 
 private:
+  virtual void
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const;
+
+  virtual void
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const;
+
+  virtual void
+  reinit_boundary_face_additional(IntegratorFace & integrator_m, unsigned int const face) const;
+
+  virtual void
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const;
+
   /*
    * Helper functions:
    *

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -433,22 +433,22 @@ protected:
 
 private:
   virtual void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const;
 
   virtual void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const;
 
   virtual void
-  reinit_boundary_face_additional(IntegratorFace & integrator_m, unsigned int const face) const;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const;
 
   virtual void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const;
 
   /*
    * Helper functions:

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -173,8 +173,12 @@ public:
   void
   initialize_dof_vector(VectorType & vector) const;
 
+  /*
+   * For time-dependent problems, the function set_time() needs to be called prior to the present
+   * function.
+   */
   virtual void
-  set_inhomogeneous_boundary_values(VectorType & solution, double const time) const;
+  set_inhomogeneous_boundary_values(VectorType & solution) const;
 
   void
   set_constrained_dofs_to_zero(VectorType & vector) const;
@@ -226,6 +230,9 @@ public:
   void
   apply(VectorType & dst, VectorType const & src) const;
 
+  /*
+   * See function apply() for a description.
+   */
   void
   apply_add(VectorType & dst, VectorType const & src) const;
 
@@ -236,10 +243,19 @@ public:
    * rhs only make sense for linear operators (but they have e.g. no meaning for linearized
    * operators of nonlinear problems). For this reason, these functions are currently defined
    * 'virtual' to provide the opportunity to override and assert these functions in derived classes.
+   *
+   * For continuous Galerkin discretizations, this function calls internally the member function
+   * set_inhomogeneous_boundary_values(). Hence, prior to calling this function, one needs to call
+   * set_time() for a correct evaluation in case of time-dependent problems.
+   *
+   * This function sets the dst vector to zero, and afterwards calls rhs_add().
    */
   virtual void
   rhs(VectorType & dst) const;
 
+  /*
+   * See function rhs() for a description.
+   */
   virtual void
   rhs_add(VectorType & dst) const;
 
@@ -250,10 +266,18 @@ public:
    * (but they have e.g. no meaning for linearized operators of nonlinear problems). For this
    * reason, these functions are currently defined 'virtual' to provide the opportunity to override
    * and assert these functions in derived classes.
+   *
+   * Unlike the function rhs(), this function does internally not call the function
+   * set_inhomogeneous_boundary_values() prior to evaluation. Hence, one needs to explicitly call
+   * the function set_inhomogeneous_boundary_values() in case of continuous Galerkin discretizations
+   * with inhomogeneous Dirichlet boundary conditions before calling the present function.
    */
   virtual void
   evaluate(VectorType & dst, VectorType const & src) const;
 
+  /*
+   * See function evaluate() for a description.
+   */
   virtual void
   evaluate_add(VectorType & dst, VectorType const & src) const;
 

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -331,9 +331,14 @@ protected:
    * These methods have to be overwritten by derived classes because these functions are
    * operator-specific and define how the operator looks like.
    */
-  virtual void
+private:
+  void
   reinit_cell(IntegratorCell & integrator, unsigned int const cell) const;
 
+  virtual void
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const;
+
+protected:
   virtual void
   reinit_face(IntegratorFace &   integrator_m,
               IntegratorFace &   integrator_p,

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -68,6 +68,8 @@ LaplaceOperator<dim, Number, n_components>::rhs_add_dirichlet_bc_from_dof_vector
   VectorType &       dst,
   VectorType const & src) const
 {
+  AssertThrow(this->is_dg, dealii::ExcMessage("This function is only implemented for DG."));
+
   VectorType tmp;
   tmp.reinit(dst, false /* init with 0 */);
 
@@ -339,6 +341,7 @@ LaplaceOperator<dim, Number, n_components>::do_boundary_integral_dirichlet_bc_fr
     value value_p = value();
     if(boundary_type == BoundaryType::Dirichlet)
     {
+      // The desired boundary value g is obtained as integrator_m.get_value(q).
       value_p = 2.0 * integrator_m.get_value(q);
     }
     else if(boundary_type == BoundaryType::Neumann)
@@ -395,14 +398,13 @@ LaplaceOperator<dim, Number, n_components>::do_boundary_integral_continuous(
 template<int dim, typename Number, int n_components>
 void
 LaplaceOperator<dim, Number, n_components>::set_inhomogeneous_boundary_values(
-  VectorType & dst,
-  double const time) const
+  VectorType & dst) const
 {
   // standard Dirichlet boundary conditions
   std::map<dealii::types::global_dof_index, double> boundary_values;
   for(auto dbc : operator_data.bc->dirichlet_bc)
   {
-    dbc.second->set_time(time);
+    dbc.second->set_time(this->get_time());
 
     dealii::ComponentMask mask     = dealii::ComponentMask();
     auto                  dbc_mask = operator_data.bc->dirichlet_bc_component_mask.find(dbc.first);

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -87,9 +87,9 @@ LaplaceOperator<dim, Number, n_components>::rhs_add_dirichlet_bc_from_dof_vector
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::reinit_face_additional(IntegratorFace &   integrator_m,
-                                                                   IntegratorFace &   integrator_p,
-                                                                   unsigned int const face) const
+LaplaceOperator<dim, Number, n_components>::reinit_face_derived(IntegratorFace &   integrator_m,
+                                                                IntegratorFace &   integrator_p,
+                                                                unsigned int const face) const
 {
   (void)face;
 
@@ -98,7 +98,7 @@ LaplaceOperator<dim, Number, n_components>::reinit_face_additional(IntegratorFac
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::reinit_boundary_face_additional(
+LaplaceOperator<dim, Number, n_components>::reinit_boundary_face_derived(
   IntegratorFace &   integrator_m,
   unsigned int const face) const
 {
@@ -109,7 +109,7 @@ LaplaceOperator<dim, Number, n_components>::reinit_boundary_face_additional(
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::reinit_face_cell_based_additional(
+LaplaceOperator<dim, Number, n_components>::reinit_face_cell_based_derived(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -394,8 +394,9 @@ LaplaceOperator<dim, Number, n_components>::do_boundary_integral_continuous(
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::set_constrained_values(VectorType & dst,
-                                                                   double const time) const
+LaplaceOperator<dim, Number, n_components>::set_inhomogeneous_boundary_values(
+  VectorType & dst,
+  double const time) const
 {
   // standard Dirichlet boundary conditions
   std::map<dealii::types::global_dof_index, double> boundary_values;

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -87,35 +87,37 @@ LaplaceOperator<dim, Number, n_components>::rhs_add_dirichlet_bc_from_dof_vector
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::reinit_face(IntegratorFace &   integrator_m,
-                                                        IntegratorFace &   integrator_p,
-                                                        unsigned int const face) const
+LaplaceOperator<dim, Number, n_components>::reinit_face_additional(IntegratorFace &   integrator_m,
+                                                                   IntegratorFace &   integrator_p,
+                                                                   unsigned int const face) const
 {
-  Base::reinit_face(integrator_m, integrator_p, face);
+  (void)face;
 
   kernel.reinit_face(integrator_m, integrator_p, operator_data.dof_index);
 }
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::reinit_boundary_face(IntegratorFace &   integrator_m,
-                                                                 unsigned int const face) const
+LaplaceOperator<dim, Number, n_components>::reinit_boundary_face_additional(
+  IntegratorFace &   integrator_m,
+  unsigned int const face) const
 {
-  Base::reinit_boundary_face(integrator_m, face);
+  (void)face;
 
   kernel.reinit_boundary_face(integrator_m, operator_data.dof_index);
 }
 
 template<int dim, typename Number, int n_components>
 void
-LaplaceOperator<dim, Number, n_components>::reinit_face_cell_based(
+LaplaceOperator<dim, Number, n_components>::reinit_face_cell_based_additional(
   IntegratorFace &                 integrator_m,
   IntegratorFace &                 integrator_p,
   unsigned int const               cell,
   unsigned int const               face,
   dealii::types::boundary_id const boundary_id) const
 {
-  Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
+  (void)cell;
+  (void)face;
 
   kernel.reinit_face_cell_based(boundary_id, integrator_m, integrator_p, operator_data.dof_index);
 }

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -278,20 +278,19 @@ public:
 
 private:
   void
-  reinit_face_additional(IntegratorFace &   integrator_m,
-                         IntegratorFace &   integrator_p,
-                         unsigned int const face) const final;
+  reinit_face_derived(IntegratorFace &   integrator_m,
+                      IntegratorFace &   integrator_p,
+                      unsigned int const face) const final;
 
   void
-  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
-                                  unsigned int const face) const final;
+  reinit_boundary_face_derived(IntegratorFace & integrator_m, unsigned int const face) const final;
 
   void
-  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
-                                    IntegratorFace &                 integrator_p,
-                                    unsigned int const               cell,
-                                    unsigned int const               face,
-                                    dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_derived(IntegratorFace &                 integrator_m,
+                                 IntegratorFace &                 integrator_p,
+                                 unsigned int const               cell,
+                                 unsigned int const               face,
+                                 dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -278,19 +278,20 @@ public:
 
 private:
   void
-  reinit_face(IntegratorFace &   integrator_m,
-              IntegratorFace &   integrator_p,
-              unsigned int const face) const final;
+  reinit_face_additional(IntegratorFace &   integrator_m,
+                         IntegratorFace &   integrator_p,
+                         unsigned int const face) const final;
 
   void
-  reinit_boundary_face(IntegratorFace & integrator_m, unsigned int const face) const final;
+  reinit_boundary_face_additional(IntegratorFace &   integrator_m,
+                                  unsigned int const face) const final;
 
   void
-  reinit_face_cell_based(IntegratorFace &                 integrator_m,
-                         IntegratorFace &                 integrator_p,
-                         unsigned int const               cell,
-                         unsigned int const               face,
-                         dealii::types::boundary_id const boundary_id) const final;
+  reinit_face_cell_based_additional(IntegratorFace &                 integrator_m,
+                                    IntegratorFace &                 integrator_p,
+                                    unsigned int const               cell,
+                                    unsigned int const               face,
+                                    dealii::types::boundary_id const boundary_id) const final;
 
   void
   do_cell_integral(IntegratorCell & integrator) const final;

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -264,15 +264,17 @@ public:
   void
   update_penalty_parameter();
 
+  // continuous FE: This function sets the inhomogeneous Dirichlet boundary values for Dirichlet
+  // degrees of freedom.
+  void
+  set_inhomogeneous_boundary_values(VectorType & solution) const final;
+
+  // only relevant for discontinuous Galerkin discretization (DG):
   // Some more functionality on top of what is provided by the base class.
   // This function evaluates the inhomogeneous boundary face integrals in DG where the
   // Dirichlet boundary condition is extracted from a dof vector instead of a dealii::Function<dim>.
   void
   rhs_add_dirichlet_bc_from_dof_vector(VectorType & dst, VectorType const & src) const;
-
-  // continuous FE: This function sets the constrained Dirichlet boundary values.
-  void
-  set_inhomogeneous_boundary_values(VectorType & solution, double const time) const final;
 
 private:
   void
@@ -319,7 +321,7 @@ private:
                   VectorType const &                      src,
                   Range const &                           range) const;
 
-  // DG
+  // only relevant for discontinuous Galerkin discretization (DG)
   void
   boundary_face_loop_inhom_operator_dirichlet_bc_from_dof_vector(
     dealii::MatrixFree<dim, Number> const & matrix_free,
@@ -327,7 +329,7 @@ private:
     VectorType const &                      src,
     Range const &                           range) const;
 
-  // DG
+  // only relevant for discontinuous Galerkin discretization (DG)
   void
   do_boundary_integral_dirichlet_bc_from_dof_vector(
     IntegratorFace &                   integrator_m,

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -272,7 +272,7 @@ public:
 
   // continuous FE: This function sets the constrained Dirichlet boundary values.
   void
-  set_constrained_values(VectorType & solution, double const time) const final;
+  set_inhomogeneous_boundary_values(VectorType & solution, double const time) const final;
 
 private:
   void

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -150,6 +150,11 @@ Operator<dim, n_components, Number>::distribute_dofs()
     // copy periodicity and hanging node constraints, and add further constraints stemming from
     // Dirichlet boundary conditions
     affine_constraints.clear();
+
+    dealii::IndexSet locally_relevant_dofs;
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    affine_constraints.reinit(locally_relevant_dofs);
+
     affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
     // standard Dirichlet boundaries

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -526,19 +526,13 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
     check_multigrid.check();
   }
 
-  unsigned int n_iterations = 0;
+  unsigned int n_iterations = iterative_solver->solve(sol, rhs);
 
+  // Set Dirichlet degrees of freedom according to Dirichlet boundary condition.
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {
-    n_iterations = iterative_solver->solve(sol, rhs);
-
-    // Set Dirichlet degrees of freedom according to Dirichlet boundary condition.
     laplace_operator.set_time(time);
     laplace_operator.set_inhomogeneous_boundary_values(sol);
-  }
-  else
-  {
-    n_iterations = iterative_solver->solve(sol, rhs);
   }
 
   return n_iterations;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -530,17 +530,10 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
 
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {
-    // Set constrained degrees of freedom corresponding to Dirichlet boundary conditions.
-    VectorType rhs_modified = rhs;
+    n_iterations = iterative_solver->solve(sol, rhs);
+
+    // Set Dirichlet degrees of freedom according to Dirichlet boundary condition.
     laplace_operator.set_time(time);
-    laplace_operator.set_inhomogeneous_boundary_values(rhs_modified);
-
-    n_iterations = iterative_solver->solve(sol, rhs_modified);
-
-    // This step should actually be optional: The constrained degrees of freedom of the
-    // rhs vector contain the Dirichlet boundary values and the linear operator contains
-    // values of 1 on the diagonal. Hence, sol should already contain the correct
-    // inhomogeneous Dirichlet boundary values. TODO
     laplace_operator.set_inhomogeneous_boundary_values(sol);
   }
   else

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -138,19 +138,16 @@ Operator<dim, n_components, Number>::distribute_dofs()
   // Affine constraints are only relevant for continuous Galerkin discretizations.
   if(param.spatial_discretization == SpatialDiscretization::CG)
   {
-    affine_constraints.clear();
     affine_constraints_periodicity_and_hanging_nodes.clear();
 
     dealii::IndexSet locally_relevant_dofs;
     dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-    affine_constraints.reinit(locally_relevant_dofs);
     affine_constraints_periodicity_and_hanging_nodes.reinit(locally_relevant_dofs);
 
     // hanging nodes (needs to be done before imposing periodicity constraints and boundary
     // conditions)
     if(this->grid->triangulation->has_hanging_nodes())
     {
-      dealii::DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints);
       dealii::DoFTools::make_hanging_node_constraints(
         dof_handler, affine_constraints_periodicity_and_hanging_nodes);
     }
@@ -161,12 +158,16 @@ Operator<dim, n_components, Number>::distribute_dofs()
       auto periodic_faces_dof = GridUtilities::transform_periodic_face_pairs_to_dof_cell_iterator(
         this->grid->periodic_face_pairs, dof_handler);
 
-      dealii::DoFTools::make_periodicity_constraints<dim, dim, Number>(periodic_faces_dof,
-                                                                       affine_constraints);
-
       dealii::DoFTools::make_periodicity_constraints<dim, dim, Number>(
         periodic_faces_dof, affine_constraints_periodicity_and_hanging_nodes);
     }
+
+    affine_constraints_periodicity_and_hanging_nodes.close();
+
+    // copy periodicity and hanging node constraints, and add further constraints stemming from
+    // Dirichlet boundary conditions
+    affine_constraints.clear();
+    affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
     // standard Dirichlet boundaries
     for(auto it : this->boundary_descriptor->dirichlet_bc)
@@ -190,11 +191,7 @@ Operator<dim, n_components, Number>::distribute_dofs()
       dealii::DoFTools::make_zero_boundary_constraints(dof_handler, it, affine_constraints, mask);
     }
 
-    // We explicitly do not add Dirichlet boundary conditions for
-    // affine_constraints_periodicity_and_hanging_nodes.
-
     affine_constraints.close();
-    affine_constraints_periodicity_and_hanging_nodes.close();
   }
 
   pcout << std::endl;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -486,10 +486,8 @@ template<int dim, int n_components, typename Number>
 void
 Operator<dim, n_components, Number>::rhs(VectorType & dst, double const time) const
 {
-  dst = 0;
-
   laplace_operator.set_time(time);
-  laplace_operator.rhs_add(dst);
+  laplace_operator.rhs(dst);
 
   if(param.right_hand_side)
     rhs_operator.evaluate_add(dst, time);
@@ -529,7 +527,8 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
   {
     // Set constrained degrees of freedom corresponding to Dirichlet boundary conditions.
     VectorType rhs_modified = rhs;
-    laplace_operator.set_inhomogeneous_boundary_values(rhs_modified, time);
+    laplace_operator.set_time(time);
+    laplace_operator.set_inhomogeneous_boundary_values(rhs_modified);
 
     n_iterations = iterative_solver->solve(sol, rhs_modified);
 
@@ -537,7 +536,7 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
     // rhs vector contain the Dirichlet boundary values and the linear operator contains
     // values of 1 on the diagonal. Hence, sol should already contain the correct
     // inhomogeneous Dirichlet boundary values. TODO
-    laplace_operator.set_inhomogeneous_boundary_values(sol, time);
+    laplace_operator.set_inhomogeneous_boundary_values(sol);
   }
   else
   {

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -278,7 +278,12 @@ Operator<dim, n_components, Number>::setup_operators()
 {
   // Laplace operator
   Poisson::LaplaceOperatorData<rank, dim> laplace_operator_data;
-  laplace_operator_data.dof_index  = get_dof_index();
+  laplace_operator_data.dof_index = get_dof_index();
+  if(param.spatial_discretization == SpatialDiscretization::CG)
+  {
+    laplace_operator_data.dof_index_inhomogeneous =
+      get_dof_index_periodicity_and_hanging_node_constraints();
+  }
   laplace_operator_data.quad_index = get_quad_index();
   if(param.spatial_discretization == SpatialDiscretization::CG and
      not(boundary_descriptor->dirichlet_cached_bc.empty()))

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -209,8 +209,8 @@ private:
   // apply() functions in iterative solvers for linear systems of equations and preconditioners
   // such as multigrid, implemented via dealii::MatrixFree and FEEvaluation::read_dof_values()
   // (or gather_evaluate()).
-  // The actual inhomogeneous boundary data needs to be imposed separately using another object
-  // of type AffineConstraints (see below).
+  // To deal with inhomogeneous boundary data, a separate object of type AffineConstraints is
+  // needed (see below).
   mutable dealii::AffineConstraints<Number> affine_constraints;
 
   // To treat inhomogeneous Dirichlet BCs correctly in the context of matrix-free operator

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -154,6 +154,12 @@ private:
   std::string
   get_dof_name() const;
 
+  unsigned int
+  get_dof_index_periodicity_and_hanging_node_constraints() const;
+
+  std::string
+  get_dof_name_periodicity_and_hanging_node_constraints() const;
+
   std::string
   get_quad_name() const;
 
@@ -199,11 +205,26 @@ private:
 
   dealii::DoFHandler<dim> dof_handler;
 
+  // This AffineConstraints object applies homogeneous boundary conditions as needed by vmult()/
+  // apply() functions in iterative solvers for linear systems of equations and preconditioners
+  // such as multigrid, implemented via dealii::MatrixFree and FEEvaluation::read_dof_values()
+  // (or gather_evaluate()).
+  // The actual inhomogeneous boundary data needs to be imposed separately using another object
+  // of type AffineConstraints (see below).
   mutable dealii::AffineConstraints<Number> affine_constraints;
 
-  std::string const dof_index                = "laplace";
-  std::string const quad_index               = "laplace";
-  std::string const quad_index_gauss_lobatto = "laplace_gauss_lobatto";
+  // To treat inhomogeneous Dirichlet BCs correctly in the context of matrix-free operator
+  // evaluation using dealii::MatrixFree/FEEvaluation, we need a separate AffineConstraints
+  // object containing only periodicity and hanging node constraints. This is only relevant
+  // for continuous Galerkin discretizations.
+  dealii::AffineConstraints<Number> affine_constraints_periodicity_and_hanging_nodes;
+
+  std::string const dof_index = "dof";
+  std::string const dof_index_periodicity_and_handing_node_constraints =
+    "dof_periodicity_hanging_nodes";
+
+  std::string const quad_index               = "quad";
+  std::string const quad_index_gauss_lobatto = "quad_gauss_lobatto";
 
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;

--- a/include/exadg/postprocessor/normal_flux_calculation.cpp
+++ b/include/exadg/postprocessor/normal_flux_calculation.cpp
@@ -77,6 +77,7 @@ NormalFluxCalculator<dim, Number>::evaluate(VectorType const & solution,
     if(it != flux.end())
     {
       integrator.reinit(face);
+      // TODO: note that this will not be correct in case of hanging nodes
       integrator.read_dof_values_plain(solution);
       integrator.evaluate(dealii::EvaluationFlags::gradients);
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -78,6 +78,13 @@ public:
 
 private:
   void
+  initialize_dof_handler_and_constraints(
+    bool const                         operator_is_singular,
+    dealii::FiniteElement<dim> const & fe,
+    Map_DBC const &                    dirichlet_bc,
+    Map_DBC_ComponentMask const &      dirichlet_bc_component_mask) final;
+
+  void
   fill_matrix_free_data(MatrixFreeData<dim, MultigridNumber> & matrix_free_data,
                         unsigned int const                     level,
                         unsigned int const                     dealii_tria_level) final;
@@ -101,6 +108,11 @@ private:
   OperatorData<dim> data;
 
   ElasticityOperatorBase<dim, Number> const * pde_operator;
+
+  // additional constraints without Dirichlet degrees of freedom
+  dealii::MGLevelObject<std::shared_ptr<dealii::DoFHandler<dim> const>> dof_handlers_inhomogeneous;
+  dealii::MGLevelObject<std::shared_ptr<dealii::AffineConstraints<MultigridNumber>>>
+    constraints_inhomogeneous;
 
   bool nonlinear;
 };

--- a/include/exadg/structure/spatial_discretization/interface.h
+++ b/include/exadg/structure/spatial_discretization/interface.h
@@ -61,15 +61,15 @@ public:
   virtual void
   apply_mass_operator(VectorType & dst, VectorType const & src) const = 0;
 
-  virtual void
-  compute_rhs_linear(VectorType & dst, double const time) const = 0;
-
   virtual std::tuple<unsigned int, unsigned int>
   solve_nonlinear(VectorType &       sol,
                   VectorType const & rhs,
                   double const       factor,
                   double const       time,
                   bool const         update_preconditioner) const = 0;
+
+  virtual void
+  rhs(VectorType & dst, double const time) const = 0;
 
   virtual unsigned int
   solve_linear(VectorType &       sol,

--- a/include/exadg/structure/spatial_discretization/interface.h
+++ b/include/exadg/structure/spatial_discretization/interface.h
@@ -59,7 +59,7 @@ public:
                                double const       time) const = 0;
 
   virtual void
-  apply_mass_operator(VectorType & dst, VectorType const & src) const = 0;
+  evaluate_mass_operator(VectorType & dst, VectorType const & src) const = 0;
 
   virtual std::tuple<unsigned int, unsigned int>
   solve_nonlinear(VectorType &       sol,

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -936,8 +936,7 @@ Operator<dim, Number>::solve_nonlinear(VectorType &       sol,
   residual_operator.update(rhs, factor, time);
   linearized_operator.update(factor, time);
 
-  // set inhomogeneous Dirichlet values (this is necessary since we use
-  // FEEvaluation::read_dof_values_plain() to evaluate the operator) TODO
+  // set inhomogeneous Dirichlet values in order to evaluate the nonlinear residual correctly
   elasticity_operator_nonlinear.set_inhomogeneous_boundary_values(sol, time);
 
   // call Newton solver

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -394,7 +394,7 @@ Operator<dim, Number>::setup_operators()
   operator_data.quad_index = get_quad_index();
   if(param.large_deformation)
   {
-    operator_data.dof_index_nonlinear_residual =
+    operator_data.dof_index_inhomogeneous =
       get_dof_index_periodicity_and_hanging_node_constraints();
   }
   if(not(boundary_descriptor->dirichlet_cached_bc.empty()))

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -862,7 +862,7 @@ Operator<dim, Number>::evaluate_nonlinear_residual(VectorType &       dst,
   // for constrained degrees of freedom as well, which might not be the case
   // in general, e.g. due to const_vector. Hence, we set the constrained
   // degrees of freedom explicitly to zero.
-  elasticity_operator_nonlinear.set_constrained_values_to_zero(dst);
+  elasticity_operator_nonlinear.set_constrained_dofs_to_zero(dst);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -880,8 +880,8 @@ Operator<dim, Number>::solve_nonlinear(VectorType &       sol,
   linearized_operator.update(factor, time);
 
   // set inhomogeneous Dirichlet values (this is necessary since we use
-  // FEEvaluation::read_dof_values_plain() to evaluate the operator)
-  elasticity_operator_nonlinear.set_constrained_values(sol, time);
+  // FEEvaluation::read_dof_values_plain() to evaluate the operator) TODO
+  elasticity_operator_nonlinear.set_inhomogeneous_boundary_values(sol, time);
 
   // call Newton solver
   Newton::UpdateData update;
@@ -898,8 +898,8 @@ Operator<dim, Number>::solve_nonlinear(VectorType &       sol,
   // (because the residual vector forming the rhs of the linearized problem is zero
   // for constrained degrees of freedom, the initial solution of the linearized
   // solver is also zero, and the linearized operator contains values of 1 on the
-  // diagonal for constrained degrees of freedom).
-  elasticity_operator_nonlinear.set_constrained_values(sol, time);
+  // diagonal for constrained degrees of freedom). TODO
+  elasticity_operator_nonlinear.set_inhomogeneous_boundary_values(sol, time);
 
   return iter;
 }
@@ -918,19 +918,18 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
 
   linear_solver->update_preconditioner(update_preconditioner);
 
-  // Set constrained degrees of freedom of rhs vector according to the prescribed
-  // Dirichlet boundary conditions.
-  VectorType & rhs_mutable = const_cast<VectorType &>(rhs);
-  elasticity_operator_linear.set_constrained_values(rhs_mutable, time);
+  // Set constrained degrees of freedom corresponding to Dirichlet boundary conditions.
+  VectorType rhs_modified = rhs;
+  elasticity_operator_linear.set_inhomogeneous_boundary_values(rhs_modified, time);
 
   // solve linear system of equations
-  unsigned int const iterations = linear_solver->solve(sol, rhs_mutable);
+  unsigned int const iterations = linear_solver->solve(sol, rhs_modified);
 
   // This step should actually be optional: The constrained degrees of freedom of the
   // rhs vector contain the Dirichlet boundary values and the linear operator contains
   // values of 1 on the diagonal. Hence, sol should already contain the correct
-  // Dirichlet boundary values for constrained degrees of freedom.
-  elasticity_operator_linear.set_constrained_values(sol, time);
+  // Dirichlet boundary values for constrained degrees of freedom. TODO
+  elasticity_operator_linear.set_inhomogeneous_boundary_values(sol, time);
 
   return iterations;
 }

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -145,27 +145,26 @@ Operator<dim, Number>::distribute_dofs()
 
   affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
-  // standard Dirichlet boundaries
-  for(auto it : this->boundary_descriptor->dirichlet_bc)
-  {
-    dealii::ComponentMask mask = dealii::ComponentMask();
+  // use all the component masks defined by the user
+  std::map<dealii::types::boundary_id, dealii::ComponentMask> map_bid_to_mask =
+    boundary_descriptor->dirichlet_bc_component_mask;
 
-    auto it_mask = this->boundary_descriptor->dirichlet_bc_component_mask.find(it.first);
-    if(it_mask != this->boundary_descriptor->dirichlet_bc_component_mask.end())
-      mask = it_mask->second;
+  // Dirichlet constraints
+  std::map<dealii::types::boundary_id, dealii::ComponentMask> map_boundary_id_to_component_mask;
 
-    dealii::DoFTools::make_zero_boundary_constraints(this->dof_handler,
-                                                     it.first,
-                                                     affine_constraints,
-                                                     mask);
-  }
+  // collect all Dirichlet boundary IDs in a set:
+  // DirichletCached boundary IDs are already provided as a set
+  std::set<dealii::types::boundary_id> all_dirichlet_bids =
+    boundary_descriptor->dirichlet_cached_bc;
 
-  // DirichletCached boundaries
-  for(auto it : this->boundary_descriptor->dirichlet_cached_bc)
-  {
-    dealii::ComponentMask mask = dealii::ComponentMask();
-    dealii::DoFTools::make_zero_boundary_constraints(dof_handler, it, affine_constraints, mask);
-  }
+  // standard Dirichlet boundaries: extract keys from map
+  fill_keys_of_map_into_set(all_dirichlet_bids, boundary_descriptor->dirichlet_bc);
+
+  // fill with default mask if no mask has been defined
+  fill_map_bid_to_mask_with_default_mask(map_bid_to_mask, all_dirichlet_bids);
+
+  // call deal.II utility function to add Dirichlet constraints
+  add_homogeneous_dirichlet_constraints(affine_constraints, dof_handler, map_bid_to_mask);
 
   affine_constraints.close();
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -138,6 +138,11 @@ Operator<dim, Number>::distribute_dofs()
   // copy periodicity and hanging node constraints, and add further constraints stemming from
   // Dirichlet boundary conditions
   affine_constraints.clear();
+
+  dealii::IndexSet locally_relevant_dofs;
+  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  affine_constraints.reinit(locally_relevant_dofs);
+
   affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
   // standard Dirichlet boundaries

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -368,7 +368,7 @@ Operator<dim, Number>::setup_operators()
     mass_data.dof_index               = get_dof_index();
     mass_data.dof_index_inhomogeneous = get_dof_index_periodicity_and_hanging_node_constraints();
     mass_data.quad_index              = get_quad_index();
-    mass_data.dirichlet_bc            = field_functions->initial_acceleration_dirichlet_boundary;
+    mass_data.bc                      = boundary_descriptor;
 
     mass_operator.initialize(*matrix_free, affine_constraints, mass_data);
 

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -379,6 +379,21 @@ private:
   std::shared_ptr<dealii::FiniteElement<dim>> fe;
   dealii::DoFHandler<dim>                     dof_handler;
   dealii::AffineConstraints<Number>           affine_constraints;
+
+  // For nonlinear problems, we need a separate AffineConstraints object containing only periodicity
+  // and hanging node constraints. The background is the imposition of inhomogeneous Dirichlet
+  // boundary conditions for nonlinear problems with nonlinear residual evaluation using
+  // dealii::MatrixFree/FEEvaluation. When using the standard AffineConstraints object including
+  // Dirichlet boundary conditions, inhomogeneous boundary data would be ignored by
+  // dealii::FEEvaluation::read_dof_values(). While dealii::FEEvaluation::read_dof_values_plain()
+  // would take into account inhomogeneous Dirichlet data using the standard AffineConstraints
+  // object, hanging-node constraints would not be resolved correctly. The solution/workaround is to
+  // use dealii::FEEvaluation::read_dof_values() for a correct handling of hanging nodes, but to
+  // exclude Dirichlet degrees of freedom from the AffineConstraints object so that it is possible
+  // to read inhomogeneous boundary data (to be set correctly in separate routines) when calling
+  // dealii::FEEvaluation::read_dof_values().
+  dealii::AffineConstraints<Number> affine_constraints_periodicity_and_hanging_nodes;
+
   // constraints for mass operator (we use a separate AffineConstraints object, because we do not
   // apply constraints from Dirichlet boundary conditions here)
   dealii::AffineConstraints<Number> constraints_mass;

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -35,6 +35,7 @@
 #include <exadg/structure/spatial_discretization/interface.h>
 #include <exadg/structure/spatial_discretization/operators/body_force_operator.h>
 #include <exadg/structure/spatial_discretization/operators/linear_operator.h>
+#include <exadg/structure/spatial_discretization/operators/mass_operator.h>
 #include <exadg/structure/spatial_discretization/operators/nonlinear_operator.h>
 #include <exadg/structure/user_interface/boundary_descriptor.h>
 #include <exadg/structure/user_interface/field_functions.h>
@@ -441,7 +442,7 @@ private:
   // the mass operator term applied to a constant vector (independent
   // of new displacements) appearing on the right-hand side for linear
   // problems and in the residual for nonlinear problems.
-  MassOperator<dim, dim, Number> mass_operator;
+  Structure::MassOperator<dim, Number> mass_operator;
 
   /*
    * Solution of nonlinear systems of equations

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -314,6 +314,9 @@ private:
   get_dof_name() const;
 
   std::string
+  get_dof_name_periodicity_and_hanging_node_constraints() const;
+
+  std::string
   get_dof_name_mass() const;
 
   std::string
@@ -321,6 +324,9 @@ private:
 
   std::string
   get_quad_gauss_lobatto_name() const;
+
+  unsigned int
+  get_dof_index_periodicity_and_hanging_node_constraints() const;
 
   unsigned int
   get_dof_index_mass() const;
@@ -398,8 +404,11 @@ private:
   // apply constraints from Dirichlet boundary conditions here)
   dealii::AffineConstraints<Number> constraints_mass;
 
-  std::string const dof_index                = "dof";
-  std::string const dof_index_mass           = "dof_mass";
+  std::string const dof_index = "dof";
+  std::string const dof_index_periodicity_and_handing_node_constraints =
+    "dof_periodicity_hanging_nodes";
+  std::string const dof_index_mass = "dof_mass";
+
   std::string const quad_index               = "quad";
   std::string const quad_index_gauss_lobatto = "quad_gauss_lobatto";
 

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -213,9 +213,14 @@ public:
   void
   prescribe_initial_velocity(VectorType & velocity, double const time) const final;
 
+  /*
+   * This computes computes the intial acceleration field by evaluating all PDE terms for the given
+   * initial condition, shifting all terms to the right-hand side of the equations, and solving a
+   * mass matrix system to obtain the initial acceleration.
+   */
   void
-  compute_initial_acceleration(VectorType &       acceleration,
-                               VectorType const & displacement,
+  compute_initial_acceleration(VectorType &       initial_acceleration,
+                               VectorType const & initial_displacement,
                                double const       time) const final;
 
   void
@@ -325,9 +330,6 @@ private:
   get_dof_name_periodicity_and_hanging_node_constraints() const;
 
   std::string
-  get_dof_name_mass() const;
-
-  std::string
   get_quad_name() const;
 
   std::string
@@ -335,9 +337,6 @@ private:
 
   unsigned int
   get_dof_index_periodicity_and_hanging_node_constraints() const;
-
-  unsigned int
-  get_dof_index_mass() const;
 
   unsigned int
   get_quad_index() const;
@@ -408,14 +407,9 @@ private:
   // set correctly in separate routines) when calling dealii::FEEvaluation::read_dof_values().
   dealii::AffineConstraints<Number> affine_constraints_periodicity_and_hanging_nodes;
 
-  // constraints for mass operator (we use a separate AffineConstraints object, because we do not
-  // apply constraints from Dirichlet boundary conditions here)
-  dealii::AffineConstraints<Number> constraints_mass;
-
   std::string const dof_index = "dof";
   std::string const dof_index_periodicity_and_handing_node_constraints =
     "dof_periodicity_hanging_nodes";
-  std::string const dof_index_mass = "dof_mass";
 
   std::string const quad_index               = "quad";
   std::string const quad_index_gauss_lobatto = "quad_gauss_lobatto";

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -222,15 +222,9 @@ public:
   apply_mass_operator(VectorType & dst, VectorType const & src) const final;
 
   /*
-   * This function calculates the right-hand side of the linear system
-   * of equations for linear elasticity problems.
-   */
-  void
-  compute_rhs_linear(VectorType & dst, double const time) const final;
-
-  /*
-   * This function evaluates the nonlinear residual which is required by
-   * the Newton solver.
+   * This function evaluates the nonlinear residual which is required by the Newton solver. In order
+   * to evaluate inhomogeneous Dirichlet boundary conditions correctly, inhomogeneous Dirichlet
+   * degrees of freedom need to be set correctly in the src-vector prior to calling this function.
    */
   void
   evaluate_nonlinear_residual(VectorType &       dst,
@@ -261,19 +255,33 @@ public:
                         double const       time) const;
 
   /*
-   * This function solves the (non-)linear system of equations.
+   * This function solves the system of equations for nonlinear problems. This function needs to
+   * make sure that Dirichlet degrees of freedom are filled correctly with their inhomogeneous
+   * boundary data before calling the nonlinear solver.
    */
   std::tuple<unsigned int, unsigned int>
   solve_nonlinear(VectorType &       sol,
-                  VectorType const & rhs,
-                  double const       factor,
+                  VectorType const & const_vector,
+                  double const       scaling_factor_mass,
                   double const       time,
                   bool const         update_preconditioner) const final;
 
+  /*
+   * This function calculates the right-hand side of the linear system of equations for linear
+   * elasticity problems.
+   */
+  void
+  rhs(VectorType & dst, double const time) const final;
+
+  /*
+   * This function solves the system of equations for linear problems.
+   *
+   * Before calling this function, make sure that the function rhs() has been called.
+   */
   unsigned int
   solve_linear(VectorType &       sol,
                VectorType const & rhs,
-               double const       factor,
+               double const       scaling_factor_mass,
                double const       time,
                bool const         update_preconditioner) const final;
 

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -224,7 +224,7 @@ public:
                                double const       time) const final;
 
   void
-  apply_mass_operator(VectorType & dst, VectorType const & src) const final;
+  evaluate_mass_operator(VectorType & dst, VectorType const & src) const final;
 
   /*
    * This function evaluates the nonlinear residual which is required by the Newton solver. In order

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -386,18 +386,18 @@ private:
   dealii::DoFHandler<dim>                     dof_handler;
   dealii::AffineConstraints<Number>           affine_constraints;
 
-  // For nonlinear problems, we need a separate AffineConstraints object containing only periodicity
-  // and hanging node constraints. The background is the imposition of inhomogeneous Dirichlet
-  // boundary conditions for nonlinear problems with nonlinear residual evaluation using
-  // dealii::MatrixFree/FEEvaluation. When using the standard AffineConstraints object including
-  // Dirichlet boundary conditions, inhomogeneous boundary data would be ignored by
-  // dealii::FEEvaluation::read_dof_values(). While dealii::FEEvaluation::read_dof_values_plain()
-  // would take into account inhomogeneous Dirichlet data using the standard AffineConstraints
-  // object, hanging-node constraints would not be resolved correctly. The solution/workaround is to
-  // use dealii::FEEvaluation::read_dof_values() for a correct handling of hanging nodes, but to
-  // exclude Dirichlet degrees of freedom from the AffineConstraints object so that it is possible
-  // to read inhomogeneous boundary data (to be set correctly in separate routines) when calling
-  // dealii::FEEvaluation::read_dof_values().
+  // To treat inhomogeneous Dirichlet BCsc orrectly in the context of matrix-free oeprator
+  // evaluation using dealii::MatrixFree/FEEvaluation, we need a separate AffineConstraints
+  // object containing only periodicity and hanging node constraints.
+  // When using the standard AffineConstraints object including Dirichlet boundary conditions,
+  // inhomogeneous boundary data would be ignored by dealii::FEEvaluation::read_dof_values().
+  // While dealii::FEEvaluation::read_dof_values_plain() would take into account inhomogeneous
+  // Dirichlet data using the standard AffineConstraints object, hanging-node constraints would
+  // not be resolved correctly.
+  // The solution/workaround is to use dealii::FEEvaluation::read_dof_values() for a correct
+  // handling of hanging nodes, but to exclude Dirichlet degrees of freedom from the
+  // AffineConstraints object so that it is possible to read inhomogeneous boundary data (to be
+  // set correctly in separate routines) when calling dealii::FEEvaluation::read_dof_values().
   dealii::AffineConstraints<Number> affine_constraints_periodicity_and_hanging_nodes;
 
   // constraints for mass operator (we use a separate AffineConstraints object, because we do not

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -386,7 +386,7 @@ private:
   dealii::DoFHandler<dim>                     dof_handler;
   dealii::AffineConstraints<Number>           affine_constraints;
 
-  // To treat inhomogeneous Dirichlet BCsc orrectly in the context of matrix-free oeprator
+  // To treat inhomogeneous Dirichlet BCs correctly in the context of matrix-free operator
   // evaluation using dealii::MatrixFree/FEEvaluation, we need a separate AffineConstraints
   // object containing only periodicity and hanging node constraints.
   // When using the standard AffineConstraints object including Dirichlet boundary conditions,

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -215,7 +215,7 @@ public:
   prescribe_initial_velocity(VectorType & velocity, double const time) const final;
 
   /*
-   * This computes computes the intial acceleration field by evaluating all PDE terms for the given
+   * This computes the initial acceleration field by evaluating all PDE terms for the given
    * initial condition, shifting all terms to the right-hand side of the equations, and solving a
    * mass matrix system to obtain the initial acceleration.
    */
@@ -392,7 +392,12 @@ private:
    */
   std::shared_ptr<dealii::FiniteElement<dim>> fe;
   dealii::DoFHandler<dim>                     dof_handler;
-  dealii::AffineConstraints<Number>           affine_constraints;
+
+  // AffineConstraints object as needed by iterative solvers and preconditioners for linear systems
+  // of equations. This constraint object contains additional constraints from Dirichlet boundary
+  // conditions as compared to the constraint object below. Note that the present constraint object
+  // can treat Dirichlet boundaries only in a homogeneous manner.
+  dealii::AffineConstraints<Number> affine_constraints;
 
   // To treat inhomogeneous Dirichlet BCs correctly in the context of matrix-free operator
   // evaluation using dealii::MatrixFree/FEEvaluation, we need a separate AffineConstraints
@@ -404,8 +409,9 @@ private:
   // not be resolved correctly.
   // The solution/workaround is to use dealii::FEEvaluation::read_dof_values() for a correct
   // handling of hanging nodes, but to exclude Dirichlet degrees of freedom from the
-  // AffineConstraints object so that it is possible to read inhomogeneous boundary data (to be
-  // set correctly in separate routines) when calling dealii::FEEvaluation::read_dof_values().
+  // AffineConstraints object so that it is possible to read inhomogeneous boundary data when
+  // calling dealii::FEEvaluation::read_dof_values(). This inhomogeneous boundary data needs to be
+  // set beforehand in separate routines.
   dealii::AffineConstraints<Number> affine_constraints_periodicity_and_hanging_nodes;
 
   std::string const dof_index = "dof";

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -112,8 +112,8 @@ ElasticityOperatorBase<dim, Number>::get_scaling_factor_mass_operator() const
 
 template<int dim, typename Number>
 void
-ElasticityOperatorBase<dim, Number>::set_constrained_values(VectorType & dst,
-                                                            double const time) const
+ElasticityOperatorBase<dim, Number>::set_inhomogeneous_boundary_values(VectorType & dst,
+                                                                       double const time) const
 {
   // standard Dirichlet boundary conditions
   std::map<dealii::types::global_dof_index, double> boundary_values;

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -199,8 +199,8 @@ ElasticityOperatorBase<dim, Number>::set_inhomogeneous_boundary_values(VectorTyp
 
 template<int dim, typename Number>
 void
-ElasticityOperatorBase<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                            unsigned int const cell) const
+ElasticityOperatorBase<dim, Number>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                         unsigned int const cell) const
 {
   (void)integrator;
 

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -199,10 +199,10 @@ ElasticityOperatorBase<dim, Number>::set_inhomogeneous_boundary_values(VectorTyp
 
 template<int dim, typename Number>
 void
-ElasticityOperatorBase<dim, Number>::reinit_cell(IntegratorCell &   integrator,
-                                                 unsigned int const cell) const
+ElasticityOperatorBase<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                            unsigned int const cell) const
 {
-  Base::reinit_cell(integrator, cell);
+  (void)integrator;
 
   this->material_handler.reinit(*this->matrix_free, cell);
 }

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -112,14 +112,13 @@ ElasticityOperatorBase<dim, Number>::get_scaling_factor_mass_operator() const
 
 template<int dim, typename Number>
 void
-ElasticityOperatorBase<dim, Number>::set_inhomogeneous_boundary_values(VectorType & dst,
-                                                                       double const time) const
+ElasticityOperatorBase<dim, Number>::set_inhomogeneous_boundary_values(VectorType & dst) const
 {
   // standard Dirichlet boundary conditions
   std::map<dealii::types::global_dof_index, double> boundary_values;
   for(auto dbc : operator_data.bc->dirichlet_bc)
   {
-    dbc.second->set_time(time);
+    dbc.second->set_time(this->get_time());
     dealii::ComponentMask mask =
       operator_data.bc->dirichlet_bc_component_mask.find(dbc.first)->second;
 

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -36,18 +36,12 @@ struct OperatorData : public OperatorBaseData
 {
   OperatorData()
     : OperatorBaseData(),
-      dof_index_nonlinear_residual(1),
       pull_back_traction(false),
       unsteady(false),
       density(1.0),
       quad_index_gauss_lobatto(0)
   {
   }
-
-  // In addition to the dof_index in OperatorBaseData, we need a separate dof index to evaluate the
-  // nonlinear residual, in order to be able to treat both inhomogeneous boundary data and hanging
-  // nodes.
-  unsigned int dof_index_nonlinear_residual;
 
   std::shared_ptr<BoundaryDescriptor<dim> const> bc;
   std::shared_ptr<MaterialDescriptor const>      material_descriptor;

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -102,7 +102,7 @@ public:
   get_scaling_factor_mass_operator() const;
 
   void
-  set_inhomogeneous_boundary_values(VectorType & dst, double const time) const override;
+  set_inhomogeneous_boundary_values(VectorType & dst) const final;
 
 protected:
   void

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -102,7 +102,7 @@ public:
   get_scaling_factor_mass_operator() const;
 
   void
-  set_constrained_values(VectorType & dst, double const time) const override;
+  set_inhomogeneous_boundary_values(VectorType & dst, double const time) const override;
 
 protected:
   void

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -36,12 +36,18 @@ struct OperatorData : public OperatorBaseData
 {
   OperatorData()
     : OperatorBaseData(),
+      dof_index_nonlinear_residual(1),
       pull_back_traction(false),
       unsteady(false),
       density(1.0),
       quad_index_gauss_lobatto(0)
   {
   }
+
+  // In addition to the dof_index in OperatorBaseData, we need a separate dof index to evaluate the
+  // nonlinear residual, in order to be able to treat both inhomogeneous boundary data and hanging
+  // nodes.
+  unsigned int dof_index_nonlinear_residual;
 
   std::shared_ptr<BoundaryDescriptor<dim> const> bc;
   std::shared_ptr<MaterialDescriptor const>      material_descriptor;

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -106,7 +106,7 @@ public:
 
 protected:
   void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const override;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const override;
 
   OperatorData<dim> operator_data;
 

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -106,7 +106,7 @@ public:
 
 protected:
   void
-  reinit_cell(IntegratorCell & integrator, unsigned int const cell) const override;
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const override;
 
   OperatorData<dim> operator_data;
 

--- a/include/exadg/structure/spatial_discretization/operators/mass_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/mass_operator.h
@@ -1,0 +1,60 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_STRUCTURE_SPATIAL_DISCRETIZATION_OPERATORS_MASS_OPERATOR_H_
+#define INCLUDE_EXADG_STRUCTURE_SPATIAL_DISCRETIZATION_OPERATORS_MASS_OPERATOR_H_
+
+#include <exadg/operators/mass_operator.h>
+
+namespace ExaDG
+{
+namespace Structure
+{
+template<int dim>
+struct MassOperatorData : public ExaDG::MassOperatorData<dim>
+{
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
+};
+
+template<int dim, typename Number>
+class MassOperator : public ExaDG::MassOperator<dim, dim, Number>
+{
+public:
+  void
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
+             dealii::AffineConstraints<Number> const & affine_constraints,
+             MassOperatorData<dim> const &             data)
+  {
+    operator_data = data;
+
+    ExaDG::MassOperator<dim, dim, Number>::initialize(matrix_free, affine_constraints, data);
+  }
+
+private:
+  MassOperatorData<dim> operator_data;
+};
+
+} // namespace Structure
+} // namespace ExaDG
+
+
+
+#endif /* INCLUDE_EXADG_STRUCTURE_SPATIAL_DISCRETIZATION_OPERATORS_MASS_OPERATOR_H_ */

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -37,7 +37,8 @@ NonLinearOperator<dim, Number>::initialize(
   Base::initialize(matrix_free, affine_constraints, data);
 
   integrator_lin = std::make_shared<IntegratorCell>(*this->matrix_free,
-                                                    this->operator_data.dof_index_inhomogeneous);
+                                                    this->operator_data.dof_index_inhomogeneous,
+                                                    this->operator_data.quad_index);
   // it should not make a difference here whether we use dof_index or dof_index_inhomogeneous
   this->matrix_free->initialize_dof_vector(displacement_lin, this->operator_data.dof_index);
   displacement_lin.update_ghost_values();

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -303,10 +303,10 @@ NonLinearOperator<dim, Number>::do_boundary_integral_continuous(
 
 template<int dim, typename Number>
 void
-NonLinearOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
-                                                       unsigned int const cell) const
+NonLinearOperator<dim, Number>::reinit_cell_derived(IntegratorCell &   integrator,
+                                                    unsigned int const cell) const
 {
-  Base::reinit_cell_additional(integrator, cell);
+  Base::reinit_cell_derived(integrator, cell);
 
   integrator_lin->reinit(cell);
 

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -36,8 +36,10 @@ NonLinearOperator<dim, Number>::initialize(
 {
   Base::initialize(matrix_free, affine_constraints, data);
 
-  integrator_lin = std::make_shared<IntegratorCell>(*this->matrix_free);
-  this->matrix_free->initialize_dof_vector(displacement_lin, data.dof_index);
+  integrator_lin = std::make_shared<IntegratorCell>(*this->matrix_free,
+                                                    this->operator_data.dof_index_inhomogeneous);
+  // it should not make a difference here whether we use dof_index or dof_index_inhomogeneous
+  this->matrix_free->initialize_dof_vector(displacement_lin, this->operator_data.dof_index);
   displacement_lin.update_ghost_values();
 }
 
@@ -300,10 +302,10 @@ NonLinearOperator<dim, Number>::do_boundary_integral_continuous(
 
 template<int dim, typename Number>
 void
-NonLinearOperator<dim, Number>::reinit_cell(IntegratorCell &   integrator,
-                                            unsigned int const cell) const
+NonLinearOperator<dim, Number>::reinit_cell_additional(IntegratorCell &   integrator,
+                                                       unsigned int const cell) const
 {
-  Base::reinit_cell(integrator, cell);
+  Base::reinit_cell_additional(integrator, cell);
 
   integrator_lin->reinit(cell);
 

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -128,12 +128,11 @@ NonLinearOperator<dim, Number>::cell_loop_nonlinear(
   {
     reinit_cell_nonlinear(integrator, cell);
 
-    integrator.read_dof_values(src);
-
-    integrator.evaluate(unsteady_flag | dealii::EvaluationFlags::gradients);
+    integrator.gather_evaluate(src, unsteady_flag | dealii::EvaluationFlags::gradients);
 
     do_cell_integral_nonlinear(integrator);
 
+    // TODO: does this touch Dirichlet DoFs?
     integrator.integrate_scatter(unsteady_flag | dealii::EvaluationFlags::gradients, dst);
   }
 }
@@ -154,9 +153,7 @@ NonLinearOperator<dim, Number>::cell_loop_valid_deformation(
   {
     reinit_cell_nonlinear(integrator, cell);
 
-    integrator.read_dof_values(src);
-
-    integrator.evaluate(dealii::EvaluationFlags::gradients);
+    integrator.gather_evaluate(src, dealii::EvaluationFlags::gradients);
 
     // loop over all quadrature points
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -111,14 +111,6 @@ NonLinearOperator<dim, Number>::reinit_cell_nonlinear(IntegratorCell &   integra
 
 template<int dim, typename Number>
 void
-NonLinearOperator<dim, Number>::reinit_boundary_face_nonlinear(IntegratorFace &   integrator,
-                                                               unsigned int const face) const
-{
-  integrator.reinit(face);
-}
-
-template<int dim, typename Number>
-void
 NonLinearOperator<dim, Number>::cell_loop_nonlinear(
   dealii::MatrixFree<dim, Number> const & matrix_free,
   VectorType &                            dst,

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -81,9 +81,6 @@ private:
   reinit_cell_nonlinear(IntegratorCell & integrator, unsigned int const cell) const;
 
   void
-  reinit_boundary_face_nonlinear(IntegratorFace & integrator, unsigned int const face) const;
-
-  void
   cell_loop_nonlinear(dealii::MatrixFree<dim, Number> const & matrix_free,
                       VectorType &                            dst,
                       VectorType const &                      src,

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -164,13 +164,13 @@ private:
    */
   void
   do_boundary_integral_continuous(IntegratorFace &                   integrator_m,
-                                  dealii::types::boundary_id const & boundary_id) const override;
+                                  dealii::types::boundary_id const & boundary_id) const final;
 
   /*
    * Linearized operator.
    */
   void
-  reinit_cell(IntegratorCell & integrator, unsigned int const cell) const override;
+  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
 
   /*
    * Calculates the integral

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -81,6 +81,9 @@ private:
   reinit_cell_nonlinear(IntegratorCell & integrator, unsigned int const cell) const;
 
   void
+  reinit_boundary_face_nonlinear(IntegratorFace & integrator, unsigned int const face) const;
+
+  void
   cell_loop_nonlinear(dealii::MatrixFree<dim, Number> const & matrix_free,
                       VectorType &                            dst,
                       VectorType const &                      src,
@@ -97,6 +100,15 @@ private:
                                VectorType &                            dst,
                                VectorType const &                      src,
                                Range const &                           range) const;
+
+  /*
+   * A cell loop that checks whether the Jacobian determinant is positive for all q-points.
+   */
+  void
+  cell_loop_valid_deformation(dealii::MatrixFree<dim, Number> const & matrix_free,
+                              Number &                                dst,
+                              VectorType const &                      src,
+                              Range const &                           range) const;
 
   /*
    * Calculates the integral
@@ -176,13 +188,6 @@ private:
    */
   void
   do_cell_integral(IntegratorCell & integrator) const override;
-
-  void
-  cell_loop_valid_deformation(dealii::MatrixFree<dim, Number> const & matrix_free,
-                              Number &                                dst,
-                              VectorType const &                      src,
-                              Range const &                           range) const;
-
 
   mutable std::shared_ptr<IntegratorCell> integrator_lin;
   mutable VectorType                      displacement_lin;

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -47,29 +47,41 @@ private:
   typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
 public:
+  /**
+   * Initialize function.
+   */
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              dealii::AffineConstraints<Number> const & affine_constraints,
              OperatorData<dim> const &                 data) override;
 
-  /*
+  /**
    * Evaluates the non-linear operator.
+   *
+   * This function ensures that constrained degrees of freedom are set to zero
+   * in the dst vector. Note, however, that this function does not ensure
+   * that Dirichlet degrees of freedom are set to the prescribed inhomogeneous
+   * boundary data in the src vector. This needs to be done separately prior to
+   * calling this function.
    */
   void
   evaluate_nonlinear(VectorType & dst, VectorType const & src) const;
 
-  /*
+  /**
    * Returns true if deformation state is valid.
    */
   bool
   valid_deformation(VectorType const & displacement) const;
 
-  /*
-   * Linearized operator:
+  /**
+   * Linearized operator: Sets the linearization vector.
    */
   void
   set_solution_linearization(VectorType const & vector) const;
 
+  /**
+   * Linearized operator: Returns the linearization vector.
+   */
   VectorType const &
   get_solution_linearization() const;
 
@@ -100,6 +112,8 @@ private:
 
   /*
    * A cell loop that checks whether the Jacobian determinant is positive for all q-points.
+   * Prior to calling this function, inhomogeneous Dirichlet degrees of freedom need to be
+   * set correctly.
    */
   void
   cell_loop_valid_deformation(dealii::MatrixFree<dim, Number> const & matrix_free,

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -170,7 +170,7 @@ private:
    * Linearized operator.
    */
   void
-  reinit_cell_additional(IntegratorCell & integrator, unsigned int const cell) const final;
+  reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const final;
 
   /*
    * Calculates the integral

--- a/include/exadg/structure/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/structure/time_integration/driver_steady_problems.cpp
@@ -122,7 +122,7 @@ DriverSteady<dim, Number>::do_solve()
   else // linear problem
   {
     // calculate right-hand side vector
-    pde_operator->compute_rhs_linear(rhs_vector, 0.0 /* time */);
+    pde_operator->rhs(rhs_vector, 0.0 /* time */);
 
     unsigned int const N_iter_linear =
       pde_operator->solve_linear(solution,

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -125,7 +125,7 @@ TimeIntGenAlpha<dim, Number>::do_timestep_solve()
   const_vector.reinit(displacement_n);
   rhs.reinit(displacement_n);
   this->compute_const_vector(rhs, displacement_n, velocity_n, acceleration_n);
-  pde_operator->apply_mass_operator(const_vector, rhs);
+  pde_operator->evaluate_mass_operator(const_vector, rhs);
 
   if(param.large_deformation == false) // linear case
   {

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -130,7 +130,7 @@ TimeIntGenAlpha<dim, Number>::do_timestep_solve()
   if(param.large_deformation == false) // linear case
   {
     // calculate right-hand side vector
-    pde_operator->compute_rhs_linear(rhs, this->get_mid_time());
+    pde_operator->rhs(rhs, this->get_mid_time());
     // shift const_vector to right-hand side
     rhs.add(-1.0, const_vector);
   }

--- a/include/exadg/structure/user_interface/boundary_descriptor.h
+++ b/include/exadg/structure/user_interface/boundary_descriptor.h
@@ -49,6 +49,11 @@ struct BoundaryDescriptor
   // Dirichlet
   std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
 
+  // Initial acceleration prescribed on Dirichlet boundary:
+  // This data structure will only be used if the initial_acceleration is not set in FieldFunctions
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+    dirichlet_bc_initial_acceleration;
+
   // ComponentMask
   // If a certain boundary ID is not inserted into this map, it is assumed that all components are
   // active, in analogy to the default constructor of dealii::ComponentMask.
@@ -110,6 +115,12 @@ struct BoundaryDescriptor
         dirichlet_bc_component_mask.find(boundary_id) != dirichlet_bc_component_mask.end(),
         dealii::ExcMessage(
           "dirichlet_bc_component_mask must contain the same boundary IDs as dirichlet_bc."));
+
+      AssertThrow(
+        dirichlet_bc_initial_acceleration.find(boundary_id) !=
+          dirichlet_bc_initial_acceleration.end(),
+        dealii::ExcMessage(
+          "dirichlet_bc_initial_acceleration must contain the same boundary IDs as dirichlet_bc."));
     }
 
     if(dirichlet_cached_bc.find(boundary_id) != dirichlet_cached_bc.end())

--- a/include/exadg/structure/user_interface/boundary_descriptor.h
+++ b/include/exadg/structure/user_interface/boundary_descriptor.h
@@ -50,7 +50,8 @@ struct BoundaryDescriptor
   std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
 
   // Initial acceleration prescribed on Dirichlet boundary:
-  // This data structure will only be used if the initial_acceleration is not set in FieldFunctions
+  // This data structure will only be used if the initial_acceleration is not set in FieldFunctions.
+  // Moreover, this data structure will only be used for unsteady problems.
   std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
     dirichlet_bc_initial_acceleration;
 

--- a/include/exadg/structure/user_interface/field_functions.h
+++ b/include/exadg/structure/user_interface/field_functions.h
@@ -36,16 +36,11 @@ struct FieldFunctions
 
   // Initial acceleration: Either prescribe the initial acceleration as a volume field or - if this
   // is unknown - prescribe the initial acceleration on the Dirichlet boundary, while the initial
-  // acceleration in the volume will be derived as a numerical solution of the PDE problem.
+  // acceleration in the volume will be derived as a numerical solution of the PDE problem (see
+  // BoundaryDescriptor for the second variant).
 
   // Initial acceleration as volume field:
   std::shared_ptr<dealii::Function<dim>> initial_acceleration;
-
-  // Initial acceleration prescribed on Dirichlet boundary:
-  // This data structure will only be used if the above pointer to initial_acceleration is
-  // uninitialized.
-  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
-    initial_acceleration_dirichlet_boundary;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/user_interface/field_functions.h
+++ b/include/exadg/structure/user_interface/field_functions.h
@@ -33,6 +33,19 @@ struct FieldFunctions
   std::shared_ptr<dealii::Function<dim>> right_hand_side;
   std::shared_ptr<dealii::Function<dim>> initial_displacement;
   std::shared_ptr<dealii::Function<dim>> initial_velocity;
+
+  // Initial acceleration: Either prescribe the initial acceleration as a volume field or - if this
+  // is unknown - prescribe the initial acceleration on the Dirichlet boundary, while the initial
+  // acceleration in the volume will be derived as a numerical solution of the PDE problem.
+
+  // Initial acceleration as volume field:
+  std::shared_ptr<dealii::Function<dim>> initial_acceleration;
+
+  // Initial acceleration prescribed on Dirichlet boundary:
+  // This data structure will only be used if the above pointer to initial_acceleration is
+  // uninitialized.
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
+    initial_acceleration_dirichlet_boundary;
 };
 
 } // namespace Structure


### PR DESCRIPTION
This PR aims to realize local refinements / hanging-nodes for continuous Galerkin discretizations for nonlinear problems (e.g. nonlinear structural mechanisms) with special requirements in terms of constraints / inhomogeneous BC as discussed in issue #386.

closes #386 

closes #446 (@bugrahantemur please take a look at the changes and let me know if you do not agree)

TODOs:
- ~~introduce second `AffineConstraints` object for `Poisson` spatial discretization (which is the second case of continuous Galerkin discretizations in ExaDG apart from the `Structure` module; other modules use continuous Galerkin only inside MG, which is unproblematic since the operators used in MG preconditioning are always homogeneous)~~
- ~~`set_inhomogeneous_boundary_values()` will be removed from `OperatorBase::evaluate()` functions. Make sure that all modules currently calling these functions are adapted accordingly.~~
- ~~initialize `dof_index_inhomogeneous` with an invalid number and make sure that a correct value has been set whenever using `dof_index_inhomogeneous`~~