### PR TITLE
Don't store MPI_Comm as reference

### DIFF
--- a/include/exadg/acoustic_conservation_equations/user_interface/application_base.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/application_base.h
@@ -148,7 +148,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -141,7 +141,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/convection_diffusion/user_interface/application_base.h
+++ b/include/exadg/convection_diffusion/user_interface/application_base.h
@@ -150,7 +150,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -156,7 +156,7 @@ public:
   create_postprocessor() = 0;
 
 protected:
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 
@@ -393,7 +393,7 @@ public:
   }
 
 protected:
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
+++ b/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
@@ -156,7 +156,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 
@@ -283,7 +283,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 
@@ -377,7 +377,7 @@ public:
   std::vector<std::shared_ptr<ScalarBase<dim, Number>>> scalars;
 
 protected:
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/incompressible_navier_stokes/precursor/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/precursor/user_interface/application_base.h
@@ -143,7 +143,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 
@@ -215,7 +215,7 @@ public:
   std::shared_ptr<Domain<dim, Number>> precursor, main;
 
 protected:
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -197,7 +197,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/poisson/overset_grids/user_interface/application_base.h
+++ b/include/exadg/poisson/overset_grids/user_interface/application_base.h
@@ -221,7 +221,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 
@@ -282,7 +282,7 @@ public:
     std::numeric_limits<dealii::types::boundary_id>::max() - 1;
 
 protected:
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
 private:
   std::string parameter_file;

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -163,7 +163,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
@@ -283,7 +283,7 @@ private:
     return 0;
   }
 
-  MPI_Comm const & comm;
+  MPI_Comm const comm;
 
   // flush flow field to hard drive?
   bool const write;

--- a/include/exadg/postprocessor/spectral_analysis/interpolation.h
+++ b/include/exadg/postprocessor/spectral_analysis/interpolation.h
@@ -49,7 +49,7 @@ namespace dealspectrum
 class Interpolator
 {
 public:
-  MPI_Comm const & comm;
+  MPI_Comm const comm;
   // reference to DEAL.SPECTRUM setup
   Setup & s;
   // is initialized?

--- a/include/exadg/postprocessor/spectral_analysis/permutation.h
+++ b/include/exadg/postprocessor/spectral_analysis/permutation.h
@@ -79,7 +79,7 @@ cmp(const void * a, const void * b)
  */
 class Permutator
 {
-  MPI_Comm const & comm;
+  MPI_Comm const comm;
   // reference to DEAL.SPECTRUM setup
   Setup & s;
   // is initialized?

--- a/include/exadg/postprocessor/spectral_analysis/setup.h
+++ b/include/exadg/postprocessor/spectral_analysis/setup.h
@@ -58,7 +58,7 @@ public:
   // length of header (8 ints)
   static int const HEADER_LENGTH = 8;
 
-  MPI_Comm const & comm;
+  MPI_Comm const comm;
 
   // is initialized?
   bool initialized;

--- a/include/exadg/postprocessor/spectral_analysis/spectrum.h
+++ b/include/exadg/postprocessor/spectral_analysis/spectrum.h
@@ -43,7 +43,7 @@ namespace dealspectrum
  */
 class SpectralAnalysis
 {
-  MPI_Comm const & comm;
+  MPI_Comm const comm;
 
   // reference to DEAL.SPECTRUM setup
   Setup & s;

--- a/include/exadg/structure/user_interface/application_base.h
+++ b/include/exadg/structure/user_interface/application_base.h
@@ -153,7 +153,7 @@ protected:
     prm.parse_input(parameter_file, "", true, true);
   }
 
-  MPI_Comm const & mpi_comm;
+  MPI_Comm const mpi_comm;
 
   dealii::ConditionalOStream pcout;
 


### PR DESCRIPTION
This is not urgent, but I think we should not store `MPI_Comm` as a reference.