### PR TITLE
Fix tests for acoustic

### DIFF
--- a/applications/acoustic_conservation_equations/vibrating_membrane/application.h
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/application.h
@@ -162,9 +162,6 @@ private:
   void
   set_parameters() final
   {
-    // MATHEMATICAL MODEL
-    this->param.formulation = Formulation::SkewSymmetric;
-
     // PHYSICAL QUANTITIES
     this->param.start_time = start_time;
     this->param.end_time   = number_of_periods * compute_period_duration();

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
@@ -22,7 +22,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Strong
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -123,7 +123,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Strong
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -224,7 +224,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Strong
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -325,7 +325,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Strong
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -426,7 +426,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Strong
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -527,7 +527,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Strong
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -628,7 +628,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Strong
 
 Physical quantities:
   Start time:                                0.0000e+00

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -22,7 +22,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Weak
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -123,7 +123,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Weak
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -224,7 +224,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Weak
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -325,7 +325,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Weak
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -426,7 +426,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Weak
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -527,7 +527,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Weak
 
 Physical quantities:
   Start time:                                0.0000e+00
@@ -628,7 +628,7 @@ Setting up acoustic conservation equations solver:
 List of parameters:
 
 Mathematical model:
-  Formulation:                               SkewSymmetric
+  Formulation:                               Weak
 
 Physical quantities:
   Start time:                                0.0000e+00


### PR DESCRIPTION
During `set_parameter()` the formulation was always set to `SkwSymmetric` which corrupts the tests for the strong and weak formulation. 

In the changed lines, it is interesting to see that the results stay exactly the same.