### PR TITLE
Add RHS for acoustic module

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/CMakeLists.txt
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/CMakeLists.txt
@@ -1,0 +1,34 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2023 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
+
+PROJECT(${TARGET_NAME})
+
+EXADG_PICKUP_EXE(solver.cpp ${TARGET_NAME} solver)
+
+ADD_SUBDIRECTORY(tests) 

--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -1,0 +1,304 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_CIRCULAR_MOVING_GAUSS_PULSE_H_
+#define APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_CIRCULAR_MOVING_GAUSS_PULSE_H_
+
+#include <deal.II/base/function.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include <exadg/grid/grid_utilities.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim>
+class SourceTerm : public dealii::Function<dim>
+{
+public:
+  SourceTerm(double const c, double const xi, double const alpha, double const l)
+    : dealii::Function<dim>(1, 0.0), c(c), xi(xi), alpha(alpha), l(l)
+  {
+  }
+
+  double
+  value(dealii::Point<dim> const & p, unsigned int const) const final
+  {
+    double const t        = this->get_time();
+    double const sin_xi_t = std::sin(xi * t);
+    double const cos_xi_t = std::cos(xi * t);
+
+    double const result = 1.0e-6 * 2.0 * alpha *
+                          (2.0 * c * c *
+                             (-alpha * (l * sin_xi_t - p[0]) * (l * sin_xi_t - p[0]) -
+                              alpha * (l * cos_xi_t - p[1]) * (l * cos_xi_t - p[1]) + 1.0) +
+                           l * xi * xi *
+                             (2.0 * alpha * l * (p[0] * cos_xi_t - p[1] * sin_xi_t) *
+                                (p[0] * cos_xi_t - p[1] * sin_xi_t) -
+                              p[0] * sin_xi_t - p[1] * cos_xi_t)) *
+                          std::exp(-alpha * ((l * sin_xi_t - p[0]) * (l * sin_xi_t - p[0]) +
+                                             (l * cos_xi_t - p[1]) * (l * cos_xi_t - p[1]))) /
+                          (c * c);
+
+    return result;
+  }
+
+private:
+  double const c;
+  double const xi;
+  double const alpha;
+  double const l;
+};
+
+template<int dim>
+class AnalyticalSolutionPressure : public dealii::Function<dim>
+{
+public:
+  AnalyticalSolutionPressure(double const xi, double const alpha, double const l)
+    : dealii::Function<dim>(1, 0.0), xi(xi), alpha(alpha), l(l)
+  {
+  }
+
+  double
+  value(dealii::Point<dim> const & p, unsigned int const) const final
+  {
+    double const t        = this->get_time();
+    double const sin_xi_t = std::sin(xi * t);
+    double const cos_xi_t = std::cos(xi * t);
+
+    double const result = 1.0e-6 * 2.0 * xi * alpha * l * (p[0] * cos_xi_t - p[1] * sin_xi_t) *
+                          std::exp(-1.0 * alpha *
+                                   ((p[0] - l * sin_xi_t) * (p[0] - l * sin_xi_t) +
+                                    (p[1] - l * cos_xi_t) * (p[1] - l * cos_xi_t)));
+    return result;
+  }
+
+private:
+  double const xi;
+  double const alpha;
+  double const l;
+};
+
+template<int dim>
+class AnalyticalSolutionVelocity : public dealii::Function<dim>
+{
+public:
+  AnalyticalSolutionVelocity(double const xi, double const alpha, double const l)
+    : dealii::Function<dim>(dim, 0.0), xi(xi), alpha(alpha), l(l)
+  {
+  }
+
+  double
+  value(dealii::Point<dim> const & p, unsigned int const component) const final
+  {
+    double const t        = this->get_time();
+    double const sin_xi_t = std::sin(xi * t);
+    double const cos_xi_t = std::cos(xi * t);
+
+    double result = 1.0e-6 * -2.0 * alpha *
+                    std::exp(-1.0 * alpha *
+                             ((p[0] - l * sin_xi_t) * (p[0] - l * sin_xi_t) +
+                              (p[1] - l * cos_xi_t) * (p[1] - l * cos_xi_t)));
+    if(component == 0)
+      result *= (l * sin_xi_t - p[0]);
+    else if(component == 1)
+      result *= (l * cos_xi_t - p[1]);
+
+    return result;
+  }
+
+private:
+  double const xi;
+  double const alpha;
+  double const l;
+};
+
+template<int dim, typename Number>
+class Application : public ApplicationBase<dim, Number>
+{
+public:
+  Application(std::string input_file, MPI_Comm const & comm)
+    : ApplicationBase<dim, Number>(input_file, comm)
+  {
+  }
+
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+      prm.add_parameter("RuntimeInNumberOfPulseRotations",
+                        number_of_rotations,
+                        "Number of pulse rotations during runtime.",
+                        dealii::Patterns::Double(1.0e-12));
+    }
+    prm.leave_subsection();
+  }
+
+private:
+  void
+  set_parameters() final
+  {
+    // MATHEMATICAL MODEL
+    this->param.formulation     = Formulation::SkewSymmetric;
+    this->param.right_hand_side = true;
+
+    // PHYSICAL QUANTITIES
+    this->param.start_time     = start_time;
+    this->param.end_time       = number_of_rotations * compute_rotation_duration();
+    this->param.speed_of_sound = speed_of_sound;
+    this->param.density        = density;
+
+    // TEMPORAL DISCRETIZATION
+    this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
+    this->param.cfl                           = 0.59;
+    this->param.order_time_integrator         = 2;
+    this->param.start_with_low_order          = false;
+
+    // output of solver information
+    this->param.solver_info_data.interval_time = (this->param.end_time - this->param.start_time);
+
+    // SPATIAL DISCRETIZATION
+    this->param.grid.triangulation_type = TriangulationType::Distributed;
+    this->param.mapping_degree          = 2;
+    this->param.degree_p                = this->param.degree_u;
+    this->param.degree_u                = this->param.degree_p;
+  }
+
+  void
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  {
+    (void)mapping;
+
+    auto const lambda_create_triangulation =
+      [&](dealii::Triangulation<dim, dim> & tria,
+          std::vector<dealii::GridTools::PeriodicFacePair<
+            typename dealii::Triangulation<dim>::cell_iterator>> & /*periodic_face_pairs*/,
+          unsigned int const global_refinements,
+          std::vector<unsigned int> const & /* vector_local_refinements*/) {
+        dealii::GridGenerator::hyper_ball_balanced(tria, {}, radius);
+
+        for(const auto & face : tria.active_face_iterators())
+          if(face->at_boundary())
+            face->set_boundary_id(1);
+
+        tria.refine_global(global_refinements);
+      };
+
+    GridUtilities::create_triangulation<dim>(
+      grid, this->mpi_comm, this->param.grid, lambda_create_triangulation, {});
+
+    GridUtilities::create_mapping(mapping,
+                                  this->param.grid.element_type,
+                                  this->param.mapping_degree);
+  }
+
+  void
+  set_boundary_descriptor() final
+  {
+    this->boundary_descriptor->velocity_dbc.insert(
+      std::make_pair(1, std::make_shared<AnalyticalSolutionVelocity<dim>>(xi, alpha, l)));
+  }
+
+  void
+  set_field_functions() final
+  {
+    this->field_functions->initial_solution_pressure =
+      std::make_shared<AnalyticalSolutionPressure<dim>>(xi, alpha, l);
+
+    this->field_functions->initial_solution_velocity =
+      std::make_shared<AnalyticalSolutionVelocity<dim>>(xi, alpha, l);
+
+    this->field_functions->right_hand_side =
+      std::make_shared<SourceTerm<dim>>(speed_of_sound, xi, alpha, l);
+  }
+
+  std::shared_ptr<PostProcessorBase<dim, Number>>
+  create_postprocessor() final
+  {
+    PostProcessorData<dim> pp_data;
+
+    // write output for visualization of results
+    pp_data.output_data.time_control_data.is_active  = this->output_parameters.write;
+    pp_data.output_data.time_control_data.start_time = start_time;
+    pp_data.output_data.time_control_data.trigger_interval =
+      (this->param.end_time - start_time) / 20.0;
+    pp_data.output_data.directory          = this->output_parameters.directory + "vtu/";
+    pp_data.output_data.filename           = this->output_parameters.filename;
+    pp_data.output_data.write_pressure     = true;
+    pp_data.output_data.write_velocity     = true;
+    pp_data.output_data.write_higher_order = true;
+    pp_data.output_data.degree             = this->param.degree_u;
+
+    // calculation of pressure error
+    pp_data.error_data_p.time_control_data.is_active        = true;
+    pp_data.error_data_p.time_control_data.start_time       = start_time;
+    pp_data.error_data_p.time_control_data.trigger_interval = (this->param.end_time - start_time);
+    pp_data.error_data_p.analytical_solution =
+      std::make_shared<AnalyticalSolutionPressure<dim>>(xi, alpha, l);
+    pp_data.error_data_p.calculate_relative_errors = true;
+    pp_data.error_data_p.name                      = "pressure";
+
+    // ... velocity error
+    pp_data.error_data_u.time_control_data.is_active        = true;
+    pp_data.error_data_u.time_control_data.start_time       = start_time;
+    pp_data.error_data_u.time_control_data.trigger_interval = (this->param.end_time - start_time);
+    pp_data.error_data_u.analytical_solution =
+      std::make_shared<AnalyticalSolutionVelocity<dim>>(xi, alpha, l);
+    pp_data.error_data_u.calculate_relative_errors = true;
+    pp_data.error_data_u.name                      = "velocity";
+
+    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
+    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+
+    return pp;
+  }
+
+  // problem specific parameters like physical dimensions, etc.
+  double xi                  = 4.0e5;
+  double alpha               = 1.6e5;
+  double radius              = 0.04;
+  double l                   = 0.02;
+  double speed_of_sound      = 1500.0;
+  double density             = 1000.0;
+  double number_of_rotations = 1.0;
+
+  double
+  compute_rotation_duration()
+  {
+    return (2.0 * dealii::numbers::PI / xi);
+  }
+
+  double const start_time = 0.0;
+};
+
+} // namespace Acoustics
+
+} // namespace ExaDG
+
+#include <exadg/acoustic_conservation_equations/user_interface/implement_get_application.h>
+
+#endif /* APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_CIRCULAR_MOVING_GAUSS_PULSE_H_ \
+        */

--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/input.json
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/input.json
@@ -1,0 +1,25 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "2",
+        "IsTest": "false"
+    },
+    "SpatialResolution": {
+        "DegreeMin": "5",
+        "DegreeMax": "5",
+        "RefineSpaceMin": "3",
+        "RefineSpaceMax": "3"
+    },
+    "TemporalResolution": {
+        "RefineTimeMin": "0",
+        "RefineTimeMax": "0"
+    },
+    "Application": {
+        "RuntimeInNumberOfPulseRotations": "1.0"
+    },
+    "Output": {
+        "OutputDirectory": "output/circular_moving_gauss_pulse/",
+        "OutputName": "circular_moving_gauss_pulse",
+        "WriteOutput": "false"
+    }
+}

--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/solver.cpp
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/solver.cpp
@@ -1,0 +1,26 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// solver
+#include <exadg/acoustic_conservation_equations/solver.h>
+
+// application
+#include "application.h"

--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/CMakeLists.txt
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2023 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+GET_FILENAME_COMPONENT(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+TARGETNAME(TARGET_NAME ${PARENT_DIR})
+SET(TEST_LIBRARIES exadg)
+SET(TEST_TARGET ${TARGET_NAME})
+EXADG_PICKUP_TESTS(${TARGET_NAME})

--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.json
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.json
@@ -1,0 +1,25 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "2",
+        "IsTest": "true"
+    },
+    "SpatialResolution": {
+        "DegreeMin": "5",
+        "DegreeMax": "5",
+        "RefineSpaceMin": "3",
+        "RefineSpaceMax": "3"
+    },
+    "TemporalResolution": {
+        "RefineTimeMin": "0",
+        "RefineTimeMax": "0"
+    },
+    "Application": {
+        "RuntimeInNumberOfPulseRotations": "0.1"
+    },
+    "Output": {
+        "OutputDirectory": "output/circular_moving_gauss_pulse/",
+        "OutputName": "circular_moving_gauss_pulse",
+        "WriteOutput": "false"
+    }
+}

--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.output
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.output
@@ -1,0 +1,106 @@
+
+
+
+________________________________________________________________________________
+                                                                                
+                ////////                      ///////   ////////                
+                ///                           ///  ///  ///                     
+                //////    ///  ///  ///////   ///  ///  /// ////                
+                ///         ////    //   //   ///  ///  ///  ///                
+                ////////  ///  ///  ///////// ///////   ////////                
+                                                                                
+               High-Order Discontinuous Galerkin for the Exa-Scale              
+________________________________________________________________________________
+
+
+MPI info:
+
+  Number of processes:                       1
+
+Setting up acoustic conservation equations solver:
+
+List of parameters:
+
+Mathematical model:
+  Formulation:                               SkewSymmetric
+  Right-hand side:                           true
+
+Physical quantities:
+  Start time:                                0.0000e+00
+  End time:                                  1.5708e-06
+  Speed of sound:                            1.5000e+03
+  Density:                                   1.0000e+03
+
+Temporal discretization:
+  Calculation of time step size:             CFL
+  Maximum number of time steps:              4294967295
+  Temporal refinements:                      0
+  Order of time integration scheme:          2
+  Start with low order method:               false
+  Restarted simulation:                      false
+  Restart:
+  Write restart:                             false
+
+Spatial discretization:
+  Triangulation type:                        Distributed
+  Element type:                              Hypercube
+  Number of global refinements:              3
+  Create coarse triangulations:              false
+  Mapping degree:                            2
+  Polynomial degree pressure:                5
+  Polynomial degree velocity:                5
+
+Generating grid for 2-dimensional problem:
+
+  Max. number of refinements:                3
+  Number of cells:                           768
+
+Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   36
+  number of dofs (total):                    27648
+Velocity:
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   72
+  number of dofs (total):                    55296
+Pressure and velocity:
+  number of dofs per cell:                   108
+  number of dofs (total):                    82944
+
+... done!
+
+Setup acoustic conservation equations operator ...
+
+... done!
+
+Setup Multistep time integrator ...
+
+Calculation of time step size:
+
+
+Calculation of time step size according to CFL condition:
+
+  CFL:                                       5.9000e-01
+  time step size:                            3.7597e-08
+
+... done!
+
+Starting time loop ...
+
+Calculate error for pressure at time t = 0.0000e+00:
+  Relative error (L2-norm): 1.89338e-04
+
+Calculate error for velocity at time t = 0.0000e+00:
+  Relative error (L2-norm): 2.65559e-04
+
+________________________________________________________________________________
+
+ Time step number = 1       t = 0.00000e+00 -> t + dt = 3.75969e-08
+________________________________________________________________________________
+
+Calculate error for pressure at time t = 1.5791e-06:
+  Relative error (L2-norm): 5.00126e-03
+
+Calculate error for velocity at time t = 1.5791e-06:
+  Relative error (L2-norm): 1.10293e-02

--- a/applications/acoustic_conservation_equations/vibrating_membrane/application.h
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/application.h
@@ -224,6 +224,8 @@ private:
       std::make_shared<AnalyticalSolutionVelocity<dim>>(modes,
                                                         this->param.speed_of_sound,
                                                         this->param.density);
+    this->field_functions->right_hand_side =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(1);
   }
 
   std::shared_ptr<PostProcessorBase<dim, Number>>

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
@@ -23,6 +23,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -124,7 +125,8 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
-
+  Right-hand side:                           false
+  
 Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
@@ -23,6 +23,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -124,6 +125,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -225,6 +227,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -326,6 +329,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -427,6 +431,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -528,6 +533,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -629,6 +635,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               SkewSymmetric
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
@@ -23,6 +23,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Strong
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -124,6 +125,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Strong
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -225,6 +227,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Strong
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -326,6 +329,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Strong
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -427,6 +431,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Strong
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -528,6 +533,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Strong
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -629,6 +635,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Strong
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -23,6 +23,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Weak
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -124,6 +125,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Weak
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -225,6 +227,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Weak
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -326,6 +329,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Weak
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -427,6 +431,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Weak
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -528,6 +533,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Weak
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -629,6 +635,7 @@ List of parameters:
 
 Mathematical model:
   Formulation:                               Weak
+  Right-hand side:                           false
 
 Physical quantities:
   Start time:                                0.0000e+00

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
@@ -36,6 +36,7 @@
 #include <exadg/grid/grid.h>
 #include <exadg/matrix_free/matrix_free_data.h>
 #include <exadg/operators/inverse_mass_operator.h>
+#include <exadg/operators/rhs_operator.h>
 
 namespace ExaDG
 {
@@ -255,6 +256,11 @@ private:
    */
   InverseMassOperator<dim, 1, Number>   inverse_mass_pressure;
   InverseMassOperator<dim, dim, Number> inverse_mass_velocity;
+
+  /*
+   * RHS operator that acts on the pressure DoFs
+   */
+  RHSOperator<dim, Number, 1> rhs_operator;
 
   MPI_Comm const mpi_comm;
 

--- a/include/exadg/acoustic_conservation_equations/user_interface/field_functions.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/field_functions.h
@@ -40,6 +40,13 @@ struct FieldFunctions
    * beginning of the simulation.
    */
   std::shared_ptr<dealii::Function<dim>> initial_solution_velocity;
+
+  /*
+   * The function right_hand_side is used to evaluate the acoustic source term on the right-hand
+   * side of the mass conservation equation of the acoustic conservation equations.
+   * Thus, the right_hand_side is scalar and acts on the pressure DoFs.
+   */
+  std::shared_ptr<dealii::Function<dim>> right_hand_side;
 };
 
 } // namespace Acoustics

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
@@ -34,6 +34,7 @@ namespace Acoustics
 Parameters::Parameters()
   : // MATHEMATICAL MODEL
     formulation(Formulation::Undefined),
+    right_hand_side(false),
 
     // PHYSICAL QUANTITIES
     start_time(0.),
@@ -119,6 +120,7 @@ Parameters::print_parameters_mathematical_model(dealii::ConditionalOStream const
   pcout << std::endl << "Mathematical model:" << std::endl;
 
   print_parameter(pcout, "Formulation", formulation);
+  print_parameter(pcout, "Right-hand side", right_hand_side);
 }
 
 
@@ -131,7 +133,7 @@ Parameters::print_parameters_physical_quantities(dealii::ConditionalOStream cons
   print_parameter(pcout, "Start time", start_time);
   print_parameter(pcout, "End time", end_time);
 
-  // viscosity
+  // speed of sound
   print_parameter(pcout, "Speed of sound", speed_of_sound);
 
   // mean density

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
@@ -72,6 +72,10 @@ public:
   // description: see enum declaration
   Formulation formulation;
 
+  // if there are acoustic source terms, set right_hand_side = true
+  bool right_hand_side;
+
+
   /**************************************************************************************/
   /*                                                                                    */
   /*                                 PHYSICAL QUANTITIES                                */


### PR DESCRIPTION
To be able to solve realistic acoustic problems, we need to be able to consider source terms in the mass conservation equation. This PR introduces this functionality and adds a test case with RHS for which the analytical solution is known. 
Additionally, a test is added that checks CFL time-stepping, the application of the RHS, and velocity Dirichlet BCs.

The PR is dependent on https://github.com/exadg/exadg/pull/619.

The acoustic conservation equations read:
```math
\frac{\partial p}{\partial t} + \rho c^2 \nabla\cdot\mathbf{u} = c^2 f 
```
```math
\frac{\partial \mathbf{u}}{\partial t}+\frac{1}{\rho}\nabla p =\mathbf{0}
```

Alternative
```math
 \frac{1}{c^2}\frac{\partial p}{\partial t} + \rho \nabla\cdot\mathbf{u} = f 
```
```math
\rho\frac{\partial \mathbf{u}}{\partial t}+\nabla p =\mathbf{0}
```

