### PR TITLE
Add CFL based time step size computation for acoustics

### DIFF
--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/interface.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/interface.h
@@ -51,6 +51,9 @@ public:
   // time integration: evaluate
   virtual void
   evaluate(BlockVectorType & dst, BlockVectorType const & src, double const time) const = 0;
+
+  virtual double
+  calculate_time_step_cfl() const = 0;
 };
 
 } // namespace Interface

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -336,7 +336,7 @@ SpatialOperator<dim, Number>::calculate_time_step_cfl() const
 
   // The time-step size is not adapted every time-step. Thus, we are using
   // a constant function to pass in the speed of sound, even though it is
-  // be possible to optimize calculate_time_step_cfl_local() for this case.
+  // possible to optimize calculate_time_step_cfl_local() for this case.
 
   return calculate_time_step_cfl_local<dim, Number>(
     get_matrix_free(),

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -26,6 +26,7 @@
 #include <exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h>
 #include <exadg/grid/mapping_dof_vector.h>
 #include <exadg/operators/finite_element.h>
+#include <exadg/operators/grid_related_time_step_restrictions.h>
 #include <exadg/operators/quadrature.h>
 #include <exadg/utilities/exceptions.h>
 
@@ -324,6 +325,29 @@ SpatialOperator<dim, Number>::apply_inverse_mass_operator(BlockVectorType &     
 {
   inverse_mass_pressure.apply(dst.block(block_index_pressure), src.block(block_index_pressure));
   inverse_mass_velocity.apply(dst.block(block_index_velocity), src.block(block_index_velocity));
+}
+
+template<int dim, typename Number>
+double
+SpatialOperator<dim, Number>::calculate_time_step_cfl() const
+{
+  // In case of mixed-orders use the maximum fe_degree and the corresponding
+  // quadrature rule.
+
+  // The time-step size is not adapted every time-step. Thus, we are using
+  // a constant function to pass in the speed of sound, even though it is
+  // be possible to optimize calculate_time_step_cfl_local() for this case.
+
+  return calculate_time_step_cfl_local<dim, Number>(
+    get_matrix_free(),
+    get_dof_index_velocity(),
+    get_quad_index_pressure_velocity(),
+    std::make_shared<dealii::Functions::ConstantFunction<dim>>(param.speed_of_sound, dim),
+    param.start_time /* will not be used (ConstantFunction) */,
+    std::max(param.degree_p, param.degree_u),
+    param.cfl_exponent_fe_degree,
+    CFLConditionType::VelocityNorm,
+    mpi_comm);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
@@ -167,6 +167,10 @@ public:
   void
   apply_inverse_mass_operator(BlockVectorType & dst, BlockVectorType const & src) const;
 
+  // Calculate time step size according to local CFL criterion
+  double
+  calculate_time_step_cfl() const final;
+
 private:
   void
   initialize_dof_handler_and_constraints();

--- a/include/exadg/acoustic_conservation_equations/time_integration/time_int_abm.h
+++ b/include/exadg/acoustic_conservation_equations/time_integration/time_int_abm.h
@@ -24,6 +24,7 @@
 
 
 #include <exadg/acoustic_conservation_equations/spatial_discretization/interface.h>
+#include <exadg/operators/grid_related_time_step_restrictions.h>
 #include <exadg/time_integration/time_int_abm_base.h>
 #include <exadg/time_integration/time_step_calculation.h>
 
@@ -82,10 +83,17 @@ private:
 
       print_parameter(pcout, "time step size", time_step);
     }
-    else
+    else if(param.calculation_of_time_step_size == TimeStepCalculation::CFL)
     {
-      AssertThrow(
-        false, dealii::ExcMessage("Specified type of time step calculation is not implemented."));
+      double const cfl = param.cfl / std::pow(2.0, param.n_refine_time);
+
+      time_step = cfl * this->get_underlying_operator().calculate_time_step_cfl();
+
+      this->pcout << std::endl
+                  << "Calculation of time step size according to CFL condition:" << std::endl
+                  << std::endl;
+      print_parameter(this->pcout, "CFL", cfl);
+      print_parameter(this->pcout, "time step size", time_step);
     }
 
     return time_step;

--- a/include/exadg/acoustic_conservation_equations/user_interface/enum_types.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/enum_types.h
@@ -49,7 +49,8 @@ enum class Formulation
 enum class TimeStepCalculation
 {
   Undefined,
-  UserSpecified
+  UserSpecified,
+  CFL
 };
 
 } // namespace Acoustics

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
@@ -43,6 +43,8 @@ Parameters::Parameters()
 
     // TEMPORAL DISCRETIZATION
     calculation_of_time_step_size(TimeStepCalculation::Undefined),
+    cfl(-1.),
+    cfl_exponent_fe_degree(1.5),
     time_step_size(-1.),
     max_number_of_time_steps(std::numeric_limits<unsigned int>::max()),
     n_refine_time(0),
@@ -79,6 +81,12 @@ Parameters::check() const
 
   if(calculation_of_time_step_size == TimeStepCalculation::UserSpecified)
     AssertThrow(time_step_size > 0., dealii::ExcMessage("parameter must be defined"));
+
+  if(calculation_of_time_step_size == TimeStepCalculation::CFL)
+  {
+    AssertThrow(cfl > 0., dealii::ExcMessage("parameter must be defined"));
+    AssertThrow(cfl_exponent_fe_degree > 0., dealii::ExcMessage("cfl_exponent_fe_degree > 0."));
+  }
 
   AssertThrow(not(adaptive_time_stepping),
               dealii::ExcMessage("adaptive timestepping not supported"));

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
@@ -99,6 +99,13 @@ public:
   // description: see enum declaration
   TimeStepCalculation calculation_of_time_step_size;
 
+  // cfl number: note that this cfl number is the first in a series of cfl numbers
+  // when performing temporal convergence tests, i.e., cfl_real = cfl, cfl/2, cfl/4, ...
+  double cfl;
+
+  // dt = CFL/max(k_p,k_u)^{exp} * h / c
+  double cfl_exponent_fe_degree;
+
   // user specified time step size:  note that this time_step_size is the first
   // in a series of time_step_size's when performing temporal convergence tests,
   // i.e., delta_t = time_step_size, time_step_size/2, ...

--- a/include/exadg/time_integration/time_int_abm_base.h
+++ b/include/exadg/time_integration/time_int_abm_base.h
@@ -88,6 +88,12 @@ public:
     return solution;
   }
 
+  Operator const &
+  get_underlying_operator() const
+  {
+    return *pde_operator;
+  }
+
 private:
   void
   update_time_integrator_constants() final

--- a/include/exadg/time_integration/time_int_abm_base.h
+++ b/include/exadg/time_integration/time_int_abm_base.h
@@ -88,6 +88,7 @@ public:
     return solution;
   }
 
+protected:
   Operator const &
   get_underlying_operator() const
   {


### PR DESCRIPTION
It is tedious to specify the time step size manually. With this PR the user can choose CFL-based time-stepping. Note that I didn't use the implementation in an application on purpose: I.e., I will create a test in a separate PR that additionally checks different BCs and the RHS application.