### PR TITLE
Initialization of preconditioners

### DIFF
--- a/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
+++ b/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
@@ -106,10 +106,6 @@ Setup convection-diffusion operator ...
 
 ... done!
 
-Setup solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -224,10 +220,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup convection-diffusion operator ...
-
-... done!
-
-Setup solver ...
 
 ... done!
 
@@ -348,10 +340,6 @@ Setup convection-diffusion operator ...
 
 ... done!
 
-Setup solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -469,10 +457,6 @@ Setup convection-diffusion operator ...
 
 ... done!
 
-Setup solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -587,10 +571,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup convection-diffusion operator ...
-
-... done!
-
-Setup solver ...
 
 ... done!
 

--- a/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
+++ b/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
@@ -105,14 +105,10 @@ Calculation of time step size (user-specified):
 
 ... done!
 
-Setup solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
-  Relative error (L2-norm): 5.28050e-11
+  Relative error (L2-norm): 5.28051e-11
 
 ________________________________________________________________________________
 
@@ -123,16 +119,16 @@ Calculate error for all fields at time t = 5.0000e-02:
   Relative error (L2-norm): 5.27723e-11
 
 Calculate error for all fields at time t = 1.0000e-01:
-  Relative error (L2-norm): 5.27879e-11
+  Relative error (L2-norm): 5.27880e-11
 
 Calculate error for all fields at time t = 1.5000e-01:
   Relative error (L2-norm): 5.28141e-11
 
 Calculate error for all fields at time t = 2.0000e-01:
-  Relative error (L2-norm): 5.28507e-11
+  Relative error (L2-norm): 5.28508e-11
 
 Calculate error for all fields at time t = 2.5000e-01:
-  Relative error (L2-norm): 5.28977e-11
+  Relative error (L2-norm): 5.28978e-11
 
 Calculate error for all fields at time t = 3.0000e-01:
   Relative error (L2-norm): 5.29553e-11
@@ -141,40 +137,40 @@ Calculate error for all fields at time t = 3.5000e-01:
   Relative error (L2-norm): 5.30232e-11
 
 Calculate error for all fields at time t = 4.0000e-01:
-  Relative error (L2-norm): 5.31014e-11
+  Relative error (L2-norm): 5.31015e-11
 
 Calculate error for all fields at time t = 4.5000e-01:
-  Relative error (L2-norm): 5.31900e-11
+  Relative error (L2-norm): 5.31901e-11
 
 Calculate error for all fields at time t = 5.0000e-01:
-  Relative error (L2-norm): 5.32888e-11
+  Relative error (L2-norm): 5.32889e-11
 
 Calculate error for all fields at time t = 5.5000e-01:
   Relative error (L2-norm): 5.33979e-11
 
 Calculate error for all fields at time t = 6.0000e-01:
-  Relative error (L2-norm): 5.35170e-11
+  Relative error (L2-norm): 5.35171e-11
 
 Calculate error for all fields at time t = 6.5000e-01:
-  Relative error (L2-norm): 5.36462e-11
+  Relative error (L2-norm): 5.36463e-11
 
 Calculate error for all fields at time t = 7.0000e-01:
-  Relative error (L2-norm): 5.37855e-11
+  Relative error (L2-norm): 5.37856e-11
 
 Calculate error for all fields at time t = 7.5000e-01:
-  Relative error (L2-norm): 5.39347e-11
+  Relative error (L2-norm): 5.39348e-11
 
 Calculate error for all fields at time t = 8.0000e-01:
-  Relative error (L2-norm): 5.40936e-11
+  Relative error (L2-norm): 5.40938e-11
 
 Calculate error for all fields at time t = 8.5000e-01:
-  Relative error (L2-norm): 5.42624e-11
+  Relative error (L2-norm): 5.42625e-11
 
 Calculate error for all fields at time t = 9.0000e-01:
-  Relative error (L2-norm): 5.44408e-11
+  Relative error (L2-norm): 5.44409e-11
 
 Calculate error for all fields at time t = 9.5000e-01:
-  Relative error (L2-norm): 5.46288e-11
+  Relative error (L2-norm): 5.46289e-11
 
 Calculate error for all fields at time t = 1.0000e+00:
-  Relative error (L2-norm): 5.48262e-11
+  Relative error (L2-norm): 5.48264e-11

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
@@ -119,10 +119,6 @@ Adjust time step size to hit end time:
 
 ... done!
 
-Setup solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:

--- a/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
+++ b/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
@@ -151,10 +151,6 @@ Setup incompressible Navier-Stokes operator ...
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Calculate error for velocity for initial data:
   Absolute error (L2-norm): 1.15470e+00
 
@@ -164,10 +160,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 7.79651e-13
+  Absolute error (L2-norm): 7.80921e-13
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 2.10835e-11
+  Absolute error (L2-norm): 2.10768e-11
 
 
 
@@ -321,10 +317,6 @@ Setup incompressible Navier-Stokes operator ...
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Calculate error for velocity for initial data:
   Absolute error (L2-norm): 1.15470e+00
 
@@ -334,10 +326,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 7.37921e-13
+  Absolute error (L2-norm): 4.17721e-13
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 1.41420e-11
+  Absolute error (L2-norm): 6.95824e-12
 
 
 
@@ -491,10 +483,6 @@ Setup incompressible Navier-Stokes operator ...
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Calculate error for velocity for initial data:
   Absolute error (L2-norm): 1.15470e+00
 
@@ -504,10 +492,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 3.04448e-14
+  Absolute error (L2-norm): 2.96422e-14
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 8.26406e-13
+  Absolute error (L2-norm): 8.08894e-13
 
 
 
@@ -661,10 +649,6 @@ Setup incompressible Navier-Stokes operator ...
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Calculate error for velocity for initial data:
   Absolute error (L2-norm): 1.15470e+00
 
@@ -674,7 +658,7 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 8.94271e-12
+  Absolute error (L2-norm): 9.09819e-12
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 2.25122e-10
+  Absolute error (L2-norm): 2.27289e-10

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
@@ -180,14 +180,10 @@ Calculation of time step size according to CFL condition:
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for velocity at time t = 0.0000e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 0.0000e+00:
   Relative error (L2-norm): 1.28188e-16
@@ -198,61 +194,61 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0002e+00:
-  Relative error (L2-norm): 1.06527e-15
+  Relative error (L2-norm): 1.16663e-15
 
 Calculate error for pressure at time t = 1.0002e+00:
-  Relative error (L2-norm): 3.29946e-13
+  Relative error (L2-norm): 7.19724e-14
 
 Calculate error for velocity at time t = 2.0015e+00:
-  Relative error (L2-norm): 9.26990e-16
+  Relative error (L2-norm): 3.20915e-15
 
 Calculate error for pressure at time t = 2.0015e+00:
-  Relative error (L2-norm): 2.53822e-13
+  Relative error (L2-norm): 3.95144e-13
 
 Calculate error for velocity at time t = 3.0028e+00:
-  Relative error (L2-norm): 1.03044e-15
+  Relative error (L2-norm): 2.58172e-15
 
 Calculate error for pressure at time t = 3.0028e+00:
-  Relative error (L2-norm): 1.02882e-12
+  Relative error (L2-norm): 2.70744e-13
 
 Calculate error for velocity at time t = 4.0042e+00:
-  Relative error (L2-norm): 9.32372e-16
+  Relative error (L2-norm): 1.08736e-15
 
 Calculate error for pressure at time t = 4.0042e+00:
-  Relative error (L2-norm): 4.65284e-13
+  Relative error (L2-norm): 2.08174e-13
 
 Calculate error for velocity at time t = 5.0055e+00:
-  Relative error (L2-norm): 1.09248e-15
+  Relative error (L2-norm): 1.15175e-15
 
 Calculate error for pressure at time t = 5.0055e+00:
-  Relative error (L2-norm): 9.46283e-13
+  Relative error (L2-norm): 9.06785e-14
 
 Calculate error for velocity at time t = 6.0011e+00:
-  Relative error (L2-norm): 1.75710e-15
+  Relative error (L2-norm): 1.62575e-15
 
 Calculate error for pressure at time t = 6.0011e+00:
-  Relative error (L2-norm): 2.37917e-13
+  Relative error (L2-norm): 1.03348e-13
 
 Calculate error for velocity at time t = 7.0024e+00:
-  Relative error (L2-norm): 1.14458e-15
+  Relative error (L2-norm): 9.72181e-16
 
 Calculate error for pressure at time t = 7.0024e+00:
-  Relative error (L2-norm): 1.98658e-13
+  Relative error (L2-norm): 5.03529e-13
 
 Calculate error for velocity at time t = 8.0037e+00:
-  Relative error (L2-norm): 1.02685e-15
+  Relative error (L2-norm): 9.43933e-16
 
 Calculate error for pressure at time t = 8.0037e+00:
-  Relative error (L2-norm): 1.69781e-13
+  Relative error (L2-norm): 3.68435e-13
 
 Calculate error for velocity at time t = 9.0051e+00:
-  Relative error (L2-norm): 1.56211e-15
+  Relative error (L2-norm): 3.15058e-15
 
 Calculate error for pressure at time t = 9.0051e+00:
-  Relative error (L2-norm): 2.23709e-13
+  Relative error (L2-norm): 2.78289e-13
 
 Calculate error for velocity at time t = 1.0001e+01:
-  Relative error (L2-norm): 1.18744e-15
+  Relative error (L2-norm): 1.10732e-15
 
 Calculate error for pressure at time t = 1.0001e+01:
-  Relative error (L2-norm): 2.62521e-13
+  Relative error (L2-norm): 6.66685e-14

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
@@ -178,14 +178,10 @@ Calculation of time step size according to CFL condition:
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for velocity at time t = 0.0000e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 0.0000e+00:
   Relative error (L2-norm): 1.28188e-16
@@ -196,61 +192,61 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0036e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 1.0036e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 2.0072e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 2.0072e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 3.0023e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 3.0023e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 4.0059e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 4.0059e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 5.0009e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 5.0009e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 6.0045e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 6.0045e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 7.0081e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 7.0081e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 8.0032e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 8.0032e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 9.0068e+00:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 9.0068e+00:
   Relative error (L2-norm): 1.28188e-16
 
 Calculate error for velocity at time t = 1.0002e+01:
-  Relative error (L2-norm): 1.82429e-16
+  Relative error (L2-norm): 1.77897e-16
 
 Calculate error for pressure at time t = 1.0002e+01:
   Relative error (L2-norm): 1.28188e-16

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -176,10 +176,6 @@ Calculation of time step size according to CFL condition:
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for velocity at time t = 0.0000e+00:
@@ -194,10 +190,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0036e+01:
-  Absolute error (L2-norm): 1.26539e-15
+  Absolute error (L2-norm): 1.05781e-15
 
 Calculate error for pressure at time t = 1.0036e+01:
-  Absolute error (L2-norm): 1.44206e-14
+  Absolute error (L2-norm): 7.59009e-15
 
 ________________________________________________________________________________
 
@@ -205,10 +201,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 2.0076e+01:
-  Absolute error (L2-norm): 1.18377e-15
+  Absolute error (L2-norm): 1.33599e-15
 
 Calculate error for pressure at time t = 2.0076e+01:
-  Absolute error (L2-norm): 2.27940e-15
+  Absolute error (L2-norm): 4.52028e-15
 
 ________________________________________________________________________________
 
@@ -216,10 +212,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 3.0117e+01:
-  Absolute error (L2-norm): 1.14072e-15
+  Absolute error (L2-norm): 9.34674e-16
 
 Calculate error for pressure at time t = 3.0117e+01:
-  Absolute error (L2-norm): 1.27709e-14
+  Absolute error (L2-norm): 2.40863e-15
 
 ________________________________________________________________________________
 
@@ -227,10 +223,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 4.0017e+01:
-  Absolute error (L2-norm): 1.23467e-15
+  Absolute error (L2-norm): 1.37728e-15
 
 Calculate error for pressure at time t = 4.0017e+01:
-  Absolute error (L2-norm): 2.05179e-14
+  Absolute error (L2-norm): 5.96696e-15
 
 ________________________________________________________________________________
 
@@ -238,10 +234,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 5.0057e+01:
-  Absolute error (L2-norm): 1.35670e-15
+  Absolute error (L2-norm): 1.18129e-15
 
 Calculate error for pressure at time t = 5.0057e+01:
-  Absolute error (L2-norm): 1.01704e-14
+  Absolute error (L2-norm): 1.79116e-14
 
 ________________________________________________________________________________
 
@@ -249,10 +245,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 6.0098e+01:
-  Absolute error (L2-norm): 1.12516e-15
+  Absolute error (L2-norm): 1.21225e-15
 
 Calculate error for pressure at time t = 6.0098e+01:
-  Absolute error (L2-norm): 7.43169e-15
+  Absolute error (L2-norm): 1.12196e-15
 
 ________________________________________________________________________________
 
@@ -260,10 +256,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 7.0139e+01:
-  Absolute error (L2-norm): 1.22333e-15
+  Absolute error (L2-norm): 1.05462e-15
 
 Calculate error for pressure at time t = 7.0139e+01:
-  Absolute error (L2-norm): 5.71454e-15
+  Absolute error (L2-norm): 1.77663e-15
 
 ________________________________________________________________________________
 
@@ -271,10 +267,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 8.0038e+01:
-  Absolute error (L2-norm): 1.23367e-15
+  Absolute error (L2-norm): 1.46342e-15
 
 Calculate error for pressure at time t = 8.0038e+01:
-  Absolute error (L2-norm): 2.17933e-15
+  Absolute error (L2-norm): 3.74663e-15
 
 ________________________________________________________________________________
 
@@ -282,10 +278,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0079e+01:
-  Absolute error (L2-norm): 1.27886e-15
+  Absolute error (L2-norm): 1.19480e-15
 
 Calculate error for pressure at time t = 9.0079e+01:
-  Absolute error (L2-norm): 1.08951e-14
+  Absolute error (L2-norm): 8.77709e-16
 
 ________________________________________________________________________________
 
@@ -293,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0012e+02:
-  Absolute error (L2-norm): 1.28291e-15
+  Absolute error (L2-norm): 9.90462e-16
 
 Calculate error for pressure at time t = 1.0012e+02:
-  Absolute error (L2-norm): 7.25196e-15
+  Absolute error (L2-norm): 2.38753e-15

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -176,10 +176,6 @@ Calculation of time step size according to CFL condition:
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for velocity at time t = 0.0000e+00:
@@ -194,10 +190,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0127e+01:
-  Absolute error (L2-norm): 1.14394e-15
+  Absolute error (L2-norm): 1.00239e-15
 
 Calculate error for pressure at time t = 1.0127e+01:
-  Absolute error (L2-norm): 6.88115e-15
+  Absolute error (L2-norm): 2.27622e-15
 
 ________________________________________________________________________________
 
@@ -205,10 +201,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 2.0010e+01:
-  Absolute error (L2-norm): 9.64108e-16
+  Absolute error (L2-norm): 1.07249e-15
 
 Calculate error for pressure at time t = 2.0010e+01:
-  Absolute error (L2-norm): 4.31363e-15
+  Absolute error (L2-norm): 1.30657e-14
 
 ________________________________________________________________________________
 
@@ -216,10 +212,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 3.0037e+01:
-  Absolute error (L2-norm): 1.10713e-15
+  Absolute error (L2-norm): 1.12749e-15
 
 Calculate error for pressure at time t = 3.0037e+01:
-  Absolute error (L2-norm): 7.31908e-15
+  Absolute error (L2-norm): 3.63990e-15
 
 ________________________________________________________________________________
 
@@ -227,10 +223,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 4.0064e+01:
-  Absolute error (L2-norm): 9.43704e-16
+  Absolute error (L2-norm): 1.32380e-15
 
 Calculate error for pressure at time t = 4.0064e+01:
-  Absolute error (L2-norm): 4.10667e-15
+  Absolute error (L2-norm): 1.45014e-14
 
 ________________________________________________________________________________
 
@@ -238,10 +234,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 5.0091e+01:
-  Absolute error (L2-norm): 1.01834e-15
+  Absolute error (L2-norm): 1.02682e-15
 
 Calculate error for pressure at time t = 5.0091e+01:
-  Absolute error (L2-norm): 1.45269e-15
+  Absolute error (L2-norm): 4.15255e-15
 
 ________________________________________________________________________________
 
@@ -249,10 +245,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 6.0118e+01:
-  Absolute error (L2-norm): 7.41663e-16
+  Absolute error (L2-norm): 1.11015e-15
 
 Calculate error for pressure at time t = 6.0118e+01:
-  Absolute error (L2-norm): 1.43543e-14
+  Absolute error (L2-norm): 1.58100e-14
 
 ________________________________________________________________________________
 
@@ -260,10 +256,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 7.0001e+01:
-  Absolute error (L2-norm): 9.08230e-16
+  Absolute error (L2-norm): 8.42746e-16
 
 Calculate error for pressure at time t = 7.0001e+01:
-  Absolute error (L2-norm): 7.27625e-15
+  Absolute error (L2-norm): 1.24026e-15
 
 ________________________________________________________________________________
 
@@ -271,10 +267,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 8.0028e+01:
-  Absolute error (L2-norm): 1.06426e-15
+  Absolute error (L2-norm): 8.96033e-16
 
 Calculate error for pressure at time t = 8.0028e+01:
-  Absolute error (L2-norm): 6.74728e-15
+  Absolute error (L2-norm): 3.44003e-15
 
 ________________________________________________________________________________
 
@@ -282,10 +278,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0055e+01:
-  Absolute error (L2-norm): 1.06337e-15
+  Absolute error (L2-norm): 1.03990e-15
 
 Calculate error for pressure at time t = 9.0055e+01:
-  Absolute error (L2-norm): 1.34551e-14
+  Absolute error (L2-norm): 1.04503e-14
 
 ________________________________________________________________________________
 
@@ -293,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0008e+02:
-  Absolute error (L2-norm): 9.29354e-16
+  Absolute error (L2-norm): 7.65877e-16
 
 Calculate error for pressure at time t = 1.0008e+02:
-  Absolute error (L2-norm): 4.45805e-16
+  Absolute error (L2-norm): 1.10990e-14

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -176,10 +176,6 @@ Calculation of time step size according to CFL condition:
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for velocity at time t = 0.0000e+00:
@@ -197,7 +193,7 @@ Calculate error for velocity at time t = 1.0059e+01:
   Absolute error (L2-norm): 1.68241e-01
 
 Calculate error for pressure at time t = 1.0059e+01:
-  Absolute error (L2-norm): 3.97849e-10
+  Absolute error (L2-norm): 4.47221e-10
 
 ________________________________________________________________________________
 
@@ -208,7 +204,7 @@ Calculate error for velocity at time t = 2.0123e+01:
   Absolute error (L2-norm): 1.36953e-02
 
 Calculate error for pressure at time t = 2.0123e+01:
-  Absolute error (L2-norm): 2.49567e-11
+  Absolute error (L2-norm): 4.70190e-11
 
 ________________________________________________________________________________
 
@@ -219,7 +215,7 @@ Calculate error for velocity at time t = 3.0047e+01:
   Absolute error (L2-norm): 1.15467e-03
 
 Calculate error for pressure at time t = 3.0047e+01:
-  Absolute error (L2-norm): 3.49131e-12
+  Absolute error (L2-norm): 5.10255e-12
 
 ________________________________________________________________________________
 
@@ -230,7 +226,7 @@ Calculate error for velocity at time t = 4.0089e+01:
   Absolute error (L2-norm): 9.45165e-05
 
 Calculate error for pressure at time t = 4.0089e+01:
-  Absolute error (L2-norm): 4.23032e-13
+  Absolute error (L2-norm): 1.93651e-13
 
 ________________________________________________________________________________
 
@@ -241,7 +237,7 @@ Calculate error for velocity at time t = 5.0130e+01:
   Absolute error (L2-norm): 7.73955e-06
 
 Calculate error for pressure at time t = 5.0130e+01:
-  Absolute error (L2-norm): 1.45998e-14
+  Absolute error (L2-norm): 1.40239e-14
 
 ________________________________________________________________________________
 
@@ -252,7 +248,7 @@ Calculate error for velocity at time t = 6.0029e+01:
   Absolute error (L2-norm): 6.56494e-07
 
 Calculate error for pressure at time t = 6.0029e+01:
-  Absolute error (L2-norm): 4.04763e-15
+  Absolute error (L2-norm): 1.51672e-15
 
 ________________________________________________________________________________
 
@@ -263,7 +259,7 @@ Calculate error for velocity at time t = 7.0070e+01:
   Absolute error (L2-norm): 5.37574e-08
 
 Calculate error for pressure at time t = 7.0070e+01:
-  Absolute error (L2-norm): 6.85418e-16
+  Absolute error (L2-norm): 2.22077e-15
 
 ________________________________________________________________________________
 
@@ -274,7 +270,7 @@ Calculate error for velocity at time t = 8.0111e+01:
   Absolute error (L2-norm): 4.40196e-09
 
 Calculate error for pressure at time t = 8.0111e+01:
-  Absolute error (L2-norm): 8.60933e-16
+  Absolute error (L2-norm): 1.32044e-15
 
 ________________________________________________________________________________
 
@@ -282,10 +278,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0010e+01:
-  Absolute error (L2-norm): 3.73379e-10
+  Absolute error (L2-norm): 3.73382e-10
 
 Calculate error for pressure at time t = 9.0010e+01:
-  Absolute error (L2-norm): 1.54894e-15
+  Absolute error (L2-norm): 9.87651e-16
 
 ________________________________________________________________________________
 
@@ -293,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0005e+02:
-  Absolute error (L2-norm): 3.05662e-11
+  Absolute error (L2-norm): 3.05692e-11
 
 Calculate error for pressure at time t = 1.0005e+02:
-  Absolute error (L2-norm): 8.73198e-16
+  Absolute error (L2-norm): 1.30636e-15

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -176,10 +176,6 @@ Calculation of time step size according to CFL condition:
 
 ... done!
 
-Setup incompressible Navier-Stokes solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for velocity at time t = 0.0000e+00:
@@ -197,7 +193,7 @@ Calculate error for velocity at time t = 1.0056e+01:
   Absolute error (L2-norm): 1.68135e-01
 
 Calculate error for pressure at time t = 1.0056e+01:
-  Absolute error (L2-norm): 4.13674e-10
+  Absolute error (L2-norm): 4.15952e-10
 
 ________________________________________________________________________________
 
@@ -208,7 +204,7 @@ Calculate error for velocity at time t = 2.0119e+01:
   Absolute error (L2-norm): 1.36693e-02
 
 Calculate error for pressure at time t = 2.0119e+01:
-  Absolute error (L2-norm): 3.37113e-12
+  Absolute error (L2-norm): 9.63754e-12
 
 ________________________________________________________________________________
 
@@ -219,7 +215,7 @@ Calculate error for velocity at time t = 3.0043e+01:
   Absolute error (L2-norm): 1.15089e-03
 
 Calculate error for pressure at time t = 3.0043e+01:
-  Absolute error (L2-norm): 1.03113e-12
+  Absolute error (L2-norm): 4.48146e-13
 
 ________________________________________________________________________________
 
@@ -230,7 +226,7 @@ Calculate error for velocity at time t = 4.0085e+01:
   Absolute error (L2-norm): 9.40746e-05
 
 Calculate error for pressure at time t = 4.0085e+01:
-  Absolute error (L2-norm): 2.79389e-14
+  Absolute error (L2-norm): 1.50021e-14
 
 ________________________________________________________________________________
 
@@ -241,7 +237,7 @@ Calculate error for velocity at time t = 5.0126e+01:
   Absolute error (L2-norm): 7.69248e-06
 
 Calculate error for pressure at time t = 5.0126e+01:
-  Absolute error (L2-norm): 3.10408e-15
+  Absolute error (L2-norm): 8.85091e-15
 
 ________________________________________________________________________________
 
@@ -252,7 +248,7 @@ Calculate error for velocity at time t = 6.0025e+01:
   Absolute error (L2-norm): 6.51593e-07
 
 Calculate error for pressure at time t = 6.0025e+01:
-  Absolute error (L2-norm): 8.03386e-16
+  Absolute error (L2-norm): 3.46411e-15
 
 ________________________________________________________________________________
 
@@ -263,7 +259,7 @@ Calculate error for velocity at time t = 7.0066e+01:
   Absolute error (L2-norm): 5.32807e-08
 
 Calculate error for pressure at time t = 7.0066e+01:
-  Absolute error (L2-norm): 8.47126e-16
+  Absolute error (L2-norm): 2.03147e-15
 
 ________________________________________________________________________________
 
@@ -274,7 +270,7 @@ Calculate error for velocity at time t = 8.0107e+01:
   Absolute error (L2-norm): 4.35676e-09
 
 Calculate error for pressure at time t = 8.0107e+01:
-  Absolute error (L2-norm): 5.92357e-15
+  Absolute error (L2-norm): 2.24639e-15
 
 ________________________________________________________________________________
 
@@ -282,10 +278,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0006e+01:
-  Absolute error (L2-norm): 3.69031e-10
+  Absolute error (L2-norm): 3.69033e-10
 
 Calculate error for pressure at time t = 9.0006e+01:
-  Absolute error (L2-norm): 3.49310e-15
+  Absolute error (L2-norm): 3.87394e-15
 
 ________________________________________________________________________________
 
@@ -293,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0005e+02:
-  Absolute error (L2-norm): 3.01731e-11
+  Absolute error (L2-norm): 3.01711e-11
 
 Calculate error for pressure at time t = 1.0005e+02:
-  Absolute error (L2-norm): 4.39027e-15
+  Absolute error (L2-norm): 7.07261e-15

--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -82,10 +82,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -172,10 +168,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -268,10 +260,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -358,10 +346,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -454,10 +438,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -544,10 +524,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -640,10 +616,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -730,10 +702,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -826,10 +794,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -916,10 +880,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -1012,10 +972,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -1105,15 +1061,11 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.58639e-11
+  Relative error (L2-norm): 4.58640e-11
 
 
 
@@ -1198,15 +1150,11 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.25198e-11
+  Relative error (L2-norm): 4.25200e-11
 
 
 
@@ -1291,15 +1239,11 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 2.43692e-12
+  Relative error (L2-norm): 2.43664e-12
 
 
 
@@ -1384,12 +1328,8 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 1.54749e-12
+  Relative error (L2-norm): 1.54768e-12

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -82,10 +82,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -172,10 +168,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -268,10 +260,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -358,10 +346,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -454,10 +438,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -547,10 +527,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -637,10 +613,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -82,10 +82,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -172,10 +168,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -268,10 +260,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -358,10 +346,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 
@@ -454,10 +438,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -547,10 +527,6 @@ Setup Poisson operator ...
 
 ... done!
 
-Setup Poisson solver ...
-
-... done!
-
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
@@ -637,10 +613,6 @@ Discontinuous Galerkin finite element discretization:
 ... done!
 
 Setup Poisson operator ...
-
-... done!
-
-Setup Poisson solver ...
 
 ... done!
 

--- a/applications/structure/bar/tests/weak_damping.output
+++ b/applications/structure/bar/tests/weak_damping.output
@@ -107,10 +107,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:

--- a/applications/structure/manufactured/tests/2d.output
+++ b/applications/structure/manufactured/tests/2d.output
@@ -102,10 +102,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -219,10 +215,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 
@@ -342,10 +334,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -459,10 +447,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 
@@ -582,10 +566,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -699,10 +679,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 
@@ -822,10 +798,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -942,10 +914,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -1059,10 +1027,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 

--- a/applications/structure/manufactured/tests/3d.output
+++ b/applications/structure/manufactured/tests/3d.output
@@ -102,10 +102,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -219,10 +215,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 
@@ -342,10 +334,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -459,10 +447,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 
@@ -582,10 +566,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -699,10 +679,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 
@@ -822,10 +798,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -942,10 +914,6 @@ Setup elasticity time integrator ...
 
 ... done!
 
-Setup elasticity solver ...
-
-... done!
-
 Starting time loop ...
 
 Calculate error for all fields at time t = 0.0000e+00:
@@ -1059,10 +1027,6 @@ Setup elasticity operator ...
 ... done!
 
 Setup elasticity time integrator ...
-
-... done!
-
-Setup elasticity solver ...
 
 ... done!
 

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -124,51 +124,6 @@ Driver<dim, Number>::setup()
     {
       AssertThrow(false, dealii::ExcMessage("Not implemented"));
     }
-
-    // setup solvers in case of BDF time integration or steady problems
-    typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
-    VectorType const *                                         velocity_ptr = nullptr;
-    VectorType                                                 velocity;
-
-    if(application->get_parameters().problem_type == ProblemType::Unsteady)
-    {
-      if(application->get_parameters().temporal_discretization == TemporalDiscretization::BDF)
-      {
-        std::shared_ptr<TimeIntBDF<dim, Number>> time_integrator_bdf =
-          std::dynamic_pointer_cast<TimeIntBDF<dim, Number>>(time_integrator);
-
-        if(application->get_parameters().get_type_velocity_field() == TypeVelocityField::DoFVector)
-        {
-          pde_operator->initialize_dof_vector_velocity(velocity);
-          pde_operator->interpolate_velocity(velocity, time_integrator->get_time());
-          velocity_ptr = &velocity;
-        }
-
-        pde_operator->setup_solver(time_integrator_bdf->get_scaling_factor_time_derivative_term(),
-                                   velocity_ptr);
-      }
-      else
-      {
-        AssertThrow(application->get_parameters().temporal_discretization ==
-                      TemporalDiscretization::ExplRK,
-                    dealii::ExcMessage("Not implemented."));
-      }
-    }
-    else if(application->get_parameters().problem_type == ProblemType::Steady)
-    {
-      if(application->get_parameters().get_type_velocity_field() == TypeVelocityField::DoFVector)
-      {
-        pde_operator->initialize_dof_vector_velocity(velocity);
-        pde_operator->interpolate_velocity(velocity, 0.0 /* time */);
-        velocity_ptr = &velocity;
-      }
-
-      pde_operator->setup_solver(1.0 /* scaling_factor_time_derivative_term */, velocity_ptr);
-    }
-    else
-    {
-      AssertThrow(false, dealii::ExcMessage("Not implemented"));
-    }
   }
 
   timer_tree.insert({"Convection-diffusion", "Setup"}, timer.wall_time());

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -101,7 +101,8 @@ MultigridPreconditioner<dim, Number>::initialize(
                    fe,
                    data.operator_is_singular,
                    dirichlet_bc,
-                   dirichlet_bc_component_mask);
+                   dirichlet_bc_component_mask,
+                   false /* initialize_preconditioners */);
 }
 
 template<int dim, typename Number>
@@ -167,6 +168,8 @@ MultigridPreconditioner<dim, Number>::update()
   // functionality implemented in the base class.
   this->update_smoothers();
   this->update_coarse_solver();
+
+  this->update_needed = false;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -399,12 +399,14 @@ Operator<dim, Number>::initialize_preconditioner()
   else if(param.preconditioner == Preconditioner::PointJacobi)
   {
     preconditioner =
-      std::make_shared<JacobiPreconditioner<CombinedOperator<dim, Number>>>(combined_operator);
+      std::make_shared<JacobiPreconditioner<CombinedOperator<dim, Number>>>(combined_operator,
+                                                                            false);
   }
   else if(param.preconditioner == Preconditioner::BlockJacobi)
   {
     preconditioner =
-      std::make_shared<BlockJacobiPreconditioner<CombinedOperator<dim, Number>>>(combined_operator);
+      std::make_shared<BlockJacobiPreconditioner<CombinedOperator<dim, Number>>>(combined_operator,
+                                                                                 false);
   }
   else if(param.preconditioner == Preconditioner::Multigrid)
   {

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -347,35 +347,11 @@ Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number> con
 
   setup_operators();
 
-  pcout << std::endl << "... done!" << std::endl;
-}
-
-template<int dim, typename Number>
-void
-Operator<dim, Number>::setup_solver(double const scaling_factor_mass, VectorType const * velocity)
-{
-  pcout << std::endl << "Setup solver ..." << std::endl;
-
   if(param.linear_system_has_to_be_solved())
   {
-    combined_operator.set_scaling_factor_mass_operator(scaling_factor_mass);
+    setup_preconditioner();
 
-    // The velocity vector needs to be set in case the velocity field is stored in DoF vector.
-    // Otherwise, certain preconditioners requiring the velocity field during initialization can not
-    // be initialized.
-    if(param.get_type_velocity_field() == TypeVelocityField::DoFVector)
-    {
-      AssertThrow(
-        velocity != nullptr,
-        dealii::ExcMessage(
-          "In case of a numerical velocity field, a velocity vector has to be provided."));
-
-      combined_operator.set_velocity_ptr(*velocity);
-    }
-
-    initialize_preconditioner();
-
-    initialize_solver();
+    setup_solver();
   }
 
   pcout << std::endl << "... done!" << std::endl;
@@ -383,7 +359,7 @@ Operator<dim, Number>::setup_solver(double const scaling_factor_mass, VectorType
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::initialize_preconditioner()
+Operator<dim, Number>::setup_preconditioner()
 {
   if(param.preconditioner == Preconditioner::InverseMassMatrix)
   {
@@ -472,7 +448,7 @@ Operator<dim, Number>::initialize_preconditioner()
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::initialize_solver()
+Operator<dim, Number>::setup_solver()
 {
   if(param.solver == Solver::CG)
   {

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -83,13 +83,6 @@ public:
         std::string const &                                    dof_index_velocity_external_in = "");
 
   /*
-   * This function initializes operators, preconditioners, and solvers related to the solution of
-   * linear systems of equation required for implicit formulations.
-   */
-  void
-  setup_solver(double const scaling_factor_mass = -1.0, VectorType const * velocity = nullptr);
-
-  /*
    * Initialization of dof-vector.
    */
   void
@@ -332,13 +325,13 @@ private:
    * Initializes the preconditioner.
    */
   void
-  initialize_preconditioner();
+  setup_preconditioner();
 
   /*
    * Initializes the solver.
    */
   void
-  initialize_solver();
+  setup_solver();
 
   /*
    * Grid

--- a/include/exadg/fluid_structure_interaction/single_field_solvers/fluid.h
+++ b/include/exadg/fluid_structure_interaction/single_field_solvers/fluid.h
@@ -162,9 +162,6 @@ SolverFluid<dim, Number>::setup(std::shared_ptr<FluidFSI::ApplicationBase<dim, N
     pde_operator, helpers_ale, postprocessor, application->get_parameters(), mpi_comm, is_test);
 
   time_integrator->setup(application->get_parameters().restarted_simulation);
-
-  pde_operator->setup_solvers(time_integrator->get_scaling_factor_time_derivative_term(),
-                              time_integrator->get_velocity());
 }
 
 template<int dim, typename Number>

--- a/include/exadg/fluid_structure_interaction/single_field_solvers/structure.h
+++ b/include/exadg/fluid_structure_interaction/single_field_solvers/structure.h
@@ -96,9 +96,6 @@ SolverStructure<dim, Number>::setup(
     pde_operator, postprocessor, application->get_parameters(), mpi_comm, is_test);
 
   time_integrator->setup(application->get_parameters().restarted_simulation);
-
-  pde_operator->setup_solver(time_integrator->get_scaling_factor_acceleration(),
-                             time_integrator->get_scaling_factor_velocity());
 }
 
 } // namespace FSI

--- a/include/exadg/grid/mapping_deformation_poisson.h
+++ b/include/exadg/grid/mapping_deformation_poisson.h
@@ -59,13 +59,11 @@ public:
       pcout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0),
       iterations({0, 0})
   {
-    // initialize PDE operator
+    // create and setup PDE operator
     pde_operator = std::make_shared<Poisson::Operator<dim, dim, Number>>(
       grid, mapping_undeformed, boundary_descriptor, field_functions, param, field, mpi_comm);
 
-    // setup PDE operator and solver
     pde_operator->setup();
-    pde_operator->setup_solver();
 
     // finally, initialize dof vector
     pde_operator->initialize_dof_vector(displacement);

--- a/include/exadg/grid/mapping_deformation_structure.h
+++ b/include/exadg/grid/mapping_deformation_structure.h
@@ -73,7 +73,6 @@ public:
 
     // setup PDE operator and solver
     pde_operator->setup();
-    pde_operator->setup_solver(0.0 /* no acceleration term */, 0.0 /* no damping term */);
 
     // finally, initialize dof vector
     pde_operator->initialize_dof_vector(displacement);

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -448,7 +448,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
       if(operator_type == OperatorType::CoupledNonlinearResidual)
         operator_coupled->evaluate_nonlinear_residual(dst1,src1,&src1.block(0), 0.0, 1.0);
       else if(operator_type == OperatorType::CoupledLinearized)
-        operator_coupled->apply_linearized_problem(dst1,src1, 0.0, 1.0);
+        operator_coupled->apply_linearized_problem(dst1,src1);
       else if(operator_type == OperatorType::ConvectiveOperator)
         operator_coupled->evaluate_convective_term(dst2,src2,0.0);
       else if(operator_type == OperatorType::InverseMassOperator)

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -145,13 +145,12 @@ Driver<dim, Number>::setup()
     postprocessor = application->create_postprocessor();
     postprocessor->setup(*pde_operator);
 
-    // setup time integrator before calling setup_solvers
-    // (this is necessary since the setup of the solvers
-    // depends on quantities such as the time_step_size or gamma0!)
     if(application->get_parameters().solver_type == SolverType::Unsteady)
     {
       time_integrator = create_time_integrator<dim, Number>(
         pde_operator, helpers_ale, postprocessor, application->get_parameters(), mpi_comm, is_test);
+
+      time_integrator->setup(application->get_parameters().restarted_simulation);
     }
     else if(application->get_parameters().solver_type == SolverType::Steady)
     {
@@ -161,24 +160,8 @@ Driver<dim, Number>::setup()
       // initialize driver for steady state problem that depends on pde_operator
       driver_steady = std::make_shared<DriverSteadyProblems<dim, Number>>(
         operator_coupled, postprocessor, application->get_parameters(), mpi_comm, is_test);
-    }
-    else
-    {
-      AssertThrow(false, dealii::ExcMessage("Not implemented."));
-    }
 
-    if(application->get_parameters().solver_type == SolverType::Unsteady)
-    {
-      time_integrator->setup(application->get_parameters().restarted_simulation);
-
-      pde_operator->setup_solvers(time_integrator->get_scaling_factor_time_derivative_term(),
-                                  time_integrator->get_velocity());
-    }
-    else if(application->get_parameters().solver_type == SolverType::Steady)
-    {
       driver_steady->setup();
-
-      pde_operator->setup_solvers(1.0 /* dummy */, driver_steady->get_velocity());
     }
     else
     {

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -85,7 +85,8 @@ MultigridPreconditioner<dim, Number>::initialize(
                    fe,
                    false /*operator_is_singular*/,
                    dirichlet_bc,
-                   dirichlet_bc_component_mask);
+                   dirichlet_bc_component_mask,
+                   false /*initialize_preconditioners*/);
 }
 
 
@@ -157,6 +158,8 @@ MultigridPreconditioner<dim, Number>::update()
     this->update_smoothers();
     this->update_coarse_solver();
   }
+
+  this->update_needed = false;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -208,6 +208,10 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
                                  *this->constraints[level],
                                  data);
 
+  // The operator also depends on the time. This is due to the fact that the linearized
+  // convective term does not only depend on the linearized velocity field but also on Dirichlet
+  // boundary data which itself depends on the current time.
+  pde_operator_level->set_time(pde_operator->get_time());
   // make sure that scaling factor of time derivative term has been set before the smoothers are
   // initialized
   pde_operator_level->set_scaling_factor_mass_operator(

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -153,7 +153,8 @@ MultigridPreconditioner<dim, Number>::update()
   // In case the operators have been updated, we also need to update the smoothers and the coarse
   // grid solver. This is generic functionality implemented in the base class.
   if(mesh_is_moving or data.unsteady_problem or
-     (mg_operator_type == MultigridOperatorType::ReactionConvectionDiffusion))
+     (mg_operator_type == MultigridOperatorType::ReactionConvectionDiffusion) or
+     this->update_needed)
   {
     this->update_smoothers();
     this->update_coarse_solver();

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -59,7 +59,8 @@ MultigridPreconditionerProjection<dim, Number>::initialize(
                    fe,
                    false /*operator_is_singular*/,
                    dirichlet_bc,
-                   dirichlet_bc_component_mask);
+                   dirichlet_bc_component_mask,
+                   false /* initialize_preconditioners */);
 }
 
 template<int dim, typename Number>
@@ -118,6 +119,8 @@ MultigridPreconditionerProjection<dim, Number>::update()
   // functionality implemented in the base class.
   this->update_smoothers();
   this->update_coarse_solver();
+
+  this->update_needed = false;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/precursor/driver.h
+++ b/include/exadg/incompressible_navier_stokes/precursor/driver.h
@@ -89,13 +89,7 @@ public:
     time_integrator = create_time_integrator<dim, Number>(
       pde_operator, helpers_ale_dummy, postprocessor, domain->get_parameters(), mpi_comm, is_test);
 
-    // setup time integrator before calling setup_solvers (this is necessary since the setup of the
-    // solvers depends on quantities such as the time_step_size or gamma0!)
     time_integrator->setup(domain->get_parameters().restarted_simulation);
-
-    // setup solvers
-    pde_operator->setup_solvers(time_integrator->get_scaling_factor_time_derivative_term(),
-                                time_integrator->get_velocity());
   }
 
   /*

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -68,26 +68,24 @@ OperatorCoupled<dim, Number>::setup_derived()
 
 template<int dim, typename Number>
 void
-OperatorCoupled<dim, Number>::setup_solvers(double const &     scaling_factor_time_derivative_term,
-                                            VectorType const & velocity)
+OperatorCoupled<dim, Number>::setup_preconditioners_and_solvers()
 {
   this->pcout << std::endl << "Setup incompressible Navier-Stokes solver ..." << std::endl;
 
-  Base::setup_solvers(scaling_factor_time_derivative_term, velocity);
-
-  initialize_block_preconditioner();
-
-  initialize_solver_coupled();
+  Base::setup_preconditioners_and_solvers();
 
   if(this->param.apply_penalty_terms_in_postprocessing_step)
-    this->setup_projection_solver();
+    Base::setup_projection_solver();
+
+  setup_block_preconditioner();
+  setup_solver_coupled();
 
   this->pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, typename Number>
 void
-OperatorCoupled<dim, Number>::initialize_solver_coupled()
+OperatorCoupled<dim, Number>::setup_solver_coupled()
 {
   linear_operator.initialize(*this);
 
@@ -391,7 +389,7 @@ OperatorCoupled<dim, Number>::evaluate_nonlinear_residual_steady(BlockVectorType
 
 template<int dim, typename Number>
 void
-OperatorCoupled<dim, Number>::initialize_block_preconditioner()
+OperatorCoupled<dim, Number>::setup_block_preconditioner()
 {
   block_preconditioner.initialize(this);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -70,8 +70,6 @@ template<int dim, typename Number>
 void
 OperatorCoupled<dim, Number>::setup_preconditioners_and_solvers()
 {
-  this->pcout << std::endl << "Setup incompressible Navier-Stokes solver ..." << std::endl;
-
   Base::setup_preconditioners_and_solvers();
 
   if(this->param.apply_penalty_terms_in_postprocessing_step)
@@ -79,8 +77,6 @@ OperatorCoupled<dim, Number>::setup_preconditioners_and_solvers()
 
   setup_block_preconditioner();
   setup_solver_coupled();
-
-  this->pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -428,14 +428,15 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_velocity_block()
 
   if(type == MomentumPreconditioner::PointJacobi)
   {
-    preconditioner_momentum = std::make_shared<JacobiPreconditioner<MomentumOperator<dim, Number>>>(
-      this->momentum_operator);
+    preconditioner_momentum =
+      std::make_shared<JacobiPreconditioner<MomentumOperator<dim, Number>>>(this->momentum_operator,
+                                                                            false);
   }
   else if(type == MomentumPreconditioner::BlockJacobi)
   {
     preconditioner_momentum =
       std::make_shared<BlockJacobiPreconditioner<MomentumOperator<dim, Number>>>(
-        this->momentum_operator);
+        this->momentum_operator, false);
   }
   else if(type == MomentumPreconditioner::InverseMassMatrix)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -144,7 +144,7 @@ private:
   typedef OperatorCoupled<dim, Number> PDEOperator;
 
 public:
-  BlockPreconditioner() : pde_operator(nullptr)
+  BlockPreconditioner() : update_needed(true), pde_operator(nullptr)
   {
   }
 
@@ -158,6 +158,14 @@ public:
   update()
   {
     pde_operator->update_block_preconditioner();
+
+    this->update_needed = false;
+  }
+
+  bool
+  needs_update() const
+  {
+    return update_needed;
   }
 
   void
@@ -175,6 +183,9 @@ public:
 
     return std::make_shared<TimerTree>();
   }
+
+private:
+  bool update_needed;
 
   PDEOperator * pde_operator;
 };

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -224,11 +224,10 @@ private:
   void
   setup_derived() final;
 
-public:
   void
-  setup_solvers(double const &     scaling_factor_time_derivative_term,
-                VectorType const & velocity) final;
+  setup_preconditioners_and_solvers() final;
 
+public:
   /*
    *  Update divergence penalty operator by recalculating the penalty parameter
    *  which depends on the current velocity field
@@ -336,13 +335,13 @@ public:
 
 private:
   void
-  initialize_solver_coupled();
+  setup_solver_coupled();
 
   /*
    * Block preconditioner
    */
   void
-  initialize_block_preconditioner();
+  setup_block_preconditioner();
 
   void
   initialize_vectors();

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -90,8 +90,7 @@ private:
   typedef OperatorCoupled<dim, Number> PDEOperator;
 
 public:
-  LinearOperatorCoupled()
-    : dealii::Subscriptor(), pde_operator(nullptr), time(0.0), scaling_factor_mass(1.0)
+  LinearOperatorCoupled() : dealii::Subscriptor(), pde_operator(nullptr)
   {
   }
 
@@ -111,12 +110,6 @@ public:
     pde_operator->set_velocity_ptr(solution_linearization.block(0));
   }
 
-  void
-  update(double const & time, double const & scaling_factor)
-  {
-    this->time                = time;
-    this->scaling_factor_mass = scaling_factor;
-  }
 
   /*
    * The implementation of linear solvers in deal.ii requires that a function called 'vmult' is
@@ -125,14 +118,11 @@ public:
   void
   vmult(BlockVectorType & dst, BlockVectorType const & src) const
   {
-    pde_operator->apply_linearized_problem(dst, src, time, scaling_factor_mass);
+    pde_operator->apply_linearized_problem(dst, src);
   }
 
 private:
   PDEOperator const * pde_operator;
-
-  double time;
-  double scaling_factor_mass;
 };
 
 template<int dim, typename Number>
@@ -171,6 +161,10 @@ public:
   void
   vmult(BlockVectorType & dst, BlockVectorType const & src) const
   {
+    AssertThrow(this->update_needed == false,
+                dealii::ExcMessage(
+                  "BlockPreconditioner can not be applied because it is not up-to-date."));
+
     pde_operator->apply_block_preconditioner(dst, src);
   }
 
@@ -267,7 +261,6 @@ public:
   solve_linear_stokes_problem(BlockVectorType &       dst,
                               BlockVectorType const & src,
                               bool const &            update_preconditioner,
-                              double const &          time                = 0.0,
                               double const &          scaling_factor_mass = 1.0);
 
   /*
@@ -310,10 +303,7 @@ public:
    * This function calculates the matrix-vector product for the linear(ized) problem.
    */
   void
-  apply_linearized_problem(BlockVectorType &       dst,
-                           BlockVectorType const & src,
-                           double const &          time,
-                           double const &          scaling_factor_mass) const;
+  apply_linearized_problem(BlockVectorType & dst, BlockVectorType const & src) const;
 
   /*
    * This function calculates the right-hand side of the steady Stokes problem, or unsteady Stokes

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -55,17 +55,13 @@ OperatorDualSplitting<dim, Number>::~OperatorDualSplitting()
 
 template<int dim, typename Number>
 void
-OperatorDualSplitting<dim, Number>::setup_solvers(double const &     scaling_factor_mass,
-                                                  VectorType const & velocity)
+OperatorDualSplitting<dim, Number>::setup_preconditioners_and_solvers()
 {
   this->pcout << std::endl << "Setup incompressible Navier-Stokes solver ..." << std::endl;
 
-  ProjectionBase::setup_solvers(scaling_factor_mass, velocity);
+  ProjectionBase::setup_preconditioners_and_solvers();
 
-  ProjectionBase::setup_pressure_poisson_solver();
-
-  ProjectionBase::setup_projection_solver();
-
+  setup_helmholtz_preconditioner();
   setup_helmholtz_solver();
 
   this->pcout << std::endl << "... done!" << std::endl;
@@ -73,16 +69,7 @@ OperatorDualSplitting<dim, Number>::setup_solvers(double const &     scaling_fac
 
 template<int dim, typename Number>
 void
-OperatorDualSplitting<dim, Number>::setup_helmholtz_solver()
-{
-  initialize_helmholtz_preconditioner();
-
-  initialize_helmholtz_solver();
-}
-
-template<int dim, typename Number>
-void
-OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
+OperatorDualSplitting<dim, Number>::setup_helmholtz_preconditioner()
 {
   if(this->param.preconditioner_viscous == PreconditionerViscous::None)
   {
@@ -159,7 +146,7 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
 
 template<int dim, typename Number>
 void
-OperatorDualSplitting<dim, Number>::initialize_helmholtz_solver()
+OperatorDualSplitting<dim, Number>::setup_helmholtz_solver()
 {
   if(this->param.solver_viscous == SolverViscous::CG)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -57,14 +57,10 @@ template<int dim, typename Number>
 void
 OperatorDualSplitting<dim, Number>::setup_preconditioners_and_solvers()
 {
-  this->pcout << std::endl << "Setup incompressible Navier-Stokes solver ..." << std::endl;
-
   ProjectionBase::setup_preconditioners_and_solvers();
 
   setup_helmholtz_preconditioner();
   setup_helmholtz_solver();
-
-  this->pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -102,14 +102,14 @@ OperatorDualSplitting<dim, Number>::initialize_helmholtz_preconditioner()
   else if(this->param.preconditioner_viscous == PreconditionerViscous::PointJacobi)
   {
     helmholtz_preconditioner =
-      std::make_shared<JacobiPreconditioner<MomentumOperator<dim, Number>>>(
-        this->momentum_operator);
+      std::make_shared<JacobiPreconditioner<MomentumOperator<dim, Number>>>(this->momentum_operator,
+                                                                            false);
   }
   else if(this->param.preconditioner_viscous == PreconditionerViscous::BlockJacobi)
   {
     helmholtz_preconditioner =
       std::make_shared<BlockJacobiPreconditioner<MomentumOperator<dim, Number>>>(
-        this->momentum_operator);
+        this->momentum_operator, false);
   }
   else if(this->param.preconditioner_viscous == PreconditionerViscous::Multigrid)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h
@@ -66,9 +66,6 @@ public:
    */
   virtual ~OperatorDualSplitting();
 
-  void
-  setup_solvers(double const & scaling_factor_mass, VectorType const & velocity) final;
-
   /*
    * Pressure Poisson equation.
    */
@@ -139,17 +136,17 @@ public:
   interpolate_velocity_dirichlet_bc(VectorType & dst, double const & time) const;
 
 private:
+  void
+  setup_preconditioners_and_solvers() final;
+
   /*
-   * Setup of Helmholtz solver (operator, preconditioner, solver).
+   * Setup of Helmholtz solver.
    */
   void
+  setup_helmholtz_preconditioner();
+
+  void
   setup_helmholtz_solver();
-
-  void
-  initialize_helmholtz_preconditioner();
-
-  void
-  initialize_helmholtz_solver();
 
   /*
    * rhs pressure Poisson equation

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -117,14 +117,15 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
   }
   else if(this->param.preconditioner_momentum == MomentumPreconditioner::PointJacobi)
   {
-    momentum_preconditioner = std::make_shared<JacobiPreconditioner<MomentumOperator<dim, Number>>>(
-      this->momentum_operator);
+    momentum_preconditioner =
+      std::make_shared<JacobiPreconditioner<MomentumOperator<dim, Number>>>(this->momentum_operator,
+                                                                            false);
   }
   else if(this->param.preconditioner_momentum == MomentumPreconditioner::BlockJacobi)
   {
     momentum_preconditioner =
       std::make_shared<BlockJacobiPreconditioner<MomentumOperator<dim, Number>>>(
-        this->momentum_operator);
+        this->momentum_operator, false);
   }
   else if(this->param.preconditioner_momentum == MomentumPreconditioner::Multigrid)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -66,14 +66,10 @@ template<int dim, typename Number>
 void
 OperatorPressureCorrection<dim, Number>::setup_preconditioners_and_solvers()
 {
-  this->pcout << std::endl << "Setup incompressible Navier-Stokes solver ..." << std::endl;
-
   ProjectionBase::setup_preconditioners_and_solvers();
 
   setup_momentum_preconditioner();
   setup_momentum_solver();
-
-  this->pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -257,6 +257,9 @@ OperatorPressureCorrection<dim, Number>::solve_linear_momentum_equation(
   bool const &       update_preconditioner,
   double const &     scaling_factor_mass)
 {
+  // We do not need to set the time here, because time affects the operator only in the form of
+  // boundary conditions. The result of such boundary condition evaluations is handed over to this
+  // function via the vector rhs.
   this->momentum_operator.set_scaling_factor_mass_operator(scaling_factor_mass);
 
   // Note that there is no need to set the evaluation time for the momentum_operator

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -64,18 +64,14 @@ OperatorPressureCorrection<dim, Number>::setup_derived()
 
 template<int dim, typename Number>
 void
-OperatorPressureCorrection<dim, Number>::setup_solvers(double const &     scaling_factor_mass,
-                                                       VectorType const & velocity)
+OperatorPressureCorrection<dim, Number>::setup_preconditioners_and_solvers()
 {
   this->pcout << std::endl << "Setup incompressible Navier-Stokes solver ..." << std::endl;
 
-  ProjectionBase::setup_solvers(scaling_factor_mass, velocity);
+  ProjectionBase::setup_preconditioners_and_solvers();
 
+  setup_momentum_preconditioner();
   setup_momentum_solver();
-
-  ProjectionBase::setup_pressure_poisson_solver();
-
-  ProjectionBase::setup_projection_solver();
 
   this->pcout << std::endl << "... done!" << std::endl;
 }
@@ -93,16 +89,7 @@ OperatorPressureCorrection<dim, Number>::update_after_grid_motion(bool const upd
 
 template<int dim, typename Number>
 void
-OperatorPressureCorrection<dim, Number>::setup_momentum_solver()
-{
-  initialize_momentum_preconditioner();
-
-  initialize_momentum_solver();
-}
-
-template<int dim, typename Number>
-void
-OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
+OperatorPressureCorrection<dim, Number>::setup_momentum_preconditioner()
 {
   if(this->param.preconditioner_momentum == MomentumPreconditioner::InverseMassMatrix)
   {
@@ -175,7 +162,7 @@ OperatorPressureCorrection<dim, Number>::initialize_momentum_preconditioner()
 
 template<int dim, typename Number>
 void
-OperatorPressureCorrection<dim, Number>::initialize_momentum_solver()
+OperatorPressureCorrection<dim, Number>::setup_momentum_solver()
 {
   if(this->param.solver_momentum == SolverMomentum::CG)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
@@ -124,9 +124,6 @@ public:
   setup_derived() final;
 
   void
-  setup_solvers(double const & scaling_factor_mass, VectorType const & velocity) final;
-
-  void
   update_after_grid_motion(bool const update_matrix_free) final;
 
   /*
@@ -225,17 +222,17 @@ public:
   interpolate_pressure_dirichlet_bc(VectorType & dst, double const & time) const;
 
 private:
+  void
+  setup_preconditioners_and_solvers() final;
+
   /*
    * Setup of momentum solver (operator, preconditioner, solver).
    */
   void
+  setup_momentum_preconditioner();
+
+  void
   setup_momentum_solver();
-
-  void
-  initialize_momentum_preconditioner();
-
-  void
-  initialize_momentum_solver();
 
   /*
    * Setup of inverse mass operator for pressure.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -156,6 +156,12 @@ OperatorProjectionMethods<dim, Number>::setup_preconditioner_pressure_poisson()
       std::make_shared<JacobiPreconditioner<Poisson::LaplaceOperator<dim, Number, 1>>>(
         laplace_operator, true);
   }
+  else if(this->param.preconditioner_pressure_poisson == PreconditionerPressurePoisson::BlockJacobi)
+  {
+    preconditioner_pressure_poisson =
+      std::make_shared<BlockJacobiPreconditioner<Poisson::LaplaceOperator<dim, Number, 1>>>(
+        laplace_operator, true);
+  }
   else if(this->param.preconditioner_pressure_poisson == PreconditionerPressurePoisson::Multigrid)
   {
     MultigridData mg_data;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -72,11 +72,12 @@ OperatorProjectionMethods<dim, Number>::update_after_grid_motion(bool const upda
 
 template<int dim, typename Number>
 void
-OperatorProjectionMethods<dim, Number>::setup_pressure_poisson_solver()
+OperatorProjectionMethods<dim, Number>::setup_preconditioners_and_solvers()
 {
-  initialize_preconditioner_pressure_poisson();
+  setup_preconditioner_pressure_poisson();
+  setup_solver_pressure_poisson();
 
-  initialize_solver_pressure_poisson();
+  Base::setup_projection_solver();
 }
 
 template<int dim, typename Number>
@@ -142,7 +143,7 @@ OperatorProjectionMethods<dim, Number>::initialize_laplace_operator()
 
 template<int dim, typename Number>
 void
-OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poisson()
+OperatorProjectionMethods<dim, Number>::setup_preconditioner_pressure_poisson()
 {
   // setup preconditioner
   if(this->param.preconditioner_pressure_poisson == PreconditionerPressurePoisson::None)
@@ -193,7 +194,7 @@ OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poiss
 
 template<int dim, typename Number>
 void
-OperatorProjectionMethods<dim, Number>::initialize_solver_pressure_poisson()
+OperatorProjectionMethods<dim, Number>::setup_solver_pressure_poisson()
 {
   if(this->param.solver_pressure_poisson == SolverPressurePoisson::CG)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -153,7 +153,7 @@ OperatorProjectionMethods<dim, Number>::initialize_preconditioner_pressure_poiss
   {
     preconditioner_pressure_poisson =
       std::make_shared<JacobiPreconditioner<Poisson::LaplaceOperator<dim, Number, 1>>>(
-        laplace_operator);
+        laplace_operator, true);
   }
   else if(this->param.preconditioner_pressure_poisson == PreconditionerPressurePoisson::Multigrid)
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -66,6 +66,9 @@ protected:
   void
   setup_derived() override;
 
+  void
+  setup_preconditioners_and_solvers() override;
+
 public:
   void
   update_after_grid_motion(bool const update_matrix_free) override;
@@ -105,15 +108,6 @@ public:
   apply_laplace_operator(VectorType & dst, VectorType const & src) const;
 
 protected:
-  /*
-   * Initializes the preconditioner and solver for the pressure Poisson equation. Can be done in
-   * this base class since it is the same for dual-splitting and pressure-correction. The function
-   * is declared virtual so that individual initializations required for derived class can be added
-   * where needed.
-   */
-  virtual void
-  setup_pressure_poisson_solver();
-
   // Pressure Poisson equation (operator, preconditioner, solver).
   Poisson::LaplaceOperator<dim, Number, 1> laplace_operator;
 
@@ -122,17 +116,17 @@ protected:
   std::shared_ptr<Krylov::SolverBase<VectorType>> pressure_poisson_solver;
 
 private:
-  /*
-   * Initialization functions called during setup of pressure Poisson solver.
-   */
   void
   initialize_laplace_operator();
 
+  /*
+   * Setup functions called during setup of pressure Poisson solver.
+   */
   void
-  initialize_preconditioner_pressure_poisson();
+  setup_preconditioner_pressure_poisson();
 
   void
-  initialize_solver_pressure_poisson();
+  setup_solver_pressure_poisson();
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1633,7 +1633,7 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
       // time step size has not been set. Hence, 'update_preconditioner = true' should be used for
       // the Jacobi preconditioner in order to use to correct diagonal for preconditioning.
       preconditioner_projection =
-        std::make_shared<JacobiPreconditioner<ProjOperator>>(*projection_operator);
+        std::make_shared<JacobiPreconditioner<ProjOperator>>(*projection_operator, false);
     }
     else if(param.preconditioner_projection == PreconditionerProjection::BlockJacobi)
     {
@@ -1642,7 +1642,7 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
       // size has not been set. Hence, 'update_preconditioner = true' should be used for the Jacobi
       // preconditioner in order to use to correct diagonal blocks for preconditioning.
       preconditioner_projection =
-        std::make_shared<BlockJacobiPreconditioner<ProjOperator>>(*projection_operator);
+        std::make_shared<BlockJacobiPreconditioner<ProjOperator>>(*projection_operator, false);
     }
     else if(param.preconditioner_projection == PreconditionerProjection::Multigrid)
     {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -723,18 +723,9 @@ SpatialOperatorBase<dim, Number>::setup(
   // Finally, do set up of derived classes
   setup_derived();
 
+  setup_preconditioners_and_solvers();
+
   pcout << std::endl << "... done!" << std::endl << std::flush;
-}
-
-template<int dim, typename Number>
-void
-SpatialOperatorBase<dim, Number>::setup_solvers(double const &     scaling_factor_mass,
-                                                VectorType const & velocity)
-{
-  momentum_operator.set_scaling_factor_mass_operator(scaling_factor_mass);
-  momentum_operator.set_velocity_ptr(velocity);
-
-  // remaining setup of preconditioners and solvers is done in derived classes
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1568,6 +1568,17 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
                                        projection_operator->get_dof_index(),
                                        projection_operator->get_quad_index());
     }
+    else if(param.preconditioner_projection == PreconditionerProjection::PointJacobi)
+    {
+      typedef Elementwise::JacobiPreconditioner<dim, dim, Number, ProjOperator> JACOBI;
+
+      elementwise_preconditioner_projection =
+        std::make_shared<JACOBI>(projection_operator->get_matrix_free(),
+                                 projection_operator->get_dof_index(),
+                                 projection_operator->get_quad_index(),
+                                 *projection_operator,
+                                 false);
+    }
     else
     {
       AssertThrow(false, dealii::ExcMessage("The specified preconditioner is not implemented."));

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -120,6 +120,17 @@ public:
         std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data,
         std::string const &                                    dof_index_temperature = "");
 
+protected:
+  /*
+   * This function initializes operators, preconditioners, and solvers related to the solution of
+   * (non-)linear systems of equation required for implicit formulations. It has to be extended
+   * by derived classes if necessary.
+   */
+  virtual void
+  setup_preconditioners_and_solvers()
+  {
+  }
+
 private:
   /**
    * Additional setup to be done by derived classes.
@@ -128,14 +139,6 @@ private:
   setup_derived() = 0;
 
 public:
-  /*
-   * This function initializes operators, preconditioners, and solvers related to the solution of
-   * (non-)linear systems of equation required for implicit formulations. It has to be extended
-   * by derived classes if necessary.
-   */
-  virtual void
-  setup_solvers(double const & scaling_factor_mass, VectorType const & velocity);
-
   /*
    * Getters and setters.
    */

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -316,7 +316,6 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
       pde_operator->solve_linear_stokes_problem(solution_np,
                                                 rhs_vector,
                                                 update_preconditioner,
-                                                this->get_next_time(),
                                                 this->get_scaling_factor_time_derivative_term());
 
     iterations.first += 1;

--- a/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
@@ -370,6 +370,7 @@ enum class PreconditionerPressurePoisson
 {
   None,
   PointJacobi,
+  BlockJacobi,
   Multigrid
 };
 

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -136,7 +136,7 @@ public:
 
       block_jacobi_preconditioner =
         std::make_shared<BlockJacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
-          mass_operator);
+          mass_operator, true /* initialize_preconditioners */);
     }
     else
     {
@@ -277,7 +277,8 @@ public:
     {
       preconditioner =
         std::make_shared<JacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
-          mass_operator);
+          mass_operator, true);
+
       solver_data.use_preconditioner = true;
     }
     else

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -136,7 +136,7 @@ public:
 
       block_jacobi_preconditioner =
         std::make_shared<BlockJacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
-          mass_operator, true /* initialize_preconditioners */);
+          mass_operator, true /* initialize_preconditioner */);
     }
     else
     {
@@ -277,7 +277,7 @@ public:
     {
       preconditioner =
         std::make_shared<JacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
-          mass_operator, true);
+          mass_operator, true /* initialize_preconditioner */);
 
       solver_data.use_preconditioner = true;
     }

--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -123,9 +123,9 @@ public:
   }
 
   void
-  initialize_block_diagonal_preconditioner() const final
+  initialize_block_diagonal_preconditioner(bool const initialize) const final
   {
-    pde_operator->initialize_block_diagonal_preconditioner();
+    pde_operator->initialize_block_diagonal_preconditioner(initialize);
   }
 
   void

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -82,7 +82,7 @@ public:
   calculate_inverse_diagonal(VectorType & inverse_diagonal_entries) const = 0;
 
   virtual void
-  initialize_block_diagonal_preconditioner() const = 0;
+  initialize_block_diagonal_preconditioner(bool const initialize) const = 0;
 
   virtual void
   update_block_diagonal_preconditioner() const = 0;

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -192,7 +192,7 @@ public:
    * preconditioner.
    */
   void
-  initialize_block_diagonal_preconditioner() const;
+  initialize_block_diagonal_preconditioner(bool const initialize) const;
 
   /*
    * Update block diagonal preconditioner: Recompute block matrices in case of matrix-based
@@ -316,7 +316,7 @@ public:
   // using the matrix-free variant with elementwise iterative solvers and matrix-free operator
   // evaluation.
   void
-  initialize_block_diagonal_preconditioner_matrix_free() const;
+  initialize_block_diagonal_preconditioner_matrix_free(bool const initialize) const;
 
   // updates block diagonal preconditioner when using the matrix-free variant with elementwise
   // iterative solvers and matrix-free operator evaluation.
@@ -325,7 +325,7 @@ public:
 
   // initializes block diagonal preconditioner for matrix-based variant
   void
-  initialize_block_diagonal_preconditioner_matrix_based() const;
+  initialize_block_diagonal_preconditioner_matrix_based(bool const initialize) const;
 
   // updates block diagonal preconditioner for matrix-based variant
   void

--- a/include/exadg/poisson/driver.h
+++ b/include/exadg/poisson/driver.h
@@ -65,8 +65,6 @@ public:
 
     if(not(is_throughput_study))
     {
-      pde_operator->setup_solver();
-
       postprocessor = application->create_postprocessor();
       postprocessor->setup(*pde_operator);
     }

--- a/include/exadg/poisson/overset_grids/driver.h
+++ b/include/exadg/poisson/overset_grids/driver.h
@@ -52,8 +52,6 @@ public:
 
     pde_operator->setup();
 
-    pde_operator->setup_solver();
-
     postprocessor = domain->create_postprocessor();
     postprocessor->setup(*pde_operator);
   }

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -52,7 +52,6 @@ MultigridPreconditioner<dim, Number, n_components>::initialize(
 
   this->mesh_is_moving = mesh_is_moving;
 
-  bool const initialize_preconditioners = true;
   Base::initialize(mg_data,
                    grid,
                    mapping,
@@ -60,7 +59,7 @@ MultigridPreconditioner<dim, Number, n_components>::initialize(
                    data.operator_is_singular,
                    dirichlet_bc,
                    dirichlet_bc_component_mask,
-                   initialize_preconditioners);
+                   true /* initialize_preconditioners */);
 
   this->update_needed = false;
 }
@@ -85,6 +84,8 @@ MultigridPreconditioner<dim, Number, n_components>::update()
     this->update_smoothers();
     this->update_coarse_solver();
   }
+
+  this->update_needed = false;
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -52,13 +52,17 @@ MultigridPreconditioner<dim, Number, n_components>::initialize(
 
   this->mesh_is_moving = mesh_is_moving;
 
+  bool const initialize_preconditioners = true;
   Base::initialize(mg_data,
                    grid,
                    mapping,
                    fe,
                    data.operator_is_singular,
                    dirichlet_bc,
-                   dirichlet_bc_component_mask);
+                   dirichlet_bc_component_mask,
+                   initialize_preconditioners);
+
+  this->update_needed = false;
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -301,8 +301,6 @@ template<int dim, int n_components, typename Number>
 void
 Operator<dim, n_components, Number>::setup_preconditioner_and_solver()
 {
-  pcout << std::endl << "Setup Poisson solver ..." << std::endl;
-
   // initialize preconditioner
   if(param.preconditioner == Poisson::Preconditioner::None)
   {
@@ -417,8 +415,6 @@ Operator<dim, n_components, Number>::setup_preconditioner_and_solver()
   {
     AssertThrow(false, dealii::ExcMessage("Specified solver is not implemented!"));
   }
-
-  pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, int n_components, typename Number>

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -308,20 +308,21 @@ Operator<dim, n_components, Number>::setup_solver()
   }
   else if(param.preconditioner == Poisson::Preconditioner::PointJacobi)
   {
-    preconditioner = std::make_shared<JacobiPreconditioner<Laplace>>(laplace_operator);
+    preconditioner = std::make_shared<JacobiPreconditioner<Laplace>>(laplace_operator, true);
   }
   else if(param.preconditioner == Poisson::Preconditioner::BlockJacobi)
   {
-    preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator);
+    preconditioner = std::make_shared<BlockJacobiPreconditioner<Laplace>>(laplace_operator, true);
   }
   else if(param.preconditioner == Poisson::Preconditioner::AdditiveSchwarz)
   {
-    preconditioner = std::make_shared<AdditiveSchwarzPreconditioner<Laplace>>(laplace_operator);
+    preconditioner =
+      std::make_shared<AdditiveSchwarzPreconditioner<Laplace>>(laplace_operator, true);
   }
   else if(param.preconditioner == Poisson::Preconditioner::AMG)
   {
     preconditioner = std::make_shared<PreconditionerAMG<Laplace, Number>>(
-      laplace_operator, param.multigrid_data.coarse_problem.amg_data);
+      laplace_operator, true, param.multigrid_data.coarse_problem.amg_data);
   }
   else if(param.preconditioner == Poisson::Preconditioner::Multigrid)
   {

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -292,12 +292,14 @@ Operator<dim, n_components, Number>::setup(
 
   setup_operators();
 
+  setup_preconditioner_and_solver();
+
   pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, int n_components, typename Number>
 void
-Operator<dim, n_components, Number>::setup_solver()
+Operator<dim, n_components, Number>::setup_preconditioner_and_solver()
 {
   pcout << std::endl << "Setup Poisson solver ..." << std::endl;
 

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -77,9 +77,6 @@ public:
         std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data);
 
   void
-  setup_solver();
-
-  void
   initialize_dof_vector(VectorType & src) const;
 
   /*
@@ -163,6 +160,9 @@ private:
 
   void
   setup_operators();
+
+  void
+  setup_preconditioner_and_solver();
 
   /*
    * Grid

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -665,6 +665,10 @@ void
 MultigridPreconditionerBase<dim, Number, MultigridNumber>::vmult(VectorType &       dst,
                                                                  VectorType const & src) const
 {
+  AssertThrow(not this->update_needed,
+              dealii::ExcMessage(
+                "Multigrid preconditioner can not be applied because it needs to be updated."));
+
   multigrid_algorithm->vmult(dst, src);
 }
 
@@ -673,6 +677,10 @@ unsigned int
 MultigridPreconditionerBase<dim, Number, MultigridNumber>::solve(VectorType &       dst,
                                                                  VectorType const & src) const
 {
+  AssertThrow(not this->update_needed,
+              dealii::ExcMessage(
+                "Multigrid preconditioner can not be applied because it needs to be updated."));
+
   return multigrid_algorithm->solve(dst, src);
 }
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -104,7 +104,15 @@ public:
              dealii::FiniteElement<dim> const &          fe,
              bool const                                  operator_is_singular,
              Map_DBC const &                             dirichlet_bc,
-             Map_DBC_ComponentMask const &               dirichlet_bc_component_mask);
+             Map_DBC_ComponentMask const &               dirichlet_bc_component_mask,
+             bool const                                  initialize_preconditioners);
+
+  /*
+   * Update of multigrid preconditioner including operators, smoothers, etc. (e.g. for problems
+   * with time-dependent coefficients).
+   */
+  void
+  update() override;
 
   /*
    * This function applies the multigrid preconditioner dst = P^{-1} src.
@@ -124,13 +132,6 @@ public:
    */
   virtual void
   apply_smoother_on_fine_level(VectorTypeMG & dst, VectorTypeMG const & src) const;
-
-  /*
-   * Update of multigrid preconditioner including operators, smoothers, etc. (e.g. for problems
-   * with time-dependent coefficients).
-   */
-  void
-  update() override;
 
   std::shared_ptr<TimerTree>
   get_timings() const override;
@@ -302,10 +303,10 @@ private:
    * Smoother.
    */
   void
-  initialize_smoothers();
+  initialize_smoothers(bool const initialize_preconditioner);
 
   void
-  initialize_smoother(Operator & matrix, unsigned int level);
+  initialize_smoother(Operator & matrix, unsigned int level, bool const initialize_preconditioner);
 
   /*
    * Coarse grid solver.

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -312,7 +312,7 @@ private:
    * Coarse grid solver.
    */
   void
-  initialize_coarse_solver(bool const operator_is_singular);
+  initialize_coarse_solver(bool const operator_is_singular, bool const initialize_preconditioners);
 
   /*
    * Initialization of actual multigrid algorithm.

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/cg_smoother.h
@@ -69,18 +69,22 @@ public:
   };
 
   void
-  initialize(Operator const & operator_in, AdditionalData const & additional_data_in)
+  setup(Operator const &       operator_in,
+        bool const             initialize_preconditioner,
+        AdditionalData const & additional_data_in)
   {
     underlying_operator = &operator_in;
     data                = additional_data_in;
 
     if(data.preconditioner == PreconditionerSmoother::PointJacobi)
     {
-      preconditioner = new JacobiPreconditioner<Operator>(*underlying_operator);
+      preconditioner =
+        new JacobiPreconditioner<Operator>(*underlying_operator, initialize_preconditioner);
     }
     else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
     {
-      preconditioner = new BlockJacobiPreconditioner<Operator>(*underlying_operator);
+      preconditioner =
+        new BlockJacobiPreconditioner<Operator>(*underlying_operator, initialize_preconditioner);
     }
     else
     {

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
@@ -30,6 +30,7 @@
 #include <exadg/solvers_and_preconditioners/multigrid/smoothers/smoother_base.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
 
 namespace ExaDG
 {
@@ -37,7 +38,12 @@ template<typename Operator, typename VectorType>
 class ChebyshevSmoother : public SmootherBase<VectorType>
 {
 public:
-  typedef dealii::PreconditionChebyshev<Operator, VectorType, dealii::DiagonalMatrix<VectorType>>
+  // TODO
+  //  typedef dealii::PreconditionChebyshev<Operator, VectorType,
+  //  dealii::DiagonalMatrix<VectorType>>
+  //    ChebyshevPointJacobi;
+
+  typedef dealii::PreconditionChebyshev<Operator, VectorType, JacobiPreconditioner<Operator>>
     ChebyshevPointJacobi;
   typedef dealii::PreconditionChebyshev<Operator, VectorType, BlockJacobiPreconditioner<Operator>>
     ChebyshevBlockJacobi;
@@ -80,15 +86,15 @@ public:
   {
     if(data.preconditioner == PreconditionerSmoother::PointJacobi)
     {
-      smoother_point_jacobi->vmult(dst, src);
+      chebyshev_point_jacobi->vmult(dst, src);
     }
     else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
     {
-      smoother_block_jacobi->vmult(dst, src);
+      chebyshev_block_jacobi->vmult(dst, src);
     }
     else if(data.preconditioner == PreconditionerSmoother::AdditiveSchwarz)
     {
-      smoother_additive_schwarz->vmult(dst, src);
+      chebyshev_additive_schwarz->vmult(dst, src);
     }
     else
     {
@@ -101,15 +107,15 @@ public:
   {
     if(data.preconditioner == PreconditionerSmoother::PointJacobi)
     {
-      smoother_point_jacobi->step(dst, src);
+      chebyshev_point_jacobi->step(dst, src);
     }
     else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
     {
-      smoother_block_jacobi->step(dst, src);
+      chebyshev_block_jacobi->step(dst, src);
     }
     else if(data.preconditioner == PreconditionerSmoother::AdditiveSchwarz)
     {
-      smoother_additive_schwarz->step(dst, src);
+      chebyshev_additive_schwarz->step(dst, src);
     }
     else
     {
@@ -123,59 +129,84 @@ public:
     AssertThrow(underlying_operator != nullptr,
                 dealii::ExcMessage("Pointer underlying_operator is uninitialized."));
 
-    initialize(*underlying_operator, data);
+    if(data.preconditioner == PreconditionerSmoother::PointJacobi)
+    {
+      preconditioner_point_jacobi->update();
+      chebyshev_point_jacobi->initialize(*underlying_operator, additional_data_point);
+    }
+    else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
+    {
+      preconditioner_block_jacobi->update();
+      chebyshev_block_jacobi->initialize(*underlying_operator, additional_data_block);
+    }
+    else if(data.preconditioner == PreconditionerSmoother::AdditiveSchwarz)
+    {
+      preconditioner_additive_schwarz->update();
+      chebyshev_additive_schwarz->initialize(*underlying_operator,
+                                             additional_data_additive_schwarz);
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcNotImplemented());
+    }
   }
 
   void
-  initialize(Operator const & operator_in, AdditionalData const & additional_data)
+  setup(Operator const &       operator_in,
+        bool const             initialize_preconditioner,
+        AdditionalData const & additional_data)
   {
     underlying_operator = &operator_in;
     data                = additional_data;
 
     if(data.preconditioner == PreconditionerSmoother::PointJacobi)
     {
-      typename ChebyshevPointJacobi::AdditionalData additional_data_dealii;
+      preconditioner_point_jacobi =
+        std::make_shared<JacobiPreconditioner<Operator>>(*underlying_operator,
+                                                         initialize_preconditioner);
 
-      std::shared_ptr<dealii::DiagonalMatrix<VectorType>> jacobi_preconditioner =
-        std::make_shared<dealii::DiagonalMatrix<VectorType>>();
-      VectorType & diagonal_vector = jacobi_preconditioner->get_vector();
+      additional_data_point.preconditioner      = preconditioner_point_jacobi;
+      additional_data_point.smoothing_range     = data.smoothing_range;
+      additional_data_point.degree              = data.degree;
+      additional_data_point.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
 
-      underlying_operator->initialize_dof_vector(diagonal_vector);
-      underlying_operator->calculate_inverse_diagonal(diagonal_vector);
+      chebyshev_point_jacobi = std::make_shared<ChebyshevPointJacobi>();
 
-      additional_data_dealii.preconditioner      = jacobi_preconditioner;
-      additional_data_dealii.smoothing_range     = data.smoothing_range;
-      additional_data_dealii.degree              = data.degree;
-      additional_data_dealii.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
-
-      smoother_point_jacobi = std::make_shared<ChebyshevPointJacobi>();
-      smoother_point_jacobi->initialize(*underlying_operator, additional_data_dealii);
+      if(initialize_preconditioner)
+        chebyshev_point_jacobi->initialize(*underlying_operator, additional_data_point);
     }
     else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
     {
-      typename ChebyshevBlockJacobi::AdditionalData additional_data_dealii;
+      preconditioner_block_jacobi =
+        std::make_shared<BlockJacobiPreconditioner<Operator>>(*underlying_operator,
+                                                              initialize_preconditioner);
 
-      additional_data_dealii.preconditioner =
-        std::make_shared<BlockJacobiPreconditioner<Operator>>(*underlying_operator);
-      additional_data_dealii.smoothing_range     = data.smoothing_range;
-      additional_data_dealii.degree              = data.degree;
-      additional_data_dealii.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
+      additional_data_block.preconditioner      = preconditioner_block_jacobi;
+      additional_data_block.smoothing_range     = data.smoothing_range;
+      additional_data_block.degree              = data.degree;
+      additional_data_block.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
 
-      smoother_block_jacobi = std::make_shared<ChebyshevBlockJacobi>();
-      smoother_block_jacobi->initialize(*underlying_operator, additional_data_dealii);
+      chebyshev_block_jacobi = std::make_shared<ChebyshevBlockJacobi>();
+
+      if(initialize_preconditioner)
+        chebyshev_block_jacobi->initialize(*underlying_operator, additional_data_block);
     }
     else if(data.preconditioner == PreconditionerSmoother::AdditiveSchwarz)
     {
-      typename ChebyshevAdditiveSchwarz::AdditionalData additional_data_dealii;
+      preconditioner_additive_schwarz =
+        std::make_shared<AdditiveSchwarzPreconditioner<Operator>>(*underlying_operator,
+                                                                  initialize_preconditioner);
 
-      additional_data_dealii.preconditioner =
-        std::make_shared<AdditiveSchwarzPreconditioner<Operator>>(*underlying_operator);
-      additional_data_dealii.smoothing_range     = data.smoothing_range;
-      additional_data_dealii.degree              = data.degree;
-      additional_data_dealii.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
+      additional_data_additive_schwarz.preconditioner      = preconditioner_additive_schwarz;
+      additional_data_additive_schwarz.smoothing_range     = data.smoothing_range;
+      additional_data_additive_schwarz.degree              = data.degree;
+      additional_data_additive_schwarz.eig_cg_n_iterations = data.iterations_eigenvalue_estimation;
 
-      smoother_additive_schwarz = std::make_shared<ChebyshevAdditiveSchwarz>();
-      smoother_additive_schwarz->initialize(*underlying_operator, additional_data_dealii);
+      chebyshev_additive_schwarz = std::make_shared<ChebyshevAdditiveSchwarz>();
+
+      if(initialize_preconditioner)
+        chebyshev_additive_schwarz->initialize(*underlying_operator,
+                                               additional_data_additive_schwarz);
     }
     else
     {
@@ -187,9 +218,17 @@ private:
   Operator const * underlying_operator;
   AdditionalData   data;
 
-  std::shared_ptr<ChebyshevPointJacobi>     smoother_point_jacobi;
-  std::shared_ptr<ChebyshevBlockJacobi>     smoother_block_jacobi;
-  std::shared_ptr<ChebyshevAdditiveSchwarz> smoother_additive_schwarz;
+  std::shared_ptr<ChebyshevPointJacobi>     chebyshev_point_jacobi;
+  std::shared_ptr<ChebyshevBlockJacobi>     chebyshev_block_jacobi;
+  std::shared_ptr<ChebyshevAdditiveSchwarz> chebyshev_additive_schwarz;
+
+  std::shared_ptr<JacobiPreconditioner<Operator>>          preconditioner_point_jacobi;
+  std::shared_ptr<BlockJacobiPreconditioner<Operator>>     preconditioner_block_jacobi;
+  std::shared_ptr<AdditiveSchwarzPreconditioner<Operator>> preconditioner_additive_schwarz;
+
+  typename ChebyshevPointJacobi::AdditionalData     additional_data_point;
+  typename ChebyshevBlockJacobi::AdditionalData     additional_data_block;
+  typename ChebyshevAdditiveSchwarz::AdditionalData additional_data_additive_schwarz;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/chebyshev_smoother.h
@@ -38,11 +38,6 @@ template<typename Operator, typename VectorType>
 class ChebyshevSmoother : public SmootherBase<VectorType>
 {
 public:
-  // TODO
-  //  typedef dealii::PreconditionChebyshev<Operator, VectorType,
-  //  dealii::DiagonalMatrix<VectorType>>
-  //    ChebyshevPointJacobi;
-
   typedef dealii::PreconditionChebyshev<Operator, VectorType, JacobiPreconditioner<Operator>>
     ChebyshevPointJacobi;
   typedef dealii::PreconditionChebyshev<Operator, VectorType, BlockJacobiPreconditioner<Operator>>

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/gmres_smoother.h
@@ -69,7 +69,9 @@ public:
   };
 
   void
-  initialize(Operator const & operator_in, AdditionalData const & additional_data_in)
+  setup(Operator const &       operator_in,
+        bool const             initialize_preconditioner,
+        AdditionalData const & additional_data_in)
   {
     underlying_operator = &operator_in;
 
@@ -77,11 +79,13 @@ public:
 
     if(data.preconditioner == PreconditionerSmoother::PointJacobi)
     {
-      preconditioner = new JacobiPreconditioner<Operator>(*underlying_operator);
+      preconditioner =
+        new JacobiPreconditioner<Operator>(*underlying_operator, initialize_preconditioner);
     }
     else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
     {
-      preconditioner = new BlockJacobiPreconditioner<Operator>(*underlying_operator);
+      preconditioner =
+        new BlockJacobiPreconditioner<Operator>(*underlying_operator, initialize_preconditioner);
     }
     else
     {

--- a/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/smoothers/jacobi_smoother.h
@@ -72,7 +72,9 @@ public:
   };
 
   void
-  initialize(Operator const & operator_in, AdditionalData const & additional_data_in)
+  setup(Operator const &       operator_in,
+        bool const             initialize_preconditioner,
+        AdditionalData const & additional_data_in)
   {
     underlying_operator = &operator_in;
 
@@ -80,15 +82,18 @@ public:
 
     if(data.preconditioner == PreconditionerSmoother::PointJacobi)
     {
-      preconditioner = new JacobiPreconditioner<Operator>(*underlying_operator);
+      preconditioner =
+        new JacobiPreconditioner<Operator>(*underlying_operator, initialize_preconditioner);
     }
     else if(data.preconditioner == PreconditionerSmoother::BlockJacobi)
     {
-      preconditioner = new BlockJacobiPreconditioner<Operator>(*underlying_operator);
+      preconditioner =
+        new BlockJacobiPreconditioner<Operator>(*underlying_operator, initialize_preconditioner);
     }
     else if(data.preconditioner == PreconditionerSmoother::AdditiveSchwarz)
     {
-      preconditioner = new AdditiveSchwarzPreconditioner<Operator>(*underlying_operator);
+      preconditioner = new AdditiveSchwarzPreconditioner<Operator>(*underlying_operator,
+                                                                   initialize_preconditioner);
     }
     else
     {

--- a/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
@@ -54,18 +54,19 @@ public:
     underlying_operator.apply_inverse_additive_schwarz_matrices(dst, src);
   }
 
-private:
   /*
    *  This function updates the additive Schwarz preconditioner.
    *  Make sure that the underlying operator has been updated
    *  when calling this function.
    */
   void
-  do_update() final
+  update() final
   {
     underlying_operator.compute_factorized_additive_schwarz_matrices();
+    this->update_needed = false;
   }
 
+private:
   Operator const & underlying_operator;
 };
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
@@ -44,13 +44,18 @@ public:
   }
 
   /*
-   *  This function applies additive Schwarz preconditioner.
+   *  This function applies the additive Schwarz preconditioner.
    *  Make sure that the additive Schwarz preconditioner has been
    *  updated when calling this function.
    */
   void
   vmult(VectorType & dst, VectorType const & src) const final
   {
+    AssertThrow(
+      not this->update_needed,
+      dealii::ExcMessage(
+        "Additive Schwarz preconditioner can not be applied because it needs to be updated."));
+
     underlying_operator.apply_inverse_additive_schwarz_matrices(dst, src);
   }
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
@@ -34,21 +34,13 @@ class AdditiveSchwarzPreconditioner : public PreconditionerBase<typename Operato
 public:
   typedef typename PreconditionerBase<typename Operator::value_type>::VectorType VectorType;
 
-  AdditiveSchwarzPreconditioner(Operator const & underlying_operator_in)
+  AdditiveSchwarzPreconditioner(Operator const & underlying_operator_in, bool const initialize)
     : underlying_operator(underlying_operator_in)
   {
-    underlying_operator.compute_factorized_additive_schwarz_matrices();
-  }
-
-  /*
-   *  This function updates the additive Schwarz preconditioner.
-   *  Make sure that the underlying operator has been updated
-   *  when calling this function.
-   */
-  void
-  update() final
-  {
-    underlying_operator.compute_factorized_additive_schwarz_matrices();
+    if(initialize)
+    {
+      this->update();
+    }
   }
 
   /*
@@ -63,6 +55,17 @@ public:
   }
 
 private:
+  /*
+   *  This function updates the additive Schwarz preconditioner.
+   *  Make sure that the underlying operator has been updated
+   *  when calling this function.
+   */
+  void
+  do_update() final
+  {
+    underlying_operator.compute_factorized_additive_schwarz_matrices();
+  }
+
   Operator const & underlying_operator;
 };
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
@@ -32,9 +32,10 @@ class BlockJacobiPreconditioner : public PreconditionerBase<typename Operator::v
 public:
   typedef typename PreconditionerBase<typename Operator::value_type>::VectorType VectorType;
 
-  BlockJacobiPreconditioner(Operator const & underlying_operator_in)
+  BlockJacobiPreconditioner(Operator const & underlying_operator_in, bool const initialize)
     : underlying_operator(underlying_operator_in)
   {
+<<<<<<< HEAD
     // initialize block Jacobi
     underlying_operator.initialize_block_diagonal_preconditioner();
   }
@@ -48,6 +49,12 @@ public:
   update() final
   {
     underlying_operator.update_block_diagonal_preconditioner();
+=======
+    if(initialize)
+    {
+      this->update();
+    }
+>>>>>>> 614c430a1 (apply changes to simple preconditioners)
   }
 
   /*
@@ -62,6 +69,17 @@ public:
   }
 
 private:
+  /*
+   *  This function updates the block Jacobi preconditioner.
+   *  Make sure that the underlying operator has been updated
+   *  when calling this function.
+   */
+  void
+  do_update() final
+  {
+    underlying_operator.update_block_diagonal_preconditioner();
+  }
+
   Operator const & underlying_operator;
 };
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
@@ -36,7 +36,10 @@ public:
     : underlying_operator(underlying_operator_in)
   {
     // initialize block Jacobi
-    underlying_operator.initialize_block_diagonal_preconditioner();
+    underlying_operator.initialize_block_diagonal_preconditioner(initialize);
+
+    if(initialize)
+      this->update_needed = false;
   }
 
   /*
@@ -60,6 +63,11 @@ public:
   void
   vmult(VectorType & dst, VectorType const & src) const final
   {
+    AssertThrow(
+      not this->update_needed,
+      dealii::ExcMessage(
+        "Block Jacobi preconditioner can not be applied because it needs to be updated."));
+
     underlying_operator.apply_inverse_block_diagonal(dst, src);
   }
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
@@ -35,7 +35,6 @@ public:
   BlockJacobiPreconditioner(Operator const & underlying_operator_in, bool const initialize)
     : underlying_operator(underlying_operator_in)
   {
-<<<<<<< HEAD
     // initialize block Jacobi
     underlying_operator.initialize_block_diagonal_preconditioner();
   }
@@ -49,12 +48,8 @@ public:
   update() final
   {
     underlying_operator.update_block_diagonal_preconditioner();
-=======
-    if(initialize)
-    {
-      this->update();
-    }
->>>>>>> 614c430a1 (apply changes to simple preconditioners)
+
+    this->update_needed = false;
   }
 
   /*
@@ -69,17 +64,6 @@ public:
   }
 
 private:
-  /*
-   *  This function updates the block Jacobi preconditioner.
-   *  Make sure that the underlying operator has been updated
-   *  when calling this function.
-   */
-  void
-  do_update() final
-  {
-    underlying_operator.update_block_diagonal_preconditioner();
-  }
-
   Operator const & underlying_operator;
 };
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/elementwise_preconditioners.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/elementwise_preconditioners.h
@@ -56,8 +56,6 @@ public:
 
   virtual void
   vmult(Number * dst, Number const * src) const = 0;
-
-private:
 };
 
 /**
@@ -111,14 +109,16 @@ public:
   JacobiPreconditioner(dealii::MatrixFree<dim, Number> const & matrix_free,
                        unsigned int const                      dof_index,
                        unsigned int const                      quad_index,
-                       Operator const &                        underlying_operator_in)
+                       Operator const &                        underlying_operator_in,
+                       bool const                              initialize)
     : underlying_operator(underlying_operator_in)
   {
     integrator = std::make_shared<Integrator>(matrix_free, dof_index, quad_index);
 
     underlying_operator.initialize_dof_vector(global_inverse_diagonal);
 
-    this->update();
+    if(initialize)
+      this->update();
   }
 
   void

--- a/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
@@ -55,13 +55,13 @@ public:
     inverse_mass_operator.apply(dst, src);
   }
 
+private:
   void
-  update() final
+  do_update() final
   {
     inverse_mass_operator.update();
   }
 
-private:
   InverseMassOperator<dim, n_components, Number> inverse_mass_operator;
 };
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
@@ -47,6 +47,8 @@ public:
                             InverseMassOperatorData const           inverse_mass_operator_data)
   {
     inverse_mass_operator.initialize(matrix_free, inverse_mass_operator_data);
+
+    this->update_needed = false;
   }
 
   void
@@ -55,13 +57,15 @@ public:
     inverse_mass_operator.apply(dst, src);
   }
 
-private:
   void
-  do_update() final
+  update() final
   {
     inverse_mass_operator.update();
+
+    this->update_needed = false;
   }
 
+private:
   InverseMassOperator<dim, n_components, Number> inverse_mass_operator;
 };
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
@@ -36,12 +36,15 @@ class JacobiPreconditioner : public PreconditionerBase<typename Operator::value_
 public:
   typedef typename PreconditionerBase<typename Operator::value_type>::VectorType VectorType;
 
-  JacobiPreconditioner(Operator const & underlying_operator_in)
+  JacobiPreconditioner(Operator const & underlying_operator_in, bool const initialize)
     : underlying_operator(underlying_operator_in)
   {
     underlying_operator.initialize_dof_vector(inverse_diagonal);
 
-    underlying_operator.calculate_inverse_diagonal(inverse_diagonal);
+    if(initialize)
+    {
+      this->update();
+    }
   }
 
   void
@@ -58,12 +61,6 @@ public:
     }
   }
 
-  void
-  update() final
-  {
-    underlying_operator.calculate_inverse_diagonal(inverse_diagonal);
-  }
-
   unsigned int
   get_size_of_diagonal()
   {
@@ -71,6 +68,12 @@ public:
   }
 
 private:
+  void
+  do_update() final
+  {
+    underlying_operator.calculate_inverse_diagonal(inverse_diagonal);
+  }
+
   Operator const & underlying_operator;
 
   VectorType inverse_diagonal;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
@@ -67,13 +67,15 @@ public:
     return inverse_diagonal.size();
   }
 
-private:
   void
-  do_update() final
+  update() final
   {
     underlying_operator.calculate_inverse_diagonal(inverse_diagonal);
+
+    this->update_needed = false;
   }
 
+private:
   Operator const & underlying_operator;
 
   VectorType inverse_diagonal;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -119,9 +119,8 @@ public:
     amg.vmult(dst, src);
   }
 
-private:
   void
-  do_update() override
+  update() override
   {
     // clear content of matrix since calculate_system_matrix() adds the result
     system_matrix *= 0.0;
@@ -131,8 +130,11 @@ private:
 
     // initialize Trilinos' AMG
     amg.initialize(system_matrix, ml_data);
+
+    this->update_needed = false;
   }
 
+private:
   // reference to matrix-free operator
   Operator const & pde_operator;
 
@@ -211,9 +213,8 @@ public:
                             });
   }
 
-private:
   void
-  do_update() override
+  update() override
   {
     // clear content of matrix since the next calculate_system_matrix calls
     // add their result; since we might run this on a sub-communicator, we
@@ -223,8 +224,11 @@ private:
       system_matrix = 0.0;
 
     calculate_preconditioner();
+
+    this->update_needed = false;
   }
 
+private:
   void
   calculate_preconditioner()
   {
@@ -323,9 +327,11 @@ public:
 
 private:
   void
-  do_update() final
+  update() final
   {
     preconditioner_amg->update();
+
+    this->update_needed = false;
   }
 
   std::shared_ptr<PreconditionerBase<NumberAMG>> preconditioner_amg;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
@@ -36,7 +36,7 @@ class PreconditionerBase
 public:
   typedef dealii::LinearAlgebra::distributed::Vector<value_type> VectorType;
 
-  PreconditionerBase() : has_been_initialized(false)
+  PreconditionerBase() : update_needed(true)
   {
   }
 
@@ -45,24 +45,27 @@ public:
   }
 
   void
-  initialize()
+  set_update_flag()
   {
-    do_initialize();
-
-    has_been_initialized = true;
+    update_needed = true;
   }
 
   bool
-  is_initialized() const
+  needs_update() const
   {
-    return has_been_initialized;
+    return update_needed;
   }
 
   virtual void
   vmult(VectorType & dst, VectorType const & src) const = 0;
 
-  virtual void
-  update() = 0;
+  void
+  update()
+  {
+    this->do_update();
+
+    update_needed = false;
+  }
 
   virtual std::shared_ptr<TimerTree>
   get_timings() const
@@ -70,11 +73,11 @@ public:
     return std::make_shared<TimerTree>();
   }
 
-private:
+protected:
   virtual void
-  do_initialize() = 0;
+  do_update() = 0;
 
-  bool has_been_initialized;
+  bool update_needed;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
@@ -36,8 +36,26 @@ class PreconditionerBase
 public:
   typedef dealii::LinearAlgebra::distributed::Vector<value_type> VectorType;
 
+  PreconditionerBase() : has_been_initialized(false)
+  {
+  }
+
   virtual ~PreconditionerBase()
   {
+  }
+
+  void
+  initialize()
+  {
+    do_initialize();
+
+    has_been_initialized = true;
+  }
+
+  bool
+  is_initialized() const
+  {
+    return has_been_initialized;
   }
 
   virtual void
@@ -51,6 +69,12 @@ public:
   {
     return std::make_shared<TimerTree>();
   }
+
+private:
+  virtual void
+  do_initialize() = 0;
+
+  bool has_been_initialized;
 };
 
 } // namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
@@ -59,13 +59,8 @@ public:
   virtual void
   vmult(VectorType & dst, VectorType const & src) const = 0;
 
-  void
-  update()
-  {
-    this->do_update();
-
-    update_needed = false;
-  }
+  virtual void
+  update() = 0;
 
   virtual std::shared_ptr<TimerTree>
   get_timings() const
@@ -74,9 +69,6 @@ public:
   }
 
 protected:
-  virtual void
-  do_update() = 0;
-
   bool update_needed;
 };
 

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
@@ -44,12 +44,6 @@ public:
   {
   }
 
-  void
-  set_update_flag()
-  {
-    update_needed = true;
-  }
-
   bool
   needs_update() const
   {

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -129,7 +129,7 @@ public:
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs) const override
+  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
     dealii::Timer timer;
 
@@ -145,6 +145,11 @@ public:
     }
     else
     {
+      if(not preconditioner.is_initialized())
+        preconditioner.initialize();
+      else if(update_preconditioner)
+        preconditioner.update();
+
       solver.solve(underlying_operator, dst, rhs, preconditioner);
     }
 
@@ -244,7 +249,7 @@ public:
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs) const override
+  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
     dealii::Timer timer;
 
@@ -272,6 +277,11 @@ public:
     }
     else
     {
+      if(not preconditioner.is_initialized())
+        preconditioner.initialize();
+      else if(update_preconditioner)
+        preconditioner.update();
+
       solver.solve(this->underlying_operator, dst, rhs, this->preconditioner);
     }
 
@@ -352,7 +362,7 @@ public:
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs) const override
+  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
   {
     dealii::Timer timer;
 
@@ -372,6 +382,11 @@ public:
     }
     else
     {
+      if(not preconditioner.is_initialized())
+        preconditioner.initialize();
+      else if(update_preconditioner)
+        preconditioner.update();
+
       solver.solve(underlying_operator, dst, rhs, preconditioner);
     }
 

--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -122,14 +122,17 @@ public:
   void
   update_preconditioner(bool const update_preconditioner) const override
   {
-    if(solver_data.use_preconditioner and update_preconditioner)
+    if(solver_data.use_preconditioner)
     {
-      preconditioner.update();
+      if(preconditioner.needs_update() or update_preconditioner)
+      {
+        preconditioner.update();
+      }
     }
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
+  solve(VectorType & dst, VectorType const & rhs) const override
   {
     dealii::Timer timer;
 
@@ -145,11 +148,6 @@ public:
     }
     else
     {
-      if(not preconditioner.is_initialized())
-        preconditioner.initialize();
-      else if(update_preconditioner)
-        preconditioner.update();
-
       solver.solve(underlying_operator, dst, rhs, preconditioner);
     }
 
@@ -242,14 +240,17 @@ public:
   void
   update_preconditioner(bool const update_preconditioner) const override
   {
-    if(solver_data.use_preconditioner and update_preconditioner)
+    if(solver_data.use_preconditioner)
     {
-      preconditioner.update();
+      if(preconditioner.needs_update() or update_preconditioner)
+      {
+        preconditioner.update();
+      }
     }
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
+  solve(VectorType & dst, VectorType const & rhs) const override
   {
     dealii::Timer timer;
 
@@ -277,11 +278,6 @@ public:
     }
     else
     {
-      if(not preconditioner.is_initialized())
-        preconditioner.initialize();
-      else if(update_preconditioner)
-        preconditioner.update();
-
       solver.solve(this->underlying_operator, dst, rhs, this->preconditioner);
     }
 
@@ -355,14 +351,17 @@ public:
   void
   update_preconditioner(bool const update_preconditioner) const override
   {
-    if(solver_data.use_preconditioner and update_preconditioner)
+    if(solver_data.use_preconditioner)
     {
-      preconditioner.update();
+      if(preconditioner.needs_update() or update_preconditioner)
+      {
+        preconditioner.update();
+      }
     }
   }
 
   unsigned int
-  solve(VectorType & dst, VectorType const & rhs, bool const update_preconditioner) const override
+  solve(VectorType & dst, VectorType const & rhs) const override
   {
     dealii::Timer timer;
 
@@ -382,11 +381,6 @@ public:
     }
     else
     {
-      if(not preconditioner.is_initialized())
-        preconditioner.initialize();
-      else if(update_preconditioner)
-        preconditioner.update();
-
       solver.solve(underlying_operator, dst, rhs, preconditioner);
     }
 

--- a/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
@@ -78,9 +78,10 @@ public:
   void
   update_preconditioner(bool const update_preconditioner) const override
   {
-    (void)update_preconditioner;
-    AssertThrow(
-      false, dealii::ExcMessage("Should not arrive here. This function has not been implemented."));
+    if(preconditioner.needs_update() or update_preconditioner)
+    {
+      preconditioner.update();
+    }
   }
 
   /**

--- a/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
@@ -55,7 +55,7 @@ compute_eigenvalues(Operator const &   op,
               &eigenvalue_tracker,
               std::placeholders::_1));
 
-  JacobiPreconditioner<Operator> preconditioner(op);
+  JacobiPreconditioner<Operator> preconditioner(op, true /* initialize */);
 
   try
   {

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -100,16 +100,6 @@ Driver<dim, Number>::setup()
     {
       AssertThrow(false, dealii::ExcMessage("Not implemented."));
     }
-
-    if(application->get_parameters().problem_type == ProblemType::Unsteady)
-    {
-      pde_operator->setup_solver(time_integrator->get_scaling_factor_acceleration(),
-                                 time_integrator->get_scaling_factor_velocity());
-    }
-    else
-    {
-      pde_operator->setup_solver(0.0 /* no acceleration term */, 0.0 /* no damping term */);
-    }
   }
 
   timer_tree.insert({"Elasticity", "Setup"}, timer.wall_time());

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -57,7 +57,8 @@ MultigridPreconditioner<dim, Number>::initialize(
                    fe,
                    false /*operator_is_singular*/,
                    dirichlet_bc,
-                   dirichlet_bc_component_mask);
+                   dirichlet_bc_component_mask,
+                   false /* initialize_preconditioners */);
 }
 
 template<int dim, typename Number>
@@ -126,6 +127,8 @@ MultigridPreconditioner<dim, Number>::update()
     this->update_smoothers();
     this->update_coarse_solver();
   }
+
+  this->update_needed = false;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -338,33 +338,16 @@ Operator<dim, Number>::setup(std::shared_ptr<dealii::MatrixFree<dim, Number> con
 
   setup_operators();
 
-  pcout << std::endl << "... done!" << std::endl;
-}
+  setup_preconditioner();
 
-template<int dim, typename Number>
-void
-Operator<dim, Number>::setup_solver(double const & scaling_factor_acceleration,
-                                    double const & scaling_factor_velocity)
-{
-  pcout << std::endl << "Setup elasticity solver ..." << std::endl;
-
-  double const scaling_factor_mass =
-    compute_scaling_factor_mass(scaling_factor_acceleration, scaling_factor_velocity);
-  if(param.large_deformation)
-    elasticity_operator_nonlinear.set_scaling_factor_mass_operator(scaling_factor_mass);
-  else
-    elasticity_operator_linear.set_scaling_factor_mass_operator(scaling_factor_mass);
-
-  initialize_preconditioner();
-
-  initialize_solver();
+  setup_solver();
 
   pcout << std::endl << "... done!" << std::endl;
 }
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::initialize_preconditioner()
+Operator<dim, Number>::setup_preconditioner()
 {
   if(param.preconditioner == Preconditioner::None)
   {
@@ -499,7 +482,7 @@ Operator<dim, Number>::initialize_preconditioner()
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::initialize_solver()
+Operator<dim, Number>::setup_solver()
 {
   // initialize linear solver
   if(param.solver == Solver::CG)

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -366,6 +366,20 @@ Operator<dim, Number>::setup_preconditioner()
         elasticity_operator_linear, false);
     }
   }
+  else if(param.preconditioner == Preconditioner::AdditiveSchwarz)
+  {
+    if(param.large_deformation)
+    {
+      preconditioner =
+        std::make_shared<AdditiveSchwarzPreconditioner<NonLinearOperator<dim, Number>>>(
+          elasticity_operator_nonlinear, false);
+    }
+    else
+    {
+      preconditioner = std::make_shared<AdditiveSchwarzPreconditioner<LinearOperator<dim, Number>>>(
+        elasticity_operator_linear, false);
+    }
+  }
   else if(param.preconditioner == Preconditioner::Multigrid)
   {
     if(param.large_deformation)

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -256,13 +256,15 @@ Operator<dim, Number>::setup_operators()
 
     mass_operator.set_scaling_factor(param.density);
 
+    // TODO: this comment can be removed once we merge setup() and setup_solvers()
     // preconditioner and solver for mass operator have to be initialized in
     // setup_operators() since the mass solver is already needed in
     // setup() function of time integration scheme.
 
     // preconditioner
     mass_preconditioner =
-      std::make_shared<JacobiPreconditioner<Structure::MassOperator<dim, Number>>>(mass_operator);
+      std::make_shared<JacobiPreconditioner<Structure::MassOperator<dim, Number>>>(mass_operator,
+                                                                                   true);
 
     // initialize solver
     Krylov::SolverDataCG solver_data;
@@ -373,12 +375,12 @@ Operator<dim, Number>::initialize_preconditioner()
     if(param.large_deformation)
     {
       preconditioner = std::make_shared<JacobiPreconditioner<NonLinearOperator<dim, Number>>>(
-        elasticity_operator_nonlinear);
+        elasticity_operator_nonlinear, false);
     }
     else
     {
       preconditioner = std::make_shared<JacobiPreconditioner<LinearOperator<dim, Number>>>(
-        elasticity_operator_linear);
+        elasticity_operator_linear, false);
     }
   }
   else if(param.preconditioner == Preconditioner::Multigrid)
@@ -478,12 +480,14 @@ Operator<dim, Number>::initialize_preconditioner()
     {
       typedef PreconditionerAMG<NonLinearOperator<dim, Number>, Number> AMG;
       preconditioner = std::make_shared<AMG>(elasticity_operator_nonlinear,
+                                             false,
                                              param.multigrid_data.coarse_problem.amg_data);
     }
     else
     {
       typedef PreconditionerAMG<LinearOperator<dim, Number>, Number> AMG;
       preconditioner = std::make_shared<AMG>(elasticity_operator_linear,
+                                             false,
                                              param.multigrid_data.coarse_problem.amg_data);
     }
   }

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -200,13 +200,6 @@ public:
         std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data);
 
   /*
-   * This function initializes operators, preconditioners, and solvers related to the solution of
-   * (non-)linear systems of equations.
-   */
-  void
-  setup_solver(double const & scaling_factor_acceleration, double const & scaling_factor_velocity);
-
-  /*
    * Initialization of dof-vector.
    */
   void
@@ -382,13 +375,13 @@ private:
    * Initializes preconditioner.
    */
   void
-  initialize_preconditioner();
+  setup_preconditioner();
 
   /**
    * Initializes solver.
    */
   void
-  initialize_solver();
+  setup_solver();
 
   /*
    * Grid

--- a/include/exadg/structure/user_interface/enum_types.h
+++ b/include/exadg/structure/user_interface/enum_types.h
@@ -112,6 +112,7 @@ enum class Preconditioner
 {
   None,
   PointJacobi,
+  AdditiveSchwarz,
   Multigrid,
   AMG
 };

--- a/include/exadg/time_integration/time_int_bdf_base.h
+++ b/include/exadg/time_integration/time_int_bdf_base.h
@@ -43,10 +43,10 @@ public:
                  MPI_Comm const &    mpi_comm_,
                  bool const          is_test_);
 
+protected:
   double
   get_scaling_factor_time_derivative_term() const;
 
-protected:
   void
   update_time_integrator_constants() override;
 

--- a/include/exadg/time_integration/time_int_gen_alpha_base.h
+++ b/include/exadg/time_integration/time_int_gen_alpha_base.h
@@ -52,13 +52,13 @@ public:
   void
   set_current_time_step_size(double const & time_step_size) final;
 
+protected:
   double
   get_scaling_factor_acceleration() const;
 
   double
   get_scaling_factor_velocity() const;
 
-protected:
   double
   get_mid_time() const;
 


### PR DESCRIPTION
In general, initialization of preconditioners depends on parameters that change during a simulation (e.g. time step size, linearization vectors). Currently, we completely initialize preconditioners in the setup-phase of a solver. The usual sequence of function calls in the `Driver` during setup is

```C++
spatial_operator->setup();
time_integrator->setup();
spatial_operator->setup_solvers(time_integrator.get_...(), ...);
```
During many discussions, most recently with @richardschu, it turned out that this procedure is quite impractical and I wonder whether we could find a better solution.

So far, the preconditioner already receives automatically the relevant information for preconditioner updates during time-dependent simulations (time steppping) or nonlinear solvers (linearization vector). Hence, we principally already have the functionality to not trigger the preconditioner init/update in the driver, but let it be triggered somewhat "automatically" (typically realized by preconditioners having a reference/pointer to the `underlying_operator`, which is the object that has to be up-to-date and from which parameters can be queried). However, what we would need in my opinion is being able to ask the preconditioner whether it as been initialized so far, such that a Krylov solver can then trigger the initialization of the preconditioner.

I think such a procedure would simplify or clarify the code overall. One downside would be that in terms of compute timings, setup costs in the sense of preconditioner initialization would appear as "solver costs" or "time integration costs", even though the initialization could be done prior to starting the time loop (exactly the procedure we do currently). However, the idea would be that for preconditioners that do not depend on dynamic parameters (say the inverse mass matrix preconditioner), we can do the initialization of the preconditioner already in the constructor. Hence, for these simple cases, `preconditioner.is_initialized()` called in the Krylov solver during the first time step would evaluate to true and nothing would have to be done.