### PR TITLE
generalize calculate_minimum_vertex_distance()

### DIFF
--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -455,7 +455,8 @@ template<int dim, typename Number>
 double
 Operator<dim, Number>::calculate_time_step_diffusion() const
 {
-  double const h_min = calculate_minimum_vertex_distance(dof_handler.get_triangulation(), mpi_comm);
+  double const h_min =
+    calculate_minimum_vertex_distance(dof_handler.get_triangulation(), get_mapping(), mpi_comm);
 
   return ExaDG::calculate_const_time_step_diff(param.dynamic_viscosity / param.reference_density,
                                                h_min,

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -962,7 +962,9 @@ template<int dim, typename Number>
 double
 Operator<dim, Number>::calculate_minimum_element_length() const
 {
-  return calculate_minimum_vertex_distance(dof_handler.get_triangulation(), mpi_comm);
+  return calculate_minimum_vertex_distance(dof_handler.get_triangulation(),
+                                           *get_mapping(),
+                                           mpi_comm);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/grid/calculate_characteristic_element_length.h
+++ b/include/exadg/grid/calculate_characteristic_element_length.h
@@ -36,24 +36,23 @@ namespace ExaDG
 template<int dim>
 inline double
 calculate_minimum_vertex_distance(dealii::Triangulation<dim> const & triangulation,
+                                  dealii::Mapping<dim> const &       mapping,
                                   MPI_Comm const &                   mpi_comm)
 {
-  double diameter = 0.0, min_cell_diameter = std::numeric_limits<double>::max();
+  double min_cell_diameter = std::numeric_limits<double>::max();
 
   for(auto const & cell : triangulation.active_cell_iterators())
   {
     if(cell->is_locally_owned())
     {
-      diameter = cell->minimum_vertex_distance();
-      if(diameter < min_cell_diameter)
-        min_cell_diameter = diameter;
+      auto const vertices = mapping.get_vertices(cell);
+      for(unsigned int i = 0; i < vertices.size(); ++i)
+        for(unsigned int j = i + 1; j < vertices.size(); ++j)
+          min_cell_diameter = std::min(min_cell_diameter, vertices[i].distance(vertices[j]));
     }
   }
 
-  double const global_min_cell_diameter =
-    -dealii::Utilities::MPI::max(-min_cell_diameter, mpi_comm);
-
-  return global_min_cell_diameter;
+  return dealii::Utilities::MPI::min(min_cell_diameter, mpi_comm);
 }
 
 /**

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1006,7 +1006,9 @@ template<int dim, typename Number>
 double
 SpatialOperatorBase<dim, Number>::calculate_minimum_element_length() const
 {
-  return calculate_minimum_vertex_distance(dof_handler_u.get_triangulation(), mpi_comm);
+  return calculate_minimum_vertex_distance(dof_handler_u.get_triangulation(),
+                                           *get_mapping(),
+                                           mpi_comm);
 }
 
 template<int dim, typename Number>


### PR DESCRIPTION
We can not get rid of the function currently, since it is has not only been used for CFL calculations, but is currently used also for other purposes.

Replaces PR #528.