### PR TITLE
shift mapping/coarse_mappings to Grid class?

### DIFF
--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -126,10 +126,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -175,10 +175,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -187,10 +187,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -142,10 +142,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -165,10 +165,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -115,10 +115,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/applications/convection_diffusion/template/application.h
+++ b/applications/convection_diffusion/template/application.h
@@ -65,10 +65,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -116,10 +116,8 @@ private:
   }
 
   void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  create_grid(Grid<dim> & grid) final
   {
-    (void)mapping;
-
     auto const lambda_create_triangulation =
       [&](dealii::Triangulation<dim, dim> &                        tria,
           std::vector<dealii::GridTools::PeriodicFacePair<

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -58,17 +58,15 @@ Driver<dim, Number>::setup()
 
   pcout << std::endl << "Setting up scalar convection-diffusion solver:" << std::endl;
 
-  application->setup(grid, grid->mapping);
+  grid = std::make_shared<Grid<dim>>();
+  application->setup(grid);
 
   if(application->get_parameters().ale_formulation) // moving mesh
   {
-    // store static mapping
-    static_mapping = grid->mapping;
-
     std::shared_ptr<dealii::Function<dim>> mesh_motion =
       application->create_mesh_movement_function();
     ale_mapping = std::make_shared<DeformedMappingFunction<dim, Number>>(
-      static_mapping,
+      grid->mapping,
       application->get_parameters().degree,
       *grid->triangulation,
       mesh_motion,
@@ -92,7 +90,6 @@ Driver<dim, Number>::setup()
 
   // initialize convection-diffusion operator
   pde_operator = std::make_shared<Operator<dim, Number>>(grid,
-                                                         grid->mapping,
                                                          application->get_boundary_descriptor(),
                                                          application->get_field_functions(),
                                                          application->get_parameters(),

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -108,8 +108,6 @@ private:
   // Grid and mapping
   std::shared_ptr<Grid<dim>> grid;
 
-  std::shared_ptr<dealii::Mapping<dim>> static_mapping;
-
   // ALE mapping
   std::shared_ptr<DeformedMappingFunction<dim, Number>> ale_mapping;
 

--- a/include/exadg/convection_diffusion/driver.h
+++ b/include/exadg/convection_diffusion/driver.h
@@ -108,7 +108,7 @@ private:
   // Grid and mapping
   std::shared_ptr<Grid<dim>> grid;
 
-  std::shared_ptr<dealii::Mapping<dim>> mapping;
+  std::shared_ptr<dealii::Mapping<dim>> static_mapping;
 
   // ALE mapping
   std::shared_ptr<DeformedMappingFunction<dim, Number>> ale_mapping;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -44,7 +44,6 @@ namespace ConvDiff
 template<int dim, typename Number>
 Operator<dim, Number>::Operator(
   std::shared_ptr<Grid<dim> const>               grid_in,
-  std::shared_ptr<dealii::Mapping<dim> const>    mapping_in,
   std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor_in,
   std::shared_ptr<FieldFunctions<dim> const>     field_functions_in,
   Parameters const &                             param_in,
@@ -52,7 +51,6 @@ Operator<dim, Number>::Operator(
   MPI_Comm const &                               mpi_comm_in)
   : dealii::Subscriptor(),
     grid(grid_in),
-    mapping(mapping_in),
     boundary_descriptor(boundary_descriptor_in),
     field_functions(field_functions_in),
     param(param_in),
@@ -1024,7 +1022,7 @@ template<int dim, typename Number>
 std::shared_ptr<dealii::Mapping<dim> const>
 Operator<dim, Number>::get_mapping() const
 {
-  return mapping;
+  return grid->mapping;
 }
 
 template class Operator<2, float>;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -54,7 +54,6 @@ public:
    * Constructor.
    */
   Operator(std::shared_ptr<Grid<dim> const>               grid,
-           std::shared_ptr<dealii::Mapping<dim> const>    mapping,
            std::shared_ptr<BoundaryDescriptor<dim> const> boundary_descriptor,
            std::shared_ptr<FieldFunctions<dim> const>     field_functions,
            Parameters const &                             param,
@@ -339,11 +338,6 @@ private:
    * Grid
    */
   std::shared_ptr<Grid<dim> const> grid;
-
-  /*
-   * Grid motion for ALE formulations
-   */
-  std::shared_ptr<dealii::Mapping<dim> const> mapping;
 
   /*
    * User interface: Boundary conditions and field functions.

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -82,7 +82,7 @@ public:
   }
 
   void
-  setup(std::shared_ptr<Grid<dim>> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping)
+  setup(std::shared_ptr<Grid<dim>> & grid)
   {
     parse_parameters();
 
@@ -92,9 +92,8 @@ public:
     param.print(pcout, "List of parameters:");
 
     // grid
-    GridUtilities::create_mapping(mapping, param.grid.element_type, param.mapping_degree);
-    grid = std::make_shared<Grid<dim>>();
-    create_grid(*grid, mapping);
+    GridUtilities::create_mapping(grid->mapping, param.grid.element_type, param.mapping_degree);
+    create_grid(*grid);
     print_grid_info(pcout, *grid);
 
     // boundary conditions
@@ -166,7 +165,7 @@ private:
   set_parameters() = 0;
 
   virtual void
-  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) = 0;
+  create_grid(Grid<dim> & grid) = 0;
 
   virtual void
   set_boundary_descriptor() = 0;

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -49,6 +49,11 @@ public:
   std::shared_ptr<dealii::Triangulation<dim>> triangulation;
 
   /**
+   * dealii::Mapping
+   */
+  std::shared_ptr<dealii::Mapping<dim>> mapping;
+
+  /**
    * dealii::GridTools::PeriodicFacePair's.
    */
   PeriodicFacePairs periodic_face_pairs;

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -143,7 +143,6 @@ Driver<dim, Number>::setup()
   {
     scalar_operator[i] = std::make_shared<ConvDiff::Operator<dim, Number>>(
       application->fluid->get_grid(),
-      dynamic_mapping,
       application->scalars[i]->get_boundary_descriptor(),
       application->scalars[i]->get_field_functions(),
       application->scalars[i]->get_parameters(),


### PR DESCRIPTION
Discussion with @richardschu on adaptive mesh refinement (#586) let us rethink whether we should shift `mapping` and `coarse_mappings` to the `Grid` class. Note that the `Grid` and `Mapping` objects have been shifted recently to the `Driver` class for the `ConvDiff` module in PR #596, the motivation behind again being adaptive mesh refinement. Further, note that `coarse_triangulations` is already a member variable of `Grid`. `coarse_mappings` currently lives in `MultigridPreconditioner`. However, several multigrid preconditioners might require the same `coarse_mappings`. So the idea would be to have this variable once at a central place. In case of grid manipulations (like ALE and adaptive mesh refinement), we further believe to have better control over these data structures in the `Driver` class (which owns these objects) rather than somewhat deeper in the code e.g. in the `MultigridPreconditioner`.

The first commit shows the basic idea for the `ConvDiff` module (which supports e.g. also ALE functionality), where I did not touch `coarse_mappings` so far. Of course, function calls like `setup(grid, grid->mapping)` can now be simplified to `setup(grid)`.