### PR TITLE
Fix Segfaults for PointwiseOutputGenerator

### DIFF
--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -436,7 +436,7 @@ private:
     pp_data.output_data.write_higher_order = false;
 
     // write data to hdf5
-    pp_data.pointwise_output_data.time_control_data.is_active  = true;
+    pp_data.pointwise_output_data.time_control_data.is_active  = false;
     pp_data.pointwise_output_data.time_control_data.start_time = START_TIME;
     pp_data.pointwise_output_data.time_control_data.end_time   = END_TIME;
     pp_data.pointwise_output_data.time_control_data.trigger_interval =
@@ -449,12 +449,11 @@ private:
     pp_data.pointwise_output_data.write_rho_u = true; // vector
     pp_data.pointwise_output_data.write_rho_E = true; // scalar
     pp_data.pointwise_output_data.update_points_before_evaluation = false;
-    if constexpr(dim == 2)
-      pp_data.pointwise_output_data.evaluation_points.emplace_back(
-        dealii::Point<dim>{0.5 * DIMENSIONS_X1, 0.5 * DIMENSIONS_X2});
-    if constexpr(dim == 3)
-      pp_data.pointwise_output_data.evaluation_points.emplace_back(
-        dealii::Point<dim>{0.5 * DIMENSIONS_X1, 0.5 * DIMENSIONS_X2, 0.0});
+
+    dealii::Point<dim> evaluation_point;
+    evaluation_point[0] = 0.5 * DIMENSIONS_X1;
+    evaluation_point[1] = 0.5 * DIMENSIONS_X2;
+    pp_data.pointwise_output_data.evaluation_points.push_back(evaluation_point);
 
     MyPostProcessorData<dim> pp_data_turb_ch;
     pp_data_turb_ch.pp_data = pp_data;

--- a/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.cpp
@@ -20,9 +20,6 @@
  */
 
 
-// deal.II
-#include <deal.II/numerics/vector_tools.h>
-
 // ExaDG
 #include <exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.h>
 #include <exadg/utilities/print_functions.h>
@@ -72,12 +69,16 @@ PointwiseOutputGenerator<dim, Number>::setup(
   dof_handler           = &dof_handler_in;
   pointwise_output_data = pointwise_output_data_in;
 
-  if(pointwise_output_data.write_rho)
-    this->add_quantity("Rho", 1);
-  if(pointwise_output_data.write_rho_u)
-    this->add_quantity("Rho_U", dim);
-  if(pointwise_output_data.write_rho_E)
-    this->add_quantity("Rho_E", 1);
+  if(pointwise_output_data.time_control_data.is_active and
+     pointwise_output_data.evaluation_points.size() > 0)
+  {
+    if(pointwise_output_data.write_rho)
+      this->add_quantity("Rho", 1);
+    if(pointwise_output_data.write_rho_u)
+      this->add_quantity("Rho_U", dim);
+    if(pointwise_output_data.write_rho_E)
+      this->add_quantity("Rho_E", 1);
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/postprocessor/pointwise_output_generator_base.cpp
+++ b/include/exadg/postprocessor/pointwise_output_generator_base.cpp
@@ -66,19 +66,22 @@ PointwiseOutputGeneratorBase<dim, VectorType>::evaluate(VectorType const & solut
 {
   AssertThrow(unsteady, dealii::ExcMessage("Only implemented for the unsteady case."));
 
-  if(first_evaluation)
+  if(pointwise_output_data.evaluation_points.size() > 0)
   {
-    first_evaluation = false;
-    AssertThrow(time_control.get_counter() == 0,
-                dealii::ExcMessage(
-                  "Only implemented in the case that the simulation is not restarted"));
+    if(first_evaluation)
+    {
+      first_evaluation = false;
+      AssertThrow(time_control.get_counter() == 0,
+                  dealii::ExcMessage(
+                    "Only implemented in the case that the simulation is not restarted"));
+    }
+
+    if(pointwise_output_data.update_points_before_evaluation)
+      reinit_remote_evaluator();
+
+    write_time(time);
+    do_evaluate(solution);
   }
-
-  if(pointwise_output_data.update_points_before_evaluation)
-    reinit_remote_evaluator();
-
-  write_time(time);
-  do_evaluate(solution);
 }
 
 template<int dim, typename VectorType>


### PR DESCRIPTION
@nfehn During restructuring https://github.com/exadg/exadg/pull/463 I came across a segmentation fault with `is_active=false` or empty lists of evaluation points. This PR fixes these errors and is a prerequisite for https://github.com/exadg/exadg/pull/463.

I changed the default value of `is_active` to `false` and changed how the evaluation points are filled as requested in https://github.com/exadg/exadg/pull/463. Additionally, I removed an unnecessary `#include`. 

