### PR TITLE
simplify affine_constraints setup in Poisson and Structure module

### DIFF
--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -91,18 +91,9 @@ Operator<dim, n_components, Number>::distribute_dofs()
                                                  *this->grid,
                                                  dof_handler);
 
-    affine_constraints_periodicity_and_hanging_nodes.close();
-
     // copy periodicity and hanging node constraints, and add further constraints stemming from
     // Dirichlet boundary conditions
-    affine_constraints.clear();
-
-    dealii::IndexSet locally_relevant_dofs;
-    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-    affine_constraints.reinit(locally_relevant_dofs);
-
-    // affine constraints to copy from need to be non-closed to add further constraints
-    affine_constraints.merge(affine_constraints_periodicity_and_hanging_nodes);
+    affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
     // use all the component masks defined by the user
     std::map<dealii::types::boundary_id, dealii::ComponentMask> map_bid_to_mask =
@@ -122,6 +113,9 @@ Operator<dim, n_components, Number>::distribute_dofs()
     // call deal.II utility function to add Dirichlet constraints
     add_homogeneous_dirichlet_constraints(affine_constraints, dof_handler, map_bid_to_mask);
 
+    // compress constraints *once after* complete setup, since affine constraints to copy from need
+    // to be non-closed to add further constraints
+    affine_constraints_periodicity_and_hanging_nodes.close();
     affine_constraints.close();
   }
 

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -91,6 +91,8 @@ Operator<dim, n_components, Number>::distribute_dofs()
                                                  *this->grid,
                                                  dof_handler);
 
+    affine_constraints_periodicity_and_hanging_nodes.close();
+
     // copy periodicity and hanging node constraints, and add further constraints stemming from
     // Dirichlet boundary conditions
     affine_constraints.clear();
@@ -100,7 +102,7 @@ Operator<dim, n_components, Number>::distribute_dofs()
     affine_constraints.reinit(locally_relevant_dofs);
 
     // affine constraints to copy from need to be non-closed to add further constraints
-    affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
+    affine_constraints.merge(affine_constraints_periodicity_and_hanging_nodes);
 
     // use all the component masks defined by the user
     std::map<dealii::types::boundary_id, dealii::ComponentMask> map_bid_to_mask =
@@ -120,8 +122,6 @@ Operator<dim, n_components, Number>::distribute_dofs()
     // call deal.II utility function to add Dirichlet constraints
     add_homogeneous_dirichlet_constraints(affine_constraints, dof_handler, map_bid_to_mask);
 
-    // compress constraints *once after* complete setup
-    affine_constraints_periodicity_and_hanging_nodes.close();
     affine_constraints.close();
   }
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -131,18 +131,9 @@ Operator<dim, Number>::distribute_dofs()
                                                *this->grid,
                                                dof_handler);
 
-  affine_constraints_periodicity_and_hanging_nodes.close();
-
   // copy periodicity and hanging node constraints, and add further constraints stemming from
   // Dirichlet boundary conditions
-  affine_constraints.clear();
-
-  dealii::IndexSet locally_relevant_dofs;
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-  affine_constraints.reinit(locally_relevant_dofs);
-
-  // affine constraints to copy from need to be non-closed to add further constraints
-  affine_constraints.merge(affine_constraints_periodicity_and_hanging_nodes);
+  affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
 
   // use all the component masks defined by the user
   std::map<dealii::types::boundary_id, dealii::ComponentMask> map_bid_to_mask =
@@ -165,6 +156,9 @@ Operator<dim, Number>::distribute_dofs()
   // call deal.II utility function to add Dirichlet constraints
   add_homogeneous_dirichlet_constraints(affine_constraints, dof_handler, map_bid_to_mask);
 
+  // compress constraints *once after* complete setup, since affine constraints to copy from need to
+  // be non-closed to add further constraints
+  affine_constraints_periodicity_and_hanging_nodes.close();
   affine_constraints.close();
 
   pcout << std::endl

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -131,6 +131,8 @@ Operator<dim, Number>::distribute_dofs()
                                                *this->grid,
                                                dof_handler);
 
+  affine_constraints_periodicity_and_hanging_nodes.close();
+
   // copy periodicity and hanging node constraints, and add further constraints stemming from
   // Dirichlet boundary conditions
   affine_constraints.clear();
@@ -140,7 +142,7 @@ Operator<dim, Number>::distribute_dofs()
   affine_constraints.reinit(locally_relevant_dofs);
 
   // affine constraints to copy from need to be non-closed to add further constraints
-  affine_constraints.copy_from(affine_constraints_periodicity_and_hanging_nodes);
+  affine_constraints.merge(affine_constraints_periodicity_and_hanging_nodes);
 
   // use all the component masks defined by the user
   std::map<dealii::types::boundary_id, dealii::ComponentMask> map_bid_to_mask =
@@ -163,8 +165,6 @@ Operator<dim, Number>::distribute_dofs()
   // call deal.II utility function to add Dirichlet constraints
   add_homogeneous_dirichlet_constraints(affine_constraints, dof_handler, map_bid_to_mask);
 
-  // compress constraints *once after* complete setup
-  affine_constraints_periodicity_and_hanging_nodes.close();
   affine_constraints.close();
 
   pcout << std::endl


### PR DESCRIPTION
alternative to the fix in #535, we can merge the constraints, such that the `clear()` and `close()` calls are closer to each other and further modularisation would be possible as well. With `copy_from` we would not need to construct `locally_relevant_dofs` (right?), which in this proposed version is needed. @kronbichler do you prefer one version over the other? 