### PR TITLE
fix bug in create_triangulation(): create triangulation before using it

### DIFF
--- a/include/exadg/grid/grid_utilities.h
+++ b/include/exadg/grid/grid_utilities.h
@@ -226,6 +226,9 @@ create_triangulation(
         dealii::TriangulationDescription::construct_multigrid_hierarchy;
     }
 
+    triangulation =
+      std::make_shared<dealii::parallel::fullydistributed::Triangulation<dim>>(mpi_comm);
+
     auto const description = dealii::TriangulationDescription::Utilities::
       create_description_from_triangulation_in_groups<dim, dim>(serial_grid_generator,
                                                                 serial_grid_partitioner,
@@ -233,9 +236,6 @@ create_triangulation(
                                                                 group_size,
                                                                 mesh_smoothing,
                                                                 triangulation_description_setting);
-
-    triangulation =
-      std::make_shared<dealii::parallel::fullydistributed::Triangulation<dim>>(mpi_comm);
 
     triangulation->create_triangulation(description);
   }


### PR DESCRIPTION
This bug only affects the `fullydistributed` case: `triangulation->get_communicator()` gives a seg-fault in the current code version.

This problem has been encountered in PR #534.