### PR TITLE
Extend div- and conti-penalty parameters to ElementType::Simplex

### DIFF
--- a/include/exadg/grid/calculate_characteristic_element_length.h
+++ b/include/exadg/grid/calculate_characteristic_element_length.h
@@ -61,8 +61,9 @@ calculate_minimum_vertex_distance(dealii::Triangulation<dim> const & triangulati
  * by the number of nodes per coordinate direction. Hence, the result depends on the function space
  * (H^1 vs. L^2).
  */
-inline double
-calculate_characteristic_element_length(double const       element_length,
+template<typename Number>
+inline Number
+calculate_characteristic_element_length(Number const       element_length,
                                         unsigned int const fe_degree,
                                         bool const         is_dg)
 {

--- a/include/exadg/grid/calculate_characteristic_element_length.h
+++ b/include/exadg/grid/calculate_characteristic_element_length.h
@@ -57,6 +57,16 @@ calculate_minimum_vertex_distance(dealii::Triangulation<dim> const & triangulati
 }
 
 /**
+ * This function calculates a characteristic element length given the volume of the element.
+ */
+template<typename Number>
+inline Number
+calculate_characteristic_element_length(Number const element_volume, unsigned int const dim)
+{
+  return std::exp(std::log(element_volume) / (double)dim);
+}
+
+/**
  * This function calculates a characteristic resolution limit for high-order Lagrange polynomials
  * given a mesh size h. This one-dimensional resolution limit is calculated as the grid size divided
  * by the number of nodes per coordinate direction. Hence, the result depends on the function space

--- a/include/exadg/grid/calculate_characteristic_element_length.h
+++ b/include/exadg/grid/calculate_characteristic_element_length.h
@@ -24,6 +24,7 @@
 
 // deal.II
 #include <deal.II/base/mpi.h>
+#include <deal.II/fe/mapping.h>
 #include <deal.II/grid/tria.h>
 
 namespace ExaDG
@@ -63,9 +64,9 @@ calculate_minimum_vertex_distance(dealii::Triangulation<dim> const & triangulati
  */
 template<typename Number>
 inline Number
-calculate_characteristic_element_length(Number const       element_length,
-                                        unsigned int const fe_degree,
-                                        bool const         is_dg)
+calculate_high_order_element_length(Number const       element_length,
+                                    unsigned int const fe_degree,
+                                    bool const         is_dg)
 {
   unsigned int n_nodes_1d = fe_degree;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
@@ -40,8 +40,8 @@ namespace IncNS
  *
  *            use viscous term:     tau_conti_viscous = K * nu / h
  *
- *                                  where h_eff = h / (k_u+1) and
- *                                  h = V_e^{1/dim} with the element volume V_e
+ *                                  where h_eff = h / (k_u+1) with a characteristic
+ *                                  element length h derived from the element volume V_e
  *
  *            use both terms:       tau_conti = tau_conti_conv + tau_conti_viscous
  */

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
@@ -172,7 +172,7 @@ public:
 
       scalar tau_convective = norm_U_mean;
       scalar h              = std::exp(std::log(volume) / (double)dim);
-      scalar h_eff          = calculate_characteristic_element_length(h, data.degree, true);
+      scalar h_eff          = calculate_high_order_element_length(h, data.degree, true);
       scalar tau_viscous    = dealii::make_vectorized_array<Number>(data.viscosity) / h_eff;
 
       if(data.type_penalty_parameter == TypePenaltyParameter::ConvectiveTerm)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
@@ -8,6 +8,7 @@
 #ifndef INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_SPATIAL_DISCRETIZATION_OPERATORS_CONTINUITY_PENALTY_OPERATOR_H_
 #define INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_SPATIAL_DISCRETIZATION_OPERATORS_CONTINUITY_PENALTY_OPERATOR_H_
 
+#include <exadg/grid/calculate_characteristic_element_length.h>
 #include <exadg/incompressible_navier_stokes/user_interface/boundary_descriptor.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
 #include <exadg/matrix_free/integrators.h>
@@ -170,7 +171,8 @@ public:
       norm_U_mean /= volume;
 
       scalar tau_convective = norm_U_mean;
-      scalar h_eff          = std::exp(std::log(volume) / (double)dim) / (double)(data.degree + 1);
+      scalar h              = std::exp(std::log(volume) / (double)dim);
+      scalar h_eff          = calculate_characteristic_element_length(h, data.degree, true);
       scalar tau_viscous    = dealii::make_vectorized_array<Number>(data.viscosity) / h_eff;
 
       if(data.type_penalty_parameter == TypePenaltyParameter::ConvectiveTerm)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
@@ -153,6 +153,9 @@ public:
 
     dealii::AlignedVector<scalar> JxW_values(integrator.n_q_points);
 
+    ElementType const element_type =
+      get_element_type(matrix_free->get_dof_handler(dof_index).get_triangulation());
+
     unsigned int n_cells = matrix_free->n_cell_batches() + matrix_free->n_ghost_cell_batches();
     for(unsigned int cell = 0; cell < n_cells; ++cell)
     {
@@ -171,7 +174,7 @@ public:
       norm_U_mean /= volume;
 
       scalar tau_convective = norm_U_mean;
-      scalar h              = calculate_characteristic_element_length(volume, dim);
+      scalar h              = calculate_characteristic_element_length(volume, dim, element_type);
       scalar h_eff          = calculate_high_order_element_length(h, data.degree, true);
       scalar tau_viscous    = dealii::make_vectorized_array<Number>(data.viscosity) / h_eff;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
@@ -171,7 +171,7 @@ public:
       norm_U_mean /= volume;
 
       scalar tau_convective = norm_U_mean;
-      scalar h              = std::exp(std::log(volume) / (double)dim);
+      scalar h              = calculate_characteristic_element_length(volume, dim);
       scalar h_eff          = calculate_high_order_element_length(h, data.degree, true);
       scalar tau_viscous    = dealii::make_vectorized_array<Number>(data.viscosity) / h_eff;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -31,8 +31,8 @@ namespace IncNS
  *
  *            use convective term:  tau_div_conv = K * ||U||_mean * h_eff
  *
- *                                  where h_eff = h / (k_u+1) and
- *                                  h = V_e^{1/3} with the element volume V_e
+ *                                  where h_eff = h / (k_u+1) with a characteristic
+ *                                  element length h derived from the element volume V_e
  *
  *            use viscous term:     tau_div_viscous = K * nu
  *

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -160,7 +160,7 @@ public:
         }
         norm_U_mean /= volume;
 
-        scalar h     = std::exp(std::log(volume) / (double)dim);
+        scalar h     = calculate_characteristic_element_length(volume, dim);
         scalar h_eff = calculate_high_order_element_length(h, data.degree, true);
 
         tau_convective = norm_U_mean * h_eff;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -161,7 +161,7 @@ public:
         norm_U_mean /= volume;
 
         scalar h     = std::exp(std::log(volume) / (double)dim);
-        scalar h_eff = calculate_characteristic_element_length(h, data.degree, true);
+        scalar h_eff = calculate_high_order_element_length(h, data.degree, true);
 
         tau_convective = norm_U_mean * h_eff;
       }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -8,6 +8,7 @@
 #ifndef INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_SPATIAL_DISCRETIZATION_OPERATORS_DIVERGENCE_PENALTY_OPERATOR_H_
 #define INCLUDE_EXADG_INCOMPRESSIBLE_NAVIER_STOKES_SPATIAL_DISCRETIZATION_OPERATORS_DIVERGENCE_PENALTY_OPERATOR_H_
 
+#include <exadg/grid/calculate_characteristic_element_length.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
 #include <exadg/matrix_free/integrators.h>
 #include <exadg/operators/integrator_flags.h>
@@ -159,7 +160,8 @@ public:
         }
         norm_U_mean /= volume;
 
-        scalar h_eff = std::exp(std::log(volume) / (double)dim) / (double)(data.degree + 1);
+        scalar h     = std::exp(std::log(volume) / (double)dim);
+        scalar h_eff = calculate_characteristic_element_length(h, data.degree, true);
 
         tau_convective = norm_U_mean * h_eff;
       }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -138,6 +138,9 @@ public:
 
     dealii::AlignedVector<scalar> JxW_values(integrator.n_q_points);
 
+    ElementType const element_type =
+      get_element_type(matrix_free->get_dof_handler(dof_index).get_triangulation());
+
     unsigned int n_cells = matrix_free->n_cell_batches() + matrix_free->n_ghost_cell_batches();
     for(unsigned int cell = 0; cell < n_cells; ++cell)
     {
@@ -160,7 +163,7 @@ public:
         }
         norm_U_mean /= volume;
 
-        scalar h     = calculate_characteristic_element_length(volume, dim);
+        scalar h     = calculate_characteristic_element_length(volume, dim, element_type);
         scalar h_eff = calculate_high_order_element_length(h, data.degree, true);
 
         tau_convective = norm_U_mean * h_eff;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -159,8 +159,9 @@ public:
         }
         norm_U_mean /= volume;
 
-        tau_convective =
-          norm_U_mean * std::exp(std::log(volume) / (double)dim) / (double)(data.degree + 1);
+        scalar h_eff = std::exp(std::log(volume) / (double)dim) / (double)(data.degree + 1);
+
+        tau_convective = norm_U_mean * h_eff;
       }
 
       if(data.type_penalty_parameter == TypePenaltyParameter::ConvectiveTerm)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1081,7 +1081,7 @@ SpatialOperatorBase<dim, Number>::get_characteristic_element_length() const
 {
   double const h_min = calculate_minimum_element_length();
 
-  return calculate_characteristic_element_length(h_min, param.degree_u, true /* is_dg */);
+  return calculate_high_order_element_length(h_min, param.degree_u, true /* is_dg */);
 }
 
 template<int dim, typename Number>


### PR DESCRIPTION
When calculating the penalty parameters, we derive a characteristic element length h from the element volume V_e (which is obtained from numerical integration / quadrature) assuming an "equilateral" shape of the element.

For hypercube elements, the relation is V_e = h^dim. However, this does not hold for simplicial elements. The present PR aims to fix these calculations in order to allow simplicial elements. Note that this PR aims to make the implementation consistent with the original idea regarding the construction of these penalty parameters (so far only realized for hypercube elements). It might be a separate topic to investigate which formula is actually ideally suited from a theoretical/methodological perspective.