### PR TITLE
Solve for rho * u

### DIFF
--- a/applications/acoustic_conservation_equations/vibrating_membrane/application.h
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/application.h
@@ -97,7 +97,7 @@ public:
         result *= std::sin(M * pi * p[0]) * std::sin(M * pi * p[1]) * std::cos(M * pi * p[2]);
     }
 
-    return result;
+    return rho * result;
   }
 
 private:

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
@@ -98,7 +98,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 1.56490e-02
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 9.44139e-03
+  Absolute error (L2-norm): 2.83242e-02
 
 
 
@@ -199,7 +199,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 8.03504e-03
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 5.61975e-04
+  Absolute error (L2-norm): 1.68592e-03
 
 
 
@@ -300,7 +300,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 7.77314e-04
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 4.40859e-05
+  Absolute error (L2-norm): 1.32258e-04
 
 
 
@@ -401,7 +401,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.18740e-05
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 3.66325e-06
+  Absolute error (L2-norm): 1.09897e-05
 
 
 
@@ -502,7 +502,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 6.14288e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 2.55887e-07
+  Absolute error (L2-norm): 7.67662e-07
 
 
 
@@ -603,7 +603,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.07805e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 1.41295e-08
+  Absolute error (L2-norm): 4.23885e-08
 
 
 
@@ -704,4 +704,4 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.07362e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 7.92203e-10
+  Absolute error (L2-norm): 2.37661e-09

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
@@ -98,7 +98,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 1.56490e-02
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 9.44139e-03
+  Absolute error (L2-norm): 2.83242e-02
 
 
 
@@ -199,7 +199,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 8.03504e-03
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 5.61975e-04
+  Absolute error (L2-norm): 1.68592e-03
 
 
 
@@ -300,7 +300,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 7.77314e-04
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 4.40859e-05
+  Absolute error (L2-norm): 1.32258e-04
 
 
 
@@ -401,7 +401,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.18740e-05
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 3.66325e-06
+  Absolute error (L2-norm): 1.09897e-05
 
 
 
@@ -502,7 +502,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 6.14288e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 2.55887e-07
+  Absolute error (L2-norm): 7.67662e-07
 
 
 
@@ -603,7 +603,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.07805e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 1.41295e-08
+  Absolute error (L2-norm): 4.23885e-08
 
 
 
@@ -704,4 +704,4 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.07362e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 7.92203e-10
+  Absolute error (L2-norm): 2.37661e-09

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -98,7 +98,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 1.56490e-02
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 9.44139e-03
+  Absolute error (L2-norm): 2.83242e-02
 
 
 
@@ -199,7 +199,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 8.03504e-03
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 5.61975e-04
+  Absolute error (L2-norm): 1.68592e-03
 
 
 
@@ -300,7 +300,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 7.77314e-04
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 4.40859e-05
+  Absolute error (L2-norm): 1.32258e-04
 
 
 
@@ -401,7 +401,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.18740e-05
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 3.66325e-06
+  Absolute error (L2-norm): 1.09897e-05
 
 
 
@@ -502,7 +502,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 6.14288e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 2.55887e-07
+  Absolute error (L2-norm): 7.67662e-07
 
 
 
@@ -603,7 +603,7 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.07805e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 1.41295e-08
+  Absolute error (L2-norm): 4.23885e-08
 
 
 
@@ -704,4 +704,4 @@ Calculate error for pressure at time t = 2.5300e-02:
   Absolute error (L2-norm): 5.07362e-06
 
 Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 7.92203e-10
+  Absolute error (L2-norm): 2.37661e-09

--- a/include/exadg/acoustic_conservation_equations/driver.cpp
+++ b/include/exadg/acoustic_conservation_equations/driver.cpp
@@ -152,8 +152,8 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
   const std::function<void(void)> operator_evaluation = [&](void) {
     if(operator_type == OperatorType::AcousticOperator)
       pde_operator->evaluate_acoustic_operator(dst, src, 0.0);
-    else if(operator_type == OperatorType::InverseMassOperator)
-      pde_operator->apply_inverse_mass_operator(dst, src);
+    else if(operator_type == OperatorType::ScaledInverseMassOperator)
+      pde_operator->apply_scaled_inverse_mass_operator(dst, src);
     else
       AssertThrow(false, dealii::ExcMessage("Not implemented."));
   };

--- a/include/exadg/acoustic_conservation_equations/driver.h
+++ b/include/exadg/acoustic_conservation_equations/driver.h
@@ -37,10 +37,11 @@ namespace Acoustics
 {
 enum class OperatorType
 {
-  AcousticOperator,   // gradient operator for scalar pressure and divergence operator for
-                      // vectorial velocity
-  InverseMassOperator // inverse mass operator: vectorial quantity (velocity) and scalar quantity
-                      // (pressure)
+  AcousticOperator,         // gradient operator for scalar pressure and divergence operator for
+                            // vectorial velocity
+  ScaledInverseMassOperator // scaled inverse mass operator: vectorial quantity (velocity) and
+                            // scalar quantity (pressure). The pressure is scaled by
+                            // speed_of_sound^2 in the evaluation of the operator
 };
 
 inline unsigned int

--- a/include/exadg/acoustic_conservation_equations/postprocessor/output_generator.cpp
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/output_generator.cpp
@@ -60,7 +60,7 @@ write_output(OutputData const &                                         output_d
 
   if(output_data.write_velocity)
   {
-    std::vector<std::string> velocity_names(dim, "velocity");
+    std::vector<std::string> velocity_names(dim, "velocity_times_density");
     std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
       velocity_component_interpretation(
         dim, dealii::DataComponentInterpretation::component_is_part_of_vector);

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -314,7 +314,7 @@ SpatialOperator<dim, Number>::evaluate(BlockVectorType &       dst,
   // shift to the right-hand side of the equation
   dst *= -1.0;
 
-  apply_inverse_mass_operator(dst, dst);
+  apply_scaled_inverse_mass_operator(dst, dst);
 }
 
 template<int dim, typename Number>
@@ -328,10 +328,12 @@ SpatialOperator<dim, Number>::evaluate_acoustic_operator(BlockVectorType &      
 
 template<int dim, typename Number>
 void
-SpatialOperator<dim, Number>::apply_inverse_mass_operator(BlockVectorType &       dst,
-                                                          BlockVectorType const & src) const
+SpatialOperator<dim, Number>::apply_scaled_inverse_mass_operator(BlockVectorType &       dst,
+                                                                 BlockVectorType const & src) const
 {
-  inverse_mass_pressure.apply(dst.block(block_index_pressure), src.block(block_index_pressure));
+  inverse_mass_pressure.apply_scale(dst.block(block_index_pressure),
+                                    param.speed_of_sound * param.speed_of_sound,
+                                    src.block(block_index_pressure));
   inverse_mass_velocity.apply(dst.block(block_index_velocity), src.block(block_index_velocity));
 }
 
@@ -422,7 +424,6 @@ SpatialOperator<dim, Number>::initialize_operators()
     data.block_index_pressure = block_index_pressure;
     data.block_index_velocity = block_index_velocity;
     data.speed_of_sound       = param.speed_of_sound;
-    data.density              = param.density;
     data.formulation          = param.formulation;
     data.bc                   = boundary_descriptor;
     acoustic_operator.initialize(*matrix_free, data);

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
@@ -45,7 +45,7 @@ namespace Acoustics
  * Spatial operator to solve for the acoustic conservation equations:
  *
  * 1/c^2 * dp/dt + div (rho * u) = f
- *  (rho * u)/dt + grad p = 0
+ * d(rho * u)/dt + grad p = 0
  *
  * This operator solves for the pressure p as well as the velocity that is
  * already scaled by the density rho * u.

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
@@ -41,6 +41,15 @@ namespace ExaDG
 {
 namespace Acoustics
 {
+/**
+ * Spatial operator to solve for the acoustic conservation equations:
+ *
+ * 1/c^2 * dp/dt + div (rho * u) = f
+ *  (rho * u)/dt + grad p = 0
+ *
+ * This operator solves for the pressure p as well as the velocity that is
+ * already scaled by the density rho * u.
+ */
 template<int dim, typename Number>
 class SpatialOperator : public Interface::SpatialOperator<Number>
 {
@@ -163,9 +172,15 @@ public:
                              BlockVectorType const & src,
                              double const            time) const;
 
-  // inverse mass operator
+  /**
+   * This function applies the inverse mass matrix and scales the pressure by c^2. This is because
+   * the PDE we are solving for reads as
+   *
+   * 1/c^2 dp/dt + div  u = f
+   *       du/dt + grad p = 0
+   */
   void
-  apply_inverse_mass_operator(BlockVectorType & dst, BlockVectorType const & src) const;
+  apply_scaled_inverse_mass_operator(BlockVectorType & dst, BlockVectorType const & src) const;
 
   // Calculate time step size according to local CFL criterion
   double


### PR DESCRIPTION
The acoustic conservation equations read:
```math
 \frac{1}{c^2}\frac{\partial p}{\partial t} + \rho \nabla\cdot\mathbf{u} = f 
```
```math
\rho\frac{\partial \mathbf{u}}{\partial t}+\nabla p =\mathbf{0}
```
Similar to solving for the kinematic pressure in the incompressible Navier-Stokes equations we can solve for  $`\rho\mathbf{u}`$ instead of  $`\mathbf{u}`$:
```math
 \frac{1}{c^2}\frac{\partial p}{\partial t} + \nabla\cdot\mathbf{u}_{\rho} = f 
```
```math
\frac{\partial \mathbf{u}_{\rho}}{\partial t}+\nabla p =\mathbf{0}
```

This PR shifts the scaling factors to the temporal derivatives (as indicated in https://github.com/exadg/exadg/pull/619). Additionally, it restructures the operators such that we solve for  $`\rho\mathbf{u}`$. This PR should be merged before continuing with https://github.com/exadg/exadg/pull/619.