### PR TITLE
Use mapping in calculate_minimum_vertex_distance

### DIFF
--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -432,7 +432,7 @@ template<int dim, typename Number>
 double
 Operator<dim, Number>::calculate_minimum_element_length() const
 {
-  return calculate_minimum_vertex_distance(dof_handler.get_triangulation(), mpi_comm);
+  return calculate_minimum_vertex_distance(dof_handler.get_triangulation(), *mapping, mpi_comm);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -957,7 +957,7 @@ template<int dim, typename Number>
 double
 Operator<dim, Number>::calculate_minimum_element_length() const
 {
-  return calculate_minimum_vertex_distance(dof_handler.get_triangulation(), mpi_comm);
+  return calculate_minimum_vertex_distance(dof_handler.get_triangulation(), *mapping, mpi_comm);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1004,7 +1004,9 @@ template<int dim, typename Number>
 double
 SpatialOperatorBase<dim, Number>::calculate_minimum_element_length() const
 {
-  return calculate_minimum_vertex_distance(dof_handler_u.get_triangulation(), mpi_comm);
+  return calculate_minimum_vertex_distance(dof_handler_u.get_triangulation(),
+                                           *get_mapping(),
+                                           mpi_comm);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -104,7 +104,7 @@ public:
     if(compute_aspect_ratio)
     {
       // this variant is only for comparison
-      double AR = calculate_aspect_ratio_vertex_distance(*grid->triangulation, mpi_comm);
+      double AR = calculate_aspect_ratio_vertex_distance(*grid->triangulation, *mapping, mpi_comm);
       pcout << std::endl << "Maximum aspect ratio (vertex distance) = " << AR << std::endl;
 
       auto const reference_cells = grid->triangulation->get_reference_cells();


### PR DESCRIPTION
In the discussion of #524, it is suggested to remove the function. This PR shows how to correctly calculate this information also on deformed geometries. Obviously, we should still assess whether the functionality is still needed, and this PR is merely there to demonstrate that the code changes are small (we just need to pass in the mapping and take the deformed vertices).