### PR TITLE
remove dynamic cast in ConvDiff::MultigridPreconditioner

### DIFF
--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -194,8 +194,7 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 
   if(data.use_cell_based_loops and this->level_info[level].is_dg())
   {
-    auto tria = dynamic_cast<dealii::parallel::distributed::Triangulation<dim> const *>(
-      &this->dof_handlers[level]->get_triangulation());
+    auto tria = &this->dof_handlers[level]->get_triangulation();
     Categorization::do_cell_based_loops(*tria, matrix_free_data.data, dealii_tria_level);
   }
 


### PR DESCRIPTION
It looks like I forgot to remove a dynamic cast in the past. This cast leads to a segfault as encountered in the context of PR #586.

In other modules of ExaDG, this cast has already been removed in the past.

@richardschu 