### PR TITLE
Add minimal acoustic solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,11 @@ SET(TARGET_SRC
      include/exadg/structure/driver.cpp
      # fluid-structure-interaction
      include/exadg/fluid_structure_interaction/driver.cpp
+     # acoustic conservation equations
+     include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
+     include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+     include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.cpp
+     include/exadg/acoustic_conservation_equations/driver.cpp
      )
 
 SET(DEAL_II_HAVE_TESTS_DIRECTORY TRUE)

--- a/applications/acoustic_conservation_equations/CMakeLists.txt
+++ b/applications/acoustic_conservation_equations/CMakeLists.txt
@@ -1,0 +1,36 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2023 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+DIRNAME(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR})
+
+PROJECT(${PROJECT_NAME})
+
+SUBDIRLIST(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
+
+FOREACH(subdir ${SUBDIRS})
+  ADD_SUBDIRECTORY(${subdir})
+ENDFOREACH()

--- a/applications/acoustic_conservation_equations/vibrating_membrane/CMakeLists.txt
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/CMakeLists.txt
@@ -1,0 +1,32 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2023 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
+
+PROJECT(${TARGET_NAME})
+
+EXADG_PICKUP_EXE(solver.cpp ${TARGET_NAME} solver)

--- a/applications/acoustic_conservation_equations/vibrating_membrane/application.h
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/application.h
@@ -1,0 +1,250 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_VIBRATING_MEMBRANE_H_
+#define APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_VIBRATING_MEMBRANE_H_
+
+#include <deal.II/base/function.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include <exadg/grid/grid_utilities.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim>
+class AnalyticalSolutionPressure : public dealii::Function<dim>
+{
+public:
+  AnalyticalSolutionPressure(double const modes, double const speed_of_sound)
+    : dealii::Function<dim>(1, 0.0), M(modes), c(speed_of_sound)
+  {
+  }
+
+  double
+  value(dealii::Point<dim> const & p, unsigned int const) const final
+  {
+    double const t  = this->get_time();
+    double const pi = dealii::numbers::PI;
+
+    double result = std::cos(M * std::sqrt(dim) * pi * c * t);
+
+    if constexpr(dim == 2)
+      result *= std::sin(M * pi * p[0]) * std::sin(M * pi * p[1]);
+    else if constexpr(dim == 3)
+      result *= std::sin(M * pi * p[0]) * std::sin(M * pi * p[1]) * std::sin(M * pi * p[2]);
+
+    return result;
+  }
+
+private:
+  double const M, c;
+};
+
+template<int dim>
+class AnalyticalSolutionVelocity : public dealii::Function<dim>
+{
+public:
+  explicit AnalyticalSolutionVelocity(double const modes,
+                                      double const speed_of_sound,
+                                      double const density)
+    : dealii::Function<dim>(dim, 0.0), M(modes), c(speed_of_sound), rho(density)
+  {
+  }
+
+  double
+  value(dealii::Point<dim> const & p, unsigned int const component) const final
+  {
+    double const t  = this->get_time();
+    double const pi = dealii::numbers::PI;
+
+    double result = -std::sin(M * std::sqrt(dim) * pi * c * t) / (std::sqrt(dim) * rho * c);
+
+    if constexpr(dim == 2)
+    {
+      if(component == 0)
+        result *= std::cos(M * pi * p[0]) * std::sin(M * pi * p[1]);
+      else if(component == 1)
+        result *= std::sin(M * pi * p[0]) * std::cos(M * pi * p[1]);
+    }
+    else if constexpr(dim == 3)
+    {
+      if(component == 0)
+        result *= std::cos(M * pi * p[0]) * std::sin(M * pi * p[1]) * std::sin(M * pi * p[2]);
+      else if(component == 1)
+        result *= std::sin(M * pi * p[0]) * std::cos(M * pi * p[1]) * std::sin(M * pi * p[2]);
+      else if(component == 2)
+        result *= std::sin(M * pi * p[0]) * std::sin(M * pi * p[1]) * std::cos(M * pi * p[2]);
+    }
+
+    return result;
+  }
+
+private:
+  double const M, c, rho;
+};
+
+template<int dim, typename Number>
+class Application : public ApplicationBase<dim, Number>
+{
+public:
+  Application(std::string input_file, MPI_Comm const & comm)
+    : ApplicationBase<dim, Number>(input_file, comm)
+  {
+  }
+
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+    }
+    prm.leave_subsection();
+  }
+
+private:
+  void
+  set_parameters() final
+  {
+    // MATHEMATICAL MODEL
+    this->param.formulation = Formulation::SkewSymmetric;
+
+    // PHYSICAL QUANTITIES
+    this->param.start_time     = start_time;
+    this->param.end_time       = number_of_periods * compute_period_duration();
+    this->param.speed_of_sound = speed_of_sound;
+    this->param.density        = density;
+
+    // TEMPORAL DISCRETIZATION
+    this->param.calculation_of_time_step_size = TimeStepCalculation::UserSpecified;
+    this->param.time_step_size                = 1e-03;
+    this->param.order_time_integrator         = 2;
+    this->param.start_with_low_order          = false;
+
+    // output of solver information
+    this->param.solver_info_data.interval_time =
+      (this->param.end_time - this->param.start_time) / 100.0;
+
+    // SPATIAL DISCRETIZATION
+    this->param.grid.triangulation_type = TriangulationType::Distributed;
+    this->param.mapping_degree          = 1;
+    this->param.degree_p                = this->param.degree_u;
+    this->param.degree_u                = this->param.degree_p;
+  }
+
+  void
+  create_grid() final
+  {
+    auto const lambda_create_triangulation =
+      [&](dealii::Triangulation<dim, dim> & tria,
+          std::vector<dealii::GridTools::PeriodicFacePair<
+            typename dealii::Triangulation<dim>::cell_iterator>> & /*periodic_face_pairs*/,
+          unsigned int const global_refinements,
+          std::vector<unsigned int> const & /* vector_local_refinements*/) {
+        dealii::GridGenerator::hyper_cube(tria, left, right);
+
+        for(const auto & face : tria.active_face_iterators())
+          if(face->at_boundary())
+            face->set_boundary_id(1);
+
+        tria.refine_global(global_refinements);
+      };
+
+    GridUtilities::create_triangulation<dim>(
+      *this->grid, this->mpi_comm, this->param.grid, lambda_create_triangulation, {});
+  }
+
+  void
+  set_boundary_descriptor() final
+  {
+    this->boundary_descriptor->pressure->dirichlet_bc.insert(
+      std::make_pair(1, std::make_shared<AnalyticalSolutionPressure<dim>>(modes, speed_of_sound)));
+    this->boundary_descriptor->velocity->neumann_bc.insert(1);
+  }
+
+  void
+  set_field_functions() final
+  {
+    this->field_functions->initial_solution_pressure =
+      std::make_shared<AnalyticalSolutionPressure<dim>>(modes, speed_of_sound);
+
+    this->field_functions->initial_solution_velocity =
+      std::make_shared<AnalyticalSolutionVelocity<dim>>(modes, speed_of_sound, density);
+  }
+
+  std::shared_ptr<PostProcessorBase<dim, Number>>
+  create_postprocessor() final
+  {
+    PostProcessorData<dim> pp_data;
+
+    // calculation of pressure error
+    pp_data.error_data_p.time_control_data.is_active        = true;
+    pp_data.error_data_p.time_control_data.start_time       = start_time;
+    pp_data.error_data_p.time_control_data.trigger_interval = (this->param.end_time - start_time);
+    pp_data.error_data_p.analytical_solution =
+      std::make_shared<AnalyticalSolutionPressure<dim>>(modes, speed_of_sound);
+    pp_data.error_data_p.calculate_relative_errors = false; // at some times the solution is 0
+    pp_data.error_data_p.name                      = "pressure";
+
+    // ... velocity error
+    pp_data.error_data_u.time_control_data.is_active        = true;
+    pp_data.error_data_u.time_control_data.start_time       = start_time;
+    pp_data.error_data_u.time_control_data.trigger_interval = (this->param.end_time - start_time);
+    pp_data.error_data_u.analytical_solution =
+      std::make_shared<AnalyticalSolutionVelocity<dim>>(modes, speed_of_sound, density);
+    pp_data.error_data_u.calculate_relative_errors = false; // at some times the solution is 0
+    pp_data.error_data_u.name                      = "velocity";
+
+    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
+    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+
+    return pp;
+  }
+
+  // set problem specific parameters like physical dimensions, etc.
+  double modes             = 2.0;
+  double speed_of_sound    = 1.0;
+  double density           = 1.0;
+  double number_of_periods = 1.0;
+
+  double
+  compute_period_duration()
+  {
+    return 2.0 / (modes * std::sqrt(dim) * speed_of_sound);
+  }
+
+  double const left  = 0.0;
+  double const right = 1.0;
+
+  double const start_time = 0.0;
+};
+
+} // namespace Acoustics
+
+} // namespace ExaDG
+
+#include <exadg/acoustic_conservation_equations/user_interface/implement_get_application.h>
+
+#endif /* APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_VIBRATING_MEMBRANE_H_ */

--- a/applications/acoustic_conservation_equations/vibrating_membrane/input.json
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/input.json
@@ -1,0 +1,24 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "2",
+        "IsTest": "false"
+    },
+    "SpatialResolution": {
+        "DegreeMin": "7",
+        "DegreeMax": "7",
+        "RefineSpaceMin": "3",
+        "RefineSpaceMax": "3"
+    },
+    "TemporalResolution": {
+        "RefineTimeMin": "0",
+        "RefineTimeMax": "0"
+    },
+    "Application": {
+    },
+    "Output": {
+        "OutputDirectory": "output/vibrating_membrane/",
+        "OutputName": "vibrating_membrane",
+        "WriteOutput": "false"
+    }
+}

--- a/applications/acoustic_conservation_equations/vibrating_membrane/solver.cpp
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/solver.cpp
@@ -1,0 +1,26 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// solver
+#include <exadg/acoustic_conservation_equations/solver.h>
+
+// application
+#include "application.h"

--- a/include/exadg/acoustic_conservation_equations/driver.cpp
+++ b/include/exadg/acoustic_conservation_equations/driver.cpp
@@ -1,0 +1,202 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// likwid
+#ifdef EXADG_WITH_LIKWID
+#  include <likwid.h>
+#endif
+
+// ExaDG
+#include <exadg/acoustic_conservation_equations/driver.h>
+#include <exadg/grid/get_dynamic_mapping.h>
+#include <exadg/operators/throughput_parameters.h>
+#include <exadg/utilities/print_solver_results.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim, typename Number>
+Driver<dim, Number>::Driver(MPI_Comm const &                              comm,
+                            std::shared_ptr<ApplicationBase<dim, Number>> app,
+                            bool const                                    is_test,
+                            bool const                                    is_throughput_study)
+  : mpi_comm(comm),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(comm) == 0),
+    is_test(is_test),
+    is_throughput_study(is_throughput_study),
+    application(app)
+{
+  print_general_info<Number>(pcout, mpi_comm, is_test);
+}
+
+template<int dim, typename Number>
+void
+Driver<dim, Number>::setup()
+{
+  dealii::Timer timer;
+  timer.restart();
+
+  pcout << std::endl << "Setting up acoustic conservation equations solver:" << std::endl;
+
+  application->setup();
+
+  std::shared_ptr<dealii::Mapping<dim> const> mapping = application->get_mapping();
+
+  pde_operator =
+    std::make_shared<SpatialOperator<dim, Number>>(application->get_grid(),
+                                                   mapping,
+                                                   application->get_boundary_descriptor(),
+                                                   application->get_field_functions(),
+                                                   application->get_parameters(),
+                                                   "acoustic",
+                                                   mpi_comm);
+
+  // setup PDE operator
+  pde_operator->setup();
+
+  if(not is_throughput_study)
+  {
+    // setup postprocessor
+    postprocessor = application->create_postprocessor();
+    postprocessor->setup(*pde_operator);
+
+    // create and setup time integrator
+    time_integrator = std::make_shared<TimeIntAdamsBashforthMoulton<Number>>(
+      pde_operator, application->get_parameters(), postprocessor, mpi_comm, is_test);
+    time_integrator->setup(application->get_parameters().restarted_simulation);
+  }
+
+  timer_tree.insert({"Acoustic conservation equations", "Setup"}, timer.wall_time());
+}
+
+template<int dim, typename Number>
+void
+Driver<dim, Number>::solve() const
+{
+  time_integrator->timeloop();
+}
+
+template<int dim, typename Number>
+void
+Driver<dim, Number>::print_performance_results(double const total_time) const
+{
+  pcout << std::endl << print_horizontal_line() << std::endl << std::endl;
+
+  pcout << "Performance results for acoustic conservation equations solver:" << std::endl;
+
+  // Iterations
+  pcout << std::endl << "Average number of iterations:" << std::endl;
+  time_integrator->print_iterations();
+
+  // Wall times
+  timer_tree.insert({"Acoustic conservation equations"}, total_time);
+
+  timer_tree.insert({"Acoustic conservation equations"}, time_integrator->get_timings());
+
+  pcout << std::endl << "Timings for level 1:" << std::endl;
+  timer_tree.print_level(pcout, 1);
+
+  pcout << std::endl << "Timings for level 2:" << std::endl;
+  timer_tree.print_level(pcout, 2);
+
+  // Throughput in DoFs/s per time step per core
+  dealii::types::global_dof_index const DoFs = pde_operator->get_number_of_dofs();
+  unsigned int const N_mpi_processes         = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
+
+  dealii::Utilities::MPI::MinMaxAvg overall_time_data =
+    dealii::Utilities::MPI::min_max_avg(total_time, mpi_comm);
+  double const overall_time_avg = overall_time_data.avg;
+
+  unsigned int const N_time_steps = time_integrator->get_number_of_time_steps();
+  print_throughput_unsteady(pcout, DoFs, overall_time_avg, N_time_steps, N_mpi_processes);
+
+  // computational costs in CPUh
+  print_costs(pcout, overall_time_avg, N_mpi_processes);
+
+  pcout << print_horizontal_line() << std::endl << std::endl;
+}
+
+template<int dim, typename Number>
+std::tuple<unsigned int, dealii::types::global_dof_index, double>
+Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
+                                    unsigned int const   n_repetitions_inner,
+                                    unsigned int const   n_repetitions_outer) const
+{
+  pcout << std::endl << "Computing matrix-vector product ..." << std::endl;
+
+  // Vectors needed for coupled solution approach
+  dealii::LinearAlgebra::distributed::BlockVector<Number> dst, src;
+
+  // initialize vectors
+  pde_operator->initialize_dof_vector(dst);
+  pde_operator->initialize_dof_vector(src);
+  src = 1.0;
+
+  // evaluate operator
+  const std::function<void(void)> operator_evaluation = [&](void) {
+    if(operator_type == OperatorType::AcousticOperator)
+      pde_operator->evaluate_acoustic_operator(dst, src, 0.0);
+    else if(operator_type == OperatorType::InverseMassOperator)
+      pde_operator->apply_inverse_mass_operator(dst, src);
+    else
+      AssertThrow(false, dealii::ExcMessage("Not implemented."));
+  };
+
+  // calculate throughput
+
+  // determine DoFs and degree
+  dealii::types::global_dof_index const dofs      = pde_operator->get_number_of_dofs();
+  unsigned int const                    fe_degree = application->get_parameters().degree_p;
+
+  // do the measurements
+  double const wall_time = measure_operator_evaluation_time(
+    operator_evaluation, fe_degree, n_repetitions_inner, n_repetitions_outer, mpi_comm);
+
+  double const throughput = (double)dofs / wall_time;
+
+  unsigned int const N_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
+
+  if(not(is_test))
+  {
+    // clang-format off
+    pcout << std::endl
+          << std::scientific << std::setprecision(4)
+          << "DoFs/sec:        " << throughput << std::endl
+          << "DoFs/(sec*core): " << throughput/(double)N_mpi_processes << std::endl;
+    // clang-format on
+  }
+
+  pcout << std::endl << " ... done." << std::endl << std::endl;
+
+  return std::tuple<unsigned int, dealii::types::global_dof_index, double>(fe_degree,
+                                                                           dofs,
+                                                                           throughput);
+}
+
+template class Driver<2, float>;
+template class Driver<3, float>;
+
+template class Driver<2, double>;
+template class Driver<3, double>;
+
+} // namespace Acoustics
+} // namespace ExaDG

--- a/include/exadg/acoustic_conservation_equations/driver.h
+++ b/include/exadg/acoustic_conservation_equations/driver.h
@@ -1,0 +1,129 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_DRIVER_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_DRIVER_H_
+
+#include <exadg/acoustic_conservation_equations/postprocessor/postprocessor_base.h>
+#include <exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h>
+#include <exadg/acoustic_conservation_equations/time_integration/time_int_abm.h>
+#include <exadg/acoustic_conservation_equations/user_interface/application_base.h>
+#include <exadg/functions_and_boundary_conditions/verify_boundary_conditions.h>
+#include <exadg/grid/get_dynamic_mapping.h>
+#include <exadg/matrix_free/matrix_free_data.h>
+#include <exadg/operators/finite_element.h>
+#include <exadg/utilities/print_general_infos.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+enum class OperatorType
+{
+  AcousticOperator,   // gradient operator for scalar pressure and divergence operator for
+                      // vectorial velocity
+  InverseMassOperator // inverse mass operator: vectorial quantity (velocity) and scalar quantity
+                      // (pressure)
+};
+
+inline unsigned int
+get_dofs_per_element(unsigned int const       dim,
+                     unsigned int const       degree,
+                     ExaDG::ElementType const element_type)
+{
+  unsigned int const pressure_dofs_per_element =
+    ExaDG::get_dofs_per_element(element_type, true /* is_dg */, 1 /* n_components */, degree, dim);
+
+  unsigned int const velocity_dofs_per_element = ExaDG::get_dofs_per_element(
+    element_type, true /* is_dg */, dim /* n_components */, degree, dim);
+
+  return velocity_dofs_per_element + pressure_dofs_per_element;
+}
+
+template<int dim, typename Number>
+class Driver
+{
+public:
+  Driver(MPI_Comm const &                              comm,
+         std::shared_ptr<ApplicationBase<dim, Number>> application,
+         bool const                                    is_test,
+         bool const                                    is_throughput_study);
+
+  void
+  setup();
+
+  void
+  solve() const;
+
+  void
+  print_performance_results(double const total_time) const;
+
+  /*
+   * Throughput study
+   */
+  std::tuple<unsigned int, dealii::types::global_dof_index, double>
+  apply_operator(OperatorType const & operator_type,
+                 unsigned int const   n_repetitions_inner,
+                 unsigned int const   n_repetitions_outer) const;
+
+private:
+  // MPI communicator
+  MPI_Comm const mpi_comm;
+
+  // output to std::cout
+  dealii::ConditionalOStream pcout;
+
+  // do not print wall times if is_test
+  bool const is_test;
+
+  // do not set up certain data structures (solver, postprocessor) in case of throughput study
+  bool const is_throughput_study;
+
+  // application
+  std::shared_ptr<ApplicationBase<dim, Number>> application;
+
+  /*
+   * Spatial discretization
+   */
+  std::shared_ptr<SpatialOperator<dim, Number>> pde_operator;
+
+  /*
+   * Postprocessor
+   */
+  std::shared_ptr<PostProcessorBase<dim, Number>> postprocessor;
+
+  /*
+   * Temporal discretization
+   */
+
+  // unsteady solver
+  std::shared_ptr<TimeIntAdamsBashforthMoulton<Number>> time_integrator;
+
+  /*
+   * Computation time (wall clock time).
+   */
+  mutable TimerTree timer_tree;
+};
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_DRIVER_H_ */

--- a/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.cpp
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.cpp
@@ -1,0 +1,75 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#include <exadg/acoustic_conservation_equations/postprocessor/postprocessor.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim, typename Number>
+PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & postprocessor_data,
+                                          MPI_Comm const &               comm)
+  : mpi_comm(comm), pp_data(postprocessor_data), error_calculator_p(comm), error_calculator_u(comm)
+
+{
+}
+
+template<int dim, typename Number>
+void
+PostProcessor<dim, Number>::setup(AcousticsOperator const & pde_operator)
+{
+  error_calculator_p.setup(pde_operator.get_dof_handler_p(),
+                           *pde_operator.get_mapping(),
+                           pp_data.error_data_p);
+
+  error_calculator_u.setup(pde_operator.get_dof_handler_u(),
+                           *pde_operator.get_mapping(),
+                           pp_data.error_data_u);
+}
+
+template<int dim, typename Number>
+void
+PostProcessor<dim, Number>::do_postprocessing(BlockVectorType const & solution,
+                                              double const            time,
+                                              types::time_step const  time_step_number)
+{
+  /*
+   *  calculate error
+   */
+  if(error_calculator_p.time_control.needs_evaluation(time, time_step_number))
+    error_calculator_p.evaluate(solution.block(block_index_pressure),
+                                time,
+                                Utilities::is_unsteady_timestep(time_step_number));
+  if(error_calculator_u.time_control.needs_evaluation(time, time_step_number))
+    error_calculator_u.evaluate(solution.block(block_index_velocity),
+                                time,
+                                Utilities::is_unsteady_timestep(time_step_number));
+}
+
+template class PostProcessor<2, float>;
+template class PostProcessor<2, double>;
+
+template class PostProcessor<3, float>;
+template class PostProcessor<3, double>;
+
+} // namespace Acoustics
+} // namespace ExaDG

--- a/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.h
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.h
@@ -1,0 +1,83 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_H_
+
+#include <exadg/acoustic_conservation_equations/postprocessor/postprocessor_base.h>
+#include <exadg/postprocessor/error_calculation.h>
+#include <exadg/postprocessor/kinetic_energy_spectrum.h>
+
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim>
+struct PostProcessorData
+{
+  PostProcessorData() = default;
+
+  ErrorCalculationData<dim> error_data_p;
+  ErrorCalculationData<dim> error_data_u;
+};
+
+template<int dim, typename Number>
+class PostProcessor : public PostProcessorBase<dim, Number>
+{
+public:
+  using Base = PostProcessorBase<dim, Number>;
+
+  using BlockVectorType = typename Base::BlockVectorType;
+
+  using AcousticsOperator = typename Base::AcousticsOperator;
+
+  static unsigned int const block_index_pressure = AcousticsOperator::block_index_pressure;
+  static unsigned int const block_index_velocity = AcousticsOperator::block_index_velocity;
+
+  PostProcessor(PostProcessorData<dim> const & postprocessor_data, MPI_Comm const & mpi_comm);
+
+  void
+  setup(AcousticsOperator const & pde_operator) final;
+
+  void
+  do_postprocessing(BlockVectorType const & solution,
+                    double const            time             = 0.0,
+                    types::time_step const  time_step_number = numbers::steady_timestep) final;
+
+protected:
+  MPI_Comm const mpi_comm;
+
+private:
+  PostProcessorData<dim> pp_data;
+
+  // calculate errors for verification purposes for problems with known analytical solution
+  ErrorCalculator<dim, Number> error_calculator_p;
+  ErrorCalculator<dim, Number> error_calculator_u;
+};
+
+
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+
+#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_H_*/

--- a/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor_base.h
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor_base.h
@@ -19,40 +19,41 @@
  *  ______________________________________________________________________
  */
 
-#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#include <exadg/utilities/enum_utilities.h>
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_BASE_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_BASE_H_
+
+#include <exadg/acoustic_conservation_equations/postprocessor/postprocessor_interface.h>
+#include <exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h>
 
 namespace ExaDG
 {
 namespace Acoustics
 {
-enum class Formulation
-{
-  Undefined,
-  /** Weak form of pressure gradient and velocity divergence terms. */
-  Weak,
-  /** Strong form of pressure gradient and velocity divergence terms. */
-  Strong,
-  /** Strong form of the pressure gradient term and weak form of the velocity divergence term.
-   *  This way, the gradient is only used on scalar variables which reduces the number of sum
-   *  factorization sweeps in the cell loop. Additionally, only the skew-symmetric formulation
-   *  mathematically guarantees that energy will be non-increasing if the numerical quadrature
-   *  is not exact (non-affine cells).
-   */
-  SkewSymmetric
-};
+template<int dim, typename Number>
+class SpatialOperatorBase;
 
 /*
- * calculation of time step size
+ *  Base class for postprocessor of the acoustic conservation equations.
  */
-enum class TimeStepCalculation
+template<int dim, typename Number>
+class PostProcessorBase : public PostProcessorInterface<Number>
 {
-  Undefined,
-  UserSpecified
+protected:
+  using VectorType = typename PostProcessorInterface<Number>::BlockVectorType;
+
+  using AcousticsOperator = SpatialOperator<dim, Number>;
+
+public:
+  virtual ~PostProcessorBase() = default;
+  /*
+   * Setup function.
+   */
+  virtual void
+  setup(AcousticsOperator const & pde_operator) = 0;
 };
+
 
 } // namespace Acoustics
 } // namespace ExaDG
 
-#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_*/
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_BASE_H_ */

--- a/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor_interface.h
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor_interface.h
@@ -19,40 +19,35 @@
  *  ______________________________________________________________________
  */
 
-#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#include <exadg/utilities/enum_utilities.h>
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_INTERFACE_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_INTERFACE_H_
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <exadg/utilities/numbers.h>
 
 namespace ExaDG
 {
 namespace Acoustics
 {
-enum class Formulation
+template<typename Number>
+class PostProcessorInterface
 {
-  Undefined,
-  /** Weak form of pressure gradient and velocity divergence terms. */
-  Weak,
-  /** Strong form of pressure gradient and velocity divergence terms. */
-  Strong,
-  /** Strong form of the pressure gradient term and weak form of the velocity divergence term.
-   *  This way, the gradient is only used on scalar variables which reduces the number of sum
-   *  factorization sweeps in the cell loop. Additionally, only the skew-symmetric formulation
-   *  mathematically guarantees that energy will be non-increasing if the numerical quadrature
-   *  is not exact (non-affine cells).
-   */
-  SkewSymmetric
-};
+protected:
+  using BlockVectorType = dealii::LinearAlgebra::distributed::BlockVector<Number>;
 
-/*
- * calculation of time step size
- */
-enum class TimeStepCalculation
-{
-  Undefined,
-  UserSpecified
+public:
+  virtual ~PostProcessorInterface() = default;
+
+  /*
+   * This function has to be called to apply the postprocessing tools.
+   */
+  virtual void
+  do_postprocessing(BlockVectorType const & solution,
+                    double const            time             = 0.0,
+                    types::time_step const  time_step_number = numbers::steady_timestep) = 0;
 };
 
 } // namespace Acoustics
 } // namespace ExaDG
 
-#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_*/
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_POSTPROCESSOR_POSTPROCESSOR_INTERFACE_H_ */

--- a/include/exadg/acoustic_conservation_equations/solver.h
+++ b/include/exadg/acoustic_conservation_equations/solver.h
@@ -1,0 +1,205 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SOLVER_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SOLVER_H_
+
+// driver
+#include <exadg/acoustic_conservation_equations/driver.h>
+
+// utilities
+#include <exadg/operators/resolution_parameters.h>
+#include <exadg/time_integration/resolution_parameters.h>
+#include <exadg/utilities/general_parameters.h>
+
+// application
+#include <exadg/acoustic_conservation_equations/user_interface/declare_get_application.h>
+
+namespace ExaDG
+{
+void
+create_input_file(std::string const & input_file)
+{
+  dealii::ParameterHandler prm;
+
+  GeneralParameters general;
+  general.add_parameters(prm);
+
+  SpatialResolutionParametersMinMax spatial;
+  spatial.add_parameters(prm);
+
+  TemporalResolutionParameters temporal;
+  temporal.add_parameters(prm);
+
+  // we have to assume a default dimension and default Number type
+  // for the automatic generation of a default input file
+  unsigned int const Dim = 2;
+  using Number           = double;
+  Acoustics::get_application<Dim, Number>(input_file, MPI_COMM_WORLD)->add_parameters(prm);
+
+  prm.print_parameters(input_file,
+                       dealii::ParameterHandler::Short |
+                         dealii::ParameterHandler::KeepDeclarationOrder);
+}
+
+template<int dim, typename Number>
+void
+run(std::string const & input_file,
+    unsigned int const  degree,
+    unsigned int const  refine_space,
+    unsigned int const  refine_time,
+    MPI_Comm const &    mpi_comm,
+    bool const          is_test)
+{
+  dealii::Timer timer;
+  timer.restart();
+
+  std::shared_ptr<Acoustics::ApplicationBase<dim, Number>> application =
+    Acoustics::get_application<dim, Number>(input_file, mpi_comm);
+
+  application->set_parameters_convergence_study(degree, refine_space, refine_time);
+
+  std::shared_ptr<Acoustics::Driver<dim, Number>> driver =
+    std::make_shared<Acoustics::Driver<dim, Number>>(mpi_comm, application, is_test, false);
+
+  driver->setup();
+
+  driver->solve();
+
+  if(not(is_test))
+    driver->print_performance_results(timer.wall_time());
+}
+
+} // namespace ExaDG
+
+//#define USE_SUB_COMMUNICATOR
+
+int
+main(int argc, char ** argv)
+{
+  dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+
+  MPI_Comm mpi_comm(MPI_COMM_WORLD);
+
+  // new communicator
+  MPI_Comm sub_comm;
+
+#ifdef USE_SUB_COMMUNICATOR
+  // use stride of n cores
+  int const n = 48; // 24;
+
+  int const rank     = dealii::Utilities::MPI::this_mpi_process(mpi_comm);
+  int const size     = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
+  int const flag     = 1;
+  int const new_rank = rank + (rank % n) * size;
+
+  // split default communicator into two groups
+  MPI_Comm_split(mpi_comm, flag, new_rank, &sub_comm);
+
+  if(rank == 0)
+    std::cout << std::endl << "Created sub communicator with stride of " << n << std::endl;
+#else
+  sub_comm = mpi_comm;
+#endif
+
+  std::string input_file;
+
+  if(argc == 1)
+  {
+    if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+    {
+      // clang-format off
+      std::cout << "To run the program, use:      ./solver input_file" << std::endl
+                << "To setup the input file, use: ./solver input_file --help" << std::endl;
+      // clang-format on
+    }
+
+    return 0;
+  }
+  else if(argc >= 2)
+  {
+    input_file = std::string(argv[1]);
+
+    if(argc == 3 and std::string(argv[2]) == "--help")
+    {
+      if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+        ExaDG::create_input_file(input_file);
+
+      return 0;
+    }
+  }
+
+  ExaDG::GeneralParameters                 general(input_file);
+  ExaDG::SpatialResolutionParametersMinMax spatial(input_file);
+  ExaDG::TemporalResolutionParameters      temporal(input_file);
+
+  // k-refinement
+  for(unsigned int degree = spatial.degree_min; degree <= spatial.degree_max; ++degree)
+  {
+    // h-refinement
+    for(unsigned int refine_space = spatial.refine_space_min;
+        refine_space <= spatial.refine_space_max;
+        ++refine_space)
+    {
+      // dt-refinement
+      for(unsigned int refine_time = temporal.refine_time_min;
+          refine_time <= temporal.refine_time_max;
+          ++refine_time)
+      {
+        // run the simulation
+        if(general.dim == 2 and general.precision == "float")
+        {
+          ExaDG::run<2, float>(
+            input_file, degree, refine_space, refine_time, sub_comm, general.is_test);
+        }
+        else if(general.dim == 2 and general.precision == "double")
+        {
+          ExaDG::run<2, double>(
+            input_file, degree, refine_space, refine_time, sub_comm, general.is_test);
+        }
+        else if(general.dim == 3 and general.precision == "float")
+        {
+          ExaDG::run<3, float>(
+            input_file, degree, refine_space, refine_time, sub_comm, general.is_test);
+        }
+        else if(general.dim == 3 and general.precision == "double")
+        {
+          ExaDG::run<3, double>(
+            input_file, degree, refine_space, refine_time, sub_comm, general.is_test);
+        }
+        else
+        {
+          AssertThrow(
+            false, dealii::ExcMessage("Only dim = 2|3 and precision = float|double implemented."));
+        }
+      }
+    }
+  }
+
+#ifdef USE_SUB_COMMUNICATOR
+  // free communicator
+  MPI_Comm_free(&sub_comm);
+#endif
+
+  return 0;
+}
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SOLVER_H_ */

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/interface.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/interface.h
@@ -19,40 +19,42 @@
  *  ______________________________________________________________________
  */
 
-#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#include <exadg/utilities/enum_utilities.h>
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_INTERFACE_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_INTERFACE_H_
+
+// deal.II
+#include <deal.II/lac/la_parallel_block_vector.h>
 
 namespace ExaDG
 {
 namespace Acoustics
 {
-enum class Formulation
+namespace Interface
 {
-  Undefined,
-  /** Weak form of pressure gradient and velocity divergence terms. */
-  Weak,
-  /** Strong form of pressure gradient and velocity divergence terms. */
-  Strong,
-  /** Strong form of the pressure gradient term and weak form of the velocity divergence term.
-   *  This way, the gradient is only used on scalar variables which reduces the number of sum
-   *  factorization sweeps in the cell loop. Additionally, only the skew-symmetric formulation
-   *  mathematically guarantees that energy will be non-increasing if the numerical quadrature
-   *  is not exact (non-affine cells).
-   */
-  SkewSymmetric
+template<typename Number>
+class SpatialOperator
+{
+public:
+  using BlockVectorType = dealii::LinearAlgebra::distributed::BlockVector<Number>;
+
+  virtual ~SpatialOperator() = default;
+
+
+  // time integration: initialize dof vector
+  virtual void
+  initialize_dof_vector(BlockVectorType & dst) const = 0;
+
+  // time integration: prescribe initial conditions
+  virtual void
+  prescribe_initial_conditions(BlockVectorType & src, double const evaluation_time) const = 0;
+
+  // time integration: evaluate
+  virtual void
+  evaluate(BlockVectorType & dst, BlockVectorType const & src, double const time) const = 0;
 };
 
-/*
- * calculation of time step size
- */
-enum class TimeStepCalculation
-{
-  Undefined,
-  UserSpecified
-};
-
+} // namespace Interface
 } // namespace Acoustics
 } // namespace ExaDG
 
-#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_*/
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_INTERFACE_H_ */

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -1,0 +1,384 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// deal.II
+#include <deal.II/numerics/vector_tools.h>
+
+// ExaDG
+#include <exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h>
+#include <exadg/grid/mapping_dof_vector.h>
+#include <exadg/operators/finite_element.h>
+#include <exadg/operators/quadrature.h>
+#include <exadg/utilities/exceptions.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim, typename Number>
+SpatialOperator<dim, Number>::SpatialOperator(
+  std::shared_ptr<Grid<dim> const>               grid_in,
+  std::shared_ptr<dealii::Mapping<dim> const>    mapping_in,
+  std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor_in,
+  std::shared_ptr<FieldFunctions<dim> const>     field_functions_in,
+  Parameters const &                             parameters_in,
+  std::string const &                            field_in,
+  MPI_Comm const &                               mpi_comm_in)
+  : Interface::SpatialOperator<Number>(),
+    grid(grid_in),
+    mapping(mapping_in),
+    boundary_descriptor(boundary_descriptor_in),
+    field_functions(field_functions_in),
+    param(parameters_in),
+    field(field_in),
+    dof_handler_p(*grid_in->triangulation),
+    dof_handler_u(*grid_in->triangulation),
+    mpi_comm(mpi_comm_in),
+    pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_in) == 0)
+{
+  pcout << std::endl
+        << "Construct acoustic conservation equations operator ..." << std::endl
+        << std::flush;
+
+  initialize_dof_handler_and_constraints();
+
+  pcout << std::endl << "... done!" << std::endl << std::flush;
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::fill_matrix_free_data(
+  MatrixFreeData<dim, Number> & matrix_free_data) const
+{
+  // append mapping flags
+  matrix_free_data.append_mapping_flags(Operators::Kernel<dim, Number>::get_mapping_flags());
+
+  // dof handler
+  matrix_free_data.insert_dof_handler(&dof_handler_p, field + dof_index_p);
+  matrix_free_data.insert_dof_handler(&dof_handler_u, field + dof_index_u);
+
+  // constraint
+  matrix_free_data.insert_constraint(&constraint_p, field + dof_index_p);
+  matrix_free_data.insert_constraint(&constraint_u, field + dof_index_u);
+
+  // quadrature for pressure
+  std::shared_ptr<dealii::Quadrature<dim>> quadrature_p =
+    create_quadrature<dim>(param.grid.element_type, param.degree_p + 1);
+  matrix_free_data.insert_quadrature(*quadrature_p, field + quad_index_p);
+
+  // quadrature for velocity
+  std::shared_ptr<dealii::Quadrature<dim>> quadrature_u =
+    create_quadrature<dim>(param.grid.element_type, param.degree_u + 1);
+  matrix_free_data.insert_quadrature(*quadrature_u, field + quad_index_u);
+
+  // quadrature that works for pressure and velocity
+  std::shared_ptr<dealii::Quadrature<dim>> quadrature_p_u =
+    create_quadrature<dim>(param.grid.element_type, std::max(param.degree_p, param.degree_u) + 1);
+  matrix_free_data.insert_quadrature(*quadrature_p_u, field + quad_index_p_u);
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::setup()
+{
+  // initialize MatrixFree and MatrixFreeData
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> mf =
+    std::make_shared<dealii::MatrixFree<dim, Number>>();
+  std::shared_ptr<MatrixFreeData<dim, Number>> mf_data =
+    std::make_shared<MatrixFreeData<dim, Number>>();
+
+  fill_matrix_free_data(*mf_data);
+
+  mf->reinit(*get_mapping(),
+             mf_data->get_dof_handler_vector(),
+             mf_data->get_constraint_vector(),
+             mf_data->get_quadrature_vector(),
+             mf_data->data);
+
+  // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
+  // arguments.
+  this->setup(mf, mf_data);
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::setup(
+  std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free_in,
+  std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data_in)
+{
+  pcout << std::endl
+        << "Setup acoustic conservation equations operator ..." << std::endl
+        << std::flush;
+
+  // MatrixFree
+  matrix_free      = matrix_free_in;
+  matrix_free_data = matrix_free_data_in;
+
+  initialize_operators();
+
+  pcout << std::endl << "... done!" << std::endl << std::flush;
+}
+
+template<int dim, typename Number>
+dealii::MatrixFree<dim, Number> const &
+SpatialOperator<dim, Number>::get_matrix_free() const
+{
+  return *matrix_free;
+}
+
+template<int dim, typename Number>
+std::string
+SpatialOperator<dim, Number>::get_dof_name_pressure() const
+{
+  return field + dof_index_p;
+}
+
+template<int dim, typename Number>
+unsigned int
+SpatialOperator<dim, Number>::get_dof_index_pressure() const
+{
+  return matrix_free_data->get_dof_index(get_dof_name_pressure());
+}
+
+template<int dim, typename Number>
+std::string
+SpatialOperator<dim, Number>::get_dof_name_velocity() const
+{
+  return field + dof_index_u;
+}
+
+template<int dim, typename Number>
+unsigned int
+SpatialOperator<dim, Number>::get_dof_index_velocity() const
+{
+  return matrix_free_data->get_dof_index(get_dof_name_velocity());
+}
+
+template<int dim, typename Number>
+unsigned int
+SpatialOperator<dim, Number>::get_quad_index_pressure_velocity() const
+{
+  return matrix_free_data->get_quad_index(field + quad_index_p_u);
+}
+
+template<int dim, typename Number>
+unsigned int
+SpatialOperator<dim, Number>::get_quad_index_pressure() const
+{
+  return matrix_free_data->get_quad_index(field + quad_index_p);
+}
+
+template<int dim, typename Number>
+unsigned int
+SpatialOperator<dim, Number>::get_quad_index_velocity() const
+{
+  return matrix_free_data->get_quad_index(field + quad_index_u);
+}
+
+template<int dim, typename Number>
+std::shared_ptr<dealii::Mapping<dim> const>
+SpatialOperator<dim, Number>::get_mapping() const
+{
+  return mapping;
+}
+
+template<int dim, typename Number>
+dealii::FiniteElement<dim> const &
+SpatialOperator<dim, Number>::get_fe_p() const
+{
+  return *fe_p;
+}
+
+template<int dim, typename Number>
+dealii::FiniteElement<dim> const &
+SpatialOperator<dim, Number>::get_fe_u() const
+{
+  return *fe_u;
+}
+
+template<int dim, typename Number>
+dealii::DoFHandler<dim> const &
+SpatialOperator<dim, Number>::get_dof_handler_p() const
+{
+  return dof_handler_p;
+}
+
+template<int dim, typename Number>
+dealii::DoFHandler<dim> const &
+SpatialOperator<dim, Number>::get_dof_handler_u() const
+{
+  return dof_handler_u;
+}
+
+template<int dim, typename Number>
+dealii::AffineConstraints<Number> const &
+SpatialOperator<dim, Number>::get_constraint_p() const
+{
+  return constraint_p;
+}
+
+template<int dim, typename Number>
+dealii::AffineConstraints<Number> const &
+SpatialOperator<dim, Number>::get_constraint_u() const
+{
+  return constraint_u;
+}
+
+template<int dim, typename Number>
+dealii::types::global_dof_index
+SpatialOperator<dim, Number>::get_number_of_dofs() const
+{
+  return dof_handler_u.n_dofs() + dof_handler_p.n_dofs();
+}
+
+/*
+ * Initialization of vectors.
+ */
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::initialize_dof_vector(BlockVectorType & dst) const
+{
+  dst.reinit(2);
+
+  matrix_free->initialize_dof_vector(dst.block(block_index_pressure), get_dof_index_pressure());
+  matrix_free->initialize_dof_vector(dst.block(block_index_velocity), get_dof_index_velocity());
+
+  dst.collect_sizes();
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::prescribe_initial_conditions(BlockVectorType & dst,
+                                                           double const      time) const
+{
+  field_functions->initial_solution_pressure->set_time(time);
+  field_functions->initial_solution_velocity->set_time(time);
+
+  // This is necessary if Number == float
+  using VectorTypeDouble = dealii::LinearAlgebra::distributed::Vector<double>;
+
+  VectorTypeDouble pressure_double;
+  VectorTypeDouble velocity_double;
+  pressure_double = dst.block(block_index_pressure);
+  velocity_double = dst.block(block_index_velocity);
+
+  dealii::VectorTools::interpolate(*get_mapping(),
+                                   dof_handler_p,
+                                   *(field_functions->initial_solution_pressure),
+                                   pressure_double);
+
+  dealii::VectorTools::interpolate(*get_mapping(),
+                                   dof_handler_u,
+                                   *(field_functions->initial_solution_velocity),
+                                   velocity_double);
+
+  dst.block(block_index_pressure) = pressure_double;
+  dst.block(block_index_velocity) = velocity_double;
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::evaluate(BlockVectorType &       dst,
+                                       BlockVectorType const & src,
+                                       double const            time) const
+{
+  evaluate_acoustic_operator(dst, src, time);
+
+  // shift to the right-hand side of the equation
+  dst *= -1.0;
+
+  apply_inverse_mass_operator(dst, dst);
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::evaluate_acoustic_operator(BlockVectorType &       dst,
+                                                         BlockVectorType const & src,
+                                                         double const            time) const
+{
+  acoustic_operator.evaluate(dst, src, time);
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::apply_inverse_mass_operator(BlockVectorType &       dst,
+                                                          BlockVectorType const & src) const
+{
+  inverse_mass_pressure.apply(dst.block(block_index_pressure), src.block(block_index_pressure));
+  inverse_mass_velocity.apply(dst.block(block_index_velocity), src.block(block_index_velocity));
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::initialize_dof_handler_and_constraints()
+{
+  fe_p = create_finite_element<dim>(param.grid.element_type, true, 1, param.degree_p);
+  fe_u = create_finite_element<dim>(param.grid.element_type, true, dim, param.degree_u);
+
+  // enumerate degrees of freedom
+  dof_handler_p.distribute_dofs(*fe_p);
+  dof_handler_u.distribute_dofs(*fe_u);
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::initialize_operators()
+{
+  // inverse mass operator pressure
+  {
+    InverseMassOperatorData data;
+    data.dof_index  = get_dof_index_pressure();
+    data.quad_index = get_quad_index_pressure();
+    inverse_mass_pressure.initialize(*matrix_free, data);
+  }
+
+  // inverse mass operator velocity
+  {
+    InverseMassOperatorData data;
+    data.dof_index  = get_dof_index_velocity();
+    data.quad_index = get_quad_index_velocity();
+    inverse_mass_velocity.initialize(*matrix_free, data);
+  }
+
+  // acoustic operator
+  {
+    OperatorData<dim> data;
+    data.dof_index_pressure   = get_dof_index_pressure();
+    data.dof_index_velocity   = get_dof_index_velocity();
+    data.quad_index           = get_quad_index_pressure_velocity();
+    data.block_index_pressure = block_index_pressure;
+    data.block_index_velocity = block_index_velocity;
+    data.speed_of_sound       = param.speed_of_sound;
+    data.density              = param.density;
+    data.formulation          = param.formulation;
+    data.bc                   = boundary_descriptor;
+    acoustic_operator.initialize(*matrix_free, data);
+  }
+}
+
+template class SpatialOperator<2, float>;
+template class SpatialOperator<3, float>;
+
+template class SpatialOperator<2, double>;
+template class SpatialOperator<3, double>;
+
+} // namespace Acoustics
+} // namespace ExaDG

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
@@ -1,0 +1,248 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_SPATIAL_OPERATOR_BASE_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_SPATIAL_OPERATOR_BASE_H_
+
+// deal.II
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_system.h>
+
+// ExaDG
+#include <exadg/acoustic_conservation_equations/spatial_discretization/interface.h>
+#include <exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h>
+#include <exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h>
+#include <exadg/acoustic_conservation_equations/user_interface/field_functions.h>
+#include <exadg/acoustic_conservation_equations/user_interface/parameters.h>
+#include <exadg/grid/grid.h>
+#include <exadg/matrix_free/matrix_free_data.h>
+#include <exadg/operators/inverse_mass_operator.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim, typename Number>
+class SpatialOperator : public Interface::SpatialOperator<Number>
+{
+  using BlockVectorType = typename Interface::SpatialOperator<Number>::BlockVectorType;
+
+public:
+  static unsigned int const block_index_pressure = 0;
+  static unsigned int const block_index_velocity = 1;
+
+  /*
+   * Constructor.
+   */
+  SpatialOperator(std::shared_ptr<Grid<dim> const>               grid,
+                  std::shared_ptr<dealii::Mapping<dim> const>    mapping,
+                  std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor,
+                  std::shared_ptr<FieldFunctions<dim> const>     field_functions,
+                  Parameters const &                             parameters,
+                  std::string const &                            field,
+                  MPI_Comm const &                               mpi_comm);
+
+  void
+  fill_matrix_free_data(MatrixFreeData<dim, Number> & matrix_free_data) const;
+
+  /**
+   * Call this setup() function if the dealii::MatrixFree object can be set up by the present class.
+   */
+  void
+  setup();
+
+  /**
+   * Call this setup() function if the dealii::MatrixFree object needs to be created outside this
+   * class. The typical use case would be multiphysics-coupling with one MatrixFree object handed
+   * over to several single-field solvers. Another typical use case is the use of an ALE
+   * formulation.
+   */
+  void
+  setup(std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free_in,
+        std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data_in);
+
+  /*
+   * Getters and setters.
+   */
+  dealii::MatrixFree<dim, Number> const &
+  get_matrix_free() const;
+
+  std::string
+  get_dof_name_pressure() const;
+
+  unsigned int
+  get_dof_index_pressure() const;
+
+  std::string
+  get_dof_name_velocity() const;
+
+  unsigned int
+  get_dof_index_velocity() const;
+
+  unsigned int
+  get_quad_index_pressure() const;
+
+  unsigned int
+  get_quad_index_velocity() const;
+
+  unsigned int
+  get_quad_index_pressure_velocity() const;
+
+  std::shared_ptr<dealii::Mapping<dim> const>
+  get_mapping() const;
+
+  dealii::FiniteElement<dim> const &
+  get_fe_p() const;
+
+  dealii::FiniteElement<dim> const &
+  get_fe_u() const;
+
+  dealii::DoFHandler<dim> const &
+  get_dof_handler_p() const;
+
+  dealii::DoFHandler<dim> const &
+  get_dof_handler_u() const;
+
+  dealii::AffineConstraints<Number> const &
+  get_constraint_p() const;
+
+  dealii::AffineConstraints<Number> const &
+  get_constraint_u() const;
+
+  dealii::types::global_dof_index
+  get_number_of_dofs() const;
+
+  /*
+   * Initialization of vectors.
+   */
+  void
+  initialize_dof_vector(BlockVectorType & dst) const final;
+
+  /*
+   * Prescribe initial conditions using a specified analytical/initial solution function.
+   */
+  void
+  prescribe_initial_conditions(BlockVectorType & dst, double const time) const final;
+
+  /*
+   *  This function is used in case of explicit time integration:
+   *  This function evaluates the right-hand side operator, the
+   *  convective and viscous terms (subsequently multiplied by -1.0 in order
+   *  to shift these terms to the right-hand side of the equations)
+   *  and finally applies the inverse mass operator.
+   */
+  void
+  evaluate(BlockVectorType & dst, BlockVectorType const & src, double const time) const final;
+
+  /*
+   * Operators.
+   */
+
+  // acoustic operator
+  void
+  evaluate_acoustic_operator(BlockVectorType &       dst,
+                             BlockVectorType const & src,
+                             double const            time) const;
+
+  // inverse mass operator
+  void
+  apply_inverse_mass_operator(BlockVectorType & dst, BlockVectorType const & src) const;
+
+private:
+  void
+  initialize_dof_handler_and_constraints();
+
+  void
+  initialize_operators();
+
+  /*
+   * Grid
+   */
+  std::shared_ptr<Grid<dim> const> grid;
+
+  /*
+   * dealii::Mapping (In case of moving meshes (ALE), this is the dynamic mapping describing the
+   * deformed configuration.)
+   */
+  std::shared_ptr<dealii::Mapping<dim> const> mapping;
+
+  /*
+   * User interface: Boundary conditions and field functions.
+   */
+  std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor;
+  std::shared_ptr<FieldFunctions<dim> const>     field_functions;
+
+  /*
+   * List of parameters.
+   */
+  Parameters const & param;
+
+  /*
+   * A name describing the field being solved.
+   */
+  std::string const field;
+
+  /*
+   * Basic finite element ingredients.
+   */
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_p;
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_u;
+
+  dealii::DoFHandler<dim> dof_handler_p;
+  dealii::DoFHandler<dim> dof_handler_u;
+
+  dealii::AffineConstraints<Number> constraint_p, constraint_u;
+
+  std::string const dof_index_p = "pressure";
+  std::string const dof_index_u = "velocity";
+
+  std::string const quad_index_p = "pressure";
+  std::string const quad_index_u = "velocity";
+
+  // Quadrature that works for both, pressure and velocity, i.e. n_q=(max(k_p,k_u)+1)^dim.
+  // This quadrature is needed for the acoustic operator which iterates over pressure and
+  // velocity quadrature points in the same loop (for performance reasons).
+  std::string const quad_index_p_u = "pressure_velocity";
+
+  std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
+  std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
+
+  /*
+   * Basic operators.
+   */
+  Operator<dim, Number> acoustic_operator;
+
+  /*
+   * Inverse mass operator
+   */
+  InverseMassOperator<dim, 1, Number>   inverse_mass_pressure;
+  InverseMassOperator<dim, dim, Number> inverse_mass_velocity;
+
+  MPI_Comm const mpi_comm;
+
+  dealii::ConditionalOStream pcout;
+};
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_SPATIAL_DISCRETIZATION_SPATIAL_OPERATOR_BASE_H_ */

--- a/include/exadg/acoustic_conservation_equations/time_integration/time_int_abm.h
+++ b/include/exadg/acoustic_conservation_equations/time_integration/time_int_abm.h
@@ -1,0 +1,127 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_TIME_INTEGRATION_TIME_INT_ABM_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_TIME_INTEGRATION_TIME_INT_ABM_H_
+
+
+#include <exadg/acoustic_conservation_equations/spatial_discretization/interface.h>
+#include <exadg/time_integration/time_int_abm_base.h>
+#include <exadg/time_integration/time_step_calculation.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<typename Number>
+class TimeIntAdamsBashforthMoulton
+  : public TimeIntAdamsBashforthMoultonBase<Interface::SpatialOperator<Number>,
+                                            dealii::LinearAlgebra::distributed::BlockVector<Number>>
+{
+public:
+  TimeIntAdamsBashforthMoulton(std::shared_ptr<Interface::SpatialOperator<Number>> pde_operator_in,
+                               Parameters const &                                  param_in,
+                               std::shared_ptr<PostProcessorInterface<Number>>     postprocessor_in,
+                               MPI_Comm const &                                    mpi_comm_in,
+                               bool const                                          is_test_in)
+    : TimeIntAdamsBashforthMoultonBase<Interface::SpatialOperator<Number>,
+                                       dealii::LinearAlgebra::distributed::BlockVector<Number>>(
+        pde_operator_in,
+        param_in.start_time,
+        param_in.end_time,
+        param_in.max_number_of_time_steps,
+        param_in.order_time_integrator,
+        param_in.start_with_low_order,
+        param_in.adaptive_time_stepping,
+        param_in.restart_data,
+        mpi_comm_in,
+        is_test_in),
+      param(param_in),
+      postprocessor(postprocessor_in),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm_in) == 0)
+  {
+  }
+
+  bool
+  print_solver_info() const final
+  {
+    return param.solver_info_data.write(this->global_timer.wall_time(),
+                                        this->time - this->start_time,
+                                        this->time_step_number);
+  }
+
+private:
+  double
+  calculate_time_step_size() final
+  {
+    pcout << std::endl << "Calculation of time step size:" << std::endl << std::endl;
+
+    double time_step = std::numeric_limits<double>::max();
+
+    if(param.calculation_of_time_step_size == TimeStepCalculation::UserSpecified)
+    {
+      time_step = calculate_const_time_step(param.time_step_size, param.n_refine_time);
+
+      print_parameter(pcout, "time step size", time_step);
+    }
+    else
+    {
+      AssertThrow(
+        false, dealii::ExcMessage("Specified type of time step calculation is not implemented."));
+    }
+
+    return time_step;
+  }
+
+  double
+  recalculate_time_step_size() const final
+  {
+    AssertThrow(not(param.calculation_of_time_step_size == TimeStepCalculation::UserSpecified),
+                dealii::ExcMessage(
+                  "Adaptive time step is not implemented for user specified time step size."));
+
+    return {};
+  }
+
+  void
+  postprocessing() const final
+  {
+    dealii::Timer timer;
+    timer.restart();
+
+    postprocessor->do_postprocessing(this->get_solution(),
+                                     this->get_time(),
+                                     this->time_step_number);
+
+    this->timer_tree->insert({"Timeloop", "Postprocessing"}, timer.wall_time());
+  }
+
+  Parameters const param;
+
+  std::shared_ptr<PostProcessorInterface<Number>> postprocessor;
+
+  dealii::ConditionalOStream pcout;
+};
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_TIME_INTEGRATION_TIME_INT_ABM_H_*/

--- a/include/exadg/acoustic_conservation_equations/user_interface/analytical_solution.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/analytical_solution.h
@@ -19,40 +19,30 @@
  *  ______________________________________________________________________
  */
 
-#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#include <exadg/utilities/enum_utilities.h>
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ANALYTICAL_SOLUTION_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ANALYTICAL_SOLUTION_H_
+
+#include <deal.II/base/function.h>
 
 namespace ExaDG
 {
 namespace Acoustics
 {
-enum class Formulation
+template<int dim>
+struct AnalyticalSolution
 {
-  Undefined,
-  /** Weak form of pressure gradient and velocity divergence terms. */
-  Weak,
-  /** Strong form of pressure gradient and velocity divergence terms. */
-  Strong,
-  /** Strong form of the pressure gradient term and weak form of the velocity divergence term.
-   *  This way, the gradient is only used on scalar variables which reduces the number of sum
-   *  factorization sweeps in the cell loop. Additionally, only the skew-symmetric formulation
-   *  mathematically guarantees that energy will be non-increasing if the numerical quadrature
-   *  is not exact (non-affine cells).
+  /*
+   *  pressure
    */
-  SkewSymmetric
-};
+  std::shared_ptr<dealii::Function<dim>> pressure;
 
-/*
- * calculation of time step size
- */
-enum class TimeStepCalculation
-{
-  Undefined,
-  UserSpecified
+  /*
+   *  velocity
+   */
+  std::shared_ptr<dealii::Function<dim>> velocity;
 };
 
 } // namespace Acoustics
 } // namespace ExaDG
 
-#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_*/
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ANALYTICAL_SOLUTION_H_ */

--- a/include/exadg/acoustic_conservation_equations/user_interface/application_base.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/application_base.h
@@ -1,0 +1,201 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_APPLICATION_BASE_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_APPLICATION_BASE_H_
+
+// deal.II
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+
+// ExaDG
+#include <exadg/acoustic_conservation_equations/postprocessor/postprocessor.h>
+#include <exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h>
+#include <exadg/acoustic_conservation_equations/user_interface/field_functions.h>
+#include <exadg/acoustic_conservation_equations/user_interface/parameters.h>
+#include <exadg/grid/grid.h>
+#include <exadg/grid/grid_utilities.h>
+#include <exadg/operators/resolution_parameters.h>
+#include <exadg/postprocessor/output_parameters.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim, typename Number>
+class ApplicationBase
+{
+public:
+  virtual void
+  add_parameters(dealii::ParameterHandler & prm)
+  {
+    output_parameters.add_parameters(prm);
+  }
+
+  ApplicationBase(std::string parameter_file, MPI_Comm const & comm)
+    : mpi_comm(comm),
+      pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
+      parameter_file(parameter_file),
+      n_subdivisions_1d_hypercube(1)
+  {
+    grid = std::make_shared<Grid<dim>>();
+  }
+
+  virtual ~ApplicationBase() = default;
+
+  void
+  set_parameters_throughput_study(unsigned int const degree,
+                                  unsigned int const refine_space,
+                                  unsigned int const n_subdivisions_1d_hypercube)
+  {
+    this->param.degree_u              = degree;
+    this->param.grid.n_refine_global  = refine_space;
+    this->n_subdivisions_1d_hypercube = n_subdivisions_1d_hypercube;
+  }
+
+  void
+  set_parameters_convergence_study(unsigned int const degree,
+                                   unsigned int const refine_space,
+                                   unsigned int const refine_time)
+  {
+    this->param.degree_u             = degree;
+    this->param.grid.n_refine_global = refine_space;
+    this->param.n_refine_time        = refine_time;
+  }
+
+  virtual void
+  setup()
+  {
+    parse_parameters();
+
+    set_parameters();
+    param.check();
+    param.print(pcout, "List of parameters:");
+
+    // grid
+    GridUtilities::create_mapping(mapping, param.grid.element_type, param.mapping_degree);
+    create_grid();
+    print_grid_info(pcout, *grid);
+
+    // boundary conditions
+    boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
+    set_boundary_descriptor();
+    verify_boundary_conditions<dim>(*boundary_descriptor, *grid);
+
+    // field functions
+    field_functions = std::make_shared<FieldFunctions<dim>>();
+    set_field_functions();
+  }
+
+  virtual std::shared_ptr<PostProcessorBase<dim, Number>>
+  create_postprocessor() = 0;
+
+  Parameters const &
+  get_parameters() const
+  {
+    return param;
+  }
+
+  std::shared_ptr<Grid<dim> const>
+  get_grid() const
+  {
+    return grid;
+  }
+
+  std::shared_ptr<dealii::Mapping<dim> const>
+  get_mapping() const
+  {
+    return mapping;
+  }
+
+  std::shared_ptr<BoundaryDescriptor<dim> const>
+  get_boundary_descriptor() const
+  {
+    return boundary_descriptor;
+  }
+
+  std::shared_ptr<FieldFunctions<dim> const>
+  get_field_functions() const
+  {
+    return field_functions;
+  }
+
+  // Analytical mesh motion
+  virtual std::shared_ptr<dealii::Function<dim>>
+  create_mesh_movement_function()
+  {
+    std::shared_ptr<dealii::Function<dim>> mesh_motion =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(dim);
+
+    return mesh_motion;
+  }
+
+protected:
+  virtual void
+  parse_parameters()
+  {
+    dealii::ParameterHandler prm;
+    this->add_parameters(prm);
+    prm.parse_input(parameter_file, "", true, true);
+  }
+
+  MPI_Comm const & mpi_comm;
+
+  dealii::ConditionalOStream pcout;
+
+  Parameters param;
+
+  std::shared_ptr<Grid<dim>> grid;
+
+  std::shared_ptr<dealii::Mapping<dim>> mapping;
+
+  std::shared_ptr<FieldFunctions<dim>>     field_functions;
+  std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor;
+
+  std::string parameter_file;
+
+  unsigned int n_subdivisions_1d_hypercube;
+
+  OutputParameters output_parameters;
+
+private:
+  virtual void
+  set_parameters() = 0;
+
+  virtual void
+  create_grid() = 0;
+
+  virtual void
+  set_boundary_descriptor() = 0;
+
+  virtual void
+  set_field_functions() = 0;
+};
+
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_APPLICATION_BASE_H_ */

--- a/include/exadg/acoustic_conservation_equations/user_interface/declare_get_application.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/declare_get_application.h
@@ -1,0 +1,40 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_DECLARE_GET_APPLICATION_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_DECLARE_GET_APPLICATION_H_
+
+
+#include <exadg/incompressible_navier_stokes/user_interface/application_base.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim, typename Number>
+std::shared_ptr<ApplicationBase<dim, Number>>
+get_application(std::string input_file, MPI_Comm const & comm);
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_DECLARE_GET_APPLICATION_H_ */

--- a/include/exadg/acoustic_conservation_equations/user_interface/field_functions.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/field_functions.h
@@ -19,40 +19,30 @@
  *  ______________________________________________________________________
  */
 
-#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#include <exadg/utilities/enum_utilities.h>
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_FIELD_FUNCTIONS_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_FIELD_FUNCTIONS_H_
 
 namespace ExaDG
 {
 namespace Acoustics
 {
-enum class Formulation
+template<int dim>
+struct FieldFunctions
 {
-  Undefined,
-  /** Weak form of pressure gradient and velocity divergence terms. */
-  Weak,
-  /** Strong form of pressure gradient and velocity divergence terms. */
-  Strong,
-  /** Strong form of the pressure gradient term and weak form of the velocity divergence term.
-   *  This way, the gradient is only used on scalar variables which reduces the number of sum
-   *  factorization sweeps in the cell loop. Additionally, only the skew-symmetric formulation
-   *  mathematically guarantees that energy will be non-increasing if the numerical quadrature
-   *  is not exact (non-affine cells).
+  /*
+   * The function initial_solution_pressure is used to initialize the pressure field at the
+   * beginning of the simulation.
    */
-  SkewSymmetric
-};
+  std::shared_ptr<dealii::Function<dim>> initial_solution_pressure;
 
-/*
- * calculation of time step size
- */
-enum class TimeStepCalculation
-{
-  Undefined,
-  UserSpecified
+  /*
+   * The function initial_solution_velocity is used to initialize the velocity field at the
+   * beginning of the simulation.
+   */
+  std::shared_ptr<dealii::Function<dim>> initial_solution_velocity;
 };
 
 } // namespace Acoustics
 } // namespace ExaDG
 
-#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_*/
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_FIELD_FUNCTIONS_H_ */

--- a/include/exadg/acoustic_conservation_equations/user_interface/implement_get_application.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/implement_get_application.h
@@ -19,40 +19,25 @@
  *  ______________________________________________________________________
  */
 
-#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_
-#include <exadg/utilities/enum_utilities.h>
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_IMPLEMENT_GET_APPLICATION_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_IMPLEMENT_GET_APPLICATION_H_
+
+
+#include <exadg/incompressible_navier_stokes/user_interface/application_base.h>
 
 namespace ExaDG
 {
 namespace Acoustics
 {
-enum class Formulation
+template<int dim, typename Number>
+std::shared_ptr<ApplicationBase<dim, Number>>
+get_application(std::string input_file, MPI_Comm const & comm)
 {
-  Undefined,
-  /** Weak form of pressure gradient and velocity divergence terms. */
-  Weak,
-  /** Strong form of pressure gradient and velocity divergence terms. */
-  Strong,
-  /** Strong form of the pressure gradient term and weak form of the velocity divergence term.
-   *  This way, the gradient is only used on scalar variables which reduces the number of sum
-   *  factorization sweeps in the cell loop. Additionally, only the skew-symmetric formulation
-   *  mathematically guarantees that energy will be non-increasing if the numerical quadrature
-   *  is not exact (non-affine cells).
-   */
-  SkewSymmetric
-};
-
-/*
- * calculation of time step size
- */
-enum class TimeStepCalculation
-{
-  Undefined,
-  UserSpecified
-};
+  return std::make_shared<Application<dim, Number>>(input_file, comm);
+}
 
 } // namespace Acoustics
 } // namespace ExaDG
 
-#endif /*EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_ENUM_TYPES_H_*/
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_IMPLEMENT_GET_APPLICATION_H_ */

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
@@ -1,0 +1,168 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// deal.II
+#include <deal.II/base/exceptions.h>
+
+// ExaDG
+#include <exadg/acoustic_conservation_equations/user_interface/parameters.h>
+#include <exadg/utilities/print_functions.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+// standard constructor that initializes parameters
+Parameters::Parameters()
+  : // MATHEMATICAL MODEL
+    formulation(Formulation::Undefined),
+
+    // PHYSICAL QUANTITIES
+    start_time(0.),
+    end_time(-1.),
+    speed_of_sound(-1.),
+    density(-1.),
+
+    // TEMPORAL DISCRETIZATION
+    calculation_of_time_step_size(TimeStepCalculation::Undefined),
+    time_step_size(-1.),
+    max_number_of_time_steps(std::numeric_limits<unsigned int>::max()),
+    n_refine_time(0),
+    order_time_integrator(1),
+    start_with_low_order(true),
+    restarted_simulation(false),
+    adaptive_time_stepping(false),
+    restart_data(RestartData()),
+    solver_info_data(SolverInfoData()),
+
+    // SPATIAL DISCRETIZATION
+    grid(GridData()),
+    mapping_degree(1),
+    degree_u(1),
+    degree_p(1)
+{
+}
+
+void
+Parameters::check() const
+{
+  // MATHEMATICAL MODEL
+  AssertThrow(formulation != Formulation::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
+
+  // PHYSICAL QUANTITIES
+  AssertThrow(end_time > start_time, dealii::ExcMessage("parameter end_time must be defined"));
+  AssertThrow(speed_of_sound >= 0.0, dealii::ExcMessage("parameter must be defined"));
+  AssertThrow(density >= 0.0, dealii::ExcMessage("parameter must be defined"));
+
+  // TEMPORAL DISCRETIZATION
+  AssertThrow(calculation_of_time_step_size != TimeStepCalculation::Undefined,
+              dealii::ExcMessage("parameter must be defined"));
+
+  if(calculation_of_time_step_size == TimeStepCalculation::UserSpecified)
+    AssertThrow(time_step_size > 0., dealii::ExcMessage("parameter must be defined"));
+
+  AssertThrow(not(adaptive_time_stepping),
+              dealii::ExcMessage("adaptive timestepping not supported"));
+
+  // SPATIAL DISCRETIZATION
+  grid.check();
+}
+
+void
+Parameters::print(dealii::ConditionalOStream const & pcout, std::string const & name) const
+{
+  pcout << std::endl << name << std::endl;
+
+  // MATHEMATICAL MODEL
+  print_parameters_mathematical_model(pcout);
+
+  // PHYSICAL QUANTITIES
+  print_parameters_physical_quantities(pcout);
+
+  // TEMPORAL DISCRETIZATION
+  print_parameters_temporal_discretization(pcout);
+
+  // SPATIAL DISCRETIZATION
+  print_parameters_spatial_discretization(pcout);
+}
+
+void
+Parameters::print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const
+{
+  pcout << std::endl << "Mathematical model:" << std::endl;
+
+  print_parameter(pcout, "Formulation", formulation);
+}
+
+
+void
+Parameters::print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const
+{
+  pcout << std::endl << "Physical quantities:" << std::endl;
+
+  // start and end time
+  print_parameter(pcout, "Start time", start_time);
+  print_parameter(pcout, "End time", end_time);
+
+  // viscosity
+  print_parameter(pcout, "Speed of sound", speed_of_sound);
+
+  // mean density
+  print_parameter(pcout, "Density", density);
+}
+
+void
+Parameters::print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const
+{
+  pcout << std::endl << "Temporal discretization:" << std::endl;
+
+  print_parameter(pcout, "Calculation of time step size", calculation_of_time_step_size);
+
+  // here we do not print quantities such as time_step_size because this is
+  // done by the time integration scheme (or the functions that calculate
+  // the time step size)
+
+  print_parameter(pcout, "Maximum number of time steps", max_number_of_time_steps);
+  print_parameter(pcout, "Temporal refinements", n_refine_time);
+  print_parameter(pcout, "Order of time integration scheme", order_time_integrator);
+  print_parameter(pcout, "Start with low order method", start_with_low_order);
+
+  // restart
+  print_parameter(pcout, "Restarted simulation", restarted_simulation);
+  restart_data.print(pcout);
+}
+
+void
+Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const
+{
+  pcout << std::endl << "Spatial discretization:" << std::endl;
+
+  grid.print(pcout);
+
+  print_parameter(pcout, "Mapping degree", mapping_degree);
+
+  print_parameter(pcout, "Polynomial degree pressure", degree_p);
+  print_parameter(pcout, "Polynomial degree velocity", degree_u);
+}
+
+} // namespace Acoustics
+} // namespace ExaDG

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
@@ -1,0 +1,153 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_INPUT_PARAMETERS_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_INPUT_PARAMETERS_H_
+
+// deal.II
+#include <deal.II/base/conditional_ostream.h>
+
+// ExaDG
+#include <exadg/acoustic_conservation_equations/user_interface/enum_types.h>
+#include <exadg/grid/grid_data.h>
+#include <exadg/operators/inverse_mass_parameters.h>
+#include <exadg/time_integration/enum_types.h>
+#include <exadg/time_integration/restart_data.h>
+#include <exadg/time_integration/solver_info_data.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+class Parameters
+{
+public:
+  // standard constructor that initializes parameters
+  Parameters();
+
+  void
+  check() const;
+
+  void
+  print(dealii::ConditionalOStream const & pcout, std::string const & name) const;
+
+private:
+  void
+  print_parameters_mathematical_model(dealii::ConditionalOStream const & pcout) const;
+
+  void
+  print_parameters_physical_quantities(dealii::ConditionalOStream const & pcout) const;
+
+  void
+  print_parameters_temporal_discretization(dealii::ConditionalOStream const & pcout) const;
+
+  void
+  print_parameters_spatial_discretization(dealii::ConditionalOStream const & pcout) const;
+
+public:
+  /**************************************************************************************/
+  /*                                                                                    */
+  /*                                 MATHEMATICAL MODEL                                 */
+  /*                                                                                    */
+  /**************************************************************************************/
+
+  // description: see enum declaration
+  Formulation formulation;
+
+  /**************************************************************************************/
+  /*                                                                                    */
+  /*                                 PHYSICAL QUANTITIES                                */
+  /*                                                                                    */
+  /**************************************************************************************/
+
+  // start time of simulation
+  double start_time;
+
+  // end time of simulation
+  double end_time;
+
+  // speed_of_sound of underlying fluid
+  double speed_of_sound;
+
+  // mean density of underlying fluid
+  double density;
+
+  /**************************************************************************************/
+  /*                                                                                    */
+  /*                             TEMPORAL DISCRETIZATION                                */
+  /*                                                                                    */
+  /**************************************************************************************/
+
+  // description: see enum declaration
+  TimeStepCalculation calculation_of_time_step_size;
+
+  // user specified time step size:  note that this time_step_size is the first
+  // in a series of time_step_size's when performing temporal convergence tests,
+  // i.e., delta_t = time_step_size, time_step_size/2, ...
+  double time_step_size;
+
+  // maximum number of time steps
+  unsigned int max_number_of_time_steps;
+
+  // number of refinements for temporal discretization
+  unsigned int n_refine_time;
+
+  // order of time integration scheme
+  unsigned int order_time_integrator;
+
+  // start time integrator with low order time integrator, i.e., first order Euler method
+  bool start_with_low_order;
+
+  // set this variable to true to start the simulation from restart files
+  bool restarted_simulation;
+
+  // use adaptive timestepping
+  bool adaptive_time_stepping;
+
+  // restart
+  RestartData restart_data;
+
+  // show solver performance (wall time, number of iterations)
+  SolverInfoData solver_info_data;
+
+  /**************************************************************************************/
+  /*                                                                                    */
+  /*                              SPATIAL DISCRETIZATION                                */
+  /*                                                                                    */
+  /**************************************************************************************/
+
+  // Grid data
+  GridData grid;
+
+  // Mapping
+  unsigned int mapping_degree;
+
+  // Polynomial degree of velocity shape functions
+  unsigned int degree_u;
+
+  // Polynomial degree of pressure shape functions
+  unsigned int degree_p;
+};
+
+} // namespace Acoustics
+} // namespace ExaDG
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_USER_INTERFACE_INPUT_PARAMETERS_H_ */


### PR DESCRIPTION
I added the respective structure for a minimal acoustic solver (including one simple application).

There is not a lot going on. Yet, a lot of files had to be added. Everything is oriented on the rest of ExaDG and there are no differences in the structure. I know this PR is quite lengthy, but I couldn't imagine a way to further reduce the diff. 

I think the minimal solver should at least be able to calculate errors to ensure everything works as expected. The rest of the postprocessors will be added in additional PRs.