### PR TITLE
Redesign face loops acoustics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,8 @@ SET(TARGET_SRC
      include/exadg/structure/driver.cpp
      # fluid-structure-interaction
      include/exadg/fluid_structure_interaction/driver.cpp
+     # acoustics
+     include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.cpp
      )
 
 SET(DEAL_II_HAVE_TESTS_DIRECTORY TRUE)

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.cpp
@@ -1,0 +1,35 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#include <exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template class Operator<2, float>;
+template class Operator<3, float>;
+
+template class Operator<2, double>;
+template class Operator<3, double>;
+
+} // namespace Acoustics
+} // namespace ExaDG


### PR DESCRIPTION
Follow up to PR #587, related to discussions https://github.com/exadg/exadg/pull/587/files#r1389376858 and https://github.com/exadg/exadg/pull/587/files#r1389390122. I also added a .cpp file, because the code was otherwise not built.

The second commit shows how to get rid of the template parameters. By using default arguments for `pressure_p`, `velocity_p` in `face_kernel(..., pressure_p = pressure_m, velocity_p = velocity_m)`, we could even get rid of the unused function parameters passed to the face-kernel in case of boundary face loops. The template parameter `weight_neighbor` still exists, but could now actually be removed when using the design suggested here.

Note that the new design needs essentially the same number of lines of code. The new version should however be more flexible according to discussion https://github.com/exadg/exadg/pull/587/files#r1389376858. It also does not need template parameters. Hence, I would suggest to change the design.