### PR TITLE
Replace set_zero_mean_value by subtract_mean_value

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -19,6 +19,8 @@
  *  ______________________________________________________________________
  */
 
+#include <deal.II/numerics/vector_tools_mean_value.h>
+
 #include <exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h>
 #include <exadg/poisson/preconditioners/multigrid_preconditioner.h>
@@ -1219,7 +1221,7 @@ OperatorCoupled<dim, Number>::apply_inverse_negative_laplace_operator(VectorType
 
       if(laplace_operator->operator_is_singular())
       {
-        set_zero_mean_value(vector_zero_mean);
+        dealii::VectorTools::subtract_mean_value(vector_zero_mean);
       }
 
       pointer_to_src = &vector_zero_mean;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1146,7 +1146,7 @@ SpatialOperatorBase<dim, Number>::adjust_pressure_level_if_undefined(VectorType 
     }
     else if(this->param.adjust_pressure_level == AdjustPressureLevel::ApplyZeroMeanValue)
     {
-      dealii::LinearAlgebra::set_zero_mean_value(pressure);
+      dealii::VectorTools::subtract_mean_value(pressure);
     }
     // If an analytical solution is available: shift pressure so that the numerical pressure
     // solution has a mean value identical to the "exact pressure solution" obtained by

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -19,6 +19,8 @@
  *  ______________________________________________________________________
  */
 
+#include <deal.II/numerics/vector_tools_mean_value.h>
+
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
@@ -583,7 +585,7 @@ TimeIntBDFDualSplitting<dim, Number>::rhs_pressure(VectorType & rhs) const
   // scheme and coupled solution approach due to the Dirichlet BC prescribed for the intermediate
   // velocity field and the pressure Neumann BC in case of the dual-splitting scheme.
   if(pde_operator->is_pressure_level_undefined())
-    set_zero_mean_value(rhs);
+    dealii::VectorTools::subtract_mean_value(rhs);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -19,6 +19,8 @@
  *  ______________________________________________________________________
  */
 
+#include <deal.II/numerics/vector_tools_mean_value.h>
+
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
@@ -668,7 +670,7 @@ TimeIntBDFPressureCorrection<dim, Number>::rhs_pressure(VectorType & rhs) const
   // in case of the pressure-correction scheme.
 
   if(pde_operator->is_pressure_level_undefined())
-    set_zero_mean_value(rhs);
+    dealii::VectorTools::subtract_mean_value(rhs);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -29,6 +29,7 @@
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/multigrid/mg_base.h>
+#include <deal.II/numerics/vector_tools_mean_value.h>
 
 // ExaDG
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h>
@@ -188,7 +189,7 @@ public:
   {
     VectorType r(src);
     if(additional_data.operator_is_singular)
-      set_zero_mean_value(r);
+      dealii::VectorTools::subtract_mean_value(r);
 
     if(additional_data.preconditioner == MultigridCoarseGridPreconditioner::AMG)
     {

--- a/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
@@ -22,6 +22,8 @@
 #ifndef INCLUDE_EXADG_SOLVERS_AND_PRECONDITIONERS_UTIL_COMPUTE_EIGENVALUES_H_
 #define INCLUDE_EXADG_SOLVERS_AND_PRECONDITIONERS_UTIL_COMPUTE_EIGENVALUES_H_
 
+#include <deal.II/numerics/vector_tools_mean_value.h>
+
 namespace ExaDG
 {
 // manually compute eigenvalues for the coarsest level for proper setup of the
@@ -41,7 +43,7 @@ compute_eigenvalues(Operator const &   op,
   for(unsigned int i = 0; i < rhs.locally_owned_size(); ++i)
     rhs.local_element(i) = (double)rand() / RAND_MAX;
   if(operator_is_singular)
-    set_zero_mean_value(rhs);
+    dealii::VectorTools::subtract_mean_value(rhs);
 
   dealii::SolverControl control(eig_n_iter, rhs.l2_norm() * 1e-5);
   dealii::internal::PreconditionChebyshevImplementation::EigenvalueTracker eigenvalue_tracker;


### PR DESCRIPTION
As noted by https://github.com/dealii/dealii/pull/15688#discussion_r1258201969, let us use `dealii::VectorTools::subtract_mean_value` to ensure compatibility with all versions of deal.II (9.5 and 9.6). If we need this for continuous FEM with constraints, we might extend the function in deal.II to also work with parallel vectors, I think I have the code somewhere on my machine.