### PR TITLE
add include for deal.II/multigrid/mg_tools.h in OperatorBase

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -24,6 +24,7 @@
 #include <deal.II/lac/sparse_matrix_tools.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/matrix_free/tools.h>
+#include <deal.II/multigrid/mg_tools.h>
 
 // ExaDG
 #include <exadg/operators/operator_base.h>


### PR DESCRIPTION
This should fix the compile problems that we currently see with dealii/master, e.g. in PR #614. Let's see if problems are solved with this ...