### PR TITLE
Add missing mapping flags to compute CFL condition

### DIFF
--- a/applications/acoustic_conservation_equations/vibrating_membrane/application.h
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/application.h
@@ -142,6 +142,8 @@ public:
                         "UserSpecified Timestep size.",
                         dealii::Patterns::Double());
 
+      prm.add_parameter("CFL", this->param.cfl, "CFL number.", dealii::Patterns::Double());
+
       prm.add_parameter("OrderTimeIntegrator",
                         this->param.order_time_integrator,
                         "Order of time integration.",

--- a/applications/acoustic_conservation_equations/vibrating_membrane/input.json
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/input.json
@@ -18,8 +18,9 @@
         "Formulation": "SkewSymmetric",
         "SpeedOfSound": "1.0",
         "Density": "1.0",
-        "TimeIntegrationScheme": "UserSpecified",
+        "TimeIntegrationScheme": "CFL",
         "UserSpecifiedTimeStepSize": "1.0e-3",
+        "CFL": "0.4",
         "OrderTimeIntegrator": "2",
         "RuntimeInNumberOfPeriods": "1.0",
         "Modes": "2.0"

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -72,6 +72,14 @@ SpatialOperator<dim, Number>::fill_matrix_free_data(
   // append mapping flags
   matrix_free_data.append_mapping_flags(Operators::Kernel<dim, Number>::get_mapping_flags());
 
+  // mapping flags required for CFL condition
+  if(param.calculation_of_time_step_size == TimeStepCalculation::CFL)
+  {
+    MappingFlags flags_cfl;
+    flags_cfl.cells = dealii::update_quadrature_points;
+    matrix_free_data.append_mapping_flags(flags_cfl);
+  }
+
   // dof handler
   matrix_free_data.insert_dof_handler(&dof_handler_p, field + dof_index_p);
   matrix_free_data.insert_dof_handler(&dof_handler_u, field + dof_index_u);


### PR DESCRIPTION
I missed to add the mapping flags for the CFL condition because I was always running with a right-hand side (which also appends the needed mapping flags).