### PR TITLE
make IntegratorCell/Face objects private in OperatorBase

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
@@ -151,7 +151,7 @@ ProjectionOperator<dim, Number>::reinit_cell(IntegratorCell &   integrator,
   Base::reinit_cell(integrator, cell);
 
   if(operator_data.use_divergence_penalty)
-    div_kernel->reinit_cell(*this->integrator);
+    div_kernel->reinit_cell(integrator);
 }
 
 template<int dim, typename Number>
@@ -163,7 +163,7 @@ ProjectionOperator<dim, Number>::reinit_face(IntegratorFace &   integrator_m,
   Base::reinit_face(integrator_m, integrator_p, face);
 
   if(operator_data.use_continuity_penalty)
-    conti_kernel->reinit_face(*this->integrator_m, *this->integrator_p);
+    conti_kernel->reinit_face(integrator_m, integrator_p);
 }
 
 template<int dim, typename Number>
@@ -173,7 +173,7 @@ ProjectionOperator<dim, Number>::reinit_boundary_face(IntegratorFace &   integra
 {
   Base::reinit_boundary_face(integrator_m, face);
 
-  conti_kernel->reinit_boundary_face(*this->integrator_m);
+  conti_kernel->reinit_boundary_face(integrator_m);
 }
 
 template<int dim, typename Number>
@@ -188,7 +188,7 @@ ProjectionOperator<dim, Number>::reinit_face_cell_based(
   Base::reinit_face_cell_based(integrator_m, integrator_p, cell, face, boundary_id);
 
   if(operator_data.use_continuity_penalty)
-    conti_kernel->reinit_face_cell_based(boundary_id, *this->integrator_m, *this->integrator_p);
+    conti_kernel->reinit_face_cell_based(boundary_id, integrator_m, integrator_p);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -386,10 +386,6 @@ protected:
    */
   bool is_dg;
 
-  std::shared_ptr<IntegratorCell> integrator;
-  std::shared_ptr<IntegratorFace> integrator_m;
-  std::shared_ptr<IntegratorFace> integrator_p;
-
   /*
    * Block Jacobi preconditioner/smoother: matrix-free version with elementwise iterative solver
    */
@@ -630,6 +626,13 @@ private:
    * level operator, this variable takes a value of dealii::numbers::invalid_unsigned_int.
    */
   unsigned int level;
+
+  /*
+   * Integration objects of type dealii::FEEvaluation for cell/face integrals.
+   */
+  std::shared_ptr<IntegratorCell> integrator;
+  std::shared_ptr<IntegratorFace> integrator_m;
+  std::shared_ptr<IntegratorFace> integrator_p;
 
   /*
    * Vector of matrices for block-diagonal preconditioners.

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -297,19 +297,22 @@ LaplaceOperator<dim, Number, n_components>::
     VectorType const &                      src,
     Range const &                           range) const
 {
+  IntegratorFace integrator_m =
+    IntegratorFace(*this->matrix_free, true, operator_data.dof_index, operator_data.quad_index);
+
   for(unsigned int face = range.first; face < range.second; face++)
   {
-    this->reinit_boundary_face(*this->integrator_m, face);
+    this->reinit_boundary_face(integrator_m, face);
 
     // deviating from the standard function boundary_face_loop_inhom_operator()
     // because the boundary condition comes from the vector src
-    this->integrator_m->gather_evaluate(src, this->integrator_flags.face_evaluate);
+    integrator_m.gather_evaluate(src, this->integrator_flags.face_evaluate);
 
-    do_boundary_integral_dirichlet_bc_from_dof_vector(*this->integrator_m,
+    do_boundary_integral_dirichlet_bc_from_dof_vector(integrator_m,
                                                       OperatorType::inhomogeneous,
                                                       matrix_free.get_boundary_id(face));
 
-    this->integrator_m->integrate_scatter(this->integrator_flags.face_integrate, dst);
+    integrator_m.integrate_scatter(this->integrator_flags.face_integrate, dst);
   }
 }
 

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -159,10 +159,15 @@ NonLinearOperator<dim, Number>::boundary_face_loop_nonlinear(
 {
   (void)src;
 
+  IntegratorFace integrator_m = IntegratorFace(*this->matrix_free,
+                                               true,
+                                               this->operator_data.dof_index,
+                                               this->operator_data.quad_index);
+
   // apply Neumann BCs
   for(unsigned int face = range.first; face < range.second; face++)
   {
-    this->reinit_boundary_face(*this->integrator_m, face);
+    this->reinit_boundary_face(integrator_m, face);
 
     // In case of a pull-back of the traction vector, we need to evaluate
     // the displacement gradient to obtain the surface area ratio da/dA.
@@ -170,13 +175,13 @@ NonLinearOperator<dim, Number>::boundary_face_loop_nonlinear(
     // depend on the parameter pull_back_traction.
     if(this->operator_data.pull_back_traction)
     {
-      this->integrator_m->read_dof_values_plain(src);
-      this->integrator_m->evaluate(dealii::EvaluationFlags::gradients);
+      integrator_m.read_dof_values_plain(src);
+      integrator_m.evaluate(dealii::EvaluationFlags::gradients);
     }
 
-    do_boundary_integral_continuous(*this->integrator_m, matrix_free.get_boundary_id(face));
+    do_boundary_integral_continuous(integrator_m, matrix_free.get_boundary_id(face));
 
-    this->integrator_m->integrate_scatter(this->integrator_flags.face_integrate, dst);
+    integrator_m.integrate_scatter(this->integrator_flags.face_integrate, dst);
   }
 }
 


### PR DESCRIPTION
As a first step to limit the scope of the `IntegratorCell/Face` objects and make their usage more local, I make these objects `private` in `OperatorBase`.