### PR TITLE
Make HDF5 an optional dependency and KineticEnergySpectrumCalculator an optional postprocessing routine

### DIFF
--- a/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
@@ -597,7 +597,7 @@ KineticEnergySpectrumCalculator<dim, Number>::setup(
   {
     data        = data_in;
     clear_files = data.clear_file;
-    time_control.setup(data_in.time_control_data);
+    time_control.setup(data.time_control_data);
 
     dof_handler = &dof_handler_in;
     AssertThrow(

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
@@ -596,17 +596,17 @@ KineticEnergySpectrumCalculator<dim, Number>::setup(
   data        = data_in;
   dof_handler = &dof_handler_in;
 
-  AssertThrow(
-    dof_handler->get_triangulation().all_reference_cells_are_hyper_cube(),
-    dealii::ExcMessage(
-      "This postprocessing utility is only available for meshes consisting of hypercube elements."));
-
   clear_files = data.clear_file;
 
   time_control.setup(data_in.time_control_data);
 
   if(data_in.time_control_data.is_active)
   {
+    AssertThrow(
+      dof_handler->get_triangulation().all_reference_cells_are_hyper_cube(),
+      dealii::ExcMessage(
+        "This postprocessing utility is only available for meshes consisting of hypercube elements."));
+
     if(data.write_raw_data_to_files)
     {
       AssertThrow(data.n_cells_1d_coarse_grid == 1,

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
@@ -593,15 +593,13 @@ KineticEnergySpectrumCalculator<dim, Number>::setup(
   dealii::DoFHandler<dim> const &         dof_handler_in,
   KineticEnergySpectrumData const &       data_in)
 {
-  data        = data_in;
-  dof_handler = &dof_handler_in;
-
-  clear_files = data.clear_file;
-
-  time_control.setup(data_in.time_control_data);
-
   if(data_in.time_control_data.is_active)
   {
+    data        = data_in;
+    clear_files = data.clear_file;
+    time_control.setup(data_in.time_control_data);
+
+    dof_handler = &dof_handler_in;
     AssertThrow(
       dof_handler->get_triangulation().all_reference_cells_are_hyper_cube(),
       dealii::ExcMessage(

--- a/include/exadg/postprocessor/pointwise_output_generator_base.cpp
+++ b/include/exadg/postprocessor/pointwise_output_generator_base.cpp
@@ -145,8 +145,10 @@ PointwiseOutputGeneratorBase<dim, Number>::setup_base(
 #else
   (void)triangulation_in;
   (void)mapping_in;
-  (void)pointwise_output_data_in;
-  AssertThrow(false, dealii::ExcMessage("deal.II is not compiled with HDF5!"));
+  if(pointwise_output_data_in.time_control_data.is_active)
+  {
+    AssertThrow(false, dealii::ExcMessage("deal.II is not compiled with HDF5!"));
+  }
 #endif
 }
 

--- a/include/exadg/postprocessor/pointwise_output_generator_base.cpp
+++ b/include/exadg/postprocessor/pointwise_output_generator_base.cpp
@@ -98,24 +98,23 @@ PointwiseOutputGeneratorBase<dim, Number>::setup_base(
   dealii::Mapping<dim> const &         mapping_in,
   PointwiseOutputDataBase<dim> const & pointwise_output_data_in)
 {
-#ifdef DEAL_II_WITH_HDF5
-  triangulation         = &triangulation_in;
-  pointwise_output_data = pointwise_output_data_in;
-
-
-  AssertThrow(
-    (get_unsteady_evaluation_type(pointwise_output_data_in.time_control_data) ==
-     TimeControlData::UnsteadyEvalType::Interval) or
-      (get_unsteady_evaluation_type(pointwise_output_data_in.time_control_data) ==
-       TimeControlData::UnsteadyEvalType::None),
-    dealii::ExcMessage(
-      "This module can currently only be used with time TimeControlData::UnsteadyEvalType::Interval"));
-
-  time_control.setup(pointwise_output_data_in.time_control_data);
-
-  if(pointwise_output_data.time_control_data.is_active and
-     pointwise_output_data.evaluation_points.size() > 0)
+  if(pointwise_output_data_in.time_control_data.is_active and
+     pointwise_output_data_in.evaluation_points.size() > 0)
   {
+#ifdef DEAL_II_WITH_HDF5
+    triangulation         = &triangulation_in;
+    pointwise_output_data = pointwise_output_data_in;
+
+    AssertThrow(
+      (get_unsteady_evaluation_type(pointwise_output_data_in.time_control_data) ==
+       TimeControlData::UnsteadyEvalType::Interval) or
+        (get_unsteady_evaluation_type(pointwise_output_data_in.time_control_data) ==
+         TimeControlData::UnsteadyEvalType::None),
+      dealii::ExcMessage(
+        "This module can currently only be used with time TimeControlData::UnsteadyEvalType::Interval"));
+
+    time_control.setup(pointwise_output_data_in.time_control_data);
+
     mapping = &mapping_in;
 
     // allocate memory for hyperslab
@@ -141,15 +140,13 @@ PointwiseOutputGeneratorBase<dim, Number>::setup_base(
       auto group = hdf5_file->create_group("PhysicalInformation");
       add_time_dataset(group, "Time");
     }
-  }
+
 #else
-  (void)triangulation_in;
-  (void)mapping_in;
-  if(pointwise_output_data_in.time_control_data.is_active)
-  {
+    (void)triangulation_in;
+    (void)mapping_in;
     AssertThrow(false, dealii::ExcMessage("deal.II is not compiled with HDF5!"));
-  }
 #endif
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/postprocessor/pointwise_output_generator_base.cpp
+++ b/include/exadg/postprocessor/pointwise_output_generator_base.cpp
@@ -106,14 +106,14 @@ PointwiseOutputGeneratorBase<dim, Number>::setup_base(
     pointwise_output_data = pointwise_output_data_in;
 
     AssertThrow(
-      (get_unsteady_evaluation_type(pointwise_output_data_in.time_control_data) ==
+      (get_unsteady_evaluation_type(pointwise_output_data.time_control_data) ==
        TimeControlData::UnsteadyEvalType::Interval) or
-        (get_unsteady_evaluation_type(pointwise_output_data_in.time_control_data) ==
+        (get_unsteady_evaluation_type(pointwise_output_data.time_control_data) ==
          TimeControlData::UnsteadyEvalType::None),
       dealii::ExcMessage(
         "This module can currently only be used with time TimeControlData::UnsteadyEvalType::Interval"));
 
-    time_control.setup(pointwise_output_data_in.time_control_data);
+    time_control.setup(pointwise_output_data.time_control_data);
 
     mapping = &mapping_in;
 


### PR DESCRIPTION
closes #419

in `incompressible_navier_stokes/postprocessor/postprocessor.cpp` in the `PostProcessor::setup()`, we call among others `pointwise_output_generator.setup()` and `kinetic_energy_spectrum_calculator.setup()`.
The former requires hdf5, which is only an optional dependency as far as I know and the latter requires `elementType::Hypercube`. I moved the asserts behind a `time_control.is_active`, since the setup is called in any case, but the postprocessors might not even be active.
After the setup, the `evaluate`on the postprocessors is behind a `pointwise_output_generator.time_control.needs_evaluation()` for example. So not setting them up should be fine.