### PR TITLE
Structure: Fix 'can' application

### DIFF
--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -323,7 +323,7 @@ private:
 
   double volume_force = 1.0;
 
-  enum BoundaryType
+  enum class BoundaryType
   {
     Dirichlet,
     Neumann


### PR DESCRIPTION
With my compiler (clang-16), I saw an error of the kind
```
/home/kronbichler/Work/dg/exadg/bundled/magic_enum/magic_enum.hpp:368:12: error: integer value 129 is outside the valid range of values [0, 1] for this enumeration type [-Wenum-constexpr-conversion]
    return static_cast<E>(static_cast<int>(i) + O);
           ^
/home/kronbichler/Work/dg/exadg/bundled/magic_enum/magic_enum.hpp:358:30: error: integer value 129 is outside the valid range of values [0, 1] for this enumeration type [-Wenum-constexpr-conversion]
  return n<E, static_cast<E>(V)>().size() != 0;
                             ^
/home/kronbichler/Work/dg/exadg/bundled/magic_enum/magic_enum.hpp:332:56: error: integer value 129 is outside the valid range of values [0, 1] for this enumeration type [-Wenum-constexpr-conversion]
  constexpr auto custom_name = customize::enum_name<E>(V);
...
```
I don't understand `magic_enum` completely, but we should use `enum class` to denote the boundary conditions.

~~This PR currently builds on top of #515 to ensure that the CI passes. I can rebase later.~~