### PR TITLE
allow update of inverse mass operator and refactor block-Jacobi implementation

### DIFF
--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -800,6 +800,10 @@ Operator<dim, Number>::update_after_grid_motion(bool const update_matrix_free)
   {
     diffusive_kernel->calculate_penalty_parameter(*matrix_free, get_dof_index());
   }
+
+  // The inverse mass operator might contain matrix-based components, in which cases it needs to be
+  // updated after the grid has been deformed.
+  inverse_mass_operator.update();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -82,6 +82,17 @@ OperatorPressureCorrection<dim, Number>::setup_solvers(double const &     scalin
 
 template<int dim, typename Number>
 void
+OperatorPressureCorrection<dim, Number>::update_after_grid_motion(bool const update_matrix_free)
+{
+  ProjectionBase::update_after_grid_motion(update_matrix_free);
+
+  // The inverse mass operator might contain matrix-based components, in which cases it needs to be
+  // updated after the grid has been deformed.
+  inverse_mass_pressure.update();
+}
+
+template<int dim, typename Number>
+void
 OperatorPressureCorrection<dim, Number>::setup_momentum_solver()
 {
   initialize_momentum_preconditioner();

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h
@@ -126,6 +126,9 @@ public:
   void
   setup_solvers(double const & scaling_factor_mass, VectorType const & velocity) final;
 
+  void
+  update_after_grid_motion(bool const update_matrix_free) final;
+
   /*
    * Momentum step:
    */

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -68,7 +68,7 @@ protected:
 
 public:
   void
-  update_after_grid_motion(bool const update_matrix_free) final;
+  update_after_grid_motion(bool const update_matrix_free) override;
 
   /*
    * This function evaluates the rhs-contribution of the viscous term and adds the result to the

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1518,6 +1518,11 @@ SpatialOperatorBase<dim, Number>::update_after_grid_motion(bool const update_mat
     viscous_kernel->calculate_penalty_parameter(*matrix_free, get_dof_index_velocity());
   }
 
+  // The inverse mass operator might contain matrix-based components, in which cases it needs to be
+  // updated after the grid has been deformed.
+  inverse_mass_velocity.update();
+  inverse_mass_velocity_scalar.update();
+
   // note that the update of div-div and continuity penalty terms is done separately
 }
 

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -144,6 +144,33 @@ public:
     }
   }
 
+  /**
+   * Updates the inverse mass operator. This function recomputes the diagonal/block-diagonal in case
+   * the geometry has changed (e.g. the mesh has been deformed).
+   */
+  void
+  update()
+  {
+    if(data.implementation_type == InverseMassType::MatrixfreeOperator)
+    {
+      // no updates needed as long as the MatrixFree object is up-to-date (which is not the
+      // responsibility of the present class).
+    }
+    else if(data.implementation_type == InverseMassType::ElementwiseKrylovSolver or
+            data.implementation_type == InverseMassType::BlockMatrices)
+    {
+      // the mass operator does not need to be updated as long as the MatrixFree object is
+      // up-to-date (which is not the responsibility of the present class).
+
+      // update the matrix-based components of the block-Jacobi preconditioner
+      block_jacobi_preconditioner->update();
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcMessage("The specified InverseMassType is not implemented."));
+    }
+  }
+
   void
   apply(VectorType & dst, VectorType const & src) const
   {

--- a/include/exadg/operators/multigrid_operator.h
+++ b/include/exadg/operators/multigrid_operator.h
@@ -123,6 +123,12 @@ public:
   }
 
   void
+  initialize_block_diagonal_preconditioner() const final
+  {
+    pde_operator->initialize_block_diagonal_preconditioner();
+  }
+
+  void
   update_block_diagonal_preconditioner() const final
   {
     pde_operator->update_block_diagonal_preconditioner();

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -82,6 +82,9 @@ public:
   calculate_inverse_diagonal(VectorType & inverse_diagonal_entries) const = 0;
 
   virtual void
+  initialize_block_diagonal_preconditioner() const = 0;
+
+  virtual void
   update_block_diagonal_preconditioner() const = 0;
 
   virtual void

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -42,7 +42,6 @@ OperatorBase<dim, Number, n_components>::OperatorBase()
     is_dg(true),
     data(OperatorBaseData()),
     level(dealii::numbers::invalid_unsigned_int),
-    block_diagonal_preconditioner_is_initialized(false),
     n_mpi_processes(0)
 {
 }
@@ -462,32 +461,6 @@ OperatorBase<dim, Number, n_components>::add_diagonal(VectorType & diagonal) con
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::calculate_block_diagonal_matrices() const
-{
-  AssertThrow(is_dg, dealii::ExcMessage("Block Jacobi only implemented for DG!"));
-
-  // allocate memory only the first time
-  if(not(block_diagonal_preconditioner_is_initialized) or
-     matrix_free->n_cell_batches() * vectorization_length != matrices.size())
-  {
-    auto dofs =
-      matrix_free->get_shape_info(this->data.dof_index).dofs_per_component_on_cell * n_components;
-
-    matrices.resize(matrix_free->n_cell_batches() * vectorization_length, LAPACKMatrix(dofs, dofs));
-
-    block_diagonal_preconditioner_is_initialized = true;
-  }
-  // else: reuse old memory
-
-  // clear matrices
-  initialize_block_jacobi_matrices_with_zero(matrices);
-
-  // compute block matrices
-  add_block_diagonal_matrices(matrices);
-}
-
-template<int dim, typename Number, int n_components>
-void
 OperatorBase<dim, Number, n_components>::add_block_diagonal_matrices(
   std::vector<LAPACKMatrix> & matrices) const
 {
@@ -519,19 +492,6 @@ OperatorBase<dim, Number, n_components>::add_block_diagonal_matrices(
   {
     matrix_free->cell_loop(&This::cell_loop_block_diagonal, this, matrices, matrices);
   }
-}
-
-template<int dim, typename Number, int n_components>
-void
-OperatorBase<dim, Number, n_components>::apply_block_diagonal_matrix_based(
-  VectorType &       dst,
-  VectorType const & src) const
-{
-  AssertThrow(is_dg, dealii::ExcMessage("Block Jacobi only implemented for DG!"));
-  AssertThrow(block_diagonal_preconditioner_is_initialized,
-              dealii::ExcMessage("Block Jacobi matrices have not been initialized!"));
-
-  matrix_free->cell_loop(&This::cell_loop_apply_block_diagonal_matrix_based, this, dst, src);
 }
 
 template<int dim, typename Number, int n_components>
@@ -573,8 +533,6 @@ OperatorBase<dim, Number, n_components>::apply_inverse_block_diagonal_matrix_bas
   VectorType const & src) const
 {
   AssertThrow(is_dg, dealii::ExcMessage("Block Jacobi only implemented for DG!"));
-  AssertThrow(block_diagonal_preconditioner_is_initialized,
-              dealii::ExcMessage("Block Jacobi matrices have not been initialized!"));
 
   matrix_free->cell_loop(&This::cell_loop_apply_inverse_block_diagonal_matrix_based,
                          this,
@@ -625,6 +583,40 @@ OperatorBase<dim, Number, n_components>::initialize_block_diagonal_preconditione
     *std::dynamic_pointer_cast<ELEMENTWISE_OPERATOR>(elementwise_operator),
     *std::dynamic_pointer_cast<ELEMENTWISE_PRECONDITIONER>(elementwise_preconditioner),
     iterative_solver_data);
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::update_block_diagonal_preconditioner_matrix_free() const
+{
+  elementwise_preconditioner->update();
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::initialize_block_diagonal_preconditioner_matrix_based()
+  const
+{
+  // allocate memory
+  auto dofs =
+    matrix_free->get_shape_info(this->data.dof_index).dofs_per_component_on_cell * n_components;
+  matrices.resize(matrix_free->n_cell_batches() * vectorization_length, LAPACKMatrix(dofs, dofs));
+
+  // compute and factorize matrices
+  update_block_diagonal_preconditioner_matrix_based();
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::update_block_diagonal_preconditioner_matrix_based() const
+{
+  // clear matrices
+  initialize_block_jacobi_matrices_with_zero(matrices);
+
+  // compute block matrices and add
+  add_block_diagonal_matrices(matrices);
+
+  calculate_lu_factorization_block_jacobi(matrices);
 }
 
 template<int dim, typename Number, int n_components>
@@ -698,43 +690,35 @@ OperatorBase<dim, Number, n_components>::apply_add_block_diagonal_elementwise(
 
 template<int dim, typename Number, int n_components>
 void
+OperatorBase<dim, Number, n_components>::initialize_block_diagonal_preconditioner() const
+{
+  AssertThrow(is_dg, dealii::ExcMessage("Block Jacobi only implemented for DG!"));
+
+  if(data.implement_block_diagonal_preconditioner_matrix_free)
+  {
+    initialize_block_diagonal_preconditioner_matrix_free();
+  }
+  else // matrix-based variant
+  {
+    initialize_block_diagonal_preconditioner_matrix_based();
+  }
+}
+
+template<int dim, typename Number, int n_components>
+void
 OperatorBase<dim, Number, n_components>::update_block_diagonal_preconditioner() const
 {
   AssertThrow(is_dg, dealii::ExcMessage("Block Jacobi only implemented for DG!"));
 
-  // initialization
-
-  if(not block_diagonal_preconditioner_is_initialized)
+  if(data.implement_block_diagonal_preconditioner_matrix_free)
   {
-    if(data.implement_block_diagonal_preconditioner_matrix_free)
-    {
-      initialize_block_diagonal_preconditioner_matrix_free();
-    }
-    else // matrix-based variant
-    {
-      // allocate memory only the first time
-      auto dofs =
-        matrix_free->get_shape_info(this->data.dof_index).dofs_per_component_on_cell * n_components;
-      matrices.resize(matrix_free->n_cell_batches() * vectorization_length,
-                      LAPACKMatrix(dofs, dofs));
-    }
-
-    block_diagonal_preconditioner_is_initialized = true;
+    // For the matrix-free variant we have to update the elementwise preconditioner.
+    update_block_diagonal_preconditioner_matrix_free();
   }
-
-  // update
-
-  // For the matrix-free variant there is nothing to do.
-  // For the matrix-based variant we have to recompute the block matrices.
-  if(not data.implement_block_diagonal_preconditioner_matrix_free)
+  else // matrix-based variant
   {
-    // clear matrices
-    initialize_block_jacobi_matrices_with_zero(matrices);
-
-    // compute block matrices and add
-    add_block_diagonal_matrices(matrices);
-
-    calculate_lu_factorization_block_jacobi(matrices);
+    // For the matrix-based variant we have to recompute the block matrices.
+    update_block_diagonal_preconditioner_matrix_based();
   }
 }
 
@@ -1590,43 +1574,6 @@ OperatorBase<dim, Number, n_components>::cell_loop_apply_inverse_block_diagonal_
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::cell_loop_apply_block_diagonal_matrix_based(
-  dealii::MatrixFree<dim, Number> const & matrix_free,
-  VectorType &                            dst,
-  VectorType const &                      src,
-  Range const &                           range) const
-{
-  IntegratorCell integrator =
-    IntegratorCell(matrix_free, this->data.dof_index, this->data.quad_index);
-
-  unsigned int const dofs_per_cell = integrator.dofs_per_cell;
-
-  for(unsigned int cell = range.first; cell < range.second; ++cell)
-  {
-    this->reinit_cell(integrator, cell);
-
-    integrator.read_dof_values(src);
-
-    for(unsigned int v = 0; v < vectorization_length; ++v)
-    {
-      dealii::Vector<Number> src_vector(dofs_per_cell);
-      dealii::Vector<Number> dst_vector(dofs_per_cell);
-      for(unsigned int j = 0; j < dofs_per_cell; ++j)
-        src_vector(j) = integrator.begin_dof_values()[j][v];
-
-      // apply matrix
-      matrices[cell * vectorization_length + v].vmult(dst_vector, src_vector, false);
-
-      for(unsigned int j = 0; j < dofs_per_cell; ++j)
-        integrator.begin_dof_values()[j][v] = dst_vector(j);
-    }
-
-    integrator.set_dof_values(dst);
-  }
-}
-
-template<int dim, typename Number, int n_components>
-void
 OperatorBase<dim, Number, n_components>::cell_loop_block_diagonal(
   dealii::MatrixFree<dim, Number> const & matrix_free,
   std::vector<LAPACKMatrix> &             matrices,
@@ -2189,7 +2136,9 @@ OperatorBase<dim, Number, n_components>::internal_compute_factorized_additive_sc
   const
 {
   if(is_dg)
+  {
     update_block_diagonal_preconditioner();
+  }
   else
   {
     dealii::DoFHandler<dim> const & dof_handler =

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -188,9 +188,15 @@ public:
   calculate_inverse_diagonal(VectorType & diagonal) const;
 
   /*
-   * Update block diagonal preconditioner: initialize everything related to block diagonal
-   * preconditioner when this function is called the first time. Recompute block matrices in case of
-   * matrix-based implementation.
+   * Initialize block diagonal preconditioner: initialize everything related to block diagonal
+   * preconditioner.
+   */
+  void
+  initialize_block_diagonal_preconditioner() const;
+
+  /*
+   * Update block diagonal preconditioner: Recompute block matrices in case of matrix-based
+   * implementation.
    */
   void
   update_block_diagonal_preconditioner() const;
@@ -298,16 +304,8 @@ public:
   /*
    * block Jacobi preconditioner (block-diagonal)
    */
-
-  // matrix-based implementation
-  void
-  calculate_block_diagonal_matrices() const;
-
   void
   add_block_diagonal_matrices(std::vector<LAPACKMatrix> & matrices) const;
-
-  void
-  apply_block_diagonal_matrix_based(VectorType & dst, VectorType const & src) const;
 
   void
   apply_inverse_block_diagonal_matrix_based(VectorType & dst, VectorType const & src) const;
@@ -319,6 +317,19 @@ public:
   // evaluation.
   void
   initialize_block_diagonal_preconditioner_matrix_free() const;
+
+  // updates block diagonal preconditioner when using the matrix-free variant with elementwise
+  // iterative solvers and matrix-free operator evaluation.
+  void
+  update_block_diagonal_preconditioner_matrix_free() const;
+
+  // initializes block diagonal preconditioner for matrix-based variant
+  void
+  initialize_block_diagonal_preconditioner_matrix_based() const;
+
+  // updates block diagonal preconditioner for matrix-based variant
+  void
+  update_block_diagonal_preconditioner_matrix_based() const;
 
   void
   apply_add_block_diagonal_elementwise(unsigned int const                            cell,
@@ -615,19 +626,9 @@ private:
                                  Range const &                           range) const;
 
   /*
-   * Apply block diagonal.
-   */
-  void
-  cell_loop_apply_block_diagonal_matrix_based(dealii::MatrixFree<dim, Number> const & matrix_free,
-                                              VectorType &                            dst,
-                                              VectorType const &                      src,
-                                              Range const &                           range) const;
-
-  /*
    * Apply inverse block diagonal:
    *
-   * instead of applying the block matrix B we compute dst = B^{-1} * src (LU factorization
-   * should have already been performed with the method update_inverse_block_diagonal())
+   *  we compute dst = B^{-1} * src
    */
   void
   cell_loop_apply_inverse_block_diagonal_matrix_based(
@@ -714,13 +715,6 @@ private:
    * Vector with weights for additive Schwarz preconditioner.
    */
   mutable VectorType weights;
-
-  /*
-   * We want to initialize the block diagonal preconditioner (block diagonal matrices or elementwise
-   * iterative solvers in case of matrix-free implementation) only once, so we store the status of
-   * initialization in a variable.
-   */
-  mutable bool block_diagonal_preconditioner_is_initialized;
 
   unsigned int n_mpi_processes;
 };

--- a/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
@@ -36,7 +36,7 @@ public:
     : underlying_operator(underlying_operator_in)
   {
     // initialize block Jacobi
-    underlying_operator.update_block_diagonal_preconditioner();
+    underlying_operator.initialize_block_diagonal_preconditioner();
   }
 
   /*

--- a/include/exadg/solvers_and_preconditioners/preconditioners/elementwise_preconditioners.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/elementwise_preconditioners.h
@@ -52,6 +52,9 @@ public:
   setup(unsigned int const cell) = 0;
 
   virtual void
+  update() = 0;
+
+  virtual void
   vmult(Number * dst, Number const * src) const = 0;
 
 private:
@@ -74,6 +77,12 @@ public:
 
   void
   setup(unsigned int const /* cell */) final
+  {
+    // nothing to do
+  }
+
+  void
+  update() final
   {
     // nothing to do
   }
@@ -109,7 +118,7 @@ public:
 
     underlying_operator.initialize_dof_vector(global_inverse_diagonal);
 
-    underlying_operator.calculate_inverse_diagonal(global_inverse_diagonal);
+    this->update();
   }
 
   void
@@ -117,6 +126,12 @@ public:
   {
     integrator->reinit(cell);
     integrator->read_dof_values(global_inverse_diagonal, 0);
+  }
+
+  void
+  update() final
+  {
+    underlying_operator.calculate_inverse_diagonal(global_inverse_diagonal);
   }
 
   /**
@@ -190,6 +205,13 @@ public:
   setup(unsigned int const cell) final
   {
     integrator->reinit(cell);
+  }
+
+  void
+  update() final
+  {
+    // no updates needed as long as the MatrixFree/Integrator object is up-to-date (which is not the
+    // responsibility of the present class).
   }
 
   /**

--- a/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
@@ -58,7 +58,7 @@ public:
   void
   update() final
   {
-    // do nothing
+    inverse_mass_operator.update();
   }
 
 private:


### PR DESCRIPTION
closes #601

In the past, we probably did not choose parameter combinations (ALE problems with inverse mass realized as matrix-based block-Jacobi preconditioner) that would have led to problems. The present PR aims to fix this potential bug.

@kronbichler @richardschu Someone interested in reviewing this PR? I would like to merge the present PR before continuing with #599.