### PR TITLE
Add throughput application for acoustic conservation equations

### DIFF
--- a/applications/acoustic_conservation_equations/throughput/CMakeLists.txt
+++ b/applications/acoustic_conservation_equations/throughput/CMakeLists.txt
@@ -1,0 +1,32 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2023 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
+
+PROJECT(${TARGET_NAME})
+
+EXADG_PICKUP_EXE(throughput.cpp ${TARGET_NAME} throughput)

--- a/applications/acoustic_conservation_equations/throughput/application.h
+++ b/applications/acoustic_conservation_equations/throughput/application.h
@@ -1,0 +1,149 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_THROUGHPUT_H_
+#define APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_THROUGHPUT_H_
+
+#include <exadg/grid/periodic_box.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+enum class MeshType
+{
+  Cartesian,
+  Curvilinear
+};
+
+template<int dim, typename Number>
+class Application : public ApplicationBase<dim, Number>
+{
+public:
+  Application(std::string input_file, MPI_Comm const & comm)
+    : ApplicationBase<dim, Number>(input_file, comm)
+  {
+  }
+
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+      prm.add_parameter("MeshType", mesh_type, "Type of mesh (Cartesian versus curvilinear).");
+    }
+    prm.leave_subsection();
+  }
+
+private:
+  void
+  set_parameters() final
+  {
+    // MATHEMATICAL MODEL
+    this->param.formulation = Formulation::SkewSymmetric;
+
+    // PHYSICAL QUANTITIES
+    this->param.start_time     = 0.0;
+    this->param.end_time       = 1.0;
+    this->param.speed_of_sound = 1.0;
+    this->param.density        = 1.0;
+
+    // TEMPORAL DISCRETIZATION
+    this->param.calculation_of_time_step_size = TimeStepCalculation::UserSpecified;
+    this->param.time_step_size                = 1e-03;
+    this->param.order_time_integrator         = 2;
+    this->param.start_with_low_order          = false;
+
+    // SPATIAL DISCRETIZATION
+    this->param.grid.triangulation_type = TriangulationType::Distributed;
+    this->param.mapping_degree          = 1;
+    this->param.degree_p                = this->param.degree_u;
+    this->param.degree_u                = this->param.degree_p;
+  }
+
+  void
+  create_grid() final
+  {
+    auto const lambda_create_triangulation =
+      [&](dealii::Triangulation<dim, dim> &                        tria,
+          std::vector<dealii::GridTools::PeriodicFacePair<
+            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
+          unsigned int const                                       global_refinements,
+          std::vector<unsigned int> const & /* vector_local_refinements*/) {
+        double const left = -1.0, right = 1.0;
+        double const deformation = 0.1;
+
+        create_periodic_box(tria,
+                            global_refinements,
+                            periodic_face_pairs,
+                            this->n_subdivisions_1d_hypercube,
+                            left,
+                            right,
+                            mesh_type == MeshType::Curvilinear,
+                            deformation);
+      };
+
+    GridUtilities::create_triangulation<dim>(
+      *this->grid, this->mpi_comm, this->param.grid, lambda_create_triangulation, {});
+  }
+
+  void
+  set_boundary_descriptor() final
+  {
+    // test case with purely periodic boundary conditions
+    // boundary descriptors remain empty for velocity and pressure
+  }
+
+  void
+  set_field_functions() final
+  {
+    this->field_functions->initial_solution_pressure =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(1);
+
+    this->field_functions->initial_solution_velocity =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(dim);
+  }
+
+  std::shared_ptr<PostProcessorBase<dim, Number>>
+  create_postprocessor() final
+  {
+    PostProcessorData<dim> pp_data;
+
+    // no postprocessing
+
+    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
+    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+
+    return pp;
+  }
+
+  MeshType mesh_type = MeshType::Cartesian;
+};
+
+} // namespace Acoustics
+
+} // namespace ExaDG
+
+#include <exadg/acoustic_conservation_equations/user_interface/implement_get_application.h>
+
+#endif /*APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_THROUGHPUT_H_*/

--- a/applications/acoustic_conservation_equations/throughput/input.json
+++ b/applications/acoustic_conservation_equations/throughput/input.json
@@ -1,0 +1,25 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "3",
+        "IsTest": "false"
+    },
+    "Resolution": {
+        "RunType": "FixedProblemSize",
+        "ElementType": "Hypercube",
+        "DegreeMin": "2",
+        "DegreeMax": "15",
+        "RefineSpaceMin": "3",
+        "RefineSpaceMax": "3",
+        "DofsMin": "200000",
+        "DofsMax": "500000"
+    },
+    "Throughput": {
+        "OperatorType": "AcousticOperator",
+        "RepetitionsInner": "100",
+        "RepetitionsOuter": "1"
+    },
+    "Application": {
+        "MeshType": "Cartesian"
+    }
+}

--- a/applications/acoustic_conservation_equations/throughput/throughput.cpp
+++ b/applications/acoustic_conservation_equations/throughput/throughput.cpp
@@ -1,0 +1,26 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// solver
+#include <exadg/acoustic_conservation_equations/throughput.h>
+
+// application
+#include "application.h"

--- a/include/exadg/acoustic_conservation_equations/throughput.h
+++ b/include/exadg/acoustic_conservation_equations/throughput.h
@@ -1,0 +1,193 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_THROUGHPUT_H_
+#define EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_THROUGHPUT_H_
+
+// likwid
+#ifdef EXADG_WITH_LIKWID
+#  include <likwid.h>
+#endif
+
+// ExaDG
+
+// driver
+#include <exadg/acoustic_conservation_equations/driver.h>
+
+// utilities
+#include <exadg/operators/hypercube_resolution_parameters.h>
+#include <exadg/operators/throughput_parameters.h>
+#include <exadg/utilities/general_parameters.h>
+
+// application
+#include <exadg/acoustic_conservation_equations/user_interface/declare_get_application.h>
+
+namespace ExaDG
+{
+void
+create_input_file(std::string const & input_file)
+{
+  dealii::ParameterHandler prm;
+
+  GeneralParameters general;
+  general.add_parameters(prm);
+
+  HypercubeResolutionParameters resolution;
+  resolution.add_parameters(prm);
+
+  ThroughputParameters<Acoustics::OperatorType> throughput;
+  throughput.add_parameters(prm);
+
+  // we have to assume a default dimension and default Number type
+  // for the automatic generation of a default input file
+  unsigned int const Dim = 2;
+  using Number           = double;
+  Acoustics::get_application<Dim, Number>(input_file, MPI_COMM_WORLD)->add_parameters(prm);
+
+  prm.print_parameters(input_file,
+                       dealii::ParameterHandler::Short |
+                         dealii::ParameterHandler::KeepDeclarationOrder);
+}
+
+template<int dim, typename Number>
+void
+run(ThroughputParameters<Acoustics::OperatorType> const & throughput,
+    std::string const &                                   input_file,
+    unsigned int const                                    degree,
+    unsigned int const                                    refine_space,
+    unsigned int const                                    n_cells_1d,
+    MPI_Comm const &                                      mpi_comm,
+    bool const                                            is_test)
+{
+  std::shared_ptr<Acoustics::ApplicationBase<dim, Number>> application =
+    Acoustics::get_application<dim, Number>(input_file, mpi_comm);
+
+  application->set_parameters_throughput_study(degree, refine_space, n_cells_1d);
+
+  std::shared_ptr<Acoustics::Driver<dim, Number>> driver =
+    std::make_shared<Acoustics::Driver<dim, Number>>(mpi_comm, application, is_test, true);
+
+  driver->setup();
+
+  std::tuple<unsigned int, dealii::types::global_dof_index, double> wall_time =
+    driver->apply_operator(throughput.operator_type,
+                           throughput.n_repetitions_inner,
+                           throughput.n_repetitions_outer);
+
+  throughput.wall_times.push_back(wall_time);
+}
+} // namespace ExaDG
+
+int
+main(int argc, char ** argv)
+{
+#ifdef EXADG_WITH_LIKWID
+  LIKWID_MARKER_INIT;
+#endif
+
+  dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+
+  MPI_Comm mpi_comm(MPI_COMM_WORLD);
+
+  std::string input_file;
+
+  if(argc == 1)
+  {
+    if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+    {
+      // clang-format off
+      std::cout << "To run the program, use:      ./throughput input_file" << std::endl
+                << "To setup the input file, use: ./throughput input_file --help" << std::endl;
+      // clang-format on
+    }
+
+    return 0;
+  }
+  else if(argc >= 2)
+  {
+    input_file = std::string(argv[1]);
+
+    if(argc == 3 and std::string(argv[2]) == "--help")
+    {
+      if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+        ExaDG::create_input_file(input_file);
+
+      return 0;
+    }
+  }
+
+  ExaDG::GeneralParameters                                    general(input_file);
+  ExaDG::HypercubeResolutionParameters                        resolution(input_file, general.dim);
+  ExaDG::ThroughputParameters<ExaDG::Acoustics::OperatorType> throughput(input_file);
+
+  auto const lambda_get_dofs_per_element =
+    [&](unsigned int const dim, unsigned int const degree, ExaDG::ElementType const element_type) {
+      return ExaDG::Acoustics::get_dofs_per_element(dim, degree, element_type);
+    };
+
+  // fill resolution vector depending on the operator_type
+  resolution.fill_resolution_vector(lambda_get_dofs_per_element);
+
+  // loop over resolutions vector and run simulations
+  for(auto iter = resolution.resolutions.begin(); iter != resolution.resolutions.end(); ++iter)
+  {
+    unsigned int const degree       = std::get<0>(*iter);
+    unsigned int const refine_space = std::get<1>(*iter);
+    unsigned int const n_cells_1d   = std::get<2>(*iter);
+
+    if(general.dim == 2 and general.precision == "float")
+    {
+      ExaDG::run<2, float>(
+        throughput, input_file, degree, refine_space, n_cells_1d, mpi_comm, general.is_test);
+    }
+    else if(general.dim == 2 and general.precision == "double")
+    {
+      ExaDG::run<2, double>(
+        throughput, input_file, degree, refine_space, n_cells_1d, mpi_comm, general.is_test);
+    }
+    else if(general.dim == 3 and general.precision == "float")
+    {
+      ExaDG::run<3, float>(
+        throughput, input_file, degree, refine_space, n_cells_1d, mpi_comm, general.is_test);
+    }
+    else if(general.dim == 3 and general.precision == "double")
+    {
+      ExaDG::run<3, double>(
+        throughput, input_file, degree, refine_space, n_cells_1d, mpi_comm, general.is_test);
+    }
+    else
+    {
+      AssertThrow(false,
+                  dealii::ExcMessage("Only dim = 2|3 and precision=float|double implemented."));
+    }
+  }
+
+  if(not(general.is_test))
+    throughput.print_results(mpi_comm);
+
+#ifdef EXADG_WITH_LIKWID
+  LIKWID_MARKER_CLOSE;
+#endif
+
+  return 0;
+}
+
+#endif /* EXADG_ACOUSTIC_CONSERVATION_EQUATIONS_THROUGHPUT_H_ */


### PR DESCRIPTION
To be able to determine the performance differences of acoustic operator implementations, I added a `throughput.h` application that is very similar to the other modules. 