### PR TITLE
Remove density parameter

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -169,7 +169,6 @@ private:
     this->param.start_time     = start_time;
     this->param.end_time       = number_of_rotations * compute_rotation_duration();
     this->param.speed_of_sound = speed_of_sound;
-    this->param.density        = density;
 
     // TEMPORAL DISCRETIZATION
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
@@ -282,7 +281,6 @@ private:
   double radius              = 0.04;
   double l                   = 0.02;
   double speed_of_sound      = 1500.0;
-  double density             = 1000.0;
   double number_of_rotations = 1.0;
 
   double

--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.output
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.output
@@ -29,7 +29,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  1.5708e-06
   Speed of sound:                            1.5000e+03
-  Density:                                   1.0000e+03
 
 Temporal discretization:
   Calculation of time step size:             CFL

--- a/applications/acoustic_conservation_equations/throughput/application.h
+++ b/applications/acoustic_conservation_equations/throughput/application.h
@@ -66,7 +66,6 @@ private:
     this->param.start_time     = 0.0;
     this->param.end_time       = 1.0;
     this->param.speed_of_sound = 1.0;
-    this->param.density        = 1.0;
 
     // TEMPORAL DISCRETIZATION
     this->param.calculation_of_time_step_size = TimeStepCalculation::UserSpecified;

--- a/applications/acoustic_conservation_equations/vibrating_membrane/application.h
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/application.h
@@ -129,7 +129,7 @@ public:
                         "Speed of sound.",
                         dealii::Patterns::Double());
 
-      prm.add_parameter("Density", this->param.density, "Density.", dealii::Patterns::Double());
+      prm.add_parameter("Density", density, "Density.", dealii::Patterns::Double());
 
 
       // TEMPORAL DISCRETIZATION
@@ -221,9 +221,8 @@ private:
       std::make_shared<AnalyticalSolutionPressure<dim>>(modes, this->param.speed_of_sound);
 
     this->field_functions->initial_solution_velocity =
-      std::make_shared<AnalyticalSolutionVelocity<dim>>(modes,
-                                                        this->param.speed_of_sound,
-                                                        this->param.density);
+      std::make_shared<AnalyticalSolutionVelocity<dim>>(modes, this->param.speed_of_sound, density);
+
     this->field_functions->right_hand_side =
       std::make_shared<dealii::Functions::ZeroFunction<dim>>(1);
   }
@@ -274,16 +273,14 @@ private:
     pp_data.error_data_u.time_control_data.start_time       = start_time;
     pp_data.error_data_u.time_control_data.trigger_interval = (this->param.end_time - start_time);
     pp_data.error_data_u.analytical_solution =
-      std::make_shared<AnalyticalSolutionVelocity<dim>>(modes,
-                                                        this->param.speed_of_sound,
-                                                        this->param.density);
+      std::make_shared<AnalyticalSolutionVelocity<dim>>(modes, this->param.speed_of_sound, density);
     pp_data.error_data_u.calculate_relative_errors = false; // at some times the solution is 0
     pp_data.error_data_u.name                      = "velocity";
 
     // sound energy calculation
     pp_data.sound_energy_data.time_control_data.is_active  = false;
     pp_data.sound_energy_data.time_control_data.start_time = this->param.start_time;
-    pp_data.sound_energy_data.density                      = this->param.density;
+    pp_data.sound_energy_data.density                      = density;
     pp_data.sound_energy_data.speed_of_sound               = this->param.speed_of_sound;
     pp_data.sound_energy_data.time_control_data.trigger_every_time_steps = 1;
     pp_data.sound_energy_data.directory = this->output_parameters.directory + "sound_energy/";
@@ -297,6 +294,7 @@ private:
   // problem specific parameters like physical dimensions, etc.
   double modes             = 2.0;
   double number_of_periods = 1.0;
+  double density           = 1.0;
 
   double
   compute_period_duration()

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
@@ -29,7 +29,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -131,7 +130,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
@@ -29,7 +29,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -131,7 +130,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -233,7 +231,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -335,7 +332,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -437,7 +433,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -539,7 +534,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -641,7 +635,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
@@ -29,7 +29,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -131,7 +130,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -233,7 +231,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -335,7 +332,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -437,7 +433,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -539,7 +534,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -641,7 +635,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -29,7 +29,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -131,7 +130,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -233,7 +231,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -335,7 +332,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -437,7 +433,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -539,7 +534,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified
@@ -641,7 +635,6 @@ Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
   Speed of sound:                            7.0000e+00
-  Density:                                   3.0000e+00
 
 Temporal discretization:
   Calculation of time step size:             UserSpecified

--- a/include/exadg/acoustic_conservation_equations/postprocessor/sound_energy_calculator.h
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/sound_energy_calculator.h
@@ -155,6 +155,8 @@ private:
       {
         f.open(filename.str().c_str(), std::ios::trunc);
         f << "Time, Sound energy: E = (1,p*p/(2*rho*c*c)+rho*u*u/2)_Omega" << std::endl;
+        f << "c   = " << data.speed_of_sound << std::endl;
+        f << "rho = " << data.density << std::endl;
         clear_files = false;
       }
       else

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
@@ -40,7 +40,6 @@ Parameters::Parameters()
     start_time(0.),
     end_time(-1.),
     speed_of_sound(-1.),
-    density(-1.),
 
     // TEMPORAL DISCRETIZATION
     calculation_of_time_step_size(TimeStepCalculation::Undefined),
@@ -74,7 +73,6 @@ Parameters::check() const
   // PHYSICAL QUANTITIES
   AssertThrow(end_time > start_time, dealii::ExcMessage("parameter end_time must be defined"));
   AssertThrow(speed_of_sound >= 0.0, dealii::ExcMessage("parameter must be defined"));
-  AssertThrow(density >= 0.0, dealii::ExcMessage("parameter must be defined"));
 
   // TEMPORAL DISCRETIZATION
   AssertThrow(calculation_of_time_step_size != TimeStepCalculation::Undefined,
@@ -135,9 +133,6 @@ Parameters::print_parameters_physical_quantities(dealii::ConditionalOStream cons
 
   // speed of sound
   print_parameter(pcout, "Speed of sound", speed_of_sound);
-
-  // mean density
-  print_parameter(pcout, "Density", density);
 }
 
 void

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.h
@@ -91,9 +91,6 @@ public:
   // speed_of_sound of underlying fluid
   double speed_of_sound;
 
-  // mean density of underlying fluid
-  double density;
-
   /**************************************************************************************/
   /*                                                                                    */
   /*                             TEMPORAL DISCRETIZATION                                */


### PR DESCRIPTION
We should get rid of the density parameter since we don't need it anymore.

This depends on https://github.com/exadg/exadg/pull/629 to some extent. If we merge https://github.com/exadg/exadg/pull/629 first, we have to adapt this PR. If we merge this first, we have to remove the density parameter from the application and test in https://github.com/exadg/exadg/pull/629.