### PR TITLE
add asserts related to fullydistributed::Triangulation

### DIFF
--- a/applications/acoustic_conservation_equations/throughput/application.h
+++ b/applications/acoustic_conservation_equations/throughput/application.h
@@ -86,24 +86,41 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const & /* vector_local_refinements*/) {
-        double const left = -1.0, right = 1.0;
-        double const deformation = 0.1;
+    auto const lambda_create_triangulation = [&](
+                                               dealii::Triangulation<dim, dim> & tria,
+                                               std::vector<dealii::GridTools::PeriodicFacePair<
+                                                 typename dealii::Triangulation<
+                                                   dim>::cell_iterator>> & periodic_face_pairs,
+                                               unsigned int const          global_refinements,
+                                               std::vector<
+                                                 unsigned int> const & /* vector_local_refinements*/) {
+      double const left = -1.0, right = 1.0;
+      double const deformation = 0.1;
 
-        create_periodic_box(tria,
-                            global_refinements,
-                            periodic_face_pairs,
-                            this->n_subdivisions_1d_hypercube,
-                            left,
-                            right,
-                            mesh_type == MeshType::Curvilinear,
-                            deformation);
-      };
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+      }
+
+      create_periodic_box(tria,
+                          global_refinements,
+                          periodic_face_pairs,
+                          this->n_subdivisions_1d_hypercube,
+                          left,
+                          right,
+                          mesh_type == MeshType::Curvilinear,
+                          deformation);
+    };
 
     GridUtilities::create_triangulation<dim>(
       grid, this->mpi_comm, this->param.grid, lambda_create_triangulation, {});

--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -177,60 +177,67 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        std::vector<unsigned int> repetitions({2, 1});
-        dealii::Point<dim>        point1(0.0, 0.0), point2(L, H);
-        dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
+      std::vector<unsigned int> repetitions({2, 1});
+      dealii::Point<dim>        point1(0.0, 0.0), point2(L, H);
+      dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
 
-        // indicator
-        // fixed wall = 0
-        // moving wall = 1
-        /*
-         *             indicator = 1
-         *   ___________________________________
-         *   |             --->                 |
-         *   |                                  |
-         *   | <---- periodic B.C.  --------->  |
-         *   |                                  |
-         *   |                                  |
-         *   |__________________________________|
-         *             indicator = 0
-         */
-        for(auto cell : tria)
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      // indicator
+      // fixed wall = 0
+      // moving wall = 1
+      /*
+       *             indicator = 1
+       *   ___________________________________
+       *   |             --->                 |
+       *   |                                  |
+       *   | <---- periodic B.C.  --------->  |
+       *   |                                  |
+       *   |                                  |
+       *   |__________________________________|
+       *             indicator = 0
+       */
+      for(auto cell : tria)
+      {
+        for(auto const & face : cell.face_indices())
         {
-          for(auto const & face : cell.face_indices())
+          if(std::fabs(cell.face(face)->center()(1) - point2[1]) < 1e-12)
           {
-            if(std::fabs(cell.face(face)->center()(1) - point2[1]) < 1e-12)
-            {
-              cell.face(face)->set_boundary_id(1);
-            }
-            else if(std::fabs(cell.face(face)->center()(1) - 0.0) < 1e-12)
-            {
-              cell.face(face)->set_boundary_id(0);
-            }
-            else if(std::fabs(cell.face(face)->center()(0) - 0.0) < 1e-12)
-            {
-              cell.face(face)->set_boundary_id(0 + 10);
-            }
-            else if(std::fabs(cell.face(face)->center()(0) - point2[0]) < 1e-12)
-            {
-              cell.face(face)->set_boundary_id(1 + 10);
-            }
+            cell.face(face)->set_boundary_id(1);
+          }
+          else if(std::fabs(cell.face(face)->center()(1) - 0.0) < 1e-12)
+          {
+            cell.face(face)->set_boundary_id(0);
+          }
+          else if(std::fabs(cell.face(face)->center()(0) - 0.0) < 1e-12)
+          {
+            cell.face(face)->set_boundary_id(0 + 10);
+          }
+          else if(std::fabs(cell.face(face)->center()(0) - point2[0]) < 1e-12)
+          {
+            cell.face(face)->set_boundary_id(1 + 10);
           }
         }
+      }
 
-        dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
-        tria.add_periodicity(periodic_face_pairs);
+      dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
+      tria.add_periodicity(periodic_face_pairs);
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation<dim>(grid,
                                              this->mpi_comm,

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -201,27 +201,43 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        double const pi   = dealii::numbers::PI;
-        double const left = -pi * L, right = pi * L;
-        double const deformation = 0.1;
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        create_periodic_box(tria,
-                            global_refinements,
-                            periodic_face_pairs,
-                            this->n_subdivisions_1d_hypercube,
-                            left,
-                            right,
-                            mesh_type == MeshType::Curvilinear,
-                            deformation);
-      };
+      if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+      }
+
+      double const pi   = dealii::numbers::PI;
+      double const left = -pi * L, right = pi * L;
+      double const deformation = 0.1;
+
+      create_periodic_box(tria,
+                          global_refinements,
+                          periodic_face_pairs,
+                          this->n_subdivisions_1d_hypercube,
+                          left,
+                          right,
+                          mesh_type == MeshType::Curvilinear,
+                          deformation);
+    };
 
     GridUtilities::create_triangulation<dim>(grid,
                                              this->mpi_comm,

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -120,41 +120,43 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        double const left = -1.0, right = 1.0;
-        double const deformation = 0.1;
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        bool curvilinear_mesh = false;
-        if(mesh_type == MeshType::Cartesian)
-        {
-          // do nothing
-        }
-        else if(mesh_type == MeshType::Curvilinear)
-        {
-          curvilinear_mesh = true;
-        }
-        else
-        {
-          AssertThrow(false, dealii::ExcMessage("Not implemented."));
-        }
+      if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+      }
 
-        create_periodic_box(tria,
-                            global_refinements,
-                            periodic_face_pairs,
-                            this->n_subdivisions_1d_hypercube,
-                            left,
-                            right,
-                            curvilinear_mesh,
-                            deformation);
-      };
+      double const left = -1.0, right = 1.0;
+      double const deformation = 0.1;
+
+      create_periodic_box(tria,
+                          global_refinements,
+                          periodic_face_pairs,
+                          this->n_subdivisions_1d_hypercube,
+                          left,
+                          right,
+                          mesh_type == MeshType::Cartesian,
+                          deformation);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -410,112 +410,119 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        create_triangulation(tria);
+      create_triangulation(tria);
 
-        tria.set_all_manifold_ids(0);
+      tria.set_all_manifold_ids(0);
 
-        // vectors of manifold_ids and face_ids
-        unsigned int const        manifold_id_start = 10;
-        std::vector<unsigned int> manifold_ids;
-        std::vector<unsigned int> face_ids;
+      // vectors of manifold_ids and face_ids
+      unsigned int const        manifold_id_start = 10;
+      std::vector<unsigned int> manifold_ids;
+      std::vector<unsigned int> face_ids;
 
-        dealii::Point<dim> center;
-        center[0] = X_C;
-        center[1] = Y_C;
+      dealii::Point<dim> center;
+      center[0] = X_C;
+      center[1] = Y_C;
 
-        for(auto cell : tria.cell_iterators())
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      for(auto cell : tria.cell_iterators())
+      {
+        double const TOL = 1.e-12;
+
+        // boundary IDs
+        for(auto const & f : cell->face_indices())
         {
-          double const TOL = 1.e-12;
+          double const x = cell->face(f)->center()(0);
+          double const y = cell->face(f)->center()(1);
 
-          // boundary IDs
-          for(auto const & f : cell->face_indices())
+          if(std::fabs(y - Y_0) < TOL or std::fabs(y - H) < TOL)
           {
-            double const x = cell->face(f)->center()(0);
-            double const y = cell->face(f)->center()(1);
-
-            if(std::fabs(y - Y_0) < TOL or std::fabs(y - H) < TOL)
-            {
-              cell->face(f)->set_boundary_id(BOUNDARY_ID_WALLS);
-            }
-
-            if(std::fabs(x - X_0) < TOL)
-            {
-              cell->face(f)->set_boundary_id(BOUNDARY_ID_INFLOW);
-            }
-
-            if(std::fabs(x - L) < TOL)
-            {
-              cell->face(f)->set_boundary_id(BOUNDARY_ID_OUTFLOW);
-            }
-
-            if(std::fabs(cell->face(f)->center().distance(center)) < R + TOL)
-            {
-              cell->face(f)->set_boundary_id(BOUNDARY_ID_CYLINDER);
-            }
-
-            if(std::fabs(y - (Y_C - T / 2.0)) < TOL or std::fabs(y - (Y_C + T / 2.0)) < TOL or
-               (std::fabs(y - Y_C) < T / 2.0 + TOL and std::fabs(x - (X_C + R + L_FLAG)) < TOL))
-            {
-              cell->face(f)->set_boundary_id(BOUNDARY_ID_FLAG);
-            }
+            cell->face(f)->set_boundary_id(BOUNDARY_ID_WALLS);
           }
 
-          // manifold IDs
-          for(auto const & f : cell->face_indices())
+          if(std::fabs(x - X_0) < TOL)
           {
-            if(cell->face(f)->at_boundary())
-            {
-              bool face_at_sphere_boundary = true;
-              for(auto const & v : cell->face(f)->vertex_indices())
-              {
-                if(std::abs(center.distance(cell->face(f)->vertex(v)) - R) > TOL)
-                {
-                  face_at_sphere_boundary = false;
-                  break;
-                }
-              }
+            cell->face(f)->set_boundary_id(BOUNDARY_ID_INFLOW);
+          }
 
-              if(face_at_sphere_boundary)
+          if(std::fabs(x - L) < TOL)
+          {
+            cell->face(f)->set_boundary_id(BOUNDARY_ID_OUTFLOW);
+          }
+
+          if(std::fabs(cell->face(f)->center().distance(center)) < R + TOL)
+          {
+            cell->face(f)->set_boundary_id(BOUNDARY_ID_CYLINDER);
+          }
+
+          if(std::fabs(y - (Y_C - T / 2.0)) < TOL or std::fabs(y - (Y_C + T / 2.0)) < TOL or
+             (std::fabs(y - Y_C) < T / 2.0 + TOL and std::fabs(x - (X_C + R + L_FLAG)) < TOL))
+          {
+            cell->face(f)->set_boundary_id(BOUNDARY_ID_FLAG);
+          }
+        }
+
+        // manifold IDs
+        for(auto const & f : cell->face_indices())
+        {
+          if(cell->face(f)->at_boundary())
+          {
+            bool face_at_sphere_boundary = true;
+            for(auto const & v : cell->face(f)->vertex_indices())
+            {
+              if(std::abs(center.distance(cell->face(f)->vertex(v)) - R) > TOL)
               {
-                face_ids.push_back(f);
-                unsigned int manifold_id = manifold_id_start + manifold_ids.size() + 1;
-                cell->set_all_manifold_ids(manifold_id);
-                manifold_ids.push_back(manifold_id);
+                face_at_sphere_boundary = false;
                 break;
               }
             }
-          }
-        }
 
-        // generate vector of manifolds and apply manifold to all cells that have been marked
-        static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
-        manifold_vec.resize(manifold_ids.size());
-
-        for(unsigned int i = 0; i < manifold_ids.size(); ++i)
-        {
-          for(auto cell : tria.cell_iterators())
-          {
-            if(cell->manifold_id() == manifold_ids[i])
+            if(face_at_sphere_boundary)
             {
-              manifold_vec[i] =
-                std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
-                  new OneSidedCylindricalManifold<dim>(tria, cell, face_ids[i], center)));
-              tria.set_manifold(manifold_ids[i], *(manifold_vec[i]));
+              face_ids.push_back(f);
+              unsigned int manifold_id = manifold_id_start + manifold_ids.size() + 1;
+              cell->set_all_manifold_ids(manifold_id);
+              manifold_ids.push_back(manifold_id);
+              break;
             }
           }
         }
+      }
 
-        tria.refine_global(global_refinements);
-      };
+      // generate vector of manifolds and apply manifold to all cells that have been marked
+      std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
+      manifold_vec.resize(manifold_ids.size());
+
+      for(unsigned int i = 0; i < manifold_ids.size(); ++i)
+      {
+        for(auto cell : tria.cell_iterators())
+        {
+          if(cell->manifold_id() == manifold_ids[i])
+          {
+            manifold_vec[i] =
+              std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
+                new OneSidedCylindricalManifold<dim>(tria, cell, face_ids[i], center)));
+            tria.set_manifold(manifold_ids[i], *(manifold_vec[i]));
+          }
+        }
+      }
+
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
@@ -948,108 +955,115 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        create_triangulation_structure(tria);
+      create_triangulation_structure(tria);
 
-        tria.set_all_manifold_ids(0);
+      tria.set_all_manifold_ids(0);
 
-        // vectors of manifold_ids and face_ids
-        unsigned int const        manifold_id_start = 10;
-        std::vector<unsigned int> manifold_ids;
-        std::vector<unsigned int> face_ids;
+      // vectors of manifold_ids and face_ids
+      unsigned int const        manifold_id_start = 10;
+      std::vector<unsigned int> manifold_ids;
+      std::vector<unsigned int> face_ids;
 
-        dealii::Point<dim> center;
-        center[0] = X_C;
-        center[1] = Y_C;
+      dealii::Point<dim> center;
+      center[0] = X_C;
+      center[1] = Y_C;
 
-        for(auto cell : tria.cell_iterators())
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      for(auto cell : tria.cell_iterators())
+      {
+        double const TOL = 1.e-12;
+
+        // boundary IDs
+        for(auto const & f : cell->face_indices())
         {
-          double const TOL = 1.e-12;
+          double const x = cell->face(f)->center()(0);
 
-          // boundary IDs
-          for(auto const & f : cell->face_indices())
+          if(cell->face(f)->at_boundary())
           {
-            double const x = cell->face(f)->center()(0);
-
-            if(cell->face(f)->at_boundary())
+            if(STRUCTURE_COVERS_FLAG_ONLY)
             {
-              if(STRUCTURE_COVERS_FLAG_ONLY)
+              if(x < X_C + R * std::cos(std::asin(T / (2.0 * R))) + TOL)
               {
-                if(x < X_C + R * std::cos(std::asin(T / (2.0 * R))) + TOL)
-                {
-                  cell->face(f)->set_boundary_id(BOUNDARY_ID_CYLINDER);
-                }
-              }
-              else
-              {
-                if(x < X_C + R * std::cos(std::asin(T / (2.0 * R))))
-                {
-                  cell->face(f)->set_boundary_id(BOUNDARY_ID_CYLINDER);
-                }
-              }
-
-              if(x > X_C + R * std::cos(std::asin(T / (2.0 * R))))
-              {
-                cell->face(f)->set_boundary_id(BOUNDARY_ID_FLAG);
+                cell->face(f)->set_boundary_id(BOUNDARY_ID_CYLINDER);
               }
             }
-          }
-
-          // manifold IDs
-          for(auto const & f : cell->face_indices())
-          {
-            if(cell->face(f)->at_boundary())
+            else
             {
-              bool face_at_sphere_boundary = true;
-              for(auto const & v : cell->face(f)->vertex_indices())
+              if(x < X_C + R * std::cos(std::asin(T / (2.0 * R))))
               {
-                if(std::abs(center.distance(cell->face(f)->vertex(v)) - R) > TOL)
-                {
-                  face_at_sphere_boundary = false;
-                  break;
-                }
+                cell->face(f)->set_boundary_id(BOUNDARY_ID_CYLINDER);
               }
+            }
 
-              if(face_at_sphere_boundary)
+            if(x > X_C + R * std::cos(std::asin(T / (2.0 * R))))
+            {
+              cell->face(f)->set_boundary_id(BOUNDARY_ID_FLAG);
+            }
+          }
+        }
+
+        // manifold IDs
+        for(auto const & f : cell->face_indices())
+        {
+          if(cell->face(f)->at_boundary())
+          {
+            bool face_at_sphere_boundary = true;
+            for(auto const & v : cell->face(f)->vertex_indices())
+            {
+              if(std::abs(center.distance(cell->face(f)->vertex(v)) - R) > TOL)
               {
-                face_ids.push_back(f);
-                unsigned int manifold_id = manifold_id_start + manifold_ids.size() + 1;
-                cell->set_all_manifold_ids(manifold_id);
-                manifold_ids.push_back(manifold_id);
+                face_at_sphere_boundary = false;
                 break;
               }
             }
-          }
-        }
 
-        // generate vector of manifolds and apply manifold to all cells that have been marked
-        static std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
-        manifold_vec.resize(manifold_ids.size());
-
-        for(unsigned int i = 0; i < manifold_ids.size(); ++i)
-        {
-          for(auto cell : tria.cell_iterators())
-          {
-            if(cell->manifold_id() == manifold_ids[i])
+            if(face_at_sphere_boundary)
             {
-              manifold_vec[i] =
-                std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
-                  new OneSidedCylindricalManifold<dim>(tria, cell, face_ids[i], center)));
-              tria.set_manifold(manifold_ids[i], *(manifold_vec[i]));
+              face_ids.push_back(f);
+              unsigned int manifold_id = manifold_id_start + manifold_ids.size() + 1;
+              cell->set_all_manifold_ids(manifold_id);
+              manifold_ids.push_back(manifold_id);
+              break;
             }
           }
         }
+      }
 
-        tria.refine_global(global_refinements);
-      };
+      // generate vector of manifolds and apply manifold to all cells that have been marked
+      std::vector<std::shared_ptr<dealii::Manifold<dim>>> manifold_vec;
+      manifold_vec.resize(manifold_ids.size());
+
+      for(unsigned int i = 0; i < manifold_ids.size(); ++i)
+      {
+        for(auto cell : tria.cell_iterators())
+        {
+          if(cell->manifold_id() == manifold_ids[i])
+          {
+            manifold_vec[i] =
+              std::shared_ptr<dealii::Manifold<dim>>(static_cast<dealii::Manifold<dim> *>(
+                new OneSidedCylindricalManifold<dim>(tria, cell, face_ids[i], center)));
+            tria.set_manifold(manifold_ids[i], *(manifold_vec[i]));
+          }
+        }
+      }
+
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -268,45 +268,51 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        dealii::GridGenerator::hyper_shell(
-          tria, dealii::Point<dim>(), R0, R1, (dim == 3) ? 48 : 12);
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        dealii::Point<dim> center =
-          dim == 2 ? dealii::Point<dim>(0., 0.) : dealii::Point<dim>(0., 0., 0.);
+      dealii::GridGenerator::hyper_shell(tria, dealii::Point<dim>(), R0, R1, (dim == 3) ? 48 : 12);
 
-        for(auto cell : tria.cell_iterators())
+      dealii::Point<dim> center =
+        dim == 2 ? dealii::Point<dim>(0., 0.) : dealii::Point<dim>(0., 0., 0.);
+
+      for(auto cell : tria.cell_iterators())
+      {
+        for(auto const & f : cell->face_indices())
         {
-          for(auto const & f : cell->face_indices())
+          if(cell->face(f)->at_boundary())
           {
-            if(cell->face(f)->at_boundary())
+            bool face_at_outer_boundary = true;
+            for(auto const & v : cell->face(f)->vertex_indices())
             {
-              bool face_at_outer_boundary = true;
-              for(auto const & v : cell->face(f)->vertex_indices())
+              if(std::abs(center.distance(cell->face(f)->vertex(v)) - R1) > 1e-12 * R1)
               {
-                if(std::abs(center.distance(cell->face(f)->vertex(v)) - R1) > 1e-12 * R1)
-                {
-                  face_at_outer_boundary = false;
-                  break;
-                }
+                face_at_outer_boundary = false;
+                break;
               }
-
-              if(face_at_outer_boundary)
-                cell->face(f)->set_boundary_id(1);
             }
+
+            if(face_at_outer_boundary)
+              cell->face(f)->set_boundary_id(1);
           }
         }
+      }
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -240,65 +240,72 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        if(dim == 2)
-        {
-          std::vector<unsigned int> repetitions({8, 1});
-          dealii::Point<dim>        point1(-L / 2., 0.0), point2(L / 2., H);
-          dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
-        }
-        else if(dim == 3)
-        {
-          std::vector<unsigned int> repetitions({8, 1, 8});
-          dealii::Point<dim>        point1(-L / 2., 0.0, -L / 2.), point2(L / 2., H, L / 2.);
-          dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
-        }
-        else
-        {
-          AssertThrow(false, dealii::ExcMessage("Not implemented."));
-        }
+      if(dim == 2)
+      {
+        std::vector<unsigned int> repetitions({8, 1});
+        dealii::Point<dim>        point1(-L / 2., 0.0), point2(L / 2., H);
+        dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
+      }
+      else if(dim == 3)
+      {
+        std::vector<unsigned int> repetitions({8, 1, 8});
+        dealii::Point<dim>        point1(-L / 2., 0.0, -L / 2.), point2(L / 2., H, L / 2.);
+        dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
+      }
+      else
+      {
+        AssertThrow(false, dealii::ExcMessage("Not implemented."));
+      }
 
-        // set boundary IDs: 0 by default, set left boundary to 1
-        for(auto cell : tria.cell_iterators())
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      // set boundary IDs: 0 by default, set left boundary to 1
+      for(auto cell : tria.cell_iterators())
+      {
+        for(auto const & f : cell->face_indices())
         {
-          for(auto const & f : cell->face_indices())
+          if((std::fabs(cell->face(f)->center()(1) - 0.0) < 1e-12))
+            cell->face(f)->set_boundary_id(1);
+
+          // periodicity in x-direction
+          if((std::fabs(cell->face(f)->center()(0) + L / 2.) < 1e-12))
+            cell->face(f)->set_boundary_id(10);
+          if((std::fabs(cell->face(f)->center()(0) - L / 2.) < 1e-12))
+            cell->face(f)->set_boundary_id(11);
+
+          // periodicity in z-direction
+          if(dim == 3)
           {
-            if((std::fabs(cell->face(f)->center()(1) - 0.0) < 1e-12))
-              cell->face(f)->set_boundary_id(1);
-
-            // periodicity in x-direction
-            if((std::fabs(cell->face(f)->center()(0) + L / 2.) < 1e-12))
-              cell->face(f)->set_boundary_id(10);
-            if((std::fabs(cell->face(f)->center()(0) - L / 2.) < 1e-12))
-              cell->face(f)->set_boundary_id(11);
-
-            // periodicity in z-direction
-            if(dim == 3)
-            {
-              if((std::fabs(cell->face(f)->center()(2) + L / 2.) < 1e-12))
-                cell->face(f)->set_boundary_id(12);
-              if((std::fabs(cell->face(f)->center()(2) - L / 2.) < 1e-12))
-                cell->face(f)->set_boundary_id(13);
-            }
+            if((std::fabs(cell->face(f)->center()(2) + L / 2.) < 1e-12))
+              cell->face(f)->set_boundary_id(12);
+            if((std::fabs(cell->face(f)->center()(2) - L / 2.) < 1e-12))
+              cell->face(f)->set_boundary_id(13);
           }
         }
+      }
 
-        dealii::GridTools::collect_periodic_faces(tria, 10, 11, 0, periodic_face_pairs);
-        if(dim == 3)
-          dealii::GridTools::collect_periodic_faces(tria, 12, 13, 2, periodic_face_pairs);
+      dealii::GridTools::collect_periodic_faces(tria, 10, 11, 0, periodic_face_pairs);
+      if(dim == 3)
+        dealii::GridTools::collect_periodic_faces(tria, 12, 13, 2, periodic_face_pairs);
 
-        tria.add_periodicity(periodic_face_pairs);
+      tria.add_periodicity(periodic_face_pairs);
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -257,17 +257,30 @@ public:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        Geometry::create_grid_precursor(tria, global_refinements, periodic_face_pairs);
-      };
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      Geometry::create_grid_precursor(tria, global_refinements, periodic_face_pairs);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
@@ -390,17 +403,30 @@ public:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        Geometry::create_grid(tria, global_refinements, periodic_face_pairs);
-      };
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      Geometry::create_grid(tria, global_refinements, periodic_face_pairs);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -278,18 +278,31 @@ public:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        FDANozzle::create_grid_and_set_boundary_ids_precursor(tria,
-                                                              global_refinements,
-                                                              periodic_face_pairs);
-      };
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      FDANozzle::create_grid_and_set_boundary_ids_precursor(tria,
+                                                            global_refinements,
+                                                            periodic_face_pairs);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,
@@ -430,18 +443,25 @@ public:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        FDANozzle::create_grid_and_set_boundary_ids_nozzle(tria,
-                                                           global_refinements,
-                                                           periodic_face_pairs);
-      };
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      FDANozzle::create_grid_and_set_boundary_ids_nozzle(tria,
+                                                         global_refinements,
+                                                         periodic_face_pairs);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -74,18 +74,25 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        FDANozzle::create_grid_and_set_boundary_ids_nozzle(tria,
-                                                           global_refinements,
-                                                           periodic_face_pairs);
-      };
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      FDANozzle::create_grid_and_set_boundary_ids_nozzle(tria,
+                                                         global_refinements,
+                                                         periodic_face_pairs);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -339,6 +339,7 @@ private:
           std::vector<unsigned int> const &                        vector_local_refinements) {
         create_coarse_grid<dim>(tria,
                                 periodic_face_pairs,
+                                this->param.grid.triangulation_type,
                                 cylinder_type,
                                 this->param.grid.element_type);
 

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
@@ -1461,6 +1461,7 @@ void
 create_coarse_grid(dealii::Triangulation<dim> &                             triangulation,
                    std::vector<dealii::GridTools::PeriodicFacePair<
                      typename dealii::Triangulation<dim>::cell_iterator>> & periodic_faces,
+                   TriangulationType const &                                triangulation_type,
                    CylinderType const                                       cylinder_type,
                    ElementType                                              element_type)
 {
@@ -1477,11 +1478,16 @@ create_coarse_grid(dealii::Triangulation<dim> &                             tria
   {
     case CylinderType::Circular:
     {
+      AssertThrow(element_type == ElementType::Hypercube,
+                  dealii::ExcMessage(
+                    "You are trying to create a non-Hypercube grid for the circular cylinder case, "
+                    "which is currently not supported."));
+
       AssertThrow(
-        element_type == ElementType::Hypercube,
+        triangulation_type != TriangulationType::FullyDistributed,
         dealii::ExcMessage(
-          "You are trying to create a grid with simplex elements for the circular cylinder case, "
-          "which is currently not supported."));
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
       CircularCylinder::create_coarse_triangulation<dim>(triangulation, periodic_faces);
       break;

--- a/applications/incompressible_navier_stokes/flow_past_sphere/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/application.h
@@ -279,7 +279,7 @@ public:
           std::vector<unsigned int> const &                        vector_local_refinements) {
         (void)periodic_face_pairs;
         (void)vector_local_refinements;
-        create_sphere_grid<dim>(tria, global_refinements);
+        create_sphere_grid<dim>(tria, global_refinements, this->param.grid.triangulation_type);
       };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,

--- a/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
@@ -115,8 +115,16 @@ private:
 
 template<int dim>
 void
-create_sphere_grid(dealii::Triangulation<dim> & tria, unsigned int const n_refinements)
+create_sphere_grid(dealii::Triangulation<dim> & tria,
+                   unsigned int const           n_refinements,
+                   TriangulationType const &    triangulation_type)
 {
+  AssertThrow(
+    triangulation_type != TriangulationType::FullyDistributed,
+    dealii::ExcMessage(
+      "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+      "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
   dealii::Triangulation<dim> tria1, tria2, tria3, tria4, tria_ser;
   dealii::GridGenerator::hyper_shell(tria1, dealii::Point<dim>(), radius, radius_next, 6);
   dealii::GridGenerator::hyper_shell(

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -198,39 +198,45 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        AssertThrow(dim == 2,
-                    dealii::ExcMessage("This application is only implemented for dim=2."));
+      AssertThrow(dim == 2, dealii::ExcMessage("This application is only implemented for dim=2."));
 
-        std::vector<unsigned int> repetitions({1, 1});
-        dealii::Point<dim>        point1(0.0, 0.0), point2(L, L);
-        dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
+      std::vector<unsigned int> repetitions({1, 1});
+      dealii::Point<dim>        point1(0.0, 0.0), point2(L, L);
+      dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
 
-        // periodicity in x-direction
-        for(auto cell : tria.cell_iterators())
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      // periodicity in x-direction
+      for(auto cell : tria.cell_iterators())
+      {
+        for(auto const & f : cell->face_indices())
         {
-          for(auto const & f : cell->face_indices())
-          {
-            if(std::fabs(cell->face(f)->center()(0) - 0.0) < 1e-12)
-              cell->face(f)->set_boundary_id(1);
-            if(std::fabs(cell->face(f)->center()(0) - L) < 1e-12)
-              cell->face(f)->set_boundary_id(2);
-          }
+          if(std::fabs(cell->face(f)->center()(0) - 0.0) < 1e-12)
+            cell->face(f)->set_boundary_id(1);
+          if(std::fabs(cell->face(f)->center()(0) - L) < 1e-12)
+            cell->face(f)->set_boundary_id(2);
         }
+      }
 
-        dealii::GridTools::collect_periodic_faces(tria, 1, 2, 0, periodic_face_pairs);
-        tria.add_periodicity(periodic_face_pairs);
+      dealii::GridTools::collect_periodic_faces(tria, 1, 2, 0, periodic_face_pairs);
+      tria.add_periodicity(periodic_face_pairs);
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -292,36 +292,43 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        std::vector<unsigned int> repetitions({1, 1});
-        dealii::Point<dim>        point1(0.0, -H), point2(L, H);
-        dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
+      std::vector<unsigned int> repetitions({1, 1});
+      dealii::Point<dim>        point1(0.0, -H), point2(L, H);
+      dealii::GridGenerator::subdivided_hyper_rectangle(tria, repetitions, point1, point2);
 
-        // periodicity in x-direction
-        for(auto cell : tria.cell_iterators())
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      // periodicity in x-direction
+      for(auto cell : tria.cell_iterators())
+      {
+        for(auto const & f : cell->face_indices())
         {
-          for(auto const & f : cell->face_indices())
-          {
-            if((std::fabs(cell->face(f)->center()(0) - 0.0) < 1e-12))
-              cell->face(f)->set_boundary_id(0 + 10);
-            if((std::fabs(cell->face(f)->center()(0) - L) < 1e-12))
-              cell->face(f)->set_boundary_id(1 + 10);
-          }
+          if((std::fabs(cell->face(f)->center()(0) - 0.0) < 1e-12))
+            cell->face(f)->set_boundary_id(0 + 10);
+          if((std::fabs(cell->face(f)->center()(0) - L) < 1e-12))
+            cell->face(f)->set_boundary_id(1 + 10);
         }
+      }
 
-        dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
-        tria.add_periodicity(periodic_face_pairs);
+      dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
+      tria.add_periodicity(periodic_face_pairs);
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -245,75 +245,88 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        dealii::Point<dim> p_1;
-        p_1[0] = 0.;
-        p_1[1] = H;
-        if(dim == 3)
-          p_1[2] = -width / 2.0;
+      dealii::Point<dim> p_1;
+      p_1[0] = 0.;
+      p_1[1] = H;
+      if(dim == 3)
+        p_1[2] = -width / 2.0;
 
-        dealii::Point<dim> p_2;
-        p_2[0] = length;
-        p_2[1] = H + height;
-        if(dim == 3)
-          p_2[2] = width / 2.0;
+      dealii::Point<dim> p_2;
+      p_2[0] = length;
+      p_2[1] = H + height;
+      if(dim == 3)
+        p_2[2] = width / 2.0;
 
-        // use 2 cells in x-direction on coarsest grid and 1 cell in y- and z-directions
-        std::vector<unsigned int> refinements(dim, 1);
-        refinements[0] = 2;
-        dealii::GridGenerator::subdivided_hyper_rectangle(tria, refinements, p_1, p_2);
+      // use 2 cells in x-direction on coarsest grid and 1 cell in y- and z-directions
+      std::vector<unsigned int> refinements(dim, 1);
+      refinements[0] = 2;
+      dealii::GridGenerator::subdivided_hyper_rectangle(tria, refinements, p_1, p_2);
 
-        // create hill by shifting y-coordinates of middle vertices by -H in y-direction
-        tria.last()->vertex(0)[1] = 0.;
-        if(dim == 3)
-          tria.last()->vertex(4)[1] = 0.;
+      // create hill by shifting y-coordinates of middle vertices by -H in y-direction
+      tria.last()->vertex(0)[1] = 0.;
+      if(dim == 3)
+        tria.last()->vertex(4)[1] = 0.;
 
-        // periodicity in x-direction (add 10 to avoid conflicts with dirichlet boundary, which is
-        // 0) make use of the fact that the mesh has only two elements
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
+      // periodicity in x-direction (add 10 to avoid conflicts with dirichlet boundary, which is
+      // 0) make use of the fact that the mesh has only two elements
+
+      // left element
+      tria.begin()->face(0)->set_all_boundary_ids(0 + 10);
+      // right element
+      tria.last()->face(1)->set_all_boundary_ids(1 + 10);
+
+      // periodicity in z-direction
+      if(dim == 3)
+      {
         // left element
-        tria.begin()->face(0)->set_all_boundary_ids(0 + 10);
+        tria.begin()->face(4)->set_all_boundary_ids(2 + 10);
+        tria.begin()->face(5)->set_all_boundary_ids(3 + 10);
         // right element
-        tria.last()->face(1)->set_all_boundary_ids(1 + 10);
+        tria.last()->face(4)->set_all_boundary_ids(4 + 10);
+        tria.last()->face(5)->set_all_boundary_ids(5 + 10);
+      }
 
-        // periodicity in z-direction
-        if(dim == 3)
-        {
-          // left element
-          tria.begin()->face(4)->set_all_boundary_ids(2 + 10);
-          tria.begin()->face(5)->set_all_boundary_ids(3 + 10);
-          // right element
-          tria.last()->face(4)->set_all_boundary_ids(4 + 10);
-          tria.last()->face(5)->set_all_boundary_ids(5 + 10);
-        }
+      dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
+      if(dim == 3)
+      {
+        dealii::GridTools::collect_periodic_faces(tria, 2 + 10, 3 + 10, 2, periodic_face_pairs);
+        dealii::GridTools::collect_periodic_faces(tria, 4 + 10, 5 + 10, 2, periodic_face_pairs);
+      }
 
-        dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
-        if(dim == 3)
-        {
-          dealii::GridTools::collect_periodic_faces(tria, 2 + 10, 3 + 10, 2, periodic_face_pairs);
-          dealii::GridTools::collect_periodic_faces(tria, 4 + 10, 5 + 10, 2, periodic_face_pairs);
-        }
+      tria.add_periodicity(periodic_face_pairs);
 
-        tria.add_periodicity(periodic_face_pairs);
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        unsigned int const manifold_id = 111;
-        tria.begin()->set_all_manifold_ids(manifold_id);
-        tria.last()->set_all_manifold_ids(manifold_id);
+      unsigned int const manifold_id = 111;
+      tria.begin()->set_all_manifold_ids(manifold_id);
+      tria.last()->set_all_manifold_ids(manifold_id);
 
-        static const PeriodicHillManifold<dim> manifold =
-          PeriodicHillManifold<dim>(H, length, height, grid_stretch_factor);
-        tria.set_manifold(manifold_id, manifold);
+      static const PeriodicHillManifold<dim> manifold =
+        PeriodicHillManifold<dim>(H, length, height, grid_stretch_factor);
+      tria.set_manifold(manifold_id, manifold);
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -164,31 +164,38 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        double const left = 0.0, right = 1.0;
-        dealii::GridGenerator::hyper_cube(tria, left, right);
+      double const left = 0.0, right = 1.0;
+      dealii::GridGenerator::hyper_cube(tria, left, right);
 
-        // use periodic boundary conditions
-        // x-direction
-        tria.begin()->face(0)->set_all_boundary_ids(0);
-        tria.begin()->face(1)->set_all_boundary_ids(1);
-        // y-direction
-        tria.begin()->face(2)->set_all_boundary_ids(2);
-        tria.begin()->face(3)->set_all_boundary_ids(3);
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        dealii::GridTools::collect_periodic_faces(tria, 0, 1, 0, periodic_face_pairs);
-        dealii::GridTools::collect_periodic_faces(tria, 2, 3, 1, periodic_face_pairs);
-        tria.add_periodicity(periodic_face_pairs);
+      // use periodic boundary conditions
+      // x-direction
+      tria.begin()->face(0)->set_all_boundary_ids(0);
+      tria.begin()->face(1)->set_all_boundary_ids(1);
+      // y-direction
+      tria.begin()->face(2)->set_all_boundary_ids(2);
+      tria.begin()->face(3)->set_all_boundary_ids(3);
 
-        tria.refine_global(global_refinements);
-      };
+      dealii::GridTools::collect_periodic_faces(tria, 0, 1, 0, periodic_face_pairs);
+      dealii::GridTools::collect_periodic_faces(tria, 2, 3, 1, periodic_face_pairs);
+      tria.add_periodicity(periodic_face_pairs);
+
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -303,51 +303,65 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        double const deformation = 0.5;
+      double const deformation = 0.5;
 
-        if(ALE)
+      if(ALE)
+      {
+        AssertThrow(mesh_type == MeshType::Cartesian,
+                    dealii::ExcMessage(
+                      "Taylor-Green vortex: Parameter mesh_type is invalid for ALE."));
+      }
+
+      if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+      }
+
+
+      if(exploit_symmetry == false) // periodic box
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+        create_periodic_box(tria,
+                            global_refinements,
+                            periodic_face_pairs,
+                            n_subdivisions_1d_hypercube,
+                            left,
+                            right,
+                            mesh_type == MeshType::Curvilinear,
+                            deformation);
+      }
+      else // symmetric box
+      {
+        dealii::GridGenerator::subdivided_hyper_cube(tria, n_subdivisions_1d_hypercube, 0.0, right);
+
+        if(mesh_type == MeshType::Curvilinear)
         {
-          AssertThrow(mesh_type == MeshType::Cartesian,
-                      dealii::ExcMessage(
-                        "Taylor-Green vortex: Parameter mesh_type is invalid for ALE."));
+          unsigned int const frequency = 2;
+
+          apply_deformed_cube_manifold(tria, 0.0, right, deformation, frequency);
         }
 
-        if(exploit_symmetry == false) // periodic box
-        {
-          create_periodic_box(tria,
-                              global_refinements,
-                              periodic_face_pairs,
-                              n_subdivisions_1d_hypercube,
-                              left,
-                              right,
-                              mesh_type == MeshType::Curvilinear,
-                              deformation);
-        }
-        else // symmetric box
-        {
-          dealii::GridGenerator::subdivided_hyper_cube(tria,
-                                                       n_subdivisions_1d_hypercube,
-                                                       0.0,
-                                                       right);
-
-          if(mesh_type == MeshType::Curvilinear)
-          {
-            unsigned int const frequency = 2;
-
-            apply_deformed_cube_manifold(tria, 0.0, right, deformation, frequency);
-          }
-
-          tria.refine_global(global_refinements);
-        }
-      };
+        tria.refine_global(global_refinements);
+      }
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -156,26 +156,42 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        double const left = -1.0, right = 1.0;
-        double const deformation = 0.1;
+      double const left = -1.0, right = 1.0;
+      double const deformation = 0.1;
 
-        create_periodic_box(tria,
-                            global_refinements,
-                            periodic_face_pairs,
-                            this->n_subdivisions_1d_hypercube,
-                            left,
-                            right,
-                            mesh_type == MeshType::Curvilinear,
-                            deformation);
-      };
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+      if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+      }
+
+      create_periodic_box(tria,
+                          global_refinements,
+                          periodic_face_pairs,
+                          this->n_subdivisions_1d_hypercube,
+                          left,
+                          right,
+                          mesh_type == MeshType::Curvilinear,
+                          deformation);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -321,55 +321,68 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        dealii::Tensor<1, dim> dimensions;
-        dimensions[0] = DIMENSIONS_X1;
-        dimensions[1] = DIMENSIONS_X2;
-        if(dim == 3)
-          dimensions[2] = DIMENSIONS_X3;
+      dealii::Tensor<1, dim> dimensions;
+      dimensions[0] = DIMENSIONS_X1;
+      dimensions[1] = DIMENSIONS_X2;
+      if(dim == 3)
+        dimensions[2] = DIMENSIONS_X3;
 
-        dealii::GridGenerator::hyper_rectangle(tria,
-                                               dealii::Point<dim>(-dimensions / 2.0),
-                                               dealii::Point<dim>(dimensions / 2.0));
+      dealii::GridGenerator::hyper_rectangle(tria,
+                                             dealii::Point<dim>(-dimensions / 2.0),
+                                             dealii::Point<dim>(dimensions / 2.0));
 
-        // manifold
-        unsigned int manifold_id = 1;
-        for(auto cell : tria.cell_iterators())
-        {
-          cell->set_all_manifold_ids(manifold_id);
-        }
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        // apply mesh stretching towards no-slip boundaries in y-direction
-        static const BoundaryLayerManifold<dim> manifold(dimensions, GRID_STRETCH_FAC);
-        tria.set_manifold(manifold_id, manifold);
+      // manifold
+      unsigned int manifold_id = 1;
+      for(auto cell : tria.cell_iterators())
+      {
+        cell->set_all_manifold_ids(manifold_id);
+      }
 
-        // periodicity in x--direction
-        tria.begin()->face(0)->set_all_boundary_ids(0 + 10);
-        tria.begin()->face(1)->set_all_boundary_ids(1 + 10);
-        // periodicity in z-direction
-        if(dim == 3)
-        {
-          tria.begin()->face(4)->set_all_boundary_ids(2 + 10);
-          tria.begin()->face(5)->set_all_boundary_ids(3 + 10);
-        }
+      // apply mesh stretching towards no-slip boundaries in y-direction
+      const BoundaryLayerManifold<dim> manifold(dimensions, GRID_STRETCH_FAC);
+      tria.set_manifold(manifold_id, manifold);
 
-        dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
-        if(dim == 3)
-        {
-          dealii::GridTools::collect_periodic_faces(tria, 2 + 10, 3 + 10, 2, periodic_face_pairs);
-        }
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        tria.add_periodicity(periodic_face_pairs);
+      // periodicity in x--direction
+      tria.begin()->face(0)->set_all_boundary_ids(0 + 10);
+      tria.begin()->face(1)->set_all_boundary_ids(1 + 10);
+      // periodicity in z-direction
+      if(dim == 3)
+      {
+        tria.begin()->face(4)->set_all_boundary_ids(2 + 10);
+        tria.begin()->face(5)->set_all_boundary_ids(3 + 10);
+      }
 
-        tria.refine_global(global_refinements);
-      };
+      dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 0, periodic_face_pairs);
+      if(dim == 3)
+      {
+        dealii::GridTools::collect_periodic_faces(tria, 2 + 10, 3 + 10, 2, periodic_face_pairs);
+      }
+
+      tria.add_periodicity(periodic_face_pairs);
+
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -427,53 +427,60 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        if(ALE)
+      if(ALE)
+      {
+        AssertThrow(mesh_type == MeshType::Cartesian,
+                    dealii::ExcMessage(
+                      "Taylor vortex problem: Parameter mesh_type is invalid for ALE."));
+      }
+
+      dealii::GridGenerator::subdivided_hyper_cube(tria, 2, left, right);
+
+      if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+        double const       deformation = 0.1;
+        unsigned int const frequency   = 2;
+
+        apply_deformed_cube_manifold(tria, left, right, deformation, frequency);
+      }
+
+      // boundary IDs
+      for(auto cell : tria.cell_iterators())
+      {
+        for(auto const & f : cell->face_indices())
         {
-          AssertThrow(mesh_type == MeshType::Cartesian,
-                      dealii::ExcMessage(
-                        "Taylor vortex problem: Parameter mesh_type is invalid for ALE."));
-        }
-
-        dealii::GridGenerator::subdivided_hyper_cube(tria, 2, left, right);
-
-        if(mesh_type == MeshType::Curvilinear)
-        {
-          double const       deformation = 0.1;
-          unsigned int const frequency   = 2;
-
-          apply_deformed_cube_manifold(tria, left, right, deformation, frequency);
-        }
-
-        // boundary IDs
-        for(auto cell : tria.cell_iterators())
-        {
-          for(auto const & f : cell->face_indices())
+          if(((std::fabs(cell->face(f)->center()(0) - right) < 1e-12) and
+              (cell->face(f)->center()(1) < 0)) or
+             ((std::fabs(cell->face(f)->center()(0) - left) < 1e-12) and
+              (cell->face(f)->center()(1) > 0)) or
+             ((std::fabs(cell->face(f)->center()(1) - left) < 1e-12) and
+              (cell->face(f)->center()(0) < 0)) or
+             ((std::fabs(cell->face(f)->center()(1) - right) < 1e-12) and
+              (cell->face(f)->center()(0) > 0)))
           {
-            if(((std::fabs(cell->face(f)->center()(0) - right) < 1e-12) and
-                (cell->face(f)->center()(1) < 0)) or
-               ((std::fabs(cell->face(f)->center()(0) - left) < 1e-12) and
-                (cell->face(f)->center()(1) > 0)) or
-               ((std::fabs(cell->face(f)->center()(1) - left) < 1e-12) and
-                (cell->face(f)->center()(0) < 0)) or
-               ((std::fabs(cell->face(f)->center()(1) - right) < 1e-12) and
-                (cell->face(f)->center()(0) > 0)))
-            {
-              cell->face(f)->set_boundary_id(1);
-            }
+            cell->face(f)->set_boundary_id(1);
           }
         }
+      }
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
@@ -241,28 +241,44 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        double const left = -1.0, right = 1.0;
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        double const deformation                 = 0.05;
-        unsigned int n_subdivisions_1d_hypercube = 1;
-        create_periodic_box(tria,
-                            global_refinements,
-                            periodic_face_pairs,
-                            n_subdivisions_1d_hypercube,
-                            left,
-                            right,
-                            mesh_type == MeshType::Curvilinear,
-                            deformation);
-      };
+      if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+      }
+
+      double const left = -1.0, right = 1.0;
+      double const deformation                 = 0.05;
+      unsigned int n_subdivisions_1d_hypercube = 1;
+
+      create_periodic_box(tria,
+                          global_refinements,
+                          periodic_face_pairs,
+                          n_subdivisions_1d_hypercube,
+                          left,
+                          right,
+                          mesh_type == MeshType::Curvilinear,
+                          deformation);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -232,39 +232,46 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        double const length = 1.0;
-        double const left = -length, right = length;
-        dealii::GridGenerator::subdivided_hyper_cube(tria,
-                                                     this->n_subdivisions_1d_hypercube,
-                                                     left,
-                                                     right);
+      double const length = 1.0;
+      double const left = -length, right = length;
+      dealii::GridGenerator::subdivided_hyper_cube(tria,
+                                                   this->n_subdivisions_1d_hypercube,
+                                                   left,
+                                                   right);
 
-        if(mesh_type == MeshType::Cartesian)
-        {
-          // do nothing
-        }
-        else if(mesh_type == MeshType::Curvilinear)
-        {
-          double const       deformation = 0.1;
-          unsigned int const frequency   = 2;
-          apply_deformed_cube_manifold(tria, left, right, deformation, frequency);
-        }
-        else
-        {
-          AssertThrow(false, dealii::ExcMessage("not implemented."));
-        }
+      if(mesh_type == MeshType::Cartesian)
+      {
+        // do nothing
+      }
+      else if(mesh_type == MeshType::Curvilinear)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        tria.refine_global(global_refinements);
-      };
+        double const       deformation = 0.1;
+        unsigned int const frequency   = 2;
+        apply_deformed_cube_manifold(tria, left, right, deformation, frequency);
+      }
+      else
+      {
+        AssertThrow(false, dealii::ExcMessage("not implemented."));
+      }
+
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -90,43 +90,59 @@ private:
   {
     (void)mapping;
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)vector_local_refinements;
 
-        double const left = -1.0, right = 1.0;
+      double const left = -1.0, right = 1.0;
 
-        // periodic boundary conditions are currently not available in deal.II for simplex meshes
+      // periodic boundary conditions are currently not available in deal.II for simplex meshes
 
-        if(this->param.grid.element_type == ElementType::Hypercube)
+      if(this->param.grid.element_type == ElementType::Hypercube)
+      {
+        AssertThrow(
+          this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+          dealii::ExcMessage(
+            "Periodic faces might not be applied correctly for TriangulationType::FullyDistributed. "
+            "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+
+        if(mesh_type == MeshType::Curvilinear)
         {
-          double const deformation = 0.1;
+          AssertThrow(
+            this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+            dealii::ExcMessage(
+              "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+              "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
+        }
 
-          create_periodic_box(tria,
-                              global_refinements,
-                              periodic_face_pairs,
-                              this->n_subdivisions_1d_hypercube,
-                              left,
-                              right,
-                              mesh_type == MeshType::Curvilinear,
-                              deformation);
-        }
-        else if(this->param.grid.element_type == ElementType::Simplex)
-        {
-          dealii::GridGenerator::subdivided_hyper_cube_with_simplices(
-            tria, this->n_subdivisions_1d_hypercube, left, right);
+        double const deformation = 0.1;
 
-          tria.refine_global(global_refinements);
-        }
-        else
-        {
-          AssertThrow(false, ExcNotImplemented());
-        }
-      };
+        create_periodic_box(tria,
+                            global_refinements,
+                            periodic_face_pairs,
+                            this->n_subdivisions_1d_hypercube,
+                            left,
+                            right,
+                            mesh_type == MeshType::Curvilinear,
+                            deformation);
+      }
+      else if(this->param.grid.element_type == ElementType::Simplex)
+      {
+        dealii::GridGenerator::subdivided_hyper_cube_with_simplices(
+          tria, this->n_subdivisions_1d_hypercube, left, right);
+
+        tria.refine_global(global_refinements);
+      }
+      else
+      {
+        AssertThrow(false, ExcNotImplemented());
+      }
+    };
 
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -180,47 +180,54 @@ private:
 
     AssertThrow(dim == 3, dealii::ExcMessage("This application only makes sense for dim=3."));
 
-    auto const lambda_create_triangulation =
-      [&](dealii::Triangulation<dim, dim> &                        tria,
-          std::vector<dealii::GridTools::PeriodicFacePair<
-            typename dealii::Triangulation<dim>::cell_iterator>> & periodic_face_pairs,
-          unsigned int const                                       global_refinements,
-          std::vector<unsigned int> const &                        vector_local_refinements) {
-        (void)periodic_face_pairs;
-        (void)vector_local_refinements;
+    auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
+                                                 std::vector<dealii::GridTools::PeriodicFacePair<
+                                                   typename dealii::Triangulation<
+                                                     dim>::cell_iterator>> & periodic_face_pairs,
+                                                 unsigned int const          global_refinements,
+                                                 std::vector<unsigned int> const &
+                                                   vector_local_refinements) {
+      (void)periodic_face_pairs;
+      (void)vector_local_refinements;
 
-        dealii::GridGenerator::cylinder_shell(tria, height, inner_radius, outer_radius);
+      AssertThrow(
+        this->param.grid.triangulation_type != TriangulationType::FullyDistributed,
+        dealii::ExcMessage(
+          "Manifolds might not be applied correctly for TriangulationType::FullyDistributed. "
+          "Try to use another triangulation type, or try to fix these limitations in ExaDG or deal.II."));
 
-        // 0 = bottom ; 1 = top ; 2 = inner and outer radius
-        for(auto cell : tria.cell_iterators())
+      dealii::GridGenerator::cylinder_shell(tria, height, inner_radius, outer_radius);
+
+      // 0 = bottom ; 1 = top ; 2 = inner and outer radius
+      for(auto cell : tria.cell_iterators())
+      {
+        for(auto const & f : cell->face_indices())
         {
-          for(auto const & f : cell->face_indices())
+          if(cell->face(f)->at_boundary())
           {
-            if(cell->face(f)->at_boundary())
-            {
-              dealii::Point<dim> const face_center = cell->face(f)->center();
+            dealii::Point<dim> const face_center = cell->face(f)->center();
 
-              // bottom
-              if(dim == 3 and std::abs(face_center[dim - 1] - 0.0) < 1.e-8)
-              {
-                cell->face(f)->set_boundary_id(0);
-              }
-              // top
-              else if(dim == 3 and std::abs(face_center[dim - 1] - height) < 1.e-8)
-              {
-                cell->face(f)->set_boundary_id(1);
-              }
-              // inner radius and outer radius
-              else
-              {
-                cell->face(f)->set_boundary_id(2);
-              }
+            // bottom
+            if(dim == 3 and std::abs(face_center[dim - 1] - 0.0) < 1.e-8)
+            {
+              cell->face(f)->set_boundary_id(0);
+            }
+            // top
+            else if(dim == 3 and std::abs(face_center[dim - 1] - height) < 1.e-8)
+            {
+              cell->face(f)->set_boundary_id(1);
+            }
+            // inner radius and outer radius
+            else
+            {
+              cell->face(f)->set_boundary_id(2);
             }
           }
         }
+      }
 
-        tria.refine_global(global_refinements);
-      };
+      tria.refine_global(global_refinements);
+    };
 
     GridUtilities::create_triangulation_with_multigrid<dim>(grid,
                                                             this->mpi_comm,

--- a/include/exadg/grid/deformed_cube_manifold.h
+++ b/include/exadg/grid/deformed_cube_manifold.h
@@ -131,7 +131,7 @@ apply_deformed_cube_manifold(dealii::Triangulation<dim> & triangulation,
                              double const                 deformation,
                              unsigned int const           frequency)
 {
-  static DeformedCubeManifold<dim> manifold(left, right, deformation, frequency);
+  DeformedCubeManifold<dim> manifold(left, right, deformation, frequency);
   triangulation.set_all_manifold_ids(1);
   triangulation.set_manifold(1, manifold);
 


### PR DESCRIPTION
I expect we would get wrong results when using `fullydistributed::Triangulation` in combination with manifolds or periodic faces. This problem has been documented in deal.II' issues https://github.com/dealii/dealii/issues/16312 and https://github.com/dealii/dealii/issues/16313.

I decided to add asserts for now, given that it is unclear how to fix these problems. In particular, Unless for simple problems (like hypercube grids), I do not see a general solution to apply the manifolds afterwards, i.e. after the fullydistributed triangulation has been created via `deal.II` functionality like `create_description_from_triangulation_in_groups()` functionality.

The first commit add asserts for the poisson/sine test case only. Many more problematic applications exist in ExaDG. Please check if you agree with the conditions and ExcMessage's of the added asserts.

I will then go through ExaDG and apply similar changes.