### PR TITLE
consistent naming of acceleration method

### DIFF
--- a/applications/fluid_structure_interaction/bending_wall/input.json
+++ b/applications/fluid_structure_interaction/bending_wall/input.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "FSI" : {
-        "Method": "IQN_ILS",
+        "AccelerationMethod": "IQN_ILS",
         "AbsTol": "1.e-12",
         "RelTol": "1.e-3",
         "OmegaInit": "0.1",

--- a/applications/fluid_structure_interaction/cylinder_with_flag/input.json
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/input.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "FSI" : {
-        "Method": "IQN_ILS",
+        "AccelerationMethod": "IQN_ILS",
         "AbsTol": "1.e-8",
         "RelTol": "1.e-3", 
         "OmegaInit": "0.3",

--- a/applications/fluid_structure_interaction/cylinder_with_flag/input_aitken.json
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/input_aitken.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "FSI" : {
-        "Method": "Aitken",
+        "AccelerationMethod": "Aitken",
         "AbsTol": "1.e-8",
         "RelTol": "1.e-3",
         "OmegaInit": "0.3",

--- a/applications/fluid_structure_interaction/pressure_wave/input.json
+++ b/applications/fluid_structure_interaction/pressure_wave/input.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "FSI" : {
-        "Method": "IQN_ILS",
+        "AccelerationMethod": "IQN_ILS",
         "AbsTol": "1.e-9",
         "RelTol": "1.e-3",
         "OmegaInit": "0.3",

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
@@ -28,6 +28,7 @@ namespace FSI
 {
 enum class AccelerationMethod
 {
+  Undefined,
   Aitken,
   IQN_ILS,
   IQN_IMVLS
@@ -36,7 +37,7 @@ enum class AccelerationMethod
 struct Parameters
 {
   Parameters()
-    : method(AccelerationMethod::Aitken),
+    : acceleration_method(AccelerationMethod::Undefined),
       abs_tol(1.e-12),
       rel_tol(1.e-3),
       omega_init(0.1),
@@ -51,8 +52,11 @@ struct Parameters
   {
     prm.enter_subsection(subsection_name);
     {
-      prm.add_parameter(
-        "Method", method, "Acceleration method.", Patterns::Enum<AccelerationMethod>(), true);
+      prm.add_parameter("AccelerationMethod",
+                        acceleration_method,
+                        "Acceleration method.",
+                        Patterns::Enum<AccelerationMethod>(),
+                        true);
       prm.add_parameter(
         "AbsTol", abs_tol, "Absolute solver tolerance.", dealii::Patterns::Double(0.0, 1.0), true);
       prm.add_parameter(
@@ -81,7 +85,7 @@ struct Parameters
     prm.leave_subsection();
   }
 
-  AccelerationMethod method;
+  AccelerationMethod acceleration_method;
   double             abs_tol;
   double             rel_tol;
   double             omega_init;

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
@@ -182,7 +182,7 @@ PartitionedSolver<dim, Number>::solve(
   unsigned int k = 0;
 
   // fixed-point iteration with dynamic relaxation (Aitken relaxation)
-  if(parameters.method == AccelerationMethod::Aitken)
+  if(parameters.acceleration_method == AccelerationMethod::Aitken)
   {
     VectorType r_old, d;
     structure->pde_operator->initialize_dof_vector(r_old);
@@ -236,7 +236,7 @@ PartitionedSolver<dim, Number>::solve(
       ++k;
     }
   }
-  else if(parameters.method == AccelerationMethod::IQN_ILS)
+  else if(parameters.acceleration_method == AccelerationMethod::IQN_ILS)
   {
     std::shared_ptr<std::vector<VectorType>> D, R;
     D = std::make_shared<std::vector<VectorType>>();
@@ -357,7 +357,7 @@ PartitionedSolver<dim, Number>::solve(
 
     timer_tree->insert({"IQN-ILS"}, timer.wall_time());
   }
-  else if(parameters.method == AccelerationMethod::IQN_IMVLS)
+  else if(parameters.acceleration_method == AccelerationMethod::IQN_IMVLS)
   {
     std::shared_ptr<std::vector<VectorType>> D, R;
     D = std::make_shared<std::vector<VectorType>>();
@@ -486,7 +486,7 @@ PartitionedSolver<dim, Number>::solve(
   }
   else
   {
-    AssertThrow(false, dealii::ExcMessage("This method is not implemented."));
+    AssertThrow(false, dealii::ExcMessage("This AccelerationMethod is not implemented."));
   }
 
   partitioned_iterations.first += 1;


### PR DESCRIPTION
renaming to prepare for
`AccelerationMethod` (Aitken, IQN-ILS and the like)
alongside
`UpdateMethod` (semi-implicit variants or fully implicit)
and
`CouplingMethod` (Dirichlet-Neumann or Dirichlet-Robin).
Second of which I will commit soon  :)