### PR TITLE
slightly refactor throughput studies for Structure module

### DIFF
--- a/applications/structure/manufactured/throughput.json
+++ b/applications/structure/manufactured/throughput.json
@@ -14,7 +14,7 @@
         "DofsMax": "100000"
     },
     "Throughput": {
-        "OperatorType": "Linearized",
+        "OperatorType": "Apply",
         "RepetitionsInner": "100",
         "RepetitionsOuter": "3"
     },

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -233,28 +233,20 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
   pde_operator->initialize_dof_vector(dst);
   src = 1.0;
 
-  if(application->get_parameters().large_deformation and operator_type == OperatorType::Linearized)
+  if(application->get_parameters().large_deformation and operator_type == OperatorType::Apply)
   {
     pde_operator->initialize_dof_vector(linearization);
     linearization = 1.0;
   }
 
   const std::function<void(void)> operator_evaluation = [&](void) {
-    if(application->get_parameters().large_deformation)
+    if(operator_type == OperatorType::Evaluate)
     {
-      if(operator_type == OperatorType::Nonlinear)
-      {
-        pde_operator->apply_nonlinear_operator(dst, src, 1.0, 0.0);
-      }
-      else if(operator_type == OperatorType::Linearized)
-      {
-        pde_operator->set_solution_linearization(linearization);
-        pde_operator->apply_linearized_operator(dst, src, 1.0, 0.0);
-      }
+      pde_operator->evaluate_elasticity_operator(dst, src, 1.0, 0.0);
     }
-    else
+    else if(operator_type == OperatorType::Apply)
     {
-      pde_operator->apply_linear_operator(dst, src, 1.0, 0.0);
+      pde_operator->apply_elasticity_operator(dst, src, linearization, 1.0, 0.0);
     }
   };
 

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -43,8 +43,10 @@ namespace Structure
 {
 enum class OperatorType
 {
-  Nonlinear,
-  Linearized
+  Evaluate, // includes inhomogeneous boundary conditions, where the nonlinear operator is evaluated
+            // in case of nonlinear problems
+  Apply     // homogeneous action of operator, where the linearized operator is applied in case of
+            // nonlinear problems
 };
 
 inline unsigned int

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -845,26 +845,44 @@ Operator<dim, Number>::apply_linearized_operator(VectorType &       dst,
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::apply_nonlinear_operator(VectorType &       dst,
-                                                VectorType const & src,
-                                                double const       factor,
-                                                double const       time) const
+Operator<dim, Number>::evaluate_elasticity_operator(VectorType &       dst,
+                                                    VectorType const & src,
+                                                    double const       factor,
+                                                    double const       time) const
 {
-  elasticity_operator_nonlinear.set_scaling_factor_mass_operator(factor);
-  elasticity_operator_nonlinear.set_time(time);
-  elasticity_operator_nonlinear.evaluate_nonlinear(dst, src);
+  if(param.large_deformation)
+  {
+    elasticity_operator_nonlinear.set_scaling_factor_mass_operator(factor);
+    elasticity_operator_nonlinear.set_time(time);
+    elasticity_operator_nonlinear.evaluate_nonlinear(dst, src);
+  }
+  else
+  {
+    elasticity_operator_linear.set_scaling_factor_mass_operator(factor);
+    elasticity_operator_linear.set_time(time);
+    elasticity_operator_linear.evaluate(dst, src);
+  }
 }
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::apply_linear_operator(VectorType &       dst,
-                                             VectorType const & src,
-                                             double const       factor,
-                                             double const       time) const
+Operator<dim, Number>::apply_elasticity_operator(VectorType &       dst,
+                                                 VectorType const & src,
+                                                 VectorType const & linearization,
+                                                 double const       factor,
+                                                 double const       time) const
 {
-  elasticity_operator_linear.set_scaling_factor_mass_operator(factor);
-  elasticity_operator_linear.set_time(time);
-  elasticity_operator_linear.vmult(dst, src);
+  if(param.large_deformation)
+  {
+    set_solution_linearization(linearization);
+    apply_linearized_operator(dst, src, factor, time);
+  }
+  else
+  {
+    elasticity_operator_linear.set_scaling_factor_mass_operator(factor);
+    elasticity_operator_linear.set_time(time);
+    elasticity_operator_linear.vmult(dst, src);
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -249,16 +249,17 @@ public:
                             double const       time) const;
 
   void
-  apply_nonlinear_operator(VectorType &       dst,
-                           VectorType const & src,
-                           double const       factor,
-                           double const       time) const;
+  evaluate_elasticity_operator(VectorType &       dst,
+                               VectorType const & src,
+                               double const       factor,
+                               double const       time) const;
 
   void
-  apply_linear_operator(VectorType &       dst,
-                        VectorType const & src,
-                        double const       factor,
-                        double const       time) const;
+  apply_elasticity_operator(VectorType &       dst,
+                            VectorType const & src,
+                            VectorType const & linearization,
+                            double const       factor,
+                            double const       time) const;
 
   /*
    * This function solves the (non-)linear system of equations.


### PR DESCRIPTION
The naming is adjusted according to the functions `OperatorBase::evaluate()/apply()/rhs()`.