### PR TITLE
Optional extrapolation for FSI

### DIFF
--- a/applications/fluid_structure_interaction/pressure_wave/input.json
+++ b/applications/fluid_structure_interaction/pressure_wave/input.json
@@ -17,6 +17,7 @@
         "AbsTol": "1.e-9",
         "RelTol": "1.e-3",
         "OmegaInit": "0.3",
+        "UseExtrapolation": "true",
         "PartitionedIterMax": "100",
         "ReusedTimeSteps": "10",
         "GeometricTolerance": "1.e-8"

--- a/applications/fluid_structure_interaction/pressure_wave/input.json
+++ b/applications/fluid_structure_interaction/pressure_wave/input.json
@@ -17,7 +17,7 @@
         "AbsTol": "1.e-9",
         "RelTol": "1.e-3",
         "OmegaInit": "0.3",
-        "UseExtrapolation": "true",
+        "InitialGuessCouplingScheme": "SolutionExtrapolatedToEndOfTimeStep",
         "PartitionedIterMax": "100",
         "ReusedTimeSteps": "10",
         "GeometricTolerance": "1.e-8"

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
@@ -40,6 +40,7 @@ struct Parameters
       abs_tol(1.e-12),
       rel_tol(1.e-3),
       omega_init(0.1),
+      use_extrapolation(true),
       reused_time_steps(0),
       partitioned_iter_max(100),
       geometric_tolerance(1.e-10)
@@ -62,6 +63,12 @@ struct Parameters
                         "Initial relaxation parameter.",
                         dealii::Patterns::Double(0.0, 1.0),
                         true);
+      prm.add_parameter(
+        "UseExtrapolation",
+        use_extrapolation,
+        "Use second order extrapolation in time as initial guess for FSI coupling scheme.",
+        dealii::Patterns::Bool(),
+        false);
       prm.add_parameter("ReusedTimeSteps",
                         reused_time_steps,
                         "Number of time steps reused for acceleration.",
@@ -85,6 +92,7 @@ struct Parameters
   double             abs_tol;
   double             rel_tol;
   double             omega_init;
+  bool               use_extrapolation;
   unsigned int       reused_time_steps;
   unsigned int       partitioned_iter_max;
 

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
@@ -63,12 +63,11 @@ struct Parameters
                         "Initial relaxation parameter.",
                         dealii::Patterns::Double(0.0, 1.0),
                         true);
-      prm.add_parameter(
-        "UseExtrapolation",
-        use_extrapolation,
-        "Use second order extrapolation in time as initial guess for FSI coupling scheme.",
-        dealii::Patterns::Bool(),
-        false);
+      prm.add_parameter("UseExtrapolation",
+                        use_extrapolation,
+                        "Extrapolate for initial guess in coupling scheme.",
+                        dealii::Patterns::Bool(),
+                        false);
       prm.add_parameter("ReusedTimeSteps",
                         reused_time_steps,
                         "Number of time steps reused for acceleration.",

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
@@ -34,6 +34,15 @@ enum class AccelerationMethod
   IQN_IMVLS
 };
 
+// The initial guess used in the FSI coupling loop is computed using an extrapolation of suitable
+// order (defined within the single-field time integrators) or the last iterate from the previous
+// time step.
+enum class InitialGuessCouplingScheme
+{
+  SolutionExtrapolatedToEndOfTimeStep,
+  ConvergedSolutionOfPreviousTimeStep
+};
+
 struct Parameters
 {
   Parameters()
@@ -41,7 +50,8 @@ struct Parameters
       abs_tol(1.e-12),
       rel_tol(1.e-3),
       omega_init(0.1),
-      use_extrapolation(true),
+      initial_guess_coupling_scheme(
+        InitialGuessCouplingScheme::SolutionExtrapolatedToEndOfTimeStep),
       reused_time_steps(0),
       partitioned_iter_max(100),
       geometric_tolerance(1.e-10)
@@ -67,10 +77,10 @@ struct Parameters
                         "Initial relaxation parameter.",
                         dealii::Patterns::Double(0.0, 1.0),
                         true);
-      prm.add_parameter("UseExtrapolation",
-                        use_extrapolation,
-                        "Extrapolate for initial guess in coupling scheme.",
-                        dealii::Patterns::Bool(),
+      prm.add_parameter("InitialGuessCouplingScheme",
+                        initial_guess_coupling_scheme,
+                        "Scheme for initial guess for the FSI coupling loop at every time step.",
+                        Patterns::Enum<InitialGuessCouplingScheme>(),
                         false);
       prm.add_parameter("ReusedTimeSteps",
                         reused_time_steps,
@@ -91,13 +101,13 @@ struct Parameters
     prm.leave_subsection();
   }
 
-  AccelerationMethod acceleration_method;
-  double             abs_tol;
-  double             rel_tol;
-  double             omega_init;
-  bool               use_extrapolation;
-  unsigned int       reused_time_steps;
-  unsigned int       partitioned_iter_max;
+  AccelerationMethod         acceleration_method;
+  double                     abs_tol;
+  double                     rel_tol;
+  double                     omega_init;
+  InitialGuessCouplingScheme initial_guess_coupling_scheme;
+  unsigned int               reused_time_steps;
+  unsigned int               partitioned_iter_max;
 
   // tolerance used to locate points at the fluid-structure interface
   double geometric_tolerance;

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
@@ -61,6 +61,10 @@ public:
   get_timings() const;
 
 private:
+  void
+  update_structure_displacement(VectorType &       displacement_structure,
+                                unsigned int const iteration) const;
+
   bool
   check_convergence(VectorType const & residual) const;
 
@@ -174,6 +178,28 @@ PartitionedSolver<dim, Number>::get_timings() const
 
 template<int dim, typename Number>
 void
+PartitionedSolver<dim, Number>::update_structure_displacement(VectorType & displacement_structure,
+                                                              unsigned int const iteration) const
+{
+  if(iteration == 0)
+  {
+    if(parameters.use_extrapolation)
+    {
+      structure->time_integrator->extrapolate_displacement_to_np(displacement_structure);
+    }
+    else
+    {
+      displacement_structure = structure->time_integrator->get_displacement_n();
+    }
+  }
+  else
+  {
+    displacement_structure = structure->time_integrator->get_displacement_np();
+  }
+}
+
+template<int dim, typename Number>
+void
 PartitionedSolver<dim, Number>::solve(
   std::function<void(VectorType &, VectorType const &, unsigned int)> const &
     apply_dirichlet_neumann_scheme)
@@ -194,10 +220,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      if(k == 0)
-        structure->time_integrator->extrapolate_displacement_to_np(d);
-      else
-        d = structure->time_integrator->get_displacement_np();
+      update_structure_displacement(d, k);
 
       VectorType d_tilde(d);
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
@@ -257,10 +280,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      if(k == 0)
-        structure->time_integrator->extrapolate_displacement_to_np(d);
-      else
-        d = structure->time_integrator->get_displacement_np();
+      update_structure_displacement(d, k);
 
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
 
@@ -385,10 +405,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      if(k == 0)
-        structure->time_integrator->extrapolate_displacement_to_np(d);
-      else
-        d = structure->time_integrator->get_displacement_np();
+      update_structure_displacement(d, k);
 
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
 

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
@@ -186,13 +186,21 @@ PartitionedSolver<dim, Number>::get_structure_velocity(VectorType & velocity_str
 {
   if(iteration == 0)
   {
-    if(parameters.use_extrapolation)
+    if(parameters.initial_guess_coupling_scheme ==
+       InitialGuessCouplingScheme::SolutionExtrapolatedToEndOfTimeStep)
     {
       structure->time_integrator->extrapolate_velocity_to_np(velocity_structure);
     }
-    else
+    else if(parameters.initial_guess_coupling_scheme ==
+            InitialGuessCouplingScheme::ConvergedSolutionOfPreviousTimeStep)
     {
       velocity_structure = structure->time_integrator->get_velocity_n();
+    }
+    else
+    {
+      AssertThrow(false,
+                  dealii::ExcMessage(
+                    "Behavior for this `InitialGuessCouplingScheme` is not defined."));
     }
   }
   else
@@ -208,13 +216,21 @@ PartitionedSolver<dim, Number>::get_structure_displacement(VectorType & displace
 {
   if(iteration == 0)
   {
-    if(parameters.use_extrapolation)
+    if(this->parameters.initial_guess_coupling_scheme ==
+       InitialGuessCouplingScheme::SolutionExtrapolatedToEndOfTimeStep)
     {
       structure->time_integrator->extrapolate_displacement_to_np(displacement_structure);
     }
-    else
+    else if(this->parameters.initial_guess_coupling_scheme ==
+            InitialGuessCouplingScheme::ConvergedSolutionOfPreviousTimeStep)
     {
       displacement_structure = structure->time_integrator->get_displacement_n();
+    }
+    else
+    {
+      AssertThrow(false,
+                  dealii::ExcMessage(
+                    "Behavior for this `InitialGuessCouplingScheme` is not defined."));
     }
   }
   else

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
@@ -60,10 +60,13 @@ public:
   std::shared_ptr<TimerTree>
   get_timings() const;
 
+  void
+  get_structure_velocity(VectorType & velocity_structure, unsigned int const iteration) const;
+
 private:
   void
-  update_structure_displacement(VectorType &       displacement_structure,
-                                unsigned int const iteration) const;
+  get_structure_displacement(VectorType &       displacement_structure,
+                             unsigned int const iteration) const;
 
   bool
   check_convergence(VectorType const & residual) const;
@@ -178,8 +181,30 @@ PartitionedSolver<dim, Number>::get_timings() const
 
 template<int dim, typename Number>
 void
-PartitionedSolver<dim, Number>::update_structure_displacement(VectorType & displacement_structure,
-                                                              unsigned int const iteration) const
+PartitionedSolver<dim, Number>::get_structure_velocity(VectorType & velocity_structure,
+                                                       unsigned int iteration) const
+{
+  if(iteration == 0)
+  {
+    if(parameters.use_extrapolation)
+    {
+      structure->time_integrator->extrapolate_velocity_to_np(velocity_structure);
+    }
+    else
+    {
+      velocity_structure = structure->time_integrator->get_velocity_n();
+    }
+  }
+  else
+  {
+    velocity_structure = structure->time_integrator->get_velocity_np();
+  }
+}
+
+template<int dim, typename Number>
+void
+PartitionedSolver<dim, Number>::get_structure_displacement(VectorType & displacement_structure,
+                                                           unsigned int const iteration) const
 {
   if(iteration == 0)
   {
@@ -220,7 +245,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      update_structure_displacement(d, k);
+      get_structure_displacement(d, k);
 
       VectorType d_tilde(d);
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
@@ -280,7 +305,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      update_structure_displacement(d, k);
+      get_structure_displacement(d, k);
 
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
 
@@ -405,7 +430,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      update_structure_displacement(d, k);
+      get_structure_displacement(d, k);
 
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
 

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -231,9 +231,13 @@ Driver<dim, Number>::coupling_structure_to_fluid(bool const extrapolate) const
   VectorType velocity_structure;
   structure->pde_operator->initialize_dof_vector(velocity_structure);
   if(extrapolate)
+  {
     structure->time_integrator->extrapolate_velocity_to_np(velocity_structure);
+  }
   else
+  {
     velocity_structure = structure->time_integrator->get_velocity_np();
+  }
 
   structure_to_fluid->update_data(velocity_structure);
 
@@ -281,16 +285,18 @@ Driver<dim, Number>::apply_dirichlet_neumann_scheme(VectorType &       d_tilde,
   fluid->solve_ale();
 
   // update velocity boundary condition for fluid
-  coupling_structure_to_fluid(iteration == 0);
+  coupling_structure_to_fluid(iteration == 0 and parameters.use_extrapolation);
 
   // solve fluid problem
-  fluid->time_integrator->advance_one_timestep_partitioned_solve(iteration == 0);
+  fluid->time_integrator->advance_one_timestep_partitioned_solve(iteration ==
+                                                                 0 /* use_extrapolation */);
 
   // update stress boundary condition for solid
-  coupling_fluid_to_structure(/* end_of_time_step = */ true);
+  coupling_fluid_to_structure(true /* end_of_time_step */);
 
   // solve structural problem
-  structure->time_integrator->advance_one_timestep_partitioned_solve(iteration == 0);
+  structure->time_integrator->advance_one_timestep_partitioned_solve(iteration ==
+                                                                     0 /* use_extrapolation */);
 
   d_tilde = structure->time_integrator->get_displacement_np();
 }

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -221,22 +221,7 @@ Driver<dim, Number>::coupling_structure_to_fluid(unsigned int iteration) const
 
   VectorType velocity_structure;
   structure->pde_operator->initialize_dof_vector(velocity_structure);
-  if(iteration == 0)
-  {
-    if(parameters.use_extrapolation)
-    {
-      structure->time_integrator->extrapolate_velocity_to_np(velocity_structure);
-    }
-    else
-    {
-      velocity_structure = structure->time_integrator->get_velocity_n();
-    }
-  }
-  else
-  {
-    velocity_structure = structure->time_integrator->get_velocity_np();
-  }
-
+  partitioned_solver->get_structure_velocity(velocity_structure, iteration);
   structure_to_fluid->update_data(velocity_structure);
 
   timer_tree.insert({"FSI", "Coupling structure -> fluid"}, sub_timer.wall_time());

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -74,7 +74,7 @@ private:
   coupling_structure_to_ale(VectorType const & displacement_structure) const;
 
   void
-  coupling_structure_to_fluid(bool const extrapolate) const;
+  coupling_structure_to_fluid(unsigned int const iteration) const;
 
   void
   coupling_fluid_to_structure(bool const end_of_time_step) const;

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -220,6 +220,13 @@ TimeIntGenAlpha<dim, Number>::get_displacement_np()
 }
 
 template<int dim, typename Number>
+typename TimeIntGenAlpha<dim, Number>::VectorType const &
+TimeIntGenAlpha<dim, Number>::get_displacement_n()
+{
+  return displacement_n;
+}
+
+template<int dim, typename Number>
 void
 TimeIntGenAlpha<dim, Number>::extrapolate_displacement_to_np(VectorType & displacement)
 {

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.h
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.h
@@ -79,6 +79,9 @@ public:
   VectorType const &
   get_displacement_np();
 
+  VectorType const &
+  get_displacement_n();
+
   void
   extrapolate_velocity_to_np(VectorType & velocity);
 


### PR DESCRIPTION
Add an additional parameter to let the user decide, whether or not a second-order extrapolation shall be used.

This can be beneficial for problems where the extrapolation would lead to divergence or slower convergence (e.g. when I couple a Windkessel model to the fluid, such that the outlet pressure is rapidly changing) 