### PR TITLE
Implement additive Schwarz Preconditioner

### DIFF
--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -135,15 +135,15 @@ public:
   }
 
   virtual void
-  apply_inverse_as_matrices(VectorType & dst, VectorType const & src) const final
+  apply_inverse_additive_schwarz_matrices(VectorType & dst, VectorType const & src) const final
   {
-    pde_operator->apply_inverse_as_matrices(dst, src);
+    pde_operator->apply_inverse_additive_schwarz_matrices(dst, src);
   }
 
   virtual void
-  compute_factorized_as_matrices() const final
+  compute_factorized_additive_schwarz_matrices() const final
   {
-    pde_operator->compute_factorized_as_matrices();
+    pde_operator->compute_factorized_additive_schwarz_matrices();
   }
 
 #ifdef DEAL_II_WITH_TRILINOS

--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -134,6 +134,18 @@ public:
     pde_operator->apply_inverse_block_diagonal(dst, src);
   }
 
+  virtual void
+  apply_inverse_as_matrices(VectorType & dst, VectorType const & src) const final
+  {
+    pde_operator->apply_inverse_as_matrices(dst, src);
+  }
+
+  virtual void
+  compute_factorized_as_matrices() const final
+  {
+    pde_operator->compute_factorized_as_matrices();
+  }
+
 #ifdef DEAL_II_WITH_TRILINOS
   void
   init_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix,

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -87,6 +87,12 @@ public:
   virtual void
   apply_inverse_block_diagonal(VectorType & dst, VectorType const & src) const = 0;
 
+  virtual void
+  apply_inverse_as_matrices(VectorType & dst, VectorType const & src) const = 0;
+
+  virtual void
+  compute_factorized_as_matrices() const = 0;
+
 #ifdef DEAL_II_WITH_TRILINOS
   virtual void
   init_system_matrix(dealii::TrilinosWrappers::SparseMatrix & system_matrix,

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -88,10 +88,10 @@ public:
   apply_inverse_block_diagonal(VectorType & dst, VectorType const & src) const = 0;
 
   virtual void
-  apply_inverse_as_matrices(VectorType & dst, VectorType const & src) const = 0;
+  apply_inverse_additive_schwarz_matrices(VectorType & dst, VectorType const & src) const = 0;
 
   virtual void
-  compute_factorized_as_matrices() const = 0;
+  compute_factorized_additive_schwarz_matrices() const = 0;
 
 #ifdef DEAL_II_WITH_TRILINOS
   virtual void

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -2199,6 +2199,7 @@ OperatorBase<dim, Number, n_components>::internal_compute_factorized_additive_sc
   std::vector<std::vector<dealii::types::global_dof_index>> all_dof_indices(
     n_cells, std::vector<dealii::types::global_dof_index>(dofs_per_cell));
 
+  // compute weights by counting the contributions to a DoF
   initialize_dof_vector(weights);
   for(unsigned int cell_batch_index = 0; cell_batch_index < matrix_free->n_cell_batches();
       ++cell_batch_index)
@@ -2222,6 +2223,7 @@ OperatorBase<dim, Number, n_components>::internal_compute_factorized_additive_sc
   }
   weights.compress(dealii::VectorOperation::add);
 
+  // prepare the weights vector for symmetric weighting
   for(unsigned int i = 0; i < weights.size(); ++i)
   {
     if(weights.in_local_range(i))

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -2258,11 +2258,11 @@ OperatorBase<dim, Number, n_components>::internal_compute_factorized_additive_sc
         // store the cell matrix and renumber lexicographic
         auto & lapack_matrix = matrices[cell * vectorization_length + v];
 
-        auto const & lex =
+        auto const & lex_to_hier =
           matrix_free->get_shape_info(this->data.dof_index).lexicographic_numbering;
         for(unsigned int i = 0; i < dofs_per_cell; i++)
           for(unsigned int j = 0; j < dofs_per_cell; j++)
-            lapack_matrix.set(i, j, overlapped_cell_matrix[lex[i]][lex[j]]);
+            lapack_matrix.set(i, j, overlapped_cell_matrix[lex_to_hier[i]][lex_to_hier[j]]);
 
         // factorize the cell matrix
         lapack_matrix.compute_lu_factorization();

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -2157,24 +2157,25 @@ OperatorBase<dim, Number, n_components>::evaluate_face_integrals() const
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::compute_factorized_as_matrices() const
+OperatorBase<dim, Number, n_components>::compute_factorized_additive_schwarz_matrices() const
 {
 #ifdef DEAL_II_WITH_TRILINOS
-  internal_compute_factorized_as_matrices<dealii::TrilinosWrappers::SparseMatrix>();
+  internal_compute_factorized_additive_schwarz_matrices<dealii::TrilinosWrappers::SparseMatrix>();
 #elif DEAL_II_WITH_PETSC
-  internal_compute_factorized_as_matrices<dealii::PETScWrappers::MPI::SparseMatrix>();
+  internal_compute_factorized_additive_schwarz_matrices<dealii::PETScWrappers::MPI::SparseMatrix>();
 #else
   AssertThrow(n_mpi_processes == 1,
               ExcMessage(
                 "Use Trilinos or Petsc for distributed sparse matrices needed for this function!"));
-  internal_compute_factorized_as_matrices<dealii::SparseMatrix>();
+  internal_compute_factorized_additive_schwarz_matrices<dealii::SparseMatrix>();
 #endif
 }
 
 template<int dim, typename Number, int n_components>
 template<typename SparseMatrix>
 void
-OperatorBase<dim, Number, n_components>::internal_compute_factorized_as_matrices() const
+OperatorBase<dim, Number, n_components>::internal_compute_factorized_additive_schwarz_matrices()
+  const
 {
   dealii::DoFHandler<dim> const & dof_handler =
     this->matrix_free->get_dof_handler(this->data.dof_index);
@@ -2269,8 +2270,9 @@ OperatorBase<dim, Number, n_components>::internal_compute_factorized_as_matrices
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::apply_inverse_as_matrices(VectorType &       dst,
-                                                                   VectorType const & src) const
+OperatorBase<dim, Number, n_components>::apply_inverse_additive_schwarz_matrices(
+  VectorType &       dst,
+  VectorType const & src) const
 {
   if(is_dg)
     matrix_free->cell_loop(&This::cell_loop_apply_inverse_block_diagonal_matrix_based,

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -1902,7 +1902,8 @@ OperatorBase<dim, Number, n_components>::cell_loop_calculate_system_matrix(
         // so we have to fix the order
         auto temp = dof_indices;
         for(unsigned int j = 0; j < dof_indices.size(); j++)
-          dof_indices[j] = temp[matrix_free.get_shape_info().lexicographic_numbering[j]];
+          dof_indices[j] =
+            temp[matrix_free.get_shape_info(this->data.dof_index).lexicographic_numbering[j]];
       }
 
       // choose the version of distribute_local_to_global with a single
@@ -2257,7 +2258,8 @@ OperatorBase<dim, Number, n_components>::internal_compute_factorized_additive_sc
         // store the cell matrix and renumber lexicographic
         auto & lapack_matrix = matrices[cell * vectorization_length + v];
 
-        auto const & lex = matrix_free->get_shape_info().lexicographic_numbering;
+        auto const & lex =
+          matrix_free->get_shape_info(this->data.dof_index).lexicographic_numbering;
         for(unsigned int i = 0; i < dofs_per_cell; i++)
           for(unsigned int j = 0; j < dofs_per_cell; j++)
             lapack_matrix.set(i, j, overlapped_cell_matrix[lex[i]][lex[j]]);

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -2306,11 +2306,13 @@ OperatorBase<dim, Number, n_components>::apply_inverse_additive_schwarz_matrices
 
           for(unsigned int v = 0; v < vectorization_length; ++v)
           {
+            // apply symmetric weighting, first before applying the inverse
             for(unsigned int i = 0; i < dofs_per_cell; ++i)
               local_vector[i] = integrator.begin_dof_values()[i][v] * local_weights_vector[i][v];
 
             matrices[cell * vectorization_length + v].solve(local_vector);
 
+            // and after applying the inverse
             for(unsigned int i = 0; i < dofs_per_cell; ++i)
               integrator.begin_dof_values()[i][v] = local_vector[i] * local_weights_vector[i][v];
           }

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -2302,7 +2302,9 @@ OperatorBase<dim, Number, n_components>::apply_inverse_additive_schwarz_matrices
 
           integrator.read_dof_values(src);
 
-          for(unsigned int v = 0; v < vectorization_length; ++v)
+          unsigned int const n_filled_lanes = matrix_free.n_active_entries_per_cell_batch(cell);
+
+          for(unsigned int v = 0; v < n_filled_lanes; ++v)
           {
             // apply symmetric weighting, first before applying the inverse
             for(unsigned int i = 0; i < dofs_per_cell; ++i)

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -2164,9 +2164,11 @@ OperatorBase<dim, Number, n_components>::compute_factorized_additive_schwarz_mat
 #elif DEAL_II_WITH_PETSC
   internal_compute_factorized_additive_schwarz_matrices<dealii::PETScWrappers::MPI::SparseMatrix>();
 #else
-  AssertThrow(n_mpi_processes == 1,
-              ExcMessage(
-                "Use Trilinos or Petsc for distributed sparse matrices needed for this function!"));
+  AssertThrow(
+    n_mpi_processes == 1,
+    ExcMessage(
+      "If you want to use this function in parallel you have to compile deal.II with either "
+      "Trilinos or Petsc support for distributed sparse matrices."));
   internal_compute_factorized_additive_schwarz_matrices<dealii::SparseMatrix>();
 #endif
 }

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -106,8 +106,7 @@ public:
 
   static unsigned int const vectorization_length = dealii::VectorizedArray<Number>::size();
 
-  typedef dealii::LAPACKFullMatrix<Number> CellMatrix;
-  typedef std::vector<CellMatrix>          BlockMatrix;
+  typedef dealii::LAPACKFullMatrix<Number> LAPACKMatrix;
 
   typedef dealii::FullMatrix<dealii::TrilinosScalar> FullMatrix_;
 
@@ -305,7 +304,7 @@ public:
   calculate_block_diagonal_matrices() const;
 
   void
-  add_block_diagonal_matrices(BlockMatrix & matrices) const;
+  add_block_diagonal_matrices(std::vector<LAPACKMatrix> & matrices) const;
 
   void
   apply_block_diagonal_matrix_based(VectorType & dst, VectorType const & src) const;
@@ -592,27 +591,27 @@ private:
    */
   void
   cell_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
-                           BlockMatrix &                           matrices,
-                           BlockMatrix const &                     src,
+                           std::vector<LAPACKMatrix> &             matrices,
+                           std::vector<LAPACKMatrix> const &       src,
                            Range const &                           range) const;
 
   void
   face_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
-                           BlockMatrix &                           matrices,
-                           BlockMatrix const &                     src,
+                           std::vector<LAPACKMatrix> &             matrices,
+                           std::vector<LAPACKMatrix> const &       src,
                            Range const &                           range) const;
 
   void
   boundary_face_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
-                                    BlockMatrix &                           matrices,
-                                    BlockMatrix const &                     src,
+                                    std::vector<LAPACKMatrix> &             matrices,
+                                    std::vector<LAPACKMatrix> const &       src,
                                     Range const &                           range) const;
 
   // cell-based variant for computation of both cell and face integrals
   void
   cell_based_loop_block_diagonal(dealii::MatrixFree<dim, Number> const & matrix_free,
-                                 BlockMatrix &                           matrices,
-                                 BlockMatrix const &                     src,
+                                 std::vector<LAPACKMatrix> &             matrices,
+                                 std::vector<LAPACKMatrix> const &       src,
                                  Range const &                           range) const;
 
   /*
@@ -709,7 +708,7 @@ private:
   /*
    * Vector of matrices for block-diagonal preconditioners.
    */
-  mutable BlockMatrix matrices;
+  mutable std::vector<LAPACKMatrix> matrices;
 
   /*
    * Vector with weights for additive Schwarz preconditioner.

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -331,10 +331,10 @@ public:
    * additive Schwarz preconditioner (cellwise block-diagonal)
    */
   virtual void
-  compute_factorized_as_matrices() const;
+  compute_factorized_additive_schwarz_matrices() const;
 
   void
-  apply_inverse_as_matrices(VectorType & dst, VectorType const & src) const;
+  apply_inverse_additive_schwarz_matrices(VectorType & dst, VectorType const & src) const;
 
 protected:
   void
@@ -693,7 +693,7 @@ private:
    */
   template<typename SparseMatrix>
   void
-  internal_compute_factorized_as_matrices() const;
+  internal_compute_factorized_additive_schwarz_matrices() const;
 
   /*
    * Data structure containing all operator-specific data.

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -31,6 +31,7 @@
 #include <exadg/operators/quadrature.h>
 #include <exadg/poisson/preconditioners/multigrid_preconditioner.h>
 #include <exadg/poisson/spatial_discretization/operator.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
@@ -312,6 +313,10 @@ Operator<dim, n_components, Number>::setup_solver()
   else if(param.preconditioner == Poisson::Preconditioner::BlockJacobi)
   {
     preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator);
+  }
+  else if(param.preconditioner == Poisson::Preconditioner::AdditiveSchwarz)
+  {
+    preconditioner = std::make_shared<AdditiveSchwarzPreconditioner<Laplace>>(laplace_operator);
   }
   else if(param.preconditioner == Poisson::Preconditioner::AMG)
   {

--- a/include/exadg/poisson/user_interface/enum_types.h
+++ b/include/exadg/poisson/user_interface/enum_types.h
@@ -68,6 +68,7 @@ enum class Preconditioner
   PointJacobi,
   BlockJacobi,
   AMG,
+  AdditiveSchwarz,
   Multigrid
 };
 

--- a/include/exadg/poisson/user_interface/enum_types.h
+++ b/include/exadg/poisson/user_interface/enum_types.h
@@ -67,8 +67,8 @@ enum class Preconditioner
   None,
   PointJacobi,
   BlockJacobi,
-  AMG,
   AdditiveSchwarz,
+  AMG,
   Multigrid
 };
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
@@ -162,7 +162,8 @@ enum class PreconditionerSmoother
 {
   None,
   PointJacobi,
-  BlockJacobi
+  BlockJacobi,
+  AdditiveSchwarz
 };
 
 struct SmootherData

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
@@ -26,6 +26,7 @@
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h>
 
 namespace ExaDG
 {
@@ -84,6 +85,10 @@ public:
     else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
     {
       preconditioner = new BlockJacobiPreconditioner<Operator>(*underlying_operator);
+    }
+    else if(data.preconditioner == PreconditionerSmoother::AdditiveSchwarz)
+    {
+      preconditioner = new AdditiveSchwarzPreconditioner<Operator>(*underlying_operator);
     }
     else
     {

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
@@ -24,9 +24,9 @@
 
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
-#include <exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h>
 
 namespace ExaDG
 {

--- a/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
@@ -37,7 +37,7 @@ public:
   AdditiveSchwarzPreconditioner(Operator const & underlying_operator_in)
     : underlying_operator(underlying_operator_in)
   {
-    underlying_operator.compute_factorized_as_matrices();
+    underlying_operator.compute_factorized_additive_schwarz_matrices();
   }
 
   /*
@@ -48,7 +48,7 @@ public:
   void
   update() final
   {
-    underlying_operator.compute_factorized_as_matrices();
+    underlying_operator.compute_factorized_additive_schwarz_matrices();
   }
 
   /*
@@ -59,7 +59,7 @@ public:
   void
   vmult(VectorType & dst, VectorType const & src) const final
   {
-    underlying_operator.apply_inverse_as_matrices(dst, src);
+    underlying_operator.apply_inverse_additive_schwarz_matrices(dst, src);
   }
 
 private:

--- a/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
@@ -1,0 +1,72 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_SOLVERS_AND_PRECONDITIONERS_ADDITIVESCHWARZPRECONDITIONER_H_
+#define INCLUDE_SOLVERS_AND_PRECONDITIONERS_ADDITIVESCHWARZPRECONDITIONER_H_
+
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
+
+namespace ExaDG
+{
+template<typename Operator>
+class AdditiveSchwarzPreconditioner : public PreconditionerBase<typename Operator::value_type>
+{
+public:
+  typedef typename PreconditionerBase<typename Operator::value_type>::VectorType VectorType;
+
+  AdditiveSchwarzPreconditioner(Operator const & underlying_operator_in)
+    : underlying_operator(underlying_operator_in)
+  {
+    underlying_operator.compute_factorized_as_matrices();
+  }
+
+  /*
+   *  This function updates the additive Schwarz preconditioner.
+   *  Make sure that the underlying operator has been updated
+   *  when calling this function.
+   */
+  void
+  update() final
+  {
+    underlying_operator.compute_factorized_as_matrices();
+  }
+
+  /*
+   *  This function applies additive Schwarz preconditioner.
+   *  Make sure that the additive Schwarz preconditioner has been
+   *  updated when calling this function.
+   */
+  void
+  vmult(VectorType & dst, VectorType const & src) const final
+  {
+    underlying_operator.apply_inverse_as_matrices(dst, src);
+  }
+
+private:
+  Operator const & underlying_operator;
+};
+
+} // namespace ExaDG
+
+
+#endif /* INCLUDE_SOLVERS_AND_PRECONDITIONERS_ADDITIVESCHWARZPRECONDITIONER_H_ */


### PR DESCRIPTION
This PR implements a matrix-based additive Schwarz preconditioner where a sparse matrix is assembled first, then cell blocks are cut out and factorized using LU factorization. It can then be used as a preconditioner or as a smoother in multigrid.