### PR TITLE
Move grid and mapping to driver for ConvDiff module

### DIFF
--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -126,8 +126,10 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
+    (void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -158,7 +160,7 @@ private:
         tria.refine_global(global_refinements);
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -175,8 +175,10 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
+    (void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -191,7 +193,7 @@ private:
         tria.refine_global(global_refinements);
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -187,8 +187,10 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
+    (void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -203,7 +205,7 @@ private:
         tria.refine_global(global_refinements);
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -142,8 +142,10 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
+    (void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -158,7 +160,7 @@ private:
         tria.refine_global(global_refinements);
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -165,8 +165,11 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid,
+			  std::shared_ptr<dealii::Mapping<dim>> mapping) final
   {
+	(void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -181,7 +184,7 @@ private:
         tria.refine_global(global_refinements);
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -165,10 +165,9 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid,
-			  std::shared_ptr<dealii::Mapping<dim>> mapping) final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
-	(void)mapping;
+    (void)mapping;
 
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,

--- a/applications/convection_diffusion/rotating_hill/input.json
+++ b/applications/convection_diffusion/rotating_hill/input.json
@@ -19,6 +19,6 @@
     "Output": {
         "OutputDirectory": "output/rotating_hill/",
         "OutputName": "test",
-        "WriteOutput": "true"
+        "WriteOutput": "false"
     }
 }

--- a/applications/convection_diffusion/rotating_hill/input.json
+++ b/applications/convection_diffusion/rotating_hill/input.json
@@ -19,6 +19,6 @@
     "Output": {
         "OutputDirectory": "output/rotating_hill/",
         "OutputName": "test",
-        "WriteOutput": "false"
+        "WriteOutput": "true"
     }
 }

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -115,8 +115,10 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
+    (void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -142,7 +144,7 @@ private:
         tria.refine_global(global_refinements);
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -65,8 +65,10 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
+    (void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -80,7 +82,7 @@ private:
         (void)vector_local_refinements;
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -116,8 +116,10 @@ private:
   }
 
   void
-  create_grid() final
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
   {
+    (void)mapping;
+
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<
@@ -154,7 +156,7 @@ private:
                             deformation);
       };
 
-    GridUtilities::create_triangulation_with_multigrid<dim>(*this->grid,
+    GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
                                                             this->param.grid,
                                                             this->param.involves_h_multigrid(),

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -58,8 +58,7 @@ Driver<dim, Number>::setup()
 
   pcout << std::endl << "Setting up scalar convection-diffusion solver:" << std::endl;
 
-  grid = std::make_shared<Grid<dim>>();
-  application->setup(*grid, mapping);
+  application->setup(grid, mapping);
 
   if(application->get_parameters().ale_formulation) // moving mesh
   {

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -58,16 +58,17 @@ Driver<dim, Number>::setup()
 
   pcout << std::endl << "Setting up scalar convection-diffusion solver:" << std::endl;
 
-  application->setup();
+  grid = std::make_shared<Grid<dim>>();
+  application->setup(*grid, mapping);
 
   if(application->get_parameters().ale_formulation) // moving mesh
   {
     std::shared_ptr<dealii::Function<dim>> mesh_motion =
       application->create_mesh_movement_function();
     ale_mapping = std::make_shared<DeformedMappingFunction<dim, Number>>(
-      application->get_mapping(),
+      mapping,
       application->get_parameters().degree,
-      *application->get_grid()->triangulation,
+      *grid->triangulation,
       mesh_motion,
       application->get_parameters().start_time);
 
@@ -85,10 +86,10 @@ Driver<dim, Number>::setup()
   }
 
   std::shared_ptr<dealii::Mapping<dim> const> dynamic_mapping =
-    get_dynamic_mapping<dim, Number>(application->get_mapping(), ale_mapping);
+    get_dynamic_mapping<dim, Number>(mapping, ale_mapping);
 
   // initialize convection-diffusion operator
-  pde_operator = std::make_shared<Operator<dim, Number>>(application->get_grid(),
+  pde_operator = std::make_shared<Operator<dim, Number>>(grid,
                                                          dynamic_mapping,
                                                          application->get_boundary_descriptor(),
                                                          application->get_field_functions(),
@@ -98,7 +99,7 @@ Driver<dim, Number>::setup()
 
   // setup convection-diffusion operator
   pde_operator->setup();
-
+std::cout << "##+1 here\n";
   if(not is_throughput_study)
   {
     // initialize postprocessor

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -99,7 +99,7 @@ Driver<dim, Number>::setup()
 
   // setup convection-diffusion operator
   pde_operator->setup();
-std::cout << "##+1 here\n";
+
   if(not is_throughput_study)
   {
     // initialize postprocessor

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -105,6 +105,11 @@ private:
   // application
   std::shared_ptr<ApplicationBase<dim, Number>> application;
 
+  // Grid and mapping
+  std::shared_ptr<Grid<dim>> grid;
+
+  std::shared_ptr<dealii::Mapping<dim>> mapping;
+
   // ALE mapping
   std::shared_ptr<DeformedMappingFunction<dim, Number>> ale_mapping;
 

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -82,7 +82,7 @@ public:
   }
 
   void
-  setup(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping)
+  setup(std::shared_ptr<Grid<dim>> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping)
   {
     parse_parameters();
 
@@ -91,15 +91,16 @@ public:
     param.check();
     param.print(pcout, "List of parameters:");
 
-    // create grid and mapping owned by driver
+    // grid
     GridUtilities::create_mapping(mapping, param.grid.element_type, param.mapping_degree);
-    create_grid(grid, mapping);
-    print_grid_info(pcout, grid);
+    grid = std::make_shared<Grid<dim>>();
+    create_grid(*grid, mapping);
+    print_grid_info(pcout, *grid);
 
     // boundary conditions
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
     set_boundary_descriptor();
-    verify_boundary_conditions(*boundary_descriptor, grid);
+    verify_boundary_conditions(*boundary_descriptor, *grid);
 
     // field functions
     field_functions = std::make_shared<FieldFunctions<dim>>();

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -82,8 +82,7 @@ public:
   }
 
   void
-  setup(Grid<dim> & grid,
-		std::shared_ptr<dealii::Mapping<dim>> mapping)
+  setup(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping)
   {
     parse_parameters();
 
@@ -166,8 +165,7 @@ private:
   set_parameters() = 0;
 
   virtual void
-  create_grid(Grid<dim> & grid,
-			  std::shared_ptr<dealii::Mapping<dim>> mapping) = 0;
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) = 0;
 
   virtual void
   set_boundary_descriptor() = 0;

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -55,7 +55,6 @@ public:
       parameter_file(parameter_file),
       n_subdivisions_1d_hypercube(1)
   {
-    grid = std::make_shared<Grid<dim>>();
   }
 
   virtual ~ApplicationBase()
@@ -83,7 +82,8 @@ public:
   }
 
   void
-  setup()
+  setup(Grid<dim> & grid,
+		std::shared_ptr<dealii::Mapping<dim>> mapping)
   {
     parse_parameters();
 
@@ -92,15 +92,15 @@ public:
     param.check();
     param.print(pcout, "List of parameters:");
 
-    // grid
+    // create grid and mapping owned by driver
     GridUtilities::create_mapping(mapping, param.grid.element_type, param.mapping_degree);
-    create_grid();
-    print_grid_info(pcout, *grid);
+    create_grid(grid, mapping);
+    print_grid_info(pcout, grid);
 
     // boundary conditions
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
     set_boundary_descriptor();
-    verify_boundary_conditions(*boundary_descriptor, *grid);
+    verify_boundary_conditions(*boundary_descriptor, grid);
 
     // field functions
     field_functions = std::make_shared<FieldFunctions<dim>>();
@@ -123,18 +123,6 @@ public:
   get_parameters() const
   {
     return param;
-  }
-
-  std::shared_ptr<Grid<dim> const>
-  get_grid() const
-  {
-    return grid;
-  }
-
-  std::shared_ptr<dealii::Mapping<dim> const>
-  get_mapping() const
-  {
-    return mapping;
   }
 
   std::shared_ptr<BoundaryDescriptor<dim> const>
@@ -164,10 +152,6 @@ protected:
 
   Parameters param;
 
-  std::shared_ptr<Grid<dim>> grid;
-
-  std::shared_ptr<dealii::Mapping<dim>> mapping;
-
   std::shared_ptr<FieldFunctions<dim>>     field_functions;
   std::shared_ptr<BoundaryDescriptor<dim>> boundary_descriptor;
 
@@ -182,7 +166,8 @@ private:
   set_parameters() = 0;
 
   virtual void
-  create_grid() = 0;
+  create_grid(Grid<dim> & grid,
+			  std::shared_ptr<dealii::Mapping<dim>> mapping) = 0;
 
   virtual void
   set_boundary_descriptor() = 0;


### PR DESCRIPTION
... for the convection diffusion module.
This was discussed in #586 : ownership of grid and mapping should be in driver, such that it can execute the adaptive refinement. In the application's `create_grid` I added now a `Grid &` and `Mapping &`. Getters were removed.