### PR TITLE
Fix include file for dealii::Vector

### DIFF
--- a/include/exadg/matrix_free/categorization.h
+++ b/include/exadg/matrix_free/categorization.h
@@ -72,7 +72,7 @@ do_cell_based_loops(dealii::Triangulation<dim> const & tria,
     unsigned int c_num = 0;
     for(unsigned int i = 0; i < n_faces_per_cell; i++)
     {
-      auto & face = *cell->face(i);
+      const auto face = *cell->face(i);
       if(face.at_boundary())
         c_num += factors[i] * bid_map[face.boundary_id()];
     }

--- a/include/exadg/utilities/tensor_utilities.h
+++ b/include/exadg/utilities/tensor_utilities.h
@@ -27,7 +27,7 @@
 
 // deal.II
 #include <deal.II/base/tensor.h>
-#include <deal.II/lac/la_vector.h>
+#include <deal.II/lac/vector.h>
 
 namespace ExaDG
 {

--- a/tests/time_integration/bdf_time_derivative_01.cc
+++ b/tests/time_integration/bdf_time_derivative_01.cc
@@ -22,14 +22,14 @@
 #include <iostream>
 #include <numeric>
 
-#include <deal.II/lac/la_vector.h>
+#include <deal.II/lac/vector.h>
 
 #include <exadg/time_integration/bdf_constants.h>
 
 // Check compute_bdf_time_derivative() from quantities and times
 
 using namespace ExaDG;
-using VectorType = dealii::LinearAlgebra::Vector<double>;
+using VectorType = dealii::Vector<double>;
 
 VectorType
 get_vector_with_value(double const value)


### PR DESCRIPTION
https://github.com/dealii/dealii/pull/15626 removed `LinearAlgebra::Vector` and the associated include file `deal.II/lac/la_vector.h` without deprecated. Since we are using `dealii::Vector`, we should have used the right include file from the start. We essentially only used the forward declaration of `la_vector.h` if I see things correctly, but we should be explicit in what this file uses anyway.

Edit: The second commit avoids creating a temporary for a face access, which is necessary with https://github.com/dealii/dealii/pull/15445

Both commits should be backwards compatible.