### PR TITLE
fix order of constraints closing in poisson and structure operator

### DIFF
--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -99,6 +99,7 @@ Operator<dim, n_components, Number>::distribute_dofs()
     dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
     affine_constraints.reinit(locally_relevant_dofs);
 
+    // affine constraints to copy from need to be non-closed to add further constraints
     affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
     // use all the component masks defined by the user

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -91,8 +91,6 @@ Operator<dim, n_components, Number>::distribute_dofs()
                                                  *this->grid,
                                                  dof_handler);
 
-    affine_constraints_periodicity_and_hanging_nodes.close();
-
     // copy periodicity and hanging node constraints, and add further constraints stemming from
     // Dirichlet boundary conditions
     affine_constraints.clear();
@@ -121,6 +119,8 @@ Operator<dim, n_components, Number>::distribute_dofs()
     // call deal.II utility function to add Dirichlet constraints
     add_homogeneous_dirichlet_constraints(affine_constraints, dof_handler, map_bid_to_mask);
 
+    // compress constraints *once after* complete setup
+    affine_constraints_periodicity_and_hanging_nodes.close();
     affine_constraints.close();
   }
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -131,8 +131,6 @@ Operator<dim, Number>::distribute_dofs()
                                                *this->grid,
                                                dof_handler);
 
-  affine_constraints_periodicity_and_hanging_nodes.close();
-
   // copy periodicity and hanging node constraints, and add further constraints stemming from
   // Dirichlet boundary conditions
   affine_constraints.clear();
@@ -164,6 +162,8 @@ Operator<dim, Number>::distribute_dofs()
   // call deal.II utility function to add Dirichlet constraints
   add_homogeneous_dirichlet_constraints(affine_constraints, dof_handler, map_bid_to_mask);
 
+  // compress constraints *once after* complete setup
+  affine_constraints_periodicity_and_hanging_nodes.close();
   affine_constraints.close();
 
   pcout << std::endl

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -139,6 +139,7 @@ Operator<dim, Number>::distribute_dofs()
   dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
   affine_constraints.reinit(locally_relevant_dofs);
 
+  // affine constraints to copy from need to be non-closed to add further constraints
   affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
   // use all the component masks defined by the user


### PR DESCRIPTION
copying an AffineConstraints object seems to copy the `closed` state, such that adding constraints afterwards triggers an assert in debug mode. This affects Poisson and Structure modules.