### PR TITLE
rename function distribute_dofs()

### DIFF
--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -62,7 +62,7 @@ Operator<dim, Number>::Operator(
   fe_vector = create_finite_element<dim>(ElementType::Hypercube, true, dim, param.degree);
   fe_scalar = create_finite_element<dim>(ElementType::Hypercube, true, 1, param.degree);
 
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   constraint.close();
 
@@ -466,7 +466,7 @@ Operator<dim, Number>::calculate_time_step_diffusion() const
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::distribute_dofs()
+Operator<dim, Number>::initialize_dof_handler_and_constraints()
 {
   // enumerate degrees of freedom
   dof_handler.distribute_dofs(*fe);

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -174,7 +174,7 @@ private:
   calculate_minimum_element_length() const;
 
   void
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   void
   setup_operators();

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -71,7 +71,7 @@ Operator<dim, Number>::Operator(
     dof_handler_velocity = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
   }
 
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   affine_constraints.close();
 
@@ -296,7 +296,7 @@ Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number> con
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::distribute_dofs()
+Operator<dim, Number>::initialize_dof_handler_and_constraints()
 {
   // enumerate degrees of freedom
   dof_handler.distribute_dofs(*fe);

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -293,7 +293,7 @@ private:
    * Initializes dealii::DoFHandlers.
    */
   void
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   bool
   needs_own_dof_handler_velocity() const;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -71,7 +71,7 @@ SpatialOperatorBase<dim, Number>::SpatialOperatorBase(
 
   initialize_boundary_descriptor_laplace();
 
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   constraint_u.close();
   constraint_p.close();
@@ -254,7 +254,7 @@ SpatialOperatorBase<dim, Number>::initialize_boundary_descriptor_laplace()
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::distribute_dofs()
+SpatialOperatorBase<dim, Number>::initialize_dof_handler_and_constraints()
 {
   fe_p = create_finite_element<dim>(param.grid.element_type,
                                     true,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -595,7 +595,7 @@ private:
   initialize_boundary_descriptor_laplace();
 
   void
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   void
   initialize_operators(std::string const & dof_index_temperature);

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -66,14 +66,14 @@ Operator<dim, n_components, Number>::Operator(
 {
   pcout << std::endl << "Construct Poisson operator ..." << std::endl;
 
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, int n_components, typename Number>
 void
-Operator<dim, n_components, Number>::distribute_dofs()
+Operator<dim, n_components, Number>::initialize_dof_handler_and_constraints()
 {
   fe = create_finite_element<dim>(param.grid.element_type,
                                   param.spatial_discretization == SpatialDiscretization::DG,

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -145,7 +145,7 @@ private:
   get_quad_index_gauss_lobatto() const;
 
   void
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   void
   setup_operators();

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -63,7 +63,7 @@ Operator<dim, Number>::Operator(
 {
   pcout << std::endl << "Construct elasticity operator ..." << std::endl;
 
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   pcout << std::endl << "... done!" << std::endl;
 }
@@ -114,7 +114,7 @@ Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number> con
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::distribute_dofs()
+Operator<dim, Number>::initialize_dof_handler_and_constraints()
 {
   // create finite element
   fe = create_finite_element<dim>(param.grid.element_type,

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -328,7 +328,7 @@ private:
    * Initializes dealii::DoFHandler.
    */
   void
-  distribute_dofs();
+  initialize_dof_handler_and_constraints();
 
   std::string
   get_dof_name() const;


### PR DESCRIPTION
The functions called `Operator::distribute_dofs()` do more than `dof_handler.distribute_dofs()`, which is why I suggest to rename these functions and broaden the function name.