### PR TITLE
add grid and mapping to flow set_boundary_descriptor

### DIFF
--- a/applications/compressible_navier_stokes/couette/application.h
+++ b/applications/compressible_navier_stokes/couette/application.h
@@ -247,8 +247,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
                                                                                    pair;
     typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;

--- a/applications/compressible_navier_stokes/euler_vortex/application.h
+++ b/applications/compressible_navier_stokes/euler_vortex/application.h
@@ -281,8 +281,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
                                                                                    pair;
     typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -467,8 +467,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
                                                                                    pair;
     typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;

--- a/applications/compressible_navier_stokes/poiseuille/application.h
+++ b/applications/compressible_navier_stokes/poiseuille/application.h
@@ -205,8 +205,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
                                                                                    pair;
     typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;

--- a/applications/compressible_navier_stokes/shear_flow/application.h
+++ b/applications/compressible_navier_stokes/shear_flow/application.h
@@ -205,8 +205,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
                                                                                    pair;
     typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;

--- a/applications/compressible_navier_stokes/taylor_green/application.h
+++ b/applications/compressible_navier_stokes/taylor_green/application.h
@@ -247,8 +247,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     // test case with periodic BC -> boundary descriptors remain empty
   }
 

--- a/applications/compressible_navier_stokes/template/application.h
+++ b/applications/compressible_navier_stokes/template/application.h
@@ -89,8 +89,12 @@ private:
 
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
                                                                                    pair;
     typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;

--- a/applications/compressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/compressible_navier_stokes/turbulent_channel/application.h
@@ -323,8 +323,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
                                                                                    pair;
     typedef typename std::pair<dealii::types::boundary_id, EnergyBoundaryVariable> pair_variable;

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -489,8 +489,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     std::shared_ptr<IncNS::BoundaryDescriptor<dim>> boundary_descriptor = this->boundary_descriptor;
 
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -536,8 +536,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     std::shared_ptr<IncNS::BoundaryDescriptor<dim>> boundary_descriptor = this->boundary_descriptor;
 
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -396,8 +396,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     std::shared_ptr<IncNS::BoundaryDescriptor<dim>> boundary_descriptor = this->boundary_descriptor;
 
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -388,8 +388,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     std::shared_ptr<IncNS::BoundaryDescriptor<dim>> boundary_descriptor = this->boundary_descriptor;
 
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>

--- a/applications/fluid_structure_interaction/template/application.h
+++ b/applications/fluid_structure_interaction/template/application.h
@@ -171,8 +171,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     std::shared_ptr<IncNS::BoundaryDescriptor<dim>> boundary_descriptor = this->boundary_descriptor;
 
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -303,8 +303,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -326,8 +326,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -319,8 +319,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -289,8 +289,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_flow_with_transport/template/application.h
+++ b/applications/incompressible_flow_with_transport/template/application.h
@@ -94,8 +94,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -294,8 +294,12 @@ public:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 
@@ -443,8 +447,12 @@ public:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -240,8 +240,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -246,8 +246,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     // all boundaries have ID = 0 by default -> Dirichlet boundaries
 
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -229,8 +229,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -316,8 +316,12 @@ public:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     /*
      *  FILL BOUNDARY DESCRIPTORS
      */
@@ -478,8 +482,12 @@ public:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     /*
      *  FILL BOUNDARY DESCRIPTORS
      */

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -362,8 +362,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/flow_past_sphere/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/application.h
@@ -294,8 +294,12 @@ public:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -287,8 +287,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -250,8 +250,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/kovasznay/application.h
+++ b/applications/incompressible_navier_stokes/kovasznay/application.h
@@ -290,8 +290,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -636,8 +636,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     AssertThrow(dim == 2,
                 dealii::ExcMessage("Manufactured solution for dim == 2 implemented only."));
 

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -342,8 +342,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -340,8 +340,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     // set boundary conditions
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -374,8 +374,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -209,10 +209,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
   }
-
 
   void
   set_field_functions() final

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -266,8 +266,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     // test case with pure Dirichlet boundary conditions for velocity
     // all boundaries have ID = 0 by default
 

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -396,8 +396,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     if(exploit_symmetry)
     {
       typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>

--- a/applications/incompressible_navier_stokes/template/application.h
+++ b/applications/incompressible_navier_stokes/template/application.h
@@ -92,8 +92,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/template_precursor/application.h
+++ b/applications/incompressible_navier_stokes/template_precursor/application.h
@@ -73,8 +73,12 @@ public:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
   }
@@ -148,8 +152,12 @@ public:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
   }

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -205,8 +205,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     // test case with purely periodic boundary conditions
     // boundary descriptors remain empty for velocity and pressure
   }

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -396,8 +396,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -494,8 +494,12 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
+
     typedef typename std::pair<dealii::types::boundary_id, std::shared_ptr<dealii::Function<dim>>>
       pair;
 

--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
@@ -292,8 +292,11 @@ private:
   }
 
   void
-  set_boundary_descriptor() final
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) final
   {
+    (void)grid;
+    (void)mapping;
   }
 
   void

--- a/include/exadg/compressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/compressible_navier_stokes/user_interface/application_base.h
@@ -103,7 +103,7 @@ public:
 
     // boundary conditions
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
-    set_boundary_descriptor();
+    set_boundary_descriptor(*grid, mapping);
     verify_boundary_conditions<dim>(*boundary_descriptor, *grid);
 
     // field functions
@@ -164,7 +164,8 @@ private:
   create_grid(Grid<dim> & grid, std::shared_ptr<dealii::Mapping<dim>> & mapping) = 0;
 
   virtual void
-  set_boundary_descriptor() = 0;
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) = 0;
 
   virtual void
   set_field_functions() = 0;

--- a/include/exadg/fluid_structure_interaction/user_interface/application_base.h
+++ b/include/exadg/fluid_structure_interaction/user_interface/application_base.h
@@ -261,7 +261,7 @@ public:
 
     // boundary conditions
     boundary_descriptor = std::make_shared<IncNS::BoundaryDescriptor<dim>>();
-    set_boundary_descriptor();
+    set_boundary_descriptor(*grid, mapping);
     IncNS::verify_boundary_conditions<dim>(*boundary_descriptor, *grid);
 
     // field functions
@@ -437,7 +437,8 @@ private:
               std::shared_ptr<MultigridMappings<dim, Number>> & multigrid_mappings) = 0;
 
   virtual void
-  set_boundary_descriptor() = 0;
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) = 0;
 
   virtual void
   set_field_functions() = 0;

--- a/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
+++ b/include/exadg/incompressible_flow_with_transport/user_interface/application_base.h
@@ -108,7 +108,7 @@ public:
 
     // boundary conditions
     boundary_descriptor = std::make_shared<IncNS::BoundaryDescriptor<dim>>();
-    set_boundary_descriptor();
+    set_boundary_descriptor(*grid, mapping);
     verify_boundary_conditions<dim>(*boundary_descriptor, *grid);
 
     // field functions
@@ -179,7 +179,8 @@ private:
               std::shared_ptr<MultigridMappings<dim, Number>> & multigrid_mappings) = 0;
 
   virtual void
-  set_boundary_descriptor() = 0;
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) = 0;
 
   virtual void
   set_field_functions() = 0;

--- a/include/exadg/incompressible_navier_stokes/precursor/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/precursor/user_interface/application_base.h
@@ -105,7 +105,7 @@ public:
 
     // boundary conditions
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
-    set_boundary_descriptor();
+    set_boundary_descriptor(*grid, mapping);
     verify_boundary_conditions<dim>(*boundary_descriptor, *grid);
 
     // field functions
@@ -167,7 +167,8 @@ private:
               std::shared_ptr<MultigridMappings<dim, Number>> & multigrid_mappings) = 0;
 
   virtual void
-  set_boundary_descriptor() = 0;
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) = 0;
 
   virtual void
   set_field_functions() = 0;

--- a/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/application_base.h
@@ -109,7 +109,7 @@ public:
 
     // boundary conditions
     boundary_descriptor = std::make_shared<BoundaryDescriptor<dim>>();
-    set_boundary_descriptor();
+    set_boundary_descriptor(*grid, mapping);
     verify_boundary_conditions<dim>(*boundary_descriptor, *grid);
 
     // field functions
@@ -227,7 +227,8 @@ private:
               std::shared_ptr<MultigridMappings<dim, Number>> & multigrid_mappings) = 0;
 
   virtual void
-  set_boundary_descriptor() = 0;
+  set_boundary_descriptor(Grid<dim> const &                             grid,
+                          std::shared_ptr<dealii::Mapping<dim>> const & mapping) = 0;
 
   virtual void
   set_field_functions() = 0;


### PR DESCRIPTION
in #610 and #596, we moved the `Grid` and `Mapping` from the application to the driver for all applications. In some flow simulations, one might want to create an inflow profile on a surface flagged by some boundary ID, which, however, might not have a specific shape like a circle or rectangle. In such cases, the grid and mapping are needed in the `set_boundary_descriptor()` functions the detect the flagged surface and construct an inflow profile.

Hence I introduce this functionality for flow problems only, but we can have the same arguments for all the applications (Poisson, Acoustic, ConvectionDiffusion etc ...).