### PR TITLE
initialize n_out_samples in POG

### DIFF
--- a/include/exadg/postprocessor/pointwise_output_generator_base.cpp
+++ b/include/exadg/postprocessor/pointwise_output_generator_base.cpp
@@ -83,7 +83,7 @@ PointwiseOutputGeneratorBase<dim, VectorType>::evaluate(VectorType const & solut
 
 template<int dim, typename VectorType>
 PointwiseOutputGeneratorBase<dim, VectorType>::PointwiseOutputGeneratorBase(MPI_Comm const & comm)
-  : mpi_comm(comm), first_evaluation(true)
+  : mpi_comm(comm), n_out_samples(dealii::numbers::invalid_unsigned_int), first_evaluation(true)
 {
 }
 


### PR DESCRIPTION
Fixes #502

@nfehn My compiler did not warn me before this PR, can you confirm this is the only variable that needed initialization?