### PR TITLE
Add acoustic operator

### DIFF
--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
@@ -1,0 +1,493 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_OPERATORS_OPERATOR_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_OPERATORS_OPERATOR_H_
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+
+#include <exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h>
+#include <exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h>
+#include <exadg/acoustic_conservation_equations/user_interface/enum_types.h>
+#include <exadg/matrix_free/integrators.h>
+#include <exadg/operators/integrator_flags.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+namespace Operators
+{
+template<int dim, typename Number>
+class Kernel
+{
+  using scalar = dealii::VectorizedArray<Number>;
+  using vector = dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>;
+
+  using CellIntegratorP = CellIntegrator<dim, 1, Number>;
+  using CellIntegratorU = CellIntegrator<dim, dim, Number>;
+
+public:
+  /*
+   * Volume flux for the momentum equation, i.e., the term occurring in the volume integral for
+   * weak formulation (performing integration-by-parts)
+   */
+  inline DEAL_II_ALWAYS_INLINE //
+    vector
+    get_volume_flux_weak_momentum(CellIntegratorU const & velocity, unsigned int const q) const
+  {
+    // minus sign due to integration by parts
+    return -velocity.get_value(q);
+  }
+
+  /*
+   * Volume flux for the momentum equation, i.e., the term occurring in the volume integral for
+   * strong formulation (integration-by-parts performed twice)
+   */
+  inline DEAL_II_ALWAYS_INLINE //
+    scalar
+    get_volume_flux_strong_momentum(CellIntegratorU const & velocity, unsigned int const q) const
+  {
+    return velocity.get_divergence(q);
+  }
+
+
+  /*
+   * Volume flux for the mass equation, i.e., the term occurring in the volume integral for
+   * weak formulation (performing integration-by-parts)
+   */
+  inline DEAL_II_ALWAYS_INLINE //
+    scalar
+    get_volume_flux_weak_mass(CellIntegratorP const & pressure, unsigned int const q) const
+  {
+    // minus sign due to integration by parts
+    return -pressure.get_value(q);
+  }
+
+  /*
+   * Volume flux for the mass equation, i.e., the term occurring in the volume integral for
+   * strong formulation (integration-by-parts performed twice)
+   */
+  inline DEAL_II_ALWAYS_INLINE //
+    vector
+    get_volume_flux_strong_mass(CellIntegratorP const & pressure, unsigned int const q) const
+  {
+    return pressure.get_gradient(q);
+  }
+
+  /*
+   * Lax Friedrichs flux for the momentum equation.
+   */
+  inline DEAL_II_ALWAYS_INLINE //
+    vector
+    calculate_lax_friedrichs_flux_momentum(vector const & um,
+                                           vector const & up,
+                                           Number const & gamma,
+                                           scalar const & pm,
+                                           scalar const & pp,
+                                           vector const & n) const
+  {
+    return Number{0.5} * (um + up) + gamma * (pm - pp) * n;
+  }
+
+  /*
+   * Lax Friedrichs flux for the mass equation.
+   */
+  inline DEAL_II_ALWAYS_INLINE //
+    scalar
+    calculate_lax_friedrichs_flux_mass(scalar const & pm,
+                                       scalar const & pp,
+                                       Number const & tau,
+                                       vector const & um,
+                                       vector const & up,
+                                       vector const & n) const
+  {
+    return Number{0.5} * (pm + pp) + tau * (um - up) * n;
+  }
+};
+
+} // namespace Operators
+
+template<int dim>
+struct OperatorData
+{
+  OperatorData()
+    : dof_index_pressure(0),
+      dof_index_velocity(1),
+      quad_index(0),
+      formulation(Formulation::SkewSymmetric),
+      bc(nullptr),
+      density(-1.0),
+      speed_of_sound(-1.0)
+  {
+  }
+
+  unsigned int dof_index_pressure;
+  unsigned int dof_index_velocity;
+
+  unsigned int quad_index;
+
+  Formulation formulation;
+
+  std::shared_ptr<BoundaryDescriptor<dim> const> bc;
+
+  double density;
+  double speed_of_sound;
+};
+
+template<int dim, typename Number>
+class Operator
+{
+  using This = Operator<dim, Number>;
+
+  using BlockVectorType = dealii::LinearAlgebra::distributed::BlockVector<Number>;
+
+  using scalar = dealii::VectorizedArray<Number>;
+  using vector = dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>;
+
+  using Range = std::pair<unsigned int, unsigned int>;
+
+  using CellIntegratorU = CellIntegrator<dim, dim, Number>;
+  using CellIntegratorP = CellIntegrator<dim, 1, Number>;
+
+  using FaceIntegratorU = FaceIntegrator<dim, dim, Number>;
+  using FaceIntegratorP = FaceIntegrator<dim, 1, Number>;
+
+public:
+  Operator()
+    : evaluation_time(Number{0.0}),
+      rhocc(Number{0.0}),
+      rho_inv(Number{0.0}),
+      tau(Number{0.0}),
+      gamma(Number{0.0})
+  {
+  }
+
+  void
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             OperatorData<dim> const &               data_in)
+  {
+    // Set Matrixfree and OperatorData.
+    matrix_free = &matrix_free_in;
+    data        = data_in;
+
+    // Precompute numbers that are needed in kernels.
+    rhocc   = (Number)(data_in.density * data_in.speed_of_sound * data_in.speed_of_sound);
+    rho_inv = (Number)(1.0 / data_in.density);
+    tau     = (Number)(0.5 * data_in.speed_of_sound * data_in.density);
+    gamma   = (Number)(0.5 / (data_in.speed_of_sound * data_in.density));
+
+    // Set integration flags.
+    if(data_in.formulation == Formulation::Weak)
+    {
+      integrator_flags_p.cell_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_p.cell_integrate = dealii::EvaluationFlags::gradients;
+      integrator_flags_p.face_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_p.face_integrate = dealii::EvaluationFlags::values;
+
+      integrator_flags_u.cell_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_u.cell_integrate = dealii::EvaluationFlags::gradients;
+      integrator_flags_u.face_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_u.face_integrate = dealii::EvaluationFlags::values;
+    }
+    else if(data_in.formulation == Formulation::Strong)
+    {
+      integrator_flags_p.cell_evaluate  = dealii::EvaluationFlags::gradients;
+      integrator_flags_p.cell_integrate = dealii::EvaluationFlags::values;
+      integrator_flags_p.face_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_p.face_integrate = dealii::EvaluationFlags::values;
+
+      integrator_flags_u.cell_evaluate  = dealii::EvaluationFlags::gradients;
+      integrator_flags_u.cell_integrate = dealii::EvaluationFlags::values;
+      integrator_flags_u.face_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_u.face_integrate = dealii::EvaluationFlags::values;
+    }
+    else if(data_in.formulation == Formulation::SkewSymmetric)
+    {
+      integrator_flags_p.cell_evaluate  = dealii::EvaluationFlags::gradients;
+      integrator_flags_p.cell_integrate = dealii::EvaluationFlags::gradients;
+      integrator_flags_p.face_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_p.face_integrate = dealii::EvaluationFlags::values;
+
+      integrator_flags_u.cell_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_u.cell_integrate = dealii::EvaluationFlags::values;
+      integrator_flags_u.face_evaluate  = dealii::EvaluationFlags::values;
+      integrator_flags_u.face_integrate = dealii::EvaluationFlags::values;
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
+    }
+  }
+
+  void
+  evaluate(BlockVectorType & dst, BlockVectorType const & src, double const time) const
+  {
+    do_evaluate(dst, src, true, time);
+  }
+
+  void
+  evaluate_add(BlockVectorType & dst, BlockVectorType const & src, double const time) const
+  {
+    do_evaluate(dst, src, false, time);
+  }
+
+private:
+  void
+  do_evaluate(BlockVectorType &       dst,
+              BlockVectorType const & src,
+              double const            time,
+              bool const              zero_dst_vector) const
+  {
+    evaluation_time = (Number)time;
+
+    matrix_free->loop(&This::cell_loop,
+                      &This::face_loop,
+                      &This::boundary_face_loop,
+                      this,
+                      dst,
+                      src,
+                      zero_dst_vector,
+                      dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
+                      dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
+  }
+
+  void
+  do_cell_integral(CellIntegratorP & pressure, CellIntegratorU & velocity) const
+  {
+    if(data.formulation == Formulation::Weak)
+    {
+      for(unsigned int q : pressure.quadrature_point_indices())
+      {
+        vector const flux_momentum = kernel.get_volume_flux_weak_momentum(velocity, q);
+        scalar const flux_mass     = kernel.get_volume_flux_weak_mass(pressure, q);
+
+        pressure.submit_gradient(rhocc * flux_momentum, q);
+        velocity.submit_divergence(rho_inv * flux_mass, q);
+      }
+    }
+    else if(data.formulation == Formulation::Strong)
+    {
+      for(unsigned int q : pressure.quadrature_point_indices())
+      {
+        scalar const flux_momentum = kernel.get_volume_flux_strong_momentum(velocity, q);
+        vector const flux_mass     = kernel.get_volume_flux_strong_mass(pressure, q);
+
+        pressure.submit_value(rhocc * flux_momentum, q);
+        velocity.submit_value(rho_inv * flux_mass, q);
+      }
+    }
+    else if(data.formulation == Formulation::SkewSymmetric)
+    {
+      for(unsigned int q : pressure.quadrature_point_indices())
+      {
+        vector const flux_momentum = kernel.get_volume_flux_weak_momentum(velocity, q);
+        vector const flux_mass     = kernel.get_volume_flux_strong_mass(pressure, q);
+
+        pressure.submit_gradient(rhocc * flux_momentum, q);
+        velocity.submit_value(rho_inv * flux_mass, q);
+      }
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
+    }
+  }
+
+
+  template<bool weight_neighbor, // = false for cell centric loops and boundary loops
+           typename ExteriorFaceIntegratorP,
+           typename ExteriorFaceIntegratorU>
+  void
+  do_face_integral(FaceIntegratorP &         pressure_m,
+                   ExteriorFaceIntegratorP & pressure_p,
+                   FaceIntegratorU &         velocity_m,
+                   ExteriorFaceIntegratorU & velocity_p) const
+  {
+    for(unsigned int q : pressure_m.quadrature_point_indices())
+    {
+      scalar const pm = pressure_m.get_value(q);
+      scalar const pp = pressure_p.get_value(q);
+      vector const um = velocity_m.get_value(q);
+      vector const up = velocity_p.get_value(q);
+      vector const n  = pressure_m.normal_vector(q);
+
+      vector const flux_momentum =
+        kernel.calculate_lax_friedrichs_flux_momentum(um, up, gamma, pm, pp, n);
+
+      scalar const flux_mass = kernel.calculate_lax_friedrichs_flux_mass(pm, pp, tau, um, up, n);
+
+      if(data.formulation == Formulation::Weak)
+      {
+        scalar const flux_momentum_weak = rhocc * flux_momentum * n;
+        vector const flux_mass_weak     = rho_inv * flux_mass * n;
+
+        pressure_m.submit_value(flux_momentum_weak, q);
+        velocity_m.submit_value(flux_mass_weak, q);
+
+        if constexpr(weight_neighbor)
+        {
+          // minus signs since n⁺ = - n⁻
+          pressure_p.submit_value(-flux_momentum_weak, q);
+          velocity_p.submit_value(-flux_mass_weak, q);
+        }
+      }
+      else if(data.formulation == Formulation::Strong)
+      {
+        pressure_m.submit_value(rhocc * (flux_momentum - um) * n, q);
+        velocity_m.submit_value(rho_inv * (flux_mass - pm) * n, q);
+
+        if constexpr(weight_neighbor)
+        {
+          // minus signs since n⁺ = - n⁻
+          pressure_p.submit_value(-rhocc * (flux_momentum - up) * n, q);
+          velocity_p.submit_value(-rho_inv * (flux_mass - pp) * n, q);
+        }
+      }
+      else if(data.formulation == Formulation::SkewSymmetric)
+      {
+        scalar const flux_momentum_weak = rhocc * flux_momentum * n;
+
+        pressure_m.submit_value(flux_momentum_weak, q);
+        velocity_m.submit_value(rho_inv * (flux_mass - pm) * n, q);
+
+        if constexpr(weight_neighbor)
+        {
+          // minus signs since n⁺ = - n⁻
+          pressure_p.submit_value(-flux_momentum_weak, q);
+          velocity_p.submit_value(-rho_inv * (flux_mass - pp) * n, q);
+        }
+      }
+      else
+      {
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
+      }
+    }
+  }
+
+  void
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+            BlockVectorType &                       dst,
+            BlockVectorType const &                 src,
+            Range const &                           cell_range) const
+  {
+    CellIntegratorP pressure(matrix_free_in, data.dof_index_pressure, data.quad_index);
+    CellIntegratorU velocity(matrix_free_in, data.dof_index_velocity, data.quad_index);
+
+    for(unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+    {
+      pressure.reinit(cell);
+      pressure.gather_evaluate(src.block(0), integrator_flags_p.cell_evaluate);
+
+      velocity.reinit(cell);
+      velocity.gather_evaluate(src.block(1), integrator_flags_u.cell_evaluate);
+
+      do_cell_integral(pressure, velocity);
+
+      pressure.integrate_scatter(integrator_flags_p.cell_integrate, dst.block(0));
+      velocity.integrate_scatter(integrator_flags_u.cell_integrate, dst.block(1));
+    }
+  }
+
+  void
+  face_loop(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+            BlockVectorType &                       dst,
+            BlockVectorType const &                 src,
+            Range const &                           face_range) const
+  {
+    FaceIntegratorP pressure_m(matrix_free_in, true, data.dof_index_pressure, data.quad_index);
+    FaceIntegratorP pressure_p(matrix_free_in, false, data.dof_index_pressure, data.quad_index);
+
+    FaceIntegratorU velocity_m(matrix_free_in, true, data.dof_index_velocity, data.quad_index);
+    FaceIntegratorU velocity_p(matrix_free_in, false, data.dof_index_velocity, data.quad_index);
+
+    for(unsigned int face = face_range.first; face < face_range.second; face++)
+    {
+      pressure_m.reinit(face);
+      pressure_m.gather_evaluate(src.block(0), integrator_flags_p.face_evaluate);
+      pressure_p.reinit(face);
+      pressure_p.gather_evaluate(src.block(0), integrator_flags_p.face_evaluate);
+
+      velocity_m.reinit(face);
+      velocity_m.gather_evaluate(src.block(1), integrator_flags_u.face_evaluate);
+      velocity_p.reinit(face);
+      velocity_p.gather_evaluate(src.block(1), integrator_flags_u.face_evaluate);
+
+      do_face_integral<true>(pressure_m, pressure_p, velocity_m, velocity_p);
+
+      pressure_m.integrate_scatter(integrator_flags_p.face_integrate, dst.block(0));
+      pressure_p.integrate_scatter(integrator_flags_p.face_integrate, dst.block(0));
+
+      velocity_m.integrate_scatter(integrator_flags_u.face_integrate, dst.block(1));
+      velocity_p.integrate_scatter(integrator_flags_u.face_integrate, dst.block(1));
+    }
+  }
+
+  void
+  boundary_face_loop(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                     BlockVectorType &                       dst,
+                     BlockVectorType const &                 src,
+                     Range const &                           face_range) const
+  {
+    FaceIntegratorP pressure_m(matrix_free_in, true, data.dof_index_pressure, data.quad_index);
+    BoundaryFaceIntegratorP<dim, Number> pressure_p(pressure_m, *data.bc->pressure);
+
+    FaceIntegratorU velocity_m(matrix_free_in, true, data.dof_index_velocity, data.quad_index);
+    BoundaryFaceIntegratorU<dim, Number> velocity_p(velocity_m, *data.bc->velocity);
+
+    for(unsigned int face = face_range.first; face < face_range.second; face++)
+    {
+      pressure_m.reinit(face);
+      pressure_m.gather_evaluate(src.block(0), integrator_flags_p.face_evaluate);
+      pressure_p.reinit(face, evaluation_time);
+
+      velocity_m.reinit(face);
+      velocity_m.gather_evaluate(src.block(1), integrator_flags_u.face_evaluate);
+      velocity_p.reinit(face, evaluation_time);
+
+      do_face_integral<false>(pressure_m, pressure_p, velocity_m, velocity_p);
+
+      pressure_m.integrate_scatter(integrator_flags_p.face_integrate, dst.block(0));
+      velocity_m.integrate_scatter(integrator_flags_u.face_integrate, dst.block(1));
+    }
+  }
+
+  Operators::Kernel<dim, Number> kernel;
+
+  mutable Number evaluation_time;
+
+  dealii::SmartPointer<dealii::MatrixFree<dim, Number> const> matrix_free;
+  OperatorData<dim>                                           data;
+
+  Number rhocc;
+  Number rho_inv;
+  Number tau;
+  Number gamma;
+
+  IntegratorFlags integrator_flags_p;
+  IntegratorFlags integrator_flags_u;
+};
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+
+#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_OPERATORS_OPERATOR_H_*/

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
@@ -1,0 +1,156 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_OPERATORS_WEAK_BOUNDARY_CONDITIONS_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_OPERATORS_WEAK_BOUNDARY_CONDITIONS_H_
+
+#include <exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h>
+#include <exadg/functions_and_boundary_conditions/boundary_face_integrator_base.h>
+#include <exadg/functions_and_boundary_conditions/evaluate_functions.h>
+#include <exadg/matrix_free/integrators.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+// compute exterior pressure values for different boundary types
+template<int dim, typename Number>
+inline DEAL_II_ALWAYS_INLINE //
+  dealii::VectorizedArray<Number>
+  calculate_exterior_value_pressure(unsigned int const                     q,
+                                    FaceIntegrator<dim, 1, Number> const & integrator_m,
+                                    BoundaryTypeP const &                  boundary_type,
+                                    dealii::types::boundary_id const       boundary_id,
+                                    BoundaryDescriptorP<dim> const &       boundary_descriptor,
+                                    Number const                           time)
+{
+  if(boundary_type == BoundaryTypeP::Dirichlet)
+  {
+    auto const g = FunctionEvaluator<0, dim, Number>::value(
+      *boundary_descriptor.dirichlet_bc.find(boundary_id)->second,
+      integrator_m.quadrature_point(q),
+      time);
+    return -integrator_m.get_value(q) + Number{2.0} * g;
+  }
+  else
+  {
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
+  }
+}
+
+// compute exterior velocity values for different boundary types
+template<int dim, typename Number>
+inline DEAL_II_ALWAYS_INLINE //
+  dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
+  calculate_exterior_value_velocity(unsigned int const                       q,
+                                    FaceIntegrator<dim, dim, Number> const & integrator_m,
+                                    BoundaryTypeU const &                    boundary_type,
+                                    dealii::types::boundary_id const         boundary_id,
+                                    BoundaryDescriptorU<dim> const &         boundary_descriptor,
+                                    Number const                             time)
+{
+  (void)boundary_id;
+  (void)boundary_descriptor;
+  (void)time;
+
+  if(boundary_type == BoundaryTypeU::Neumann)
+  {
+    return integrator_m.get_value(q);
+  }
+  else
+  {
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
+  }
+}
+
+
+/**
+ * Class to access values of pressure at boundaries similar to FaceIntegrators.
+ */
+template<int dim, typename Number>
+class BoundaryFaceIntegratorP : public BoundaryFaceIntegratorBase<BoundaryDescriptorP<dim>, Number>
+{
+  using FaceIntegratorP = FaceIntegrator<dim, 1, Number>;
+
+public:
+  BoundaryFaceIntegratorP(FaceIntegratorP const &          integrator_m_in,
+                          BoundaryDescriptorP<dim> const & boundary_descriptor_in)
+    : BoundaryFaceIntegratorBase<BoundaryDescriptorP<dim>, Number>(
+        integrator_m_in.get_matrix_free(),
+        boundary_descriptor_in),
+      integrator_m(integrator_m_in)
+  {
+  }
+
+  inline DEAL_II_ALWAYS_INLINE //
+    typename FaceIntegratorP::value_type
+    get_value(unsigned int const q) const
+  {
+    return calculate_exterior_value_pressure(q,
+                                             integrator_m,
+                                             this->boundary_type,
+                                             this->boundary_id,
+                                             this->boundary_descriptor,
+                                             this->evaluation_time);
+  }
+
+private:
+  FaceIntegratorP const & integrator_m;
+};
+
+/**
+ * Same as above for the velocity.
+ */
+template<int dim, typename Number>
+class BoundaryFaceIntegratorU : public BoundaryFaceIntegratorBase<BoundaryDescriptorU<dim>, Number>
+{
+  using FaceIntegratorU = FaceIntegrator<dim, dim, Number>;
+
+public:
+  BoundaryFaceIntegratorU(FaceIntegratorU const &          integrator_m_in,
+                          BoundaryDescriptorU<dim> const & boundary_descriptor_in)
+    : BoundaryFaceIntegratorBase<BoundaryDescriptorU<dim>, Number>(
+        integrator_m_in.get_matrix_free(),
+        boundary_descriptor_in),
+      integrator_m(integrator_m_in)
+  {
+  }
+
+  inline DEAL_II_ALWAYS_INLINE //
+    typename FaceIntegratorU::value_type
+    get_value(unsigned int const q) const
+  {
+    return calculate_exterior_value_velocity(q,
+                                             integrator_m,
+                                             this->boundary_type,
+                                             this->boundary_id,
+                                             this->boundary_descriptor,
+                                             this->evaluation_time);
+  }
+
+private:
+  FaceIntegratorU const & integrator_m;
+};
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_OPERATORS_WEAK_BOUNDARY_CONDITIONS_H_*/

--- a/include/exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h
@@ -1,0 +1,103 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_BOUNDARY_DESCRIPTOR_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_BOUNDARY_DESCRIPTOR_H_
+
+#include <set>
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/types.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+enum class BoundaryTypeP
+{
+  Undefined,
+  Dirichlet,
+};
+
+enum class BoundaryTypeU
+{
+  Undefined,
+  Neumann
+};
+
+template<int dim>
+struct BoundaryDescriptorP
+{
+  static constexpr int dimension = dim;
+  using BoundaryType             = BoundaryTypeP;
+
+  // Dirichlet: prescribe pressure
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> dirichlet_bc;
+
+  // return the boundary type
+  inline DEAL_II_ALWAYS_INLINE //
+    BoundaryTypeP
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
+  {
+    if(this->dirichlet_bc.find(boundary_id) != this->dirichlet_bc.end())
+      return BoundaryTypeP::Dirichlet;
+
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
+
+    return BoundaryTypeP::Undefined;
+  }
+};
+
+template<int dim>
+struct BoundaryDescriptorU
+{
+  static constexpr int dimension = dim;
+  using BoundaryType             = BoundaryTypeU;
+
+  // Neumann: only the boundary IDs are stored but no inhomogeneous boundary conditions are
+  // prescribed
+  std::set<dealii::types::boundary_id> neumann_bc;
+
+  // return the boundary type
+  inline DEAL_II_ALWAYS_INLINE //
+    BoundaryTypeU
+    get_boundary_type(dealii::types::boundary_id const & boundary_id) const
+  {
+    if(this->neumann_bc.find(boundary_id) != this->neumann_bc.end())
+      return BoundaryTypeU::Neumann;
+
+    AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
+
+    return BoundaryTypeU::Undefined;
+  }
+};
+
+template<int dim>
+struct BoundaryDescriptor
+{
+  std::shared_ptr<BoundaryDescriptorP<dim>> pressure;
+  std::shared_ptr<BoundaryDescriptorU<dim>> velocity;
+};
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_BOUNDARY_DESCRIPTOR_H_ */

--- a/include/exadg/acoustic_conservation_equations/user_interface/enum_types.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/enum_types.h
@@ -1,0 +1,50 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
+#include <exadg/utilities/enum_utilities.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+enum class Formulation
+{
+  Undefined,
+  /** Weak form of pressure gradient and velocity divergence terms. */
+  Weak,
+  /** Strong form of pressure gradient and velocity divergence terms. */
+  Strong,
+  /** Strong form of the pressure gradient term and weak form of the velocity divergence term.
+   *  This way, the gradient is only used on scalar variables which reduces the number of sum
+   *  factorization sweeps in the cell loop. Additionally, only the skew-symmetric formulation
+   *  mathematically guarantees that energy will be non-increasing if the numerical quadrature
+   *  is not exact (non-affine cells).
+   */
+  SkewSymmetric
+};
+
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_*/

--- a/include/exadg/functions_and_boundary_conditions/boundary_face_integrator_base.h
+++ b/include/exadg/functions_and_boundary_conditions/boundary_face_integrator_base.h
@@ -1,0 +1,84 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_FUNCTIONS_AND_BOUNDARY_CONDITIONS_BOUNDARY_FACE_INTEGRATOR_BASE_H_
+#define EXADG_FUNCTIONS_AND_BOUNDARY_CONDITIONS_BOUNDARY_FACE_INTEGRATOR_BASE_H_
+
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include <exadg/utilities/enum_utilities.h>
+
+namespace ExaDG
+{
+/**
+ * Base class to access boundary values with a similar interface to FaceIntegrators.
+ * In the derived class a @c get_value() has to be implemented. Since the return type
+ * depends on the derived class, a pure virtual function for this purpose can not be added.
+ */
+template<typename BoundaryDescriptorType, typename Number>
+class BoundaryFaceIntegratorBase
+{
+  using BoundaryType       = typename BoundaryDescriptorType::BoundaryType;
+  static constexpr int dim = BoundaryDescriptorType::dimension;
+
+public:
+  void
+  reinit(unsigned int const face, Number const time)
+  {
+    evaluation_time = time;
+
+    auto const boundary_id_new = matrix_free.get_boundary_id(face);
+
+    // only update boundary_type if needed to avoid an unnecessary search in boundary_descriptor
+    if(boundary_id_new != boundary_id)
+    {
+      boundary_id   = boundary_id_new;
+      boundary_type = boundary_descriptor.get_boundary_type(boundary_id);
+    }
+  }
+
+  // A corresponding function has to be implemented in the deriving class.
+  // The return type varies dependent on the value type.
+  // auto
+  // get_value();
+
+protected:
+  BoundaryFaceIntegratorBase(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                             BoundaryDescriptorType const &          boundary_descriptor_in)
+    : matrix_free(matrix_free_in),
+      boundary_descriptor(boundary_descriptor_in),
+      evaluation_time(Number{0.0}),
+      boundary_id(dealii::numbers::invalid_boundary_id),
+      boundary_type(Utilities::default_constructor<BoundaryType>())
+  {
+  }
+
+  dealii::MatrixFree<dim, Number> const & matrix_free;
+  BoundaryDescriptorType const &          boundary_descriptor;
+
+  Number                     evaluation_time;
+  dealii::types::boundary_id boundary_id;
+  BoundaryType               boundary_type;
+};
+
+} // namespace ExaDG
+
+#endif /*EXADG_FUNCTIONS_AND_BOUNDARY_CONDITIONS_BOUNDARY_FACE_INTEGRATOR_BASE_H_*/


### PR DESCRIPTION
@nfehn This PR adds a minimal version of an operator for the acoustic conservation equations. Its discretization in the strong from reads:
![discre](https://github.com/exadg/exadg/assets/43043310/da90a9a0-c9ba-40d2-bad4-7a494a4bb9b1)
The operator uses Lax--Friedrichs fluxes
![flux](https://github.com/exadg/exadg/assets/43043310/4ef4443f-aa7a-41a0-9d58-74a077a47b4c)
Since the fluxes use both primal variables, the operator is merged (not split into separate gradient and divergence operators) to keep the amount of flops low. 

In addition to the operator, the `BoundaryDescriptor` is needed, as well as relevant `enum` types and a function that prescribes the boundary conditions. 

The way how to prescribe the boundary conditions is different compared to the standard way in `ExaDG`. This design choice was made for non-matching interfaces (that are not present in this PR, but will be introduced in another PR). In my opinion this choice simplifies the operator also for BC application. This approach could be generalized for the rest of `ExaDG` in the future, in any way I would like to keep it here to be able to introduce the non-matching interfaces easily.

The operator is comparably template rich. If compile times become a problem in the future, it would be possible to shift everything into the `.cpp` file and add a class in the `.h` which only provides the interface. 

---------------------------
Once this PR is merged, a minimal acoustic solver can be implemented in a single PR since the minimal solver has no peculiarities.
