### PR TITLE
Fix compilation error

### DIFF
--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.h
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.h
@@ -73,7 +73,8 @@ private:
   /*
    *  Evaluates solution on src-side in those points specified by dst-side
    */
-  std::map<quad_index, dealii::Utilities::MPI::RemotePointEvaluation<dim>> map_evaluator;
+  std::map<quad_index, std::unique_ptr<dealii::Utilities::MPI::RemotePointEvaluation<dim>>>
+    map_evaluator;
 
   /*
    * src-side


### PR DESCRIPTION
Due to some changes in deal.II the move constructor of `RemotePointEvaluation` seems to be deleted. Storing `RemotePointEvaluation` in the `std::map` as a `std::unique_ptr` resolves the related compiler errors.