### PR TITLE
Introduce StVenantKirchhoffBase

### DIFF
--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -248,7 +248,7 @@ StVenantKirchhoffSmallDeformation<dim, Number>::
   (void)deformation_gradient;
 
   AssertThrow(false,
-              dealiiExcMessage(
+              dealii::ExcMessage(
                 "This code path is not implemented in NonLinearOperator::do_cell_integral ."));
 
   // Exploit linear stress-strain relationship and symmetrizing in

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -170,7 +170,7 @@ StVenantKirchhoffBase<dim, Number>::second_piola_kirchhoff_stress_symmetrize(
   unsigned int const cell,
   unsigned int const q) const
 {
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> S;
+  tensor S;
 
   if(E_is_variable)
   {

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -247,6 +247,10 @@ StVenantKirchhoffSmallDeformation<dim, Number>::
 {
   (void)deformation_gradient;
 
+  AssertThrow(false,
+              dealiiExcMessage(
+                "This code path is not implemented in NonLinearOperator::do_cell_integral ."));
+
   // Exploit linear stress-strain relationship and symmetrizing in
   // second_piola_kirchhoff_stress_symmetrize
   return (this->second_piola_kirchhoff_stress_symmetrize(gradient_increment, cell, q));

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.h
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.h
@@ -63,7 +63,6 @@ public:
   typedef std::pair<unsigned int, unsigned int>              Range;
   typedef CellIntegrator<dim, dim, Number>                   IntegratorCell;
 
-  typedef dealii::VectorizedArray<Number>                         scalar;
   typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
   StVenantKirchhoffBase(dealii::MatrixFree<dim, Number> const & matrix_free,

--- a/include/exadg/structure/material/material.h
+++ b/include/exadg/structure/material/material.h
@@ -53,7 +53,7 @@ public:
 
   /*
    * Evaluate the directional derivative with respect to the displacement of the 2nd Piola-Kirchhoff
-   * stress tensor given gradient of the displacment increment with respect to the reference
+   * stress tensor given gradient of the displacement increment with respect to the reference
    * configuration "gradient_increment" and deformation gradient at the current linearization point
    * "deformation_gradient".
    */

--- a/include/exadg/structure/material/material_handler.h
+++ b/include/exadg/structure/material/material_handler.h
@@ -72,10 +72,19 @@ public:
         {
           std::shared_ptr<StVenantKirchhoffData<dim>> data_svk =
             std::static_pointer_cast<StVenantKirchhoffData<dim>>(data);
-          material_map.insert(
-            Pair(id,
-                 new StVenantKirchhoff<dim, Number>(
-                   matrix_free, dof_index, quad_index, *data_svk, large_deformation)));
+
+          if(large_deformation)
+          {
+            material_map.insert(Pair(id,
+                                     new StVenantKirchhoffLargeDeformation<dim, Number>(
+                                       matrix_free, dof_index, quad_index, *data_svk)));
+          }
+          else
+          {
+            material_map.insert(Pair(id,
+                                     new StVenantKirchhoffSmallDeformation<dim, Number>(
+                                       matrix_free, dof_index, quad_index, *data_svk)));
+          }
           break;
         }
         default:


### PR DESCRIPTION
This PR introduces a base class for the St Venant solid, whichs' derived classes `StVenantKirchhoffLargeDeformation` and `...SmallDeformation` implement the  `second_piola_kirchhoff_stress` and `second_piola_kirchhoff_stress_displacement_derivative` differently (the derivative of S is now asserted for linear elasticity, if we ever try to solve linear elasticity with a Newton solver). I did not go for free functions for all of the shared functionality, even if other material models might have coefficients to store and initialize/update as well. The main reason lies in the number of coefficients and types thereof being different and we do not want to introduce them in the `Material` class. The second thing this PR achieves is that we get rid of the `if(large_deformation)` in the stress evaluation.

I only did this because I promised I would do it and I am not sure if this actually pays off, since we can assert `second_piola_kirchhoff_stress_displacement_derivative` for small displacements and I am not sure if all this is worth it for 1 `if` and 1 assert ...