### PR TITLE
Print DoF info and close constraints in acoustic module

### DIFF
--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
@@ -55,6 +55,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           64
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   64
+  number of dofs (total):                    4096
+Velocity:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   128
+  number of dofs (total):                    8192
+Pressure and velocity:
+  number of dofs per cell:                   192
+  number of dofs (total):                    12288
 
 ... done!
 
@@ -145,6 +156,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           64
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   64
+  number of dofs (total):                    4096
+Velocity:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   128
+  number of dofs (total):                    8192
+Pressure and velocity:
+  number of dofs per cell:                   192
+  number of dofs (total):                    12288
 
 ... done!
 

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
@@ -55,6 +55,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  1
+  number of dofs per cell:                   4
+  number of dofs (total):                    64
+Velocity:
+  degree of 1D polynomials:                  1
+  number of dofs per cell:                   8
+  number of dofs (total):                    128
+Pressure and velocity:
+  number of dofs per cell:                   12
+  number of dofs (total):                    192
 
 ... done!
 
@@ -145,6 +156,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   9
+  number of dofs (total):                    144
+Velocity:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   18
+  number of dofs (total):                    288
+Pressure and velocity:
+  number of dofs per cell:                   27
+  number of dofs (total):                    432
 
 ... done!
 
@@ -235,6 +257,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  3
+  number of dofs per cell:                   16
+  number of dofs (total):                    256
+Velocity:
+  degree of 1D polynomials:                  3
+  number of dofs per cell:                   32
+  number of dofs (total):                    512
+Pressure and velocity:
+  number of dofs per cell:                   48
+  number of dofs (total):                    768
 
 ... done!
 
@@ -325,6 +358,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  4
+  number of dofs per cell:                   25
+  number of dofs (total):                    400
+Velocity:
+  degree of 1D polynomials:                  4
+  number of dofs per cell:                   50
+  number of dofs (total):                    800
+Pressure and velocity:
+  number of dofs per cell:                   75
+  number of dofs (total):                    1200
 
 ... done!
 
@@ -415,6 +459,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   36
+  number of dofs (total):                    576
+Velocity:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   72
+  number of dofs (total):                    1152
+Pressure and velocity:
+  number of dofs per cell:                   108
+  number of dofs (total):                    1728
 
 ... done!
 
@@ -505,6 +560,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  6
+  number of dofs per cell:                   49
+  number of dofs (total):                    784
+Velocity:
+  degree of 1D polynomials:                  6
+  number of dofs per cell:                   98
+  number of dofs (total):                    1568
+Pressure and velocity:
+  number of dofs per cell:                   147
+  number of dofs (total):                    2352
 
 ... done!
 
@@ -595,6 +661,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   64
+  number of dofs (total):                    1024
+Velocity:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   128
+  number of dofs (total):                    2048
+Pressure and velocity:
+  number of dofs per cell:                   192
+  number of dofs (total):                    3072
 
 ... done!
 

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
@@ -55,6 +55,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  1
+  number of dofs per cell:                   4
+  number of dofs (total):                    64
+Velocity:
+  degree of 1D polynomials:                  1
+  number of dofs per cell:                   8
+  number of dofs (total):                    128
+Pressure and velocity:
+  number of dofs per cell:                   12
+  number of dofs (total):                    192
 
 ... done!
 
@@ -145,6 +156,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   9
+  number of dofs (total):                    144
+Velocity:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   18
+  number of dofs (total):                    288
+Pressure and velocity:
+  number of dofs per cell:                   27
+  number of dofs (total):                    432
 
 ... done!
 
@@ -235,6 +257,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  3
+  number of dofs per cell:                   16
+  number of dofs (total):                    256
+Velocity:
+  degree of 1D polynomials:                  3
+  number of dofs per cell:                   32
+  number of dofs (total):                    512
+Pressure and velocity:
+  number of dofs per cell:                   48
+  number of dofs (total):                    768
 
 ... done!
 
@@ -325,6 +358,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  4
+  number of dofs per cell:                   25
+  number of dofs (total):                    400
+Velocity:
+  degree of 1D polynomials:                  4
+  number of dofs per cell:                   50
+  number of dofs (total):                    800
+Pressure and velocity:
+  number of dofs per cell:                   75
+  number of dofs (total):                    1200
 
 ... done!
 
@@ -415,6 +459,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   36
+  number of dofs (total):                    576
+Velocity:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   72
+  number of dofs (total):                    1152
+Pressure and velocity:
+  number of dofs per cell:                   108
+  number of dofs (total):                    1728
 
 ... done!
 
@@ -505,6 +560,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  6
+  number of dofs per cell:                   49
+  number of dofs (total):                    784
+Velocity:
+  degree of 1D polynomials:                  6
+  number of dofs per cell:                   98
+  number of dofs (total):                    1568
+Pressure and velocity:
+  number of dofs per cell:                   147
+  number of dofs (total):                    2352
 
 ... done!
 
@@ -595,6 +661,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   64
+  number of dofs (total):                    1024
+Velocity:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   128
+  number of dofs (total):                    2048
+Pressure and velocity:
+  number of dofs per cell:                   192
+  number of dofs (total):                    3072
 
 ... done!
 

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -55,6 +55,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  1
+  number of dofs per cell:                   4
+  number of dofs (total):                    64
+Velocity:
+  degree of 1D polynomials:                  1
+  number of dofs per cell:                   8
+  number of dofs (total):                    128
+Pressure and velocity:
+  number of dofs per cell:                   12
+  number of dofs (total):                    192
 
 ... done!
 
@@ -145,6 +156,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   9
+  number of dofs (total):                    144
+Velocity:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   18
+  number of dofs (total):                    288
+Pressure and velocity:
+  number of dofs per cell:                   27
+  number of dofs (total):                    432
 
 ... done!
 
@@ -235,6 +257,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  3
+  number of dofs per cell:                   16
+  number of dofs (total):                    256
+Velocity:
+  degree of 1D polynomials:                  3
+  number of dofs per cell:                   32
+  number of dofs (total):                    512
+Pressure and velocity:
+  number of dofs per cell:                   48
+  number of dofs (total):                    768
 
 ... done!
 
@@ -325,6 +358,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  4
+  number of dofs per cell:                   25
+  number of dofs (total):                    400
+Velocity:
+  degree of 1D polynomials:                  4
+  number of dofs per cell:                   50
+  number of dofs (total):                    800
+Pressure and velocity:
+  number of dofs per cell:                   75
+  number of dofs (total):                    1200
 
 ... done!
 
@@ -415,6 +459,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   36
+  number of dofs (total):                    576
+Velocity:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   72
+  number of dofs (total):                    1152
+Pressure and velocity:
+  number of dofs per cell:                   108
+  number of dofs (total):                    1728
 
 ... done!
 
@@ -505,6 +560,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  6
+  number of dofs per cell:                   49
+  number of dofs (total):                    784
+Velocity:
+  degree of 1D polynomials:                  6
+  number of dofs per cell:                   98
+  number of dofs (total):                    1568
+Pressure and velocity:
+  number of dofs per cell:                   147
+  number of dofs (total):                    2352
 
 ... done!
 
@@ -595,6 +661,17 @@ Generating grid for 2-dimensional problem:
   Number of cells:                           16
 
 Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   64
+  number of dofs (total):                    1024
+Velocity:
+  degree of 1D polynomials:                  7
+  number of dofs per cell:                   128
+  number of dofs (total):                    2048
+Pressure and velocity:
+  number of dofs per cell:                   192
+  number of dofs (total):                    3072
 
 ... done!
 

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -336,6 +336,29 @@ SpatialOperator<dim, Number>::initialize_dof_handler_and_constraints()
   // enumerate degrees of freedom
   dof_handler_p.distribute_dofs(*fe_p);
   dof_handler_u.distribute_dofs(*fe_u);
+
+  // close constraints
+  constraint_u.close();
+  constraint_p.close();
+
+  // Output DoF information
+  pcout << "Pressure:" << std::endl;
+  print_parameter(pcout, "degree of 1D polynomials", param.degree_p);
+  print_parameter(pcout, "number of dofs per cell", fe_p->n_dofs_per_cell());
+  print_parameter(pcout, "number of dofs (total)", dof_handler_p.n_dofs());
+
+  pcout << "Velocity:" << std::endl;
+  print_parameter(pcout, "degree of 1D polynomials", param.degree_u);
+  print_parameter(pcout, "number of dofs per cell", fe_u->n_dofs_per_cell());
+  print_parameter(pcout, "number of dofs (total)", dof_handler_u.n_dofs());
+
+  pcout << "Pressure and velocity:" << std::endl;
+  print_parameter(pcout,
+                  "number of dofs per cell",
+                  fe_p->n_dofs_per_cell() + fe_u->n_dofs_per_cell());
+  print_parameter(pcout, "number of dofs (total)", get_number_of_dofs());
+
+  pcout << std::flush;
 }
 
 template<int dim, typename Number>


### PR DESCRIPTION
During `initialize_dof_handler_and_constraints()` I forgot to close the constraints. Also, it is helpful to print the information about the DoFs.