### PR TITLE
Add Admittance BC

### DIFF
--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/CMakeLists.txt
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/CMakeLists.txt
@@ -1,0 +1,34 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2023 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+TARGETNAME(TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR})
+
+PROJECT(${TARGET_NAME})
+
+EXADG_PICKUP_EXE(solver.cpp ${TARGET_NAME} solver)
+
+ADD_SUBDIRECTORY(tests) 

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
@@ -80,13 +80,11 @@ public:
       prm.add_parameter("EndTime", end_time, "End time.", dealii::Patterns::Double(1.0e-12));
 
       prm.add_parameter("Radius", radius, "Radius of domain.", dealii::Patterns::Double(1.0e-12));
-    }
-    prm.leave_subsection();
 
-    // For a reasonable test we have to create a different postprocessor, see below.
-    prm.enter_subsection("General");
-    {
-      prm.add_parameter("IsTest", is_test, "Do we run a test?", dealii::Patterns::Bool());
+      prm.add_parameter("AnalyticalSolutionAvailable",
+                        analytical_solution_is_available,
+                        "We know the analytical solution for Y=1 after the wave left domain?",
+                        dealii::Patterns::Bool());
     }
     prm.leave_subsection();
   }
@@ -187,9 +185,9 @@ private:
 
     // To be able to compute an analytical solution for testing purposes we have to make
     // multiple assumptions. The application is intended to be used with different
-    // admittances which contradicts the assumptions. Therefore, we compute the analytical
-    // solution only if we run a test and fetch this information from the input file.
-    if(is_test)
+    // admittances which contradicts the assumptions. We compute the analytical
+    // solution only if we run with Y=1 and after the wave left the domain.
+    if(analytical_solution_is_available)
     {
       // To be able to compute an error and thus test the behavior of the admittance BC for
       // Y=1 (first-oder ABC). We also have to ensure the that the wave left the domain
@@ -230,8 +228,9 @@ private:
   double end_time       = 1.0;
   double radius         = 1.0;
 
-  // only needed to setup error calculation for test
-  bool is_test = false;
+  // analytical solution only known for first oder ABC and after
+  // the wave left the domain
+  bool analytical_solution_is_available = false;
 };
 
 } // namespace Acoustics

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
@@ -207,6 +207,15 @@ private:
         std::make_shared<dealii::Functions::ZeroFunction<dim>>(1);
       pp_data.error_data_p.calculate_relative_errors = false; // analytical solution is zero
       pp_data.error_data_p.name                      = "pressure";
+
+      // calculation of velocity error
+      pp_data.error_data_u.time_control_data.is_active        = true;
+      pp_data.error_data_u.time_control_data.start_time       = this->param.start_time;
+      pp_data.error_data_u.time_control_data.trigger_interval = this->param.end_time;
+      pp_data.error_data_u.analytical_solution =
+        std::make_shared<dealii::Functions::ZeroFunction<dim>>(dim);
+      pp_data.error_data_u.calculate_relative_errors = false; // analytical solution is zero
+      pp_data.error_data_u.name                      = "velocity";
     }
 
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
@@ -1,0 +1,235 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_NORMAL_INCIDENTING_WAVE_H_
+#define APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_NORMAL_INCIDENTING_WAVE_H_
+
+#include <deal.II/base/function.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include <exadg/grid/grid_utilities.h>
+
+namespace ExaDG
+{
+namespace Acoustics
+{
+template<int dim>
+class InitialConditionPressure : public dealii::Function<dim>
+{
+public:
+  InitialConditionPressure() : dealii::Function<dim>(1, 0.0)
+  {
+  }
+
+  double
+  value(dealii::Point<dim> const & p, unsigned int const) const final
+  {
+    double exponent = 0.0;
+    for(unsigned int d = 0; d < dim; ++d)
+      exponent += p[d] * p[d];
+
+    return std::exp(-100.0 * exponent);
+  }
+};
+
+template<int dim, typename Number>
+class Application : public ApplicationBase<dim, Number>
+{
+public:
+  Application(std::string input_file, MPI_Comm const & comm)
+    : ApplicationBase<dim, Number>(input_file, comm)
+  {
+  }
+
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+      prm.add_parameter("SpeedOfSound",
+                        speed_of_sound,
+                        "Speed of sound.",
+                        dealii::Patterns::Double(1.0e-12));
+
+      prm.add_parameter("Admittance",
+                        admittance,
+                        "Admittance.",
+                        dealii::Patterns::Double(0.0, 1.0));
+
+      prm.add_parameter("EndTime", end_time, "End time.", dealii::Patterns::Double(1.0e-12));
+
+      prm.add_parameter("Radius", radius, "Radius of domain.", dealii::Patterns::Double(1.0e-12));
+    }
+    prm.leave_subsection();
+
+    // For a reasonable test we have to create a differen postprocessor, see below.
+    prm.enter_subsection("General");
+    {
+      prm.add_parameter("IsTest", is_test, "Do we run a test?", dealii::Patterns::Bool());
+    }
+    prm.leave_subsection();
+  }
+
+private:
+  void
+  set_parameters() final
+  {
+    // MATHEMATICAL MODEL
+    this->param.formulation     = Formulation::SkewSymmetric;
+    this->param.right_hand_side = false;
+
+    // PHYSICAL QUANTITIES
+    this->param.start_time     = 0.0;
+    this->param.end_time       = end_time;
+    this->param.speed_of_sound = speed_of_sound;
+
+    // TEMPORAL DISCRETIZATION
+    this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
+    this->param.cfl                           = 0.25;
+    this->param.order_time_integrator         = 2;
+    this->param.start_with_low_order          = true;
+
+    // output of solver information
+    this->param.solver_info_data.interval_time = (this->param.end_time - this->param.start_time);
+
+    // SPATIAL DISCRETIZATION
+    this->param.grid.triangulation_type = TriangulationType::Distributed;
+    this->param.mapping_degree          = 2;
+    this->param.degree_p                = this->param.degree_u;
+    this->param.degree_u                = this->param.degree_p;
+  }
+
+  void
+  create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) final
+  {
+    (void)mapping;
+
+    auto const lambda_create_triangulation =
+      [&](dealii::Triangulation<dim, dim> & tria,
+          std::vector<dealii::GridTools::PeriodicFacePair<
+            typename dealii::Triangulation<dim>::cell_iterator>> & /*periodic_face_pairs*/,
+          unsigned int const global_refinements,
+          std::vector<unsigned int> const & /* vector_local_refinements*/) {
+        dealii::GridGenerator::hyper_ball_balanced(tria, {}, radius);
+
+        for(const auto & face : tria.active_face_iterators())
+          if(face->at_boundary())
+            face->set_boundary_id(1);
+
+        tria.refine_global(global_refinements);
+      };
+
+    GridUtilities::create_triangulation<dim>(
+      grid, this->mpi_comm, this->param.grid, lambda_create_triangulation, {});
+
+    GridUtilities::create_mapping(mapping,
+                                  this->param.grid.element_type,
+                                  this->param.mapping_degree);
+  }
+
+  void
+  set_boundary_descriptor() final
+  {
+    this->boundary_descriptor->admittance_bc.insert(
+      std::make_pair(1, std::make_shared<dealii::Functions::ConstantFunction<dim>>(admittance, 1)));
+  }
+
+  void
+  set_field_functions() final
+  {
+    this->field_functions->initial_solution_pressure =
+      std::make_shared<InitialConditionPressure<dim>>();
+
+    this->field_functions->initial_solution_velocity =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(dim);
+
+    this->field_functions->right_hand_side =
+      std::make_shared<dealii::Functions::ZeroFunction<dim>>(1);
+  }
+
+  std::shared_ptr<PostProcessorBase<dim, Number>>
+  create_postprocessor() final
+  {
+    PostProcessorData<dim> pp_data;
+
+    // write output for visualization of results
+    pp_data.output_data.time_control_data.is_active  = this->output_parameters.write;
+    pp_data.output_data.time_control_data.start_time = this->param.start_time;
+    pp_data.output_data.time_control_data.trigger_interval =
+      (this->param.end_time - this->param.start_time) / 20.0;
+    pp_data.output_data.directory          = this->output_parameters.directory + "vtu/";
+    pp_data.output_data.filename           = this->output_parameters.filename;
+    pp_data.output_data.write_pressure     = true;
+    pp_data.output_data.write_velocity     = true;
+    pp_data.output_data.write_higher_order = true;
+    pp_data.output_data.degree             = this->param.degree_u;
+
+    // To be able to compute an analytical solution for testing purposes we have to make
+    // multiple assumptions. The application is intended to be used with different
+    // admittances which contradicts the assumptions. Therefore, we compute the analytical
+    // solution only if we run a test and fetch this information from the input file.
+    if(is_test)
+    {
+      // To be able to compute an error and thus test the behavior of the admittance BC for
+      // Y=1 (first-oder ABC). We also have to ensure the that the wave left the domain
+      // when computing the error.
+      AssertThrow(std::abs(admittance - 1.0) < 1.0e-12,
+                  dealii::ExcMessage("The analytical solution only holds for Y=1."));
+      AssertThrow(this->param.end_time > 1.5 * radius / speed_of_sound,
+                  dealii::ExcMessage("The end time has to be after the wave left the domain."));
+
+      // calculation of pressure error
+      pp_data.error_data_p.time_control_data.is_active        = true;
+      pp_data.error_data_p.time_control_data.start_time       = this->param.start_time;
+      pp_data.error_data_p.time_control_data.trigger_interval = this->param.end_time;
+      pp_data.error_data_p.analytical_solution =
+        std::make_shared<dealii::Functions::ZeroFunction<dim>>(1);
+      pp_data.error_data_p.calculate_relative_errors = false; // analytical solution is zero
+      pp_data.error_data_p.name                      = "pressure";
+    }
+
+    std::shared_ptr<PostProcessorBase<dim, Number>> pp;
+    pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
+
+    return pp;
+  }
+
+  // problem specific parameters
+  double speed_of_sound = 340.0;
+  double admittance     = 1.0; // Y = 1.0 -> first order ABC
+  double end_time       = 1.0;
+  double radius         = 1.0;
+
+  // only needed to setup error calculation for test
+  bool is_test = false;
+};
+
+} // namespace Acoustics
+
+} // namespace ExaDG
+
+#include <exadg/acoustic_conservation_equations/user_interface/implement_get_application.h>
+
+#endif /* APPLICATIONS_ACOUSTIC_CONSERVATION_EQUATIONS_TEST_CASES_NORMAL_INCIDENTING_WAVE_H_ \
+        */

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/application.h
@@ -83,7 +83,7 @@ public:
     }
     prm.leave_subsection();
 
-    // For a reasonable test we have to create a differen postprocessor, see below.
+    // For a reasonable test we have to create a different postprocessor, see below.
     prm.enter_subsection("General");
     {
       prm.add_parameter("IsTest", is_test, "Do we run a test?", dealii::Patterns::Bool());

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/input.json
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/input.json
@@ -1,0 +1,28 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "2",
+        "IsTest": "false"
+    },
+    "SpatialResolution": {
+        "DegreeMin": "2",
+        "DegreeMax": "2",
+        "RefineSpaceMin": "2",
+        "RefineSpaceMax": "2"
+    },
+    "TemporalResolution": {
+        "RefineTimeMin": "0",
+        "RefineTimeMax": "0"
+    },
+    "Application": {
+        "SpeedOfSound": "340.0",
+        "Admittance": "1.0",
+        "EndTime": "0.01",
+        "Radius": "1.0"
+    },
+    "Output": {
+        "OutputDirectory": "output/normal_incidenting_wave/",
+        "OutputName": "normal_incidenting_wave",
+        "WriteOutput": "false"
+    }
+}

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/input.json
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/input.json
@@ -18,7 +18,8 @@
         "SpeedOfSound": "340.0",
         "Admittance": "1.0",
         "EndTime": "0.01",
-        "Radius": "1.0"
+        "Radius": "1.0",
+        "AnalyticalSolutionAvailable": "false"
     },
     "Output": {
         "OutputDirectory": "output/normal_incidenting_wave/",

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/solver.cpp
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/solver.cpp
@@ -1,0 +1,26 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2023 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// solver
+#include <exadg/acoustic_conservation_equations/solver.h>
+
+// application
+#include "application.h"

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/CMakeLists.txt
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+#########################################################################
+# 
+#                 #######               ######  #######
+#                 ##                    ##   ## ##
+#                 #####   ##  ## #####  ##   ## ## ####
+#                 ##       ####  ## ##  ##   ## ##   ##
+#                 ####### ##  ## ###### ######  #######
+#
+#  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+#
+#  Copyright (C) 2023 by the ExaDG authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+GET_FILENAME_COMPONENT(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+TARGETNAME(TARGET_NAME ${PARENT_DIR})
+SET(TEST_LIBRARIES exadg)
+SET(TEST_TARGET ${TARGET_NAME})
+EXADG_PICKUP_TESTS(${TARGET_NAME})

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.json
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.json
@@ -18,7 +18,8 @@
         "SpeedOfSound": "340.0",
         "Admittance": "1.0",
         "EndTime": "0.01",
-        "Radius": "1.0"
+        "Radius": "1.0",
+        "AnalyticalSolutionAvailable": "true"
     },
     "Output": {
         "OutputDirectory": "output/normal_incidenting_wave/",

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.json
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.json
@@ -1,0 +1,28 @@
+{
+    "General": {
+        "Precision": "double",
+        "Dim": "2",
+        "IsTest": "true"
+    },
+    "SpatialResolution": {
+        "DegreeMin": "2",
+        "DegreeMax": "2",
+        "RefineSpaceMin": "2",
+        "RefineSpaceMax": "2"
+    },
+    "TemporalResolution": {
+        "RefineTimeMin": "0",
+        "RefineTimeMax": "0"
+    },
+    "Application": {
+        "SpeedOfSound": "340.0",
+        "Admittance": "1.0",
+        "EndTime": "0.01",
+        "Radius": "1.0"
+    },
+    "Output": {
+        "OutputDirectory": "output/normal_incidenting_wave/",
+        "OutputName": "normal_incidenting_wave",
+        "WriteOutput": "false"
+    }
+}

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.output
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.output
@@ -90,6 +90,9 @@ Starting time loop ...
 Calculate error for pressure at time t = 0.0000e+00:
   Absolute error (L2-norm): 1.19175e-01
 
+Calculate error for velocity at time t = 0.0000e+00:
+  Absolute error (L2-norm): 0.00000e+00
+
 ________________________________________________________________________________
 
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.41720e-05
@@ -97,3 +100,6 @@ ________________________________________________________________________________
 
 Calculate error for pressure at time t = 1.0005e-02:
   Absolute error (L2-norm): 5.34766e-04
+
+Calculate error for velocity at time t = 1.0005e-02:
+  Absolute error (L2-norm): 1.83535e-06

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.output
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.output
@@ -1,0 +1,99 @@
+
+
+
+________________________________________________________________________________
+                                                                                
+                ////////                      ///////   ////////                
+                ///                           ///  ///  ///                     
+                //////    ///  ///  ///////   ///  ///  /// ////                
+                ///         ////    //   //   ///  ///  ///  ///                
+                ////////  ///  ///  ///////// ///////   ////////                
+                                                                                
+               High-Order Discontinuous Galerkin for the Exa-Scale              
+________________________________________________________________________________
+
+
+MPI info:
+
+  Number of processes:                       1
+
+Setting up acoustic conservation equations solver:
+
+List of parameters:
+
+Mathematical model:
+  Formulation:                               SkewSymmetric
+  Right-hand side:                           false
+
+Physical quantities:
+  Start time:                                0.0000e+00
+  End time:                                  1.0000e-02
+  Speed of sound:                            3.4000e+02
+
+Temporal discretization:
+  Calculation of time step size:             CFL
+  Maximum number of time steps:              4294967295
+  Temporal refinements:                      0
+  Order of time integration scheme:          2
+  Start with low order method:               true
+  Restarted simulation:                      false
+  Restart:
+  Write restart:                             false
+
+Spatial discretization:
+  Triangulation type:                        Distributed
+  Element type:                              Hypercube
+  Number of global refinements:              2
+  Create coarse triangulations:              false
+  Mapping degree:                            2
+  Polynomial degree pressure:                2
+  Polynomial degree velocity:                2
+
+Generating grid for 2-dimensional problem:
+
+  Max. number of refinements:                2
+  Number of cells:                           192
+
+Construct acoustic conservation equations operator ...
+Pressure:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   9
+  number of dofs (total):                    1728
+Velocity:
+  degree of 1D polynomials:                  2
+  number of dofs per cell:                   18
+  number of dofs (total):                    3456
+Pressure and velocity:
+  number of dofs per cell:                   27
+  number of dofs (total):                    5184
+
+... done!
+
+Setup acoustic conservation equations operator ...
+
+... done!
+
+Setup Multistep time integrator ...
+
+Calculation of time step size:
+
+
+Calculation of time step size according to CFL condition:
+
+  CFL:                                       2.5000e-01
+  time step size:                            1.4172e-05
+
+... done!
+
+Starting time loop ...
+
+Calculate error for pressure at time t = 0.0000e+00:
+  Absolute error (L2-norm): 1.19175e-01
+
+________________________________________________________________________________
+
+ Time step number = 1       t = 0.00000e+00 -> t + dt = 1.41720e-05
+________________________________________________________________________________
+
+Calculate error for pressure at time t = 1.0005e-02:
+  Absolute error (L2-norm): 5.34766e-04

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
@@ -474,7 +474,10 @@ private:
     BoundaryFaceIntegratorP<dim, Number> pressure_p(pressure_m, *data.bc);
 
     FaceIntegratorU velocity_m(matrix_free_in, true, data.dof_index_velocity, data.quad_index);
-    BoundaryFaceIntegratorU<dim, Number> velocity_p(velocity_m, *data.bc);
+    BoundaryFaceIntegratorU<dim, Number> velocity_p(velocity_m,
+                                                    pressure_m,
+                                                    data.speed_of_sound,
+                                                    *data.bc);
 
     for(unsigned int face = face_range.first; face < face_range.second; face++)
     {

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
@@ -101,10 +101,10 @@ inline DEAL_II_ALWAYS_INLINE //
     auto const rho_um_tangential = rho_um - rho_um_normal;
 
     // normal share of velocty
-    auto const rho_u_n = (Number{2.0} * Y * pm / c) * n - rho_um_normal;
+    auto const rho_up_normal = (Number{2.0} * Y * pm / c) * n - rho_um_normal;
 
     // tangential share of velocity stays the same
-    return rho_u_n + rho_um_tangential;
+    return rho_up_normal + rho_um_tangential;
   }
   else
   {

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
@@ -103,7 +103,7 @@ inline DEAL_II_ALWAYS_INLINE //
     // normal share of velocty
     auto const rho_up_normal = (Number{2.0} * Y * pm / c) * n - rho_um_normal;
 
-    // tangential share of velocity stays the same
+    // tangential share of velocity stays the same (rho_up_tangential = rho_um_tangential)
     return rho_up_normal + rho_um_tangential;
   }
   else

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
@@ -100,7 +100,7 @@ inline DEAL_II_ALWAYS_INLINE //
     auto const rho_um_normal     = (rho_um * n) * n;
     auto const rho_um_tangential = rho_um - rho_um_normal;
 
-    // normal share of velocty
+    // normal share of velocity
     auto const rho_up_normal = (Number{2.0} * Y * pm / speed_of_sound) * n - rho_um_normal;
 
     // tangential share of velocity stays the same (rho_up_tangential = rho_um_tangential)

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
@@ -68,7 +68,7 @@ inline DEAL_II_ALWAYS_INLINE //
   calculate_exterior_value_velocity(unsigned int const                       q,
                                     FaceIntegrator<dim, dim, Number> const & velocity_m,
                                     FaceIntegrator<dim, 1, Number> const &   pressure_m,
-                                    double const                             c,
+                                    double const                             speed_of_sound,
                                     BoundaryType const &                     boundary_type,
                                     dealii::types::boundary_id const         boundary_id,
                                     BoundaryDescriptor<dim> const &          boundary_descriptor,
@@ -101,7 +101,7 @@ inline DEAL_II_ALWAYS_INLINE //
     auto const rho_um_tangential = rho_um - rho_um_normal;
 
     // normal share of velocty
-    auto const rho_up_normal = (Number{2.0} * Y * pm / c) * n - rho_um_normal;
+    auto const rho_up_normal = (Number{2.0} * Y * pm / speed_of_sound) * n - rho_um_normal;
 
     // tangential share of velocity stays the same (rho_up_tangential = rho_um_tangential)
     return rho_up_normal + rho_um_tangential;

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/weak_boundary_conditions.h
@@ -50,7 +50,7 @@ inline DEAL_II_ALWAYS_INLINE //
       time);
     return -pressure_m.get_value(q) + Number{2.0} * g;
   }
-  else if(boundary_type == BoundaryType::VelocityDirichlet ||
+  else if(boundary_type == BoundaryType::VelocityDirichlet or
           boundary_type == BoundaryType::Admittance)
   {
     return pressure_m.get_value(q);

--- a/include/exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h
@@ -44,6 +44,9 @@ namespace Acoustics
  * | prescribe velocity values |                         | Dirichlet:              |
  * |                           | no BCs to be prescribed | prescribe g_u           |
  * +---------------------------+-------------------------+-------------------------+
+ * | admittance BC             |                         | Admittance:             |
+ * |                           | no BCs to be prescribed | prescribe Y             |
+ * +---------------------------+-------------------------+-------------------------+
  */
 
 enum class BoundaryType
@@ -51,6 +54,7 @@ enum class BoundaryType
   Undefined,
   PressureDirichlet,
   VelocityDirichlet,
+  Admittance
 };
 
 template<int dim>
@@ -66,6 +70,12 @@ struct BoundaryDescriptor
   // Dirichlet: prescribe velocity
   std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> velocity_dbc;
 
+  // BC for Admittance Y:
+  // Special cases are:
+  // Y = 0: sound hard (perfectly reflecting)
+  // Y = 1: first order ABC
+  std::map<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>> admittance_bc;
+
   // return the boundary type
   inline DEAL_II_ALWAYS_INLINE //
     BoundaryType
@@ -76,6 +86,9 @@ struct BoundaryDescriptor
 
     if(this->velocity_dbc.find(boundary_id) != this->velocity_dbc.end())
       return BoundaryType::VelocityDirichlet;
+
+    if(this->admittance_bc.find(boundary_id) != this->admittance_bc.end())
+      return BoundaryType::Admittance;
 
     AssertThrow(false, dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
 
@@ -93,6 +106,9 @@ struct BoundaryDescriptor
       counter++;
 
     if(this->velocity_dbc.find(boundary_id) != this->velocity_dbc.end())
+      counter++;
+
+    if(this->admittance_bc.find(boundary_id) != this->admittance_bc.end())
       counter++;
 
     if(periodic_boundary_ids.find(boundary_id) != periodic_boundary_ids.end())

--- a/include/exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/boundary_descriptor.h
@@ -44,8 +44,10 @@ namespace Acoustics
  * | prescribe velocity values |                         | Dirichlet:              |
  * |                           | no BCs to be prescribed | prescribe g_u           |
  * +---------------------------+-------------------------+-------------------------+
- * | admittance BC             |                         | Admittance:             |
- * |                           | no BCs to be prescribed | prescribe Y             |
+ * | admittance (Y) BC         |                         | Admittance:             |
+ * | rho * u * n = Y / c * p   | no BCs to be prescribed | prescribe Y             |
+ * | Y = 0: sound hard         |                         |                         |
+ * | Y = 1: first order ABC    |                         |                         |
  * +---------------------------+-------------------------+-------------------------+
  */
 


### PR DESCRIPTION
Depends on https://github.com/exadg/exadg/pull/631.

This PR also depends on https://github.com/exadg/exadg/pull/619. This dependency is only because the test includes the printed parameter "rhs". I will have to force push to trigger the pipeline once both other PRs are merged. Other than that I am ready here.

In acoustics, admittance boundary conditions can be used to mimic absorbing materials at the domain boundary. We prescribe the BC as follows:
```math
\rho\mathbf{u}\cdot\mathbf{n}=\frac{Y}{c}p
```
Setting $`Y=1`$ corresponds to a first-order absorbing BC (ABC). $`Y=0`$ is equivalent to sound-hard (perfectly reflecting) materials.