### PR TITLE
introduce a second Operator::setup() function for easy use in applications

### DIFF
--- a/include/exadg/compressible_navier_stokes/driver.cpp
+++ b/include/exadg/compressible_navier_stokes/driver.cpp
@@ -67,19 +67,7 @@ Driver<dim, Number>::setup()
                                                          "fluid",
                                                          mpi_comm);
 
-  // initialize matrix_free
-  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-  matrix_free_data->append(pde_operator);
-
-  matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-  matrix_free->reinit(*application->get_mapping(),
-                      matrix_free_data->get_dof_handler_vector(),
-                      matrix_free_data->get_constraint_vector(),
-                      matrix_free_data->get_quadrature_vector(),
-                      matrix_free_data->data);
-
-  // setup compressible Navier-Stokes operator
-  pde_operator->setup(matrix_free, matrix_free_data);
+  pde_operator->setup();
 
   // initialize postprocessor
   if(not is_throughput_study)

--- a/include/exadg/compressible_navier_stokes/driver.h
+++ b/include/exadg/compressible_navier_stokes/driver.h
@@ -91,9 +91,6 @@ private:
 
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
-  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
-
   std::shared_ptr<Operator<dim, Number>> pde_operator;
 
   std::shared_ptr<PostProcessorBase<dim, Number>> postprocessor;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -251,6 +251,29 @@ Operator<dim, Number>::setup_operators()
 
 template<int dim, typename Number>
 void
+Operator<dim, Number>::setup()
+{
+  // initialize MatrixFree and MatrixFreeData
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> mf =
+    std::make_shared<dealii::MatrixFree<dim, Number>>();
+  std::shared_ptr<MatrixFreeData<dim, Number>> mf_data =
+    std::make_shared<MatrixFreeData<dim, Number>>();
+
+  fill_matrix_free_data(*mf_data);
+
+  mf->reinit(get_mapping(),
+             mf_data->get_dof_handler_vector(),
+             mf_data->get_constraint_vector(),
+             mf_data->get_quadrature_vector(),
+             mf_data->data);
+
+  // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
+  // arguments.
+  this->setup(mf, mf_data);
+}
+
+template<int dim, typename Number>
+void
 Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free_in,
                              std::shared_ptr<MatrixFreeData<dim, Number> const> matrix_free_data_in)
 {

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -61,6 +61,17 @@ public:
   void
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
 
+  /**
+   * Call this setup() function if the dealii::MatrixFree object can be set up by the present class.
+   */
+  void
+  setup();
+
+  /**
+   * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
+   * class. The typical use case would be multiphysics-coupling with one MatrixFree object handed
+   * over to several single-field solvers.
+   */
   void
   setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
         std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data);

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -80,9 +80,7 @@ Driver<dim, Number>::setup()
     };
 
     helpers_ale->update_pde_operator_after_grid_motion = [&]() {
-      matrix_free->update_mapping(*ale_mapping);
-
-      pde_operator->update_after_grid_motion();
+      pde_operator->update_after_grid_motion(true);
     };
   }
 
@@ -98,23 +96,8 @@ Driver<dim, Number>::setup()
                                                          "scalar",
                                                          mpi_comm);
 
-  // initialize matrix_free
-  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-  matrix_free_data->append(pde_operator);
-
-  matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-  if(application->get_parameters().use_cell_based_face_loops)
-    Categorization::do_cell_based_loops(*application->get_grid()->triangulation,
-                                        matrix_free_data->data);
-
-  matrix_free->reinit(*dynamic_mapping,
-                      matrix_free_data->get_dof_handler_vector(),
-                      matrix_free_data->get_constraint_vector(),
-                      matrix_free_data->get_quadrature_vector(),
-                      matrix_free_data->data);
-
   // setup convection-diffusion operator
-  pde_operator->setup(matrix_free, matrix_free_data);
+  pde_operator->setup();
 
   if(not is_throughput_study)
   {

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -111,9 +111,6 @@ private:
   // ALE helper functions required by time integrator
   std::shared_ptr<HelpersALE<Number>> helpers_ale;
 
-  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
-
   std::shared_ptr<Operator<dim, Number>> pde_operator;
 
   std::shared_ptr<PostProcessorBase<dim, Number>> postprocessor;

--- a/include/exadg/convection_diffusion/spatial_discretization/interface.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/interface.h
@@ -105,10 +105,6 @@ public:
 
   // needed for ALE-type problems
   virtual void
-  update_after_grid_motion() = 0;
-
-  // needed for ALE-type problems
-  virtual void
   fill_grid_coordinates_vector(VectorType & vector) const = 0;
 };
 } // namespace Interface

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -322,11 +322,12 @@ Operator<dim, Number>::setup()
              mf_data->get_quadrature_vector(),
              mf_data->data);
 
-  matrix_free_own_storage = mf;
+  if(param.ale_formulation)
+    matrix_free_own_storage = mf;
 
   // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
   // arguments.
-  this->setup(matrix_free_own_storage, mf_data);
+  this->setup(mf, mf_data);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -322,9 +322,11 @@ Operator<dim, Number>::setup()
              mf_data->get_quadrature_vector(),
              mf_data->data);
 
+  matrix_free_own_storage = mf;
+
   // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
   // arguments.
-  this->setup(mf, mf_data);
+  this->setup(matrix_free_own_storage, mf_data);
 }
 
 template<int dim, typename Number>
@@ -777,8 +779,16 @@ Operator<dim, Number>::update_conv_diff_operator(double const       time,
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::update_after_grid_motion()
+Operator<dim, Number>::update_after_grid_motion(bool const update_matrix_free)
 {
+  if(update_matrix_free)
+  {
+    // Since matrix_free points to matrix_free_own_storage, we also update the actual/main
+    // MatrixFree object called matrix_free.
+    matrix_free_own_storage->update_mapping(*get_mapping());
+  }
+
+
   // update SIPG penalty parameter of diffusive operator which depends on the deformation
   // of elements
   if(param.diffusive_problem())

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -304,6 +304,31 @@ Operator<dim, Number>::setup_operators()
 
 template<int dim, typename Number>
 void
+Operator<dim, Number>::setup()
+{
+  // initialize MatrixFree and MatrixFreeData
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> mf =
+    std::make_shared<dealii::MatrixFree<dim, Number>>();
+  std::shared_ptr<MatrixFreeData<dim, Number>> mf_data =
+    std::make_shared<MatrixFreeData<dim, Number>>();
+
+  fill_matrix_free_data(*mf_data);
+
+  if(param.use_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*grid->triangulation, mf_data->data);
+  mf->reinit(*get_mapping(),
+             mf_data->get_dof_handler_vector(),
+             mf_data->get_constraint_vector(),
+             mf_data->get_quadrature_vector(),
+             mf_data->data);
+
+  // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
+  // arguments.
+  this->setup(mf, mf_data);
+}
+
+template<int dim, typename Number>
+void
 Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free_in,
                              std::shared_ptr<MatrixFreeData<dim, Number> const> matrix_free_data_in,
                              std::string const & dof_index_velocity_external_in)

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -65,10 +65,17 @@ public:
   void
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
 
+  /**
+   * Call this setup() function if the dealii::MatrixFree object can be set up by the present class.
+   */
+  void
+  setup();
+
   /*
-   * Setup function. Initializes basic finite element components, matrix-free object, and basic
-   * operators. This function does not perform the setup related to the solution of linear systems
-   * of equations.
+   * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
+   * class. The typical use case would be multiphysics-coupling with one MatrixFree object handed
+   * over to several single-field solvers. Another typical use case is the use of an ALE
+   * formulation.
    */
   void
   setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free_in,
@@ -198,7 +205,7 @@ public:
    * Updates spatial operators after grid has been moved.
    */
   void
-  update_after_grid_motion() final;
+  update_after_grid_motion();
 
   /*
    * Fills a dof-vector with grid coordinates for ALE-type problems.

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -71,7 +71,7 @@ public:
   void
   setup();
 
-  /*
+  /**
    * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
    * class. The typical use case would be multiphysics-coupling with one MatrixFree object handed
    * over to several single-field solvers. Another typical use case is the use of an ALE

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -205,7 +205,7 @@ public:
    * Updates spatial operators after grid has been moved.
    */
   void
-  update_after_grid_motion();
+  update_after_grid_motion(bool const update_matrix_free);
 
   /*
    * Fills a dof-vector with grid coordinates for ALE-type problems.
@@ -393,6 +393,11 @@ private:
    */
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
+
+  // If we want to be able to update the mapping, we need a pointer to a non-const MatrixFree
+  // object. In case this object is created, we let the above object called matrix_free point to
+  // matrix_free_own_storage. This variable is needed for ALE formulations.
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_own_storage;
 
   /*
    * Basic operators.

--- a/include/exadg/fluid_structure_interaction/precice/coupling_base.h
+++ b/include/exadg/fluid_structure_interaction/precice/coupling_base.h
@@ -256,10 +256,9 @@ void
 CouplingBase<dim, data_dim, VectorizedArrayType>::print_info(bool const         reader,
                                                              unsigned int const local_size) const
 {
-  Assert(matrix_free.get() != 0, dealii::ExcNotInitialized());
   dealii::ConditionalOStream pcout(std::cout,
                                    dealii::Utilities::MPI::this_mpi_process(
-                                     matrix_free->get_dof_handler().get_communicator()) == 0);
+                                     matrix_free.get_dof_handler().get_communicator()) == 0);
   auto const                 map = (reader ? read_data_map : write_data_map);
 
   auto        names      = map.begin();
@@ -272,8 +271,7 @@ CouplingBase<dim, data_dim, VectorizedArrayType>::print_info(bool const         
         << "--     . data name(s): " << data_names << "\n"
         << "--     . associated mesh: " << mesh_name << "\n"
         << "--     . Number of coupling nodes: "
-        << dealii::Utilities::MPI::sum(local_size,
-                                       matrix_free->get_dof_handler().get_communicator())
+        << dealii::Utilities::MPI::sum(local_size, matrix_free.get_dof_handler().get_communicator())
         << "\n"
         << "--     . Node location: " << get_surface_type() << "\n"
         << std::endl;

--- a/include/exadg/fluid_structure_interaction/precice/coupling_base.h
+++ b/include/exadg/fluid_structure_interaction/precice/coupling_base.h
@@ -65,7 +65,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 class CouplingBase
 {
 public:
-  CouplingBase(std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
+  CouplingBase(dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
                std::shared_ptr<precice::SolverInterface> precice,
 #endif
@@ -141,7 +141,7 @@ protected:
   print_info(bool const reader, unsigned int const local_size) const;
 
   /// The dealii::MatrixFree object (preCICE can only handle double precision)
-  std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> matrix_free;
+  dealii::MatrixFree<dim, double, VectorizedArrayType> const & matrix_free;
 
   /// public precice solverinterface
 #ifdef EXADG_WITH_PRECICE
@@ -167,7 +167,7 @@ protected:
 
 template<int dim, int data_dim, typename VectorizedArrayType>
 CouplingBase<dim, data_dim, VectorizedArrayType>::CouplingBase(
-  std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> matrix_free_,
+  dealii::MatrixFree<dim, double, VectorizedArrayType> const & matrix_free_,
 #ifdef EXADG_WITH_PRECICE
   std::shared_ptr<precice::SolverInterface> precice,
 #endif
@@ -181,8 +181,6 @@ CouplingBase<dim, data_dim, VectorizedArrayType>::CouplingBase(
     dealii_boundary_surface_id(surface_id),
     write_data_type(WriteDataType::undefined)
 {
-  Assert(matrix_free_.get() != nullptr, dealii::ExcNotInitialized());
-
 #ifdef EXADG_WITH_PRECICE
   Assert(precice.get() != nullptr, dealii::ExcNotInitialized());
 

--- a/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
@@ -43,7 +43,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 class DoFCoupling : public CouplingBase<dim, data_dim, VectorizedArrayType>
 {
 public:
-  DoFCoupling(std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
+  DoFCoupling(dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
               std::shared_ptr<precice::SolverInterface> precice,
 #endif
@@ -88,7 +88,7 @@ private:
 
 template<int dim, int data_dim, typename VectorizedArrayType>
 DoFCoupling<dim, data_dim, VectorizedArrayType>::DoFCoupling(
-  std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
+  dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
   std::shared_ptr<precice::SolverInterface> precice,
 #endif
@@ -129,14 +129,14 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
     // TODO: This is super inefficient, have a look at the
     // dof_handler.n_boundary_dofs implementation for a proper version
     dealii::IndexSet const indices =
-      (dealii::DoFTools::extract_boundary_dofs(this->matrix_free->get_dof_handler(mf_dof_index),
+      (dealii::DoFTools::extract_boundary_dofs(this->matrix_free.get_dof_handler(mf_dof_index),
                                                component_mask,
                                                std::set<dealii::types::boundary_id>{
                                                  this->dealii_boundary_surface_id}) &
-       this->matrix_free->get_dof_handler(mf_dof_index).locally_owned_dofs());
+       this->matrix_free.get_dof_handler(mf_dof_index).locally_owned_dofs());
 
     Assert(indices.n_elements() * data_dim ==
-             this->matrix_free->get_dof_handler(mf_dof_index)
+             this->matrix_free.get_dof_handler(mf_dof_index)
                .n_boundary_dofs(
                  std::set<dealii::types::boundary_id>{this->dealii_boundary_surface_id}),
            dealii::ExcInternalError());
@@ -163,8 +163,8 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
   component_mask.set(0, true);
 
   dealii::DoFTools::map_boundary_dofs_to_support_points(
-    *(this->matrix_free->get_mapping_info().mapping),
-    this->matrix_free->get_dof_handler(mf_dof_index),
+    *(this->matrix_free.get_mapping_info().mapping),
+    this->matrix_free.get_dof_handler(mf_dof_index),
     support_points,
     component_mask,
     this->dealii_boundary_surface_id);

--- a/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
@@ -85,7 +85,7 @@ public:
         this->precice_parameters.write_mesh_name,
         {this->precice_parameters.stress_data_name},
         this->precice_parameters.write_data_type,
-        fluid->matrix_free,
+        fluid->pde_operator->get_matrix_free(),
         fluid->pde_operator->get_dof_index_velocity(),
         fluid->pde_operator->get_quad_index_velocity_linear());
     }
@@ -126,7 +126,7 @@ public:
 
     // structure to fluid
     {
-      this->precice->add_read_surface(fluid->matrix_free,
+      this->precice->add_read_surface(fluid->pde_operator->get_matrix_free(),
                                       fluid->pde_operator->get_container_interface_data(),
                                       this->precice_parameters.read_mesh_name,
                                       {this->precice_parameters.velocity_data_name});

--- a/include/exadg/fluid_structure_interaction/precice/driver_solid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_solid.h
@@ -89,7 +89,7 @@ public:
         {this->precice_parameters.displacement_data_name,
          this->precice_parameters.velocity_data_name},
         this->precice_parameters.write_data_type,
-        structure->matrix_free,
+        *structure->pde_operator->get_matrix_free(),
         structure->pde_operator->get_dof_index(),
         dealii::numbers::invalid_unsigned_int);
     }
@@ -97,7 +97,7 @@ public:
     // fluid to structure
     {
       this->precice->add_read_surface(
-        structure->matrix_free,
+        *structure->pde_operator->get_matrix_free(),
         structure->pde_operator->get_container_interface_data_neumann(),
         this->precice_parameters.read_mesh_name,
         {this->precice_parameters.stress_data_name});

--- a/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
@@ -43,7 +43,7 @@ public:
   static unsigned int const rank = n_components_to_rank<data_dim, dim>();
 
   ExaDGCoupling(
-    std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
+    dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
     std::shared_ptr<precice::SolverInterface> precice,
 #endif
@@ -88,7 +88,7 @@ private:
 
 template<int dim, int data_dim, typename VectorizedArrayType>
 ExaDGCoupling<dim, data_dim, VectorizedArrayType>::ExaDGCoupling(
-  std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
+  dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
   std::shared_ptr<precice::SolverInterface> precice,
 #endif

--- a/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
+++ b/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
@@ -103,21 +103,20 @@ public:
   initialize_precice(VectorType const & dealii_to_precice);
 
   void
-  add_write_surface(
-    dealii::types::boundary_id const                                            surface_id,
-    std::string const &                                                         mesh_name,
-    std::vector<std::string> const &                                            write_data_names,
-    WriteDataType const                                                         write_data_type,
-    std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
-    unsigned int const                                                          dof_index,
-    unsigned int const                                                          write_quad_index);
+  add_write_surface(dealii::types::boundary_id const                             surface_id,
+                    std::string const &                                          mesh_name,
+                    std::vector<std::string> const &                             write_data_names,
+                    WriteDataType const                                          write_data_type,
+                    dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
+                    unsigned int const                                           dof_index,
+                    unsigned int const                                           write_quad_index);
 
 
   void
-  add_read_surface(std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
-                   std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data,
-                   std::string const &                                        mesh_name,
-                   std::vector<std::string> const &                           read_data_name);
+  add_read_surface(dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
+                   std::shared_ptr<ContainerInterfaceData<rank, dim, double>>   interface_data,
+                   std::string const &                                          mesh_name,
+                   std::vector<std::string> const &                             read_data_name);
 
   /**
    * @brief      Advances preCICE after every timestep
@@ -234,13 +233,13 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::Adapter(ParameterClass 
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
 void
 Adapter<dim, data_dim, VectorType, VectorizedArrayType>::add_write_surface(
-  dealii::types::boundary_id const dealii_boundary_surface_id,
-  std::string const &              mesh_name,
-  std::vector<std::string> const & write_data_names,
-  WriteDataType const              write_data_type,
-  std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
-  unsigned int const                                                          dof_index,
-  unsigned int const                                                          quad_index)
+  dealii::types::boundary_id const                             dealii_boundary_surface_id,
+  std::string const &                                          mesh_name,
+  std::vector<std::string> const &                             write_data_names,
+  WriteDataType const                                          write_data_type,
+  dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
+  unsigned int const                                           dof_index,
+  unsigned int const                                           quad_index)
 {
   // Check, if we already have such an interface
   auto const found_reader = reader.find(mesh_name);
@@ -294,10 +293,10 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::add_write_surface(
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
 void
 Adapter<dim, data_dim, VectorType, VectorizedArrayType>::add_read_surface(
-  std::shared_ptr<dealii::MatrixFree<dim, double, VectorizedArrayType> const> data,
-  std::shared_ptr<ContainerInterfaceData<rank, dim, double>>                  interface_data,
-  std::string const &                                                         mesh_name,
-  std::vector<std::string> const &                                            read_data_names)
+  dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
+  std::shared_ptr<ContainerInterfaceData<rank, dim, double>>   interface_data,
+  std::string const &                                          mesh_name,
+  std::vector<std::string> const &                             read_data_names)
 {
   reader.insert(
     {mesh_name,

--- a/include/exadg/fluid_structure_interaction/single_field_solvers/fluid.h
+++ b/include/exadg/fluid_structure_interaction/single_field_solvers/fluid.h
@@ -175,7 +175,7 @@ SolverFluid<dim, Number>::setup(std::shared_ptr<FluidFSI::ApplicationBase<dim, N
   helpers_ale->update_pde_operator_after_grid_motion = [&]() {
     matrix_free->update_mapping(*ale_mapping);
 
-    pde_operator->update_after_grid_motion();
+    pde_operator->update_after_grid_motion(false /* update_matrix_free */);
   };
 
   time_integrator = IncNS::create_time_integrator<dim, Number>(

--- a/include/exadg/grid/mapping_deformation_poisson.h
+++ b/include/exadg/grid/mapping_deformation_poisson.h
@@ -63,24 +63,8 @@ public:
     pde_operator = std::make_shared<Poisson::Operator<dim, dim, Number>>(
       grid, mapping_undeformed, boundary_descriptor, field_functions, param, field, mpi_comm);
 
-    // initialize matrix_free_data
-    matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-
-    if(param.enable_cell_based_face_loops)
-      Categorization::do_cell_based_loops(*grid->triangulation, matrix_free_data->data);
-
-    matrix_free_data->append(pde_operator);
-
-    // initialize matrix_free
-    matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-    matrix_free->reinit(*mapping_undeformed,
-                        matrix_free_data->get_dof_handler_vector(),
-                        matrix_free_data->get_constraint_vector(),
-                        matrix_free_data->get_quadrature_vector(),
-                        matrix_free_data->data);
-
     // setup PDE operator and solver
-    pde_operator->setup(matrix_free, matrix_free_data);
+    pde_operator->setup();
     pde_operator->setup_solver();
 
     // finally, initialize dof vector
@@ -96,7 +80,7 @@ public:
   std::shared_ptr<dealii::MatrixFree<dim, Number> const>
   get_matrix_free() const
   {
-    return matrix_free;
+    return pde_operator->get_matrix_free();
   }
 
   /**
@@ -151,10 +135,6 @@ public:
   }
 
 private:
-  // matrix-free
-  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
-
   // PDE operator
   std::shared_ptr<Poisson::Operator<dim, dim, Number>> pde_operator;
 

--- a/include/exadg/grid/mapping_deformation_poisson.h
+++ b/include/exadg/grid/mapping_deformation_poisson.h
@@ -77,10 +77,10 @@ public:
     return pde_operator;
   }
 
-  std::shared_ptr<dealii::MatrixFree<dim, Number> const>
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const
   {
-    return pde_operator->get_matrix_free();
+    return *pde_operator->get_matrix_free();
   }
 
   /**

--- a/include/exadg/grid/mapping_deformation_structure.h
+++ b/include/exadg/grid/mapping_deformation_structure.h
@@ -85,10 +85,10 @@ public:
     return pde_operator;
   }
 
-  std::shared_ptr<dealii::MatrixFree<dim, Number> const>
+  dealii::MatrixFree<dim, Number> const &
   get_matrix_free() const
   {
-    return pde_operator->get_matrix_free();
+    return *pde_operator->get_matrix_free();
   }
 
   /**

--- a/include/exadg/grid/mapping_deformation_structure.h
+++ b/include/exadg/grid/mapping_deformation_structure.h
@@ -71,21 +71,8 @@ public:
                                                            field,
                                                            mpi_comm);
 
-    // ALE: initialize matrix_free_data
-    matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-
-    matrix_free_data->append(pde_operator);
-
-    // initialize matrix_free
-    matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-    matrix_free->reinit(*mapping_undeformed,
-                        matrix_free_data->get_dof_handler_vector(),
-                        matrix_free_data->get_constraint_vector(),
-                        matrix_free_data->get_quadrature_vector(),
-                        matrix_free_data->data);
-
     // setup PDE operator and solver
-    pde_operator->setup(matrix_free, matrix_free_data);
+    pde_operator->setup();
     pde_operator->setup_solver(0.0 /* no acceleration term */, 0.0 /* no damping term */);
 
     // finally, initialize dof vector
@@ -101,7 +88,7 @@ public:
   std::shared_ptr<dealii::MatrixFree<dim, Number> const>
   get_matrix_free() const
   {
-    return matrix_free;
+    return pde_operator->get_matrix_free();
   }
 
   /**

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -91,6 +91,8 @@ Driver<dim, Number>::setup()
     };
 
     helpers_ale->update_pde_operator_after_grid_motion = [&]() {
+      // Since we use the same MatrixFree object for the fluid field and the scalar transport field,
+      // we need to update MatrixFree here in the Driver.
       matrix_free->update_mapping(*ale_mapping);
 
       fluid_operator->update_after_grid_motion(false /* update_matrix_free */);
@@ -257,7 +259,7 @@ Driver<dim, Number>::setup()
 
     fluid_time_integrator->setup(application->fluid->get_parameters().restarted_simulation);
 
-    // setup solvers once time integrator has been initialized
+    // setup solvers once the time integrator has been initialized
     fluid_operator->setup_solvers(fluid_time_integrator->get_scaling_factor_time_derivative_term(),
                                   fluid_time_integrator->get_velocity());
   }
@@ -265,6 +267,7 @@ Driver<dim, Number>::setup()
   {
     fluid_driver_steady->setup();
 
+    // setup solvers once the driver for steady problems has been initialized
     fluid_operator->setup_solvers(1.0 /* dummy */, fluid_driver_steady->get_velocity());
   }
   else

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -93,9 +93,9 @@ Driver<dim, Number>::setup()
     helpers_ale->update_pde_operator_after_grid_motion = [&]() {
       matrix_free->update_mapping(*ale_mapping);
 
-      fluid_operator->update_after_grid_motion();
+      fluid_operator->update_after_grid_motion(false /* update_matrix_free */);
       for(unsigned int i = 0; i < application->scalars.size(); ++i)
-        scalar_operator[i]->update_after_grid_motion();
+        scalar_operator[i]->update_after_grid_motion(false /* update_matrix_free */);
     };
   }
 

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -103,9 +103,7 @@ Driver<dim, Number>::setup()
     };
 
     helpers_ale->update_pde_operator_after_grid_motion = [&]() {
-      matrix_free->update_mapping(*grid_motion);
-
-      pde_operator->update_after_grid_motion();
+      pde_operator->update_after_grid_motion(true);
     };
   }
 
@@ -138,23 +136,8 @@ Driver<dim, Number>::setup()
     AssertThrow(false, dealii::ExcMessage("Not implemented."));
   }
 
-  // initialize matrix_free
-  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-  matrix_free_data->append(pde_operator);
-
-  matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-  if(application->get_parameters().use_cell_based_face_loops)
-    Categorization::do_cell_based_loops(*application->get_grid()->triangulation,
-                                        matrix_free_data->data);
-
-  matrix_free->reinit(*mapping_fluid,
-                      matrix_free_data->get_dof_handler_vector(),
-                      matrix_free_data->get_constraint_vector(),
-                      matrix_free_data->get_quadrature_vector(),
-                      matrix_free_data->data);
-
   // setup Navier-Stokes operator
-  pde_operator->setup(matrix_free, matrix_free_data);
+  pde_operator->setup();
 
   if(not is_throughput_study)
   {

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -168,12 +168,6 @@ private:
   std::shared_ptr<HelpersALE<Number>> helpers_ale;
 
   /*
-   * MatrixFree
-   */
-  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
-
-  /*
    * Spatial discretization
    */
   std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_operator;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -61,13 +61,8 @@ OperatorCoupled<dim, Number>::~OperatorCoupled()
 
 template<int dim, typename Number>
 void
-OperatorCoupled<dim, Number>::setup(
-  std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
-  std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
-  std::string const &                                    dof_index_temperature)
+OperatorCoupled<dim, Number>::setup_derived()
 {
-  Base::setup(matrix_free, matrix_free_data, dof_index_temperature);
-
   this->initialize_vector_velocity(temp_vector);
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -209,11 +209,11 @@ public:
    */
   virtual ~OperatorCoupled();
 
+private:
   void
-  setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
-        std::string const &                                    dof_index_temperature = "") final;
+  setup_derived() final;
 
+public:
   void
   setup_solvers(double const &     scaling_factor_time_derivative_term,
                 VectorType const & velocity) final;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -55,12 +55,9 @@ OperatorPressureCorrection<dim, Number>::~OperatorPressureCorrection()
 
 template<int dim, typename Number>
 void
-OperatorPressureCorrection<dim, Number>::setup(
-  std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
-  std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
-  std::string const &                                    dof_index_temperature)
+OperatorPressureCorrection<dim, Number>::setup_derived()
 {
-  ProjectionBase::setup(matrix_free, matrix_free_data, dof_index_temperature);
+  ProjectionBase::setup_derived();
 
   setup_inverse_mass_operator_pressure();
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
@@ -116,15 +116,12 @@ public:
   virtual ~OperatorPressureCorrection();
 
   /*
-   * Calls setup() function of base class and additionally initializes the inverse pressure mass
-   * matrix operator needed for the pressure correction scheme, as well as the pressure mass
-   * operator needed in the ALE case only (where the mass operator may be evaluated at different
-   * times depending on the specific ALE formulation chosen).
+   * Initializes the inverse pressure mass matrix operator needed for the pressure correction
+   * scheme, as well as the pressure mass operator needed in the ALE case only (where the mass
+   * operator may be evaluated at different times depending on the specific ALE formulation chosen).
    */
   void
-  setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
-        std::string const &                                    dof_index_temperature = "") final;
+  setup_derived() final;
 
   void
   setup_solvers(double const & scaling_factor_mass, VectorType const & velocity) final;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -61,9 +61,9 @@ OperatorProjectionMethods<dim, Number>::setup_derived()
 
 template<int dim, typename Number>
 void
-OperatorProjectionMethods<dim, Number>::update_after_grid_motion()
+OperatorProjectionMethods<dim, Number>::update_after_grid_motion(bool const update_matrix_free)
 {
-  Base::update_after_grid_motion();
+  Base::update_after_grid_motion(update_matrix_free);
 
   // update SIPG penalty parameter of Laplace operator which depends on the deformation
   // of elements

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -54,13 +54,8 @@ OperatorProjectionMethods<dim, Number>::~OperatorProjectionMethods()
 
 template<int dim, typename Number>
 void
-OperatorProjectionMethods<dim, Number>::setup(
-  std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
-  std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
-  std::string const &                                    dof_index_temperature)
+OperatorProjectionMethods<dim, Number>::setup_derived()
 {
-  Base::setup(matrix_free, matrix_free_data, dof_index_temperature);
-
   initialize_laplace_operator();
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -58,15 +58,15 @@ public:
    */
   virtual ~OperatorProjectionMethods();
 
+protected:
   /*
    * Calls setup() function of base class and additionally initializes the pressure Poisson operator
    * needed for projection-type methods.
    */
   void
-  setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
-        std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
-        std::string const &                                    dof_index_temperature = "") override;
+  setup_derived() override;
 
+public:
   void
   update_after_grid_motion() override;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -68,7 +68,7 @@ protected:
 
 public:
   void
-  update_after_grid_motion() override;
+  update_after_grid_motion(bool const update_matrix_free) final;
 
   /*
    * This function evaluates the rhs-contribution of the viscous term and adds the result to the

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -717,7 +717,7 @@ SpatialOperatorBase<dim, Number>::setup()
 
   // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
   // arguments.
-  this->setup(matrix_free_own_storage, mf_data);
+  this->setup(mf, mf_data);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -400,7 +400,7 @@ public:
    * Updates operators after grid has been moved.
    */
   virtual void
-  update_after_grid_motion();
+  update_after_grid_motion(bool const update_matrix_free);
 
   /*
    * Fills a dof-vector with grid coordinates for ALE-type problems.
@@ -511,6 +511,11 @@ private:
 
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
+
+  // If we want to be able to update the mapping, we need a pointer to a non-const MatrixFree
+  // object. In case this object is created, we let the above object called matrix_free point to
+  // matrix_free_own_storage. This variable is needed for ALE formulations.
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_own_storage;
 
   bool pressure_level_is_undefined;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -103,16 +103,31 @@ public:
   void
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
 
-  /*
-   * Setup function. Initializes basic finite element components, matrix-free object, and basic
-   * operators. This function does not perform the setup related to the solution of linear systems
-   * of equations.
+  /**
+   * Call this setup() function if the dealii::MatrixFree object can be set up by the present class.
    */
-  virtual void
+  void
+  setup();
+
+  /**
+   * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
+   * class. The typical use case would be multiphysics-coupling with one MatrixFree object handed
+   * over to several single-field solvers. Another typical use case is the use of an ALE
+   * formulation.
+   */
+  void
   setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
         std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
         std::string const &                                    dof_index_temperature = "");
 
+private:
+  /**
+   * Additional setup to be done by derived classes.
+   */
+  virtual void
+  setup_derived() = 0;
+
+public:
   /*
    * This function initializes operators, preconditioners, and solvers related to the solution of
    * (non-)linear systems of equation required for implicit formulations. It has to be extended

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -61,20 +61,7 @@ public:
                                                             "Poisson",
                                                             mpi_comm);
 
-    matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-    matrix_free_data->append(pde_operator);
-
-    matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-    if(application->get_parameters().enable_cell_based_face_loops)
-      Categorization::do_cell_based_loops(*application->get_grid()->triangulation,
-                                          matrix_free_data->data);
-    matrix_free->reinit(*application->get_mapping(),
-                        matrix_free_data->get_dof_handler_vector(),
-                        matrix_free_data->get_constraint_vector(),
-                        matrix_free_data->get_quadrature_vector(),
-                        matrix_free_data->data);
-
-    pde_operator->setup(matrix_free, matrix_free_data);
+    pde_operator->setup();
 
     if(not(is_throughput_study))
     {
@@ -87,10 +74,6 @@ public:
 
   std::shared_ptr<Operator<dim, n_components, Number>>          pde_operator;
   std::shared_ptr<PostProcessorBase<dim, n_components, Number>> postprocessor;
-
-private:
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
-  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
 };
 
 template<int dim, typename Number>

--- a/include/exadg/poisson/overset_grids/driver.h
+++ b/include/exadg/poisson/overset_grids/driver.h
@@ -50,20 +50,7 @@ public:
                                                             "Poisson",
                                                             mpi_comm);
 
-    matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-    matrix_free_data->append(pde_operator);
-
-    matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-    if(domain->get_parameters().enable_cell_based_face_loops)
-      Categorization::do_cell_based_loops(*domain->get_grid()->triangulation,
-                                          matrix_free_data->data);
-    matrix_free->reinit(*domain->get_mapping(),
-                        matrix_free_data->get_dof_handler_vector(),
-                        matrix_free_data->get_constraint_vector(),
-                        matrix_free_data->get_quadrature_vector(),
-                        matrix_free_data->data);
-
-    pde_operator->setup(matrix_free, matrix_free_data);
+    pde_operator->setup();
 
     pde_operator->setup_solver();
 
@@ -73,10 +60,6 @@ public:
 
   std::shared_ptr<Operator<dim, n_components, Number>>          pde_operator;
   std::shared_ptr<PostProcessorBase<dim, n_components, Number>> postprocessor;
-
-private:
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
-  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
 };
 
 template<int dim, int n_components, typename Number>

--- a/include/exadg/poisson/postprocessor/postprocessor.cpp
+++ b/include/exadg/poisson/postprocessor/postprocessor.cpp
@@ -52,7 +52,7 @@ PostProcessor<dim, n_components, Number>::setup(
   if(pp_data.normal_flux_data.evaluate)
   {
     normal_flux_calculator =
-      std::make_shared<NormalFluxCalculator<dim, Number>>(pde_operator.get_matrix_free(),
+      std::make_shared<NormalFluxCalculator<dim, Number>>(*pde_operator.get_matrix_free(),
                                                           pde_operator.get_dof_index(),
                                                           pde_operator.get_quad_index(),
                                                           pp_data.normal_flux_data,

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -253,6 +253,31 @@ Operator<dim, n_components, Number>::setup_operators()
 
 template<int dim, int n_components, typename Number>
 void
+Operator<dim, n_components, Number>::setup()
+{
+  // initialize MatrixFree and MatrixFreeData
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> mf =
+    std::make_shared<dealii::MatrixFree<dim, Number>>();
+  std::shared_ptr<MatrixFreeData<dim, Number>> mf_data =
+    std::make_shared<MatrixFreeData<dim, Number>>();
+
+  fill_matrix_free_data(*mf_data);
+
+  if(param.enable_cell_based_face_loops)
+    Categorization::do_cell_based_loops(*grid->triangulation, mf_data->data);
+  mf->reinit(*get_mapping(),
+             mf_data->get_dof_handler_vector(),
+             mf_data->get_constraint_vector(),
+             mf_data->get_quadrature_vector(),
+             mf_data->data);
+
+  // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
+  // arguments.
+  this->setup(mf, mf_data);
+}
+
+template<int dim, int n_components, typename Number>
+void
 Operator<dim, n_components, Number>::setup(
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free_in,
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data_in)
@@ -474,10 +499,10 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
 }
 
 template<int dim, int n_components, typename Number>
-dealii::MatrixFree<dim, Number> const &
+std::shared_ptr<dealii::MatrixFree<dim, Number> const>
 Operator<dim, n_components, Number>::get_matrix_free() const
 {
-  return *matrix_free;
+  return matrix_free;
 }
 
 template<int dim, int n_components, typename Number>

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -61,6 +61,17 @@ public:
   void
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
 
+  /**
+   * Call this setup() function if the dealii::MatrixFree object can be set up by the present class.
+   */
+  void
+  setup();
+
+  /**
+   * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
+   * function. The typical use case would be multiphysics-coupling with one MatrixFree object handed
+   * over to several single-field solvers.
+   */
   void
   setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
         std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data);
@@ -93,7 +104,7 @@ public:
    * Setters and getters.
    */
 
-  dealii::MatrixFree<dim, Number> const &
+  std::shared_ptr<dealii::MatrixFree<dim, Number> const>
   get_matrix_free() const;
 
   dealii::DoFHandler<dim> const &

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -69,7 +69,7 @@ public:
 
   /**
    * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
-   * function. The typical use case would be multiphysics-coupling with one MatrixFree object handed
+   * class. The typical use case would be multiphysics-coupling with one MatrixFree object handed
    * over to several single-field solvers.
    */
   void

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -69,18 +69,7 @@ Driver<dim, Number>::setup()
                                                          "elasticity",
                                                          mpi_comm);
 
-  // initialize matrix_free
-  matrix_free_data = std::make_shared<MatrixFreeData<dim, Number>>();
-  matrix_free_data->append(pde_operator);
-
-  matrix_free = std::make_shared<dealii::MatrixFree<dim, Number>>();
-  matrix_free->reinit(*application->get_mapping(),
-                      matrix_free_data->get_dof_handler_vector(),
-                      matrix_free_data->get_constraint_vector(),
-                      matrix_free_data->get_quadrature_vector(),
-                      matrix_free_data->data);
-
-  pde_operator->setup(matrix_free, matrix_free_data);
+  pde_operator->setup();
 
   if(not is_throughput_study)
   {

--- a/include/exadg/structure/driver.h
+++ b/include/exadg/structure/driver.h
@@ -94,10 +94,6 @@ private:
   // user parameters
   Parameters param;
 
-  // matrix-free
-  std::shared_ptr<MatrixFreeData<dim, Number>>     matrix_free_data;
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free;
-
   // operator
   std::shared_ptr<Operator<dim, Number>> pde_operator;
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -301,6 +301,29 @@ Operator<dim, Number>::setup_operators()
 
 template<int dim, typename Number>
 void
+Operator<dim, Number>::setup()
+{
+  // initialize MatrixFree and MatrixFreeData
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> mf =
+    std::make_shared<dealii::MatrixFree<dim, Number>>();
+  std::shared_ptr<MatrixFreeData<dim, Number>> mf_data =
+    std::make_shared<MatrixFreeData<dim, Number>>();
+
+  fill_matrix_free_data(*mf_data);
+
+  mf->reinit(get_mapping(),
+             mf_data->get_dof_handler_vector(),
+             mf_data->get_constraint_vector(),
+             mf_data->get_quadrature_vector(),
+             mf_data->data);
+
+  // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
+  // arguments.
+  this->setup(mf, mf_data);
+}
+
+template<int dim, typename Number>
+void
 Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free_in,
                              std::shared_ptr<MatrixFreeData<dim, Number> const> matrix_free_data_in)
 {
@@ -981,10 +1004,10 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
 }
 
 template<int dim, typename Number>
-dealii::MatrixFree<dim, Number> const &
+std::shared_ptr<dealii::MatrixFree<dim, Number> const>
 Operator<dim, Number>::get_matrix_free() const
 {
-  return *matrix_free;
+  return matrix_free;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -184,9 +184,16 @@ public:
   void
   fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
 
-  /*
-   * Setup function. Initializes basic operators. This function does not perform the setup
-   * related to the solution of linear systems of equations.
+  /**
+   * Call this setup() function if the dealii::MatrixFree object can be set up by the present class.
+   */
+  void
+  setup();
+
+  /**
+   * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
+   * class. The typical use case would be multiphysics-coupling with one MatrixFree object handed
+   * over to several single-field solvers.
    */
   void
   setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free,
@@ -194,7 +201,7 @@ public:
 
   /*
    * This function initializes operators, preconditioners, and solvers related to the solution of
-   * linear systems of equation required for implicit formulations.
+   * (non-)linear systems of equation.
    */
   void
   setup_solver(double const & scaling_factor_acceleration, double const & scaling_factor_velocity);
@@ -300,7 +307,7 @@ public:
   /*
    * Setters and getters.
    */
-  dealii::MatrixFree<dim, Number> const &
+  std::shared_ptr<dealii::MatrixFree<dim, Number> const>
   get_matrix_free() const;
 
   dealii::Mapping<dim> const &

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -201,7 +201,7 @@ public:
 
   /*
    * This function initializes operators, preconditioners, and solvers related to the solution of
-   * (non-)linear systems of equation.
+   * (non-)linear systems of equations.
    */
   void
   setup_solver(double const & scaling_factor_acceleration, double const & scaling_factor_velocity);


### PR DESCRIPTION
We currently have to write lengthy code in the `Driver` classes in order to set up the spatial operators. In many cases, the `MatrixFree(Data)` objects can be created inside the `Operator` class. I therefore suggest to introduce a second `setup()` function in order to make it easier to write solvers/drivers for new problems/applications.

The original `setup()` function with `MatrixFree(Data)` as arguments will still be necessary whenever we need to create the `MatrixFree` object outside the spatial operator class. The typical use case would be multiphysics coupling with one `MatrixFree` object to be used/handed over to many single-field solvers.

~~So far, I only addressed the Poisson module.~~ One can see from the changes that the same sequence of instructions is currently copied three times in ExaDG regarding the Poisson module. The present PR removes this redundancy.

The use of ALE methods requires a special treatment because of the function doing `matrix_free->update_mapping(mapping)`, which is not `const`. Hence, the usual shared pointer to `MatrixFree const` does not work in this case.