### PR TITLE
Semi implicit fsi

### DIFF
--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -99,6 +99,20 @@ public:
   {
   }
 
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    // clang format off
+    prm.enter_subsection("Fluid");
+    prm.add_parameter("TemporalDiscretization",
+                      temporal_discretization,
+                      "Temporal discretization of Navier-Stokes euqaitons.",
+                      Patterns::Enum<IncNS::TemporalDiscretization>(),
+                      false);
+    prm.leave_subsection();
+    // clang format on
+  }
+
 private:
   void
   set_parameters() final
@@ -128,7 +142,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     param.solver_type                     = SolverType::Unsteady;
-    param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    param.temporal_discretization         = temporal_discretization;
     param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     param.order_time_integrator           = 2;
     param.start_with_low_order            = true;
@@ -601,6 +615,9 @@ private:
     field_functions->initial_displacement.reset(new dealii::Functions::ZeroFunction<dim>(dim));
     field_functions->initial_velocity.reset(new dealii::Functions::ZeroFunction<dim>(dim));
   }
+
+  IncNS::TemporalDiscretization temporal_discretization =
+    IncNS::TemporalDiscretization::BDFDualSplittingScheme;
 };
 } // namespace FluidFSI
 

--- a/applications/fluid_structure_interaction/pressure_wave/input.json
+++ b/applications/fluid_structure_interaction/pressure_wave/input.json
@@ -12,8 +12,12 @@
         "Degree": "1",
         "RefineSpace": "0"
     },
+    "Fluid" : {
+        "TemporalDiscretization": "BDFDualSplittingScheme"
+    },
     "FSI" : {
         "AccelerationMethod": "IQN_ILS",
+        "UpdateMethod": "Implicit",
         "AbsTol": "1.e-9",
         "RelTol": "1.e-3",
         "OmegaInit": "0.3",

--- a/applications/fluid_structure_interaction/pressure_wave/input.json
+++ b/applications/fluid_structure_interaction/pressure_wave/input.json
@@ -17,6 +17,7 @@
         "AbsTol": "1.e-9",
         "RelTol": "1.e-3",
         "OmegaInit": "0.3",
+        "UseExtrapolation": "true",
         "PartitionedIterMax": "100",
         "ReusedTimeSteps": "10",
         "GeometricTolerance": "1.e-8"

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
@@ -34,10 +34,20 @@ enum class AccelerationMethod
   IQN_IMVLS
 };
 
+enum class UpdateMethod
+{
+  Undefined,
+  Implicit,
+  GeometricExplicit,
+  ImplicitPressureStructure,
+  ImplicitVelocityStructure
+};
+
 struct Parameters
 {
   Parameters()
     : acceleration_method(AccelerationMethod::Undefined),
+      update_method(UpdateMethod::Implicit),
       abs_tol(1.e-12),
       rel_tol(1.e-3),
       omega_init(0.1),
@@ -58,6 +68,8 @@ struct Parameters
                         "Acceleration method.",
                         Patterns::Enum<AccelerationMethod>(),
                         true);
+      prm.add_parameter(
+        "UpdateMethod", update_method, "Update method.", Patterns::Enum<UpdateMethod>(), false);
       prm.add_parameter(
         "AbsTol", abs_tol, "Absolute solver tolerance.", dealii::Patterns::Double(0.0, 1.0), true);
       prm.add_parameter(
@@ -92,6 +104,7 @@ struct Parameters
   }
 
   AccelerationMethod acceleration_method;
+  UpdateMethod       update_method;
   double             abs_tol;
   double             rel_tol;
   double             omega_init;

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/parameters.h
@@ -41,6 +41,7 @@ struct Parameters
       abs_tol(1.e-12),
       rel_tol(1.e-3),
       omega_init(0.1),
+      use_extrapolation(true),
       reused_time_steps(0),
       partitioned_iter_max(100),
       geometric_tolerance(1.e-10)
@@ -66,6 +67,11 @@ struct Parameters
                         "Initial relaxation parameter.",
                         dealii::Patterns::Double(0.0, 1.0),
                         true);
+      prm.add_parameter("UseExtrapolation",
+                        use_extrapolation,
+                        "Extrapolate for initial guess in coupling scheme.",
+                        dealii::Patterns::Bool(),
+                        false);
       prm.add_parameter("ReusedTimeSteps",
                         reused_time_steps,
                         "Number of time steps reused for acceleration.",
@@ -89,6 +95,7 @@ struct Parameters
   double             abs_tol;
   double             rel_tol;
   double             omega_init;
+  bool               use_extrapolation;
   unsigned int       reused_time_steps;
   unsigned int       partitioned_iter_max;
 

--- a/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
+++ b/include/exadg/fluid_structure_interaction/acceleration_schemes/partitioned_solver.h
@@ -61,6 +61,10 @@ public:
   get_timings() const;
 
 private:
+  void
+  update_structure_displacement(VectorType &       displacement_structure,
+                                unsigned int const iteration) const;
+
   bool
   check_convergence(VectorType const & residual) const;
 
@@ -174,6 +178,28 @@ PartitionedSolver<dim, Number>::get_timings() const
 
 template<int dim, typename Number>
 void
+PartitionedSolver<dim, Number>::update_structure_displacement(VectorType & displacement_structure,
+                                                              unsigned int const iteration) const
+{
+  if(iteration == 0)
+  {
+    if(parameters.use_extrapolation)
+    {
+      structure->time_integrator->extrapolate_displacement_to_np(displacement_structure);
+    }
+    else
+    {
+      displacement_structure = structure->time_integrator->get_displacement_n();
+    }
+  }
+  else
+  {
+    displacement_structure = structure->time_integrator->get_displacement_np();
+  }
+}
+
+template<int dim, typename Number>
+void
 PartitionedSolver<dim, Number>::solve(
   std::function<void(VectorType &, VectorType const &, unsigned int)> const &
     apply_dirichlet_neumann_scheme)
@@ -194,10 +220,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      if(k == 0)
-        structure->time_integrator->extrapolate_displacement_to_np(d);
-      else
-        d = structure->time_integrator->get_displacement_np();
+      update_structure_displacement(d, k);
 
       VectorType d_tilde(d);
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
@@ -257,10 +280,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      if(k == 0)
-        structure->time_integrator->extrapolate_displacement_to_np(d);
-      else
-        d = structure->time_integrator->get_displacement_np();
+      update_structure_displacement(d, k);
 
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
 
@@ -385,10 +405,7 @@ PartitionedSolver<dim, Number>::solve(
     {
       print_solver_info_header(k);
 
-      if(k == 0)
-        structure->time_integrator->extrapolate_displacement_to_np(d);
-      else
-        d = structure->time_integrator->get_displacement_np();
+      update_structure_displacement(d, k);
 
       apply_dirichlet_neumann_scheme(d_tilde, d, k);
 

--- a/include/exadg/fluid_structure_interaction/driver.cpp
+++ b/include/exadg/fluid_structure_interaction/driver.cpp
@@ -282,30 +282,83 @@ Driver<dim, Number>::coupling_fluid_to_structure(bool const end_of_time_step) co
 
 template<int dim, typename Number>
 void
-Driver<dim, Number>::apply_dirichlet_neumann_scheme(VectorType &       d_tilde,
-                                                    VectorType const & d,
-                                                    unsigned int       iteration) const
+Driver<dim, Number>::solve_subproblem_mesh(VectorType const & displacement_structure) const
 {
-  coupling_structure_to_ale(d);
+  // update displacement condition at interface
+  coupling_structure_to_ale(displacement_structure);
 
   // move the fluid mesh and update dependent data structures
   fluid->solve_ale();
+}
 
+template<int dim, typename Number>
+void
+Driver<dim, Number>::solve_subproblem_fluid(unsigned int const iteration,
+                                            bool const         update_velocity,
+                                            bool const         update_pressure) const
+{
   // update velocity boundary condition for fluid
   coupling_structure_to_fluid(iteration);
 
   // solve fluid problem
-  fluid->time_integrator->advance_one_timestep_partitioned_solve(iteration ==
-                                                                 0 /* use_extrapolation */);
+  fluid->time_integrator->advance_one_timestep_partitioned_solve(
+    iteration == 0 /* use_extrapolation */, update_velocity, update_pressure);
+}
 
+template<int dim, typename Number>
+void
+Driver<dim, Number>::solve_subproblem_structure(unsigned int const iteration) const
+{
   // update stress boundary condition for solid
   coupling_fluid_to_structure(true /* end_of_time_step */);
 
   // solve structural problem
   structure->time_integrator->advance_one_timestep_partitioned_solve(iteration ==
                                                                      0 /* use_extrapolation */);
+}
 
-  d_tilde = structure->time_integrator->get_displacement_np();
+template<int dim, typename Number>
+void
+Driver<dim, Number>::apply_dirichlet_neumann_scheme(VectorType &       displacement_structure_tilde,
+                                                    VectorType const & displacement_structure,
+                                                    unsigned int       iteration) const
+{
+  if(parameters.update_method == UpdateMethod::Implicit)
+  {
+    solve_subproblem_mesh(displacement_structure);
+    solve_subproblem_fluid(iteration, true /* update_velocity */, true /* update_pressure */);
+    solve_subproblem_structure(iteration);
+  }
+  else if(parameters.update_method == UpdateMethod::GeometricExplicit)
+  {
+    if(iteration == 0)
+    {
+      solve_subproblem_mesh(displacement_structure);
+    }
+    solve_subproblem_fluid(iteration, true /* update_velocity */, true /* update_pressure */);
+    solve_subproblem_structure(iteration);
+  }
+  else if(parameters.update_method == UpdateMethod::ImplicitPressureStructure or
+          parameters.update_method == UpdateMethod::ImplicitVelocityStructure)
+  {
+    if(iteration == 0)
+    {
+      solve_subproblem_mesh(displacement_structure);
+    }
+
+    bool const update_velocity =
+      iteration == 0 or parameters.update_method == UpdateMethod::ImplicitVelocityStructure;
+    bool const update_pressure =
+      iteration == 0 or parameters.update_method == UpdateMethod::ImplicitPressureStructure;
+    solve_subproblem_fluid(iteration, update_velocity, update_pressure);
+    solve_subproblem_structure(iteration);
+  }
+  else
+  {
+    AssertThrow(false, dealii::ExcMessage("UpdateMethod not implemented."));
+  }
+
+  displacement_structure_tilde = structure->time_integrator->get_displacement_np();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -74,7 +74,7 @@ private:
   coupling_structure_to_ale(VectorType const & displacement_structure) const;
 
   void
-  coupling_structure_to_fluid(bool const extrapolate) const;
+  coupling_structure_to_fluid(unsigned int const iteration) const;
 
   void
   coupling_fluid_to_structure(bool const end_of_time_step) const;

--- a/include/exadg/fluid_structure_interaction/driver.h
+++ b/include/exadg/fluid_structure_interaction/driver.h
@@ -80,8 +80,19 @@ private:
   coupling_fluid_to_structure(bool const end_of_time_step) const;
 
   void
-  apply_dirichlet_neumann_scheme(VectorType &       d_tilde,
-                                 VectorType const & d,
+  solve_subproblem_mesh(VectorType const & displacement_structure) const;
+
+  void
+  solve_subproblem_fluid(unsigned int const iteration,
+                         bool const         update_velocity,
+                         bool const         update_pressure) const;
+
+  void
+  solve_subproblem_structure(unsigned int const iteration) const;
+
+  void
+  apply_dirichlet_neumann_scheme(VectorType &       displacement_structure_tilde,
+                                 VectorType const & displacement_structure,
                                  unsigned int       iteration) const;
 
   // MPI communicator

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -92,7 +92,9 @@ public:
   ale_update();
 
   void
-  advance_one_timestep_partitioned_solve(bool const use_extrapolation);
+  advance_one_timestep_partitioned_solve(bool const use_extrapolation,
+                                         bool const update_velocity,
+                                         bool const update_pressure);
 
   virtual void
   print_iterations() const = 0;
@@ -135,6 +137,8 @@ protected:
   // required for strongly-coupled partitioned iteration
   bool use_extrapolation;
   bool store_solution;
+  bool update_velocity;
+  bool update_pressure;
 
   // This object allows to access utility functions needed for ALE
   std::shared_ptr<HelpersALE<Number> const> helpers_ale;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -316,20 +316,30 @@ TimeIntBDFDualSplitting<dim, Number>::do_timestep_solve()
   pde_operator->interpolate_velocity_dirichlet_bc(velocity_dbc_np, this->get_next_time());
 
   // perform the sub-steps of the dual-splitting method
-  convective_step();
+  if(this->update_velocity)
+  {
+    convective_step();
+  }
 
-  pressure_step();
+  if(this->update_pressure)
+  {
+    pressure_step();
+  }
 
-  projection_step();
+  if(this->update_velocity)
+  {
+    projection_step();
 
-  viscous_step();
+    viscous_step();
 
-  if(this->param.apply_penalty_terms_in_postprocessing_step)
-    penalty_step();
+    if(this->param.apply_penalty_terms_in_postprocessing_step)
+    {
+      penalty_step();
+    }
 
-  // evaluate convective term once the final solution at time
-  // t_{n+1} is known
-  evaluate_convective_term();
+    // evaluate convective term once the final solution at time t_{n+1} is known
+    evaluate_convective_term();
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -318,19 +318,26 @@ void
 TimeIntBDFPressureCorrection<dim, Number>::do_timestep_solve()
 {
   // perform the sub-steps of the pressure-correction scheme
+  if(this->update_velocity)
+  {
+    momentum_step();
+  }
 
-  momentum_step();
+  if(this->update_pressure)
+  {
+    VectorType pressure_increment;
+    pressure_increment.reinit(pressure_np, false /* init with zero */);
 
-  VectorType pressure_increment;
-  pressure_increment.reinit(pressure_np, false /* init with zero */);
+    pressure_step(pressure_increment);
 
-  pressure_step(pressure_increment);
+    projection_step(pressure_increment);
+  }
 
-  projection_step(pressure_increment);
-
-  // evaluate convective term once the final solution at time
-  // t_{n+1} is known
-  evaluate_convective_term();
+  // evaluate convective term once the final solution at time t_{n+1} is known
+  if(this->update_velocity)
+  {
+    evaluate_convective_term();
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.cpp
@@ -220,6 +220,13 @@ TimeIntGenAlpha<dim, Number>::get_displacement_np()
 }
 
 template<int dim, typename Number>
+typename TimeIntGenAlpha<dim, Number>::VectorType const &
+TimeIntGenAlpha<dim, Number>::get_displacement_n()
+{
+  return displacement_n;
+}
+
+template<int dim, typename Number>
 void
 TimeIntGenAlpha<dim, Number>::extrapolate_displacement_to_np(VectorType & displacement)
 {

--- a/include/exadg/structure/time_integration/time_int_gen_alpha.h
+++ b/include/exadg/structure/time_integration/time_int_gen_alpha.h
@@ -79,6 +79,9 @@ public:
   VectorType const &
   get_displacement_np();
 
+  VectorType const &
+  get_displacement_n();
+
   void
   extrapolate_velocity_to_np(VectorType & velocity);
 


### PR DESCRIPTION
... based on #573 -> partly same lines are affected, address #573 first.
Add an Enum `UpdateMethod` to control if we want **implicit coupling**, **geometric explicit**, or **pressure&structure** (added-mass stable) or **velocity&structure** (added-viscosity stable) implicit coupling.
Member variables `update_velocity` and `update_pressure` control execution of sub-steps in the splitting/projection fluid time integrators.  