### PR TITLE
AMR: explicit timestepping for convection diffusion module

### DIFF
--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -122,16 +122,16 @@ private:
     // TEMPORAL DISCRETIZATION
     this->param.start_with_low_order = false;
     if(use_explicit_time_integration)
-	{
-	  this->param.temporal_discretization = TemporalDiscretization::ExplRK;
-	  this->param.time_integrator_rk      = TimeIntegratorRK::ExplRK3Stage7Reg2;
-	}
-	else
-	{
-	  this->param.temporal_discretization      = TemporalDiscretization::BDF;
-	  this->param.order_time_integrator        = 2; // instabilities for BDF 3 and 4
-	  this->param.treatment_of_convective_term = TreatmentOfConvectiveTerm::Implicit;
-	}
+    {
+      this->param.temporal_discretization = TemporalDiscretization::ExplRK;
+      this->param.time_integrator_rk      = TimeIntegratorRK::ExplRK3Stage7Reg2;
+    }
+    else
+    {
+      this->param.temporal_discretization      = TemporalDiscretization::BDF;
+      this->param.order_time_integrator        = 2; // instabilities for BDF 3 and 4
+      this->param.treatment_of_convective_term = TreatmentOfConvectiveTerm::Implicit;
+    }
 
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
     this->param.adaptive_time_stepping        = false;
@@ -297,7 +297,7 @@ private:
   double const left  = -1.0;
   double const right = +1.0;
 
-  bool enable_adaptivity = false;
+  bool enable_adaptivity             = false;
   bool use_explicit_time_integration = false;
 };
 

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -96,6 +96,10 @@ public:
                         enable_adaptivity,
                         "Enable adaptive mesh refinement.",
                         dealii::Patterns::Bool());
+      prm.add_parameter("UseExplicitTimeIntegration",
+                        use_explicit_time_integration,
+                        "Use explicit or implicit time integration.",
+                        dealii::Patterns::Bool());
     }
     prm.leave_subsection();
   }
@@ -116,13 +120,18 @@ private:
     this->param.diffusivity = 0.0;
 
     // TEMPORAL DISCRETIZATION
-    this->param.temporal_discretization      = TemporalDiscretization::BDF;
-    this->param.order_time_integrator        = 2; // instabilities for BDF 3 and 4
-    this->param.treatment_of_convective_term = TreatmentOfConvectiveTerm::Implicit;
-    this->param.start_with_low_order         = false;
-
-    //    this->param.temporal_discretization      = TemporalDiscretization::ExplRK;
-    //    this->param.time_integrator_rk           = TimeIntegratorRK::ExplRK3Stage7Reg2;
+    this->param.start_with_low_order = false;
+    if(use_explicit_time_integration)
+	{
+	  this->param.temporal_discretization = TemporalDiscretization::ExplRK;
+	  this->param.time_integrator_rk      = TimeIntegratorRK::ExplRK3Stage7Reg2;
+	}
+	else
+	{
+	  this->param.temporal_discretization      = TemporalDiscretization::BDF;
+	  this->param.order_time_integrator        = 2; // instabilities for BDF 3 and 4
+	  this->param.treatment_of_convective_term = TreatmentOfConvectiveTerm::Implicit;
+	}
 
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
     this->param.adaptive_time_stepping        = false;
@@ -289,6 +298,7 @@ private:
   double const right = +1.0;
 
   bool enable_adaptivity = false;
+  bool use_explicit_time_integration = false;
 };
 
 } // namespace ConvDiff

--- a/applications/convection_diffusion/rotating_hill/input.json
+++ b/applications/convection_diffusion/rotating_hill/input.json
@@ -15,7 +15,8 @@
         "RefineTimeMax": "0"
     },
     "Application": {
-        "EnableAdaptivity": "true"
+        "EnableAdaptivity": "true",
+        "UseExplicitTimeIntegration": "false"
     },
     "Output": {
         "OutputDirectory": "output/rotating_hill/",

--- a/applications/convection_diffusion/rotating_hill/tests/convective_explicit_time_int_amr.json
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_explicit_time_int_amr.json
@@ -5,8 +5,8 @@
         "IsTest": "true"
     },
     "SpatialResolution": {
-        "DegreeMin": "4",
-        "DegreeMax": "4",
+        "DegreeMin": "5",
+        "DegreeMax": "5",
         "RefineSpaceMin": "3",
         "RefineSpaceMax": "3"
     },
@@ -16,7 +16,7 @@
     },
     "Application": {
         "EnableAdaptivity": "true",
-        "UseExplicitTimeIntegration": "false"
+        "UseExplicitTimeIntegration": "true"
     },
     "Output": {
         "OutputDirectory": "output/rotating_hill/",

--- a/applications/convection_diffusion/rotating_hill/tests/convective_explicit_time_int_amr.output
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_explicit_time_int_amr.output
@@ -1,0 +1,332 @@
+
+
+
+________________________________________________________________________________
+                                                                                
+                ////////                      ///////   ////////                
+                ///                           ///  ///  ///                     
+                //////    ///  ///  ///////   ///  ///  /// ////                
+                ///         ////    //   //   ///  ///  ///  ///                
+                ////////  ///  ///  ///////// ///////   ////////                
+                                                                                
+               High-Order Discontinuous Galerkin for the Exa-Scale              
+________________________________________________________________________________
+
+
+MPI info:
+
+  Number of processes:                       1
+
+Setting up scalar convection-diffusion solver:
+
+List of parameters:
+
+Mathematical model:
+  Problem type:                              Unsteady
+  Equation type:                             Convection
+  Right-hand side:                           false
+  Analytical velocity field:                 true
+  ALE formulation:                           false
+  Formulation convective term:               DivergenceFormulation
+
+Physical quantities:
+  Start time:                                0.0000e+00
+  End time:                                  1.0000e+00
+
+Temporal discretization:
+  Temporal discretization method:            ExplRK
+  Explicit time integrator:                  ExplRK3Stage7Reg2
+  Maximum number of time steps:              4294967295
+  Temporal refinements:                      0
+  Calculation of time step size:             CFL
+  Adaptive time stepping:                    false
+  Restarted simulation:                      false
+  Restart:
+  Write restart:                             false
+
+Spatial Discretization:
+  Triangulation type:                        Distributed
+  Element type:                              Hypercube
+  Number of global refinements:              3
+  Create coarse triangulations:              true
+  Mapping degree:                            5
+  Polynomial degree:                         5
+  Enable adaptivity:                         true
+  Triggered every n time steps:              30
+  Maximum refinement level:                  4
+  Minimum refinement level:                  0
+  Preserve boundary cells:                   false
+  Fraction of cells to be refined:           2.5000e-02
+  Fraction of cells to be coarsened:         4.0000e-01
+  Numerical flux convective term:            LaxFriedrichsFlux
+
+Numerical parameters:
+  Use cell-based face loops:                 false
+  Use combined operator:                     true
+  Use over-integration:                      false
+
+Generating grid for 2-dimensional problem:
+
+  Max. number of refinements:                3
+  Number of cells:                           64
+
+Construct convection-diffusion operator ...
+
+Discontinuous Galerkin finite element discretization:
+
+  degree of 1D polynomials:                  5
+  number of dofs per cell:                   36
+  number of dofs (total):                    2304
+
+... done!
+
+Setup convection-diffusion operator ...
+
+... done!
+
+Setup time integrator ...
+
+Calculation of time step size according to CFL condition:
+
+  CFL:                                       2.5000e-01
+  Time step size (CFL global):               4.8902e-04
+
+Adjust time step size to hit end time:
+
+  Time step size:                            4.8900e-04
+
+... done!
+
+Starting time loop ...
+
+Calculate error for all fields at time t = 0.0000e+00:
+  Relative error (L2-norm): 4.02848e-02
+
+________________________________________________________________________________
+
+ Time step number = 1       t = 0.00000e+00 -> t + dt = 4.88998e-04
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:1980
+  number of dofs (total) after adaptive mesh refinement:1872
+  number of dofs (total) after adaptive mesh refinement:1764
+  number of dofs (total) after adaptive mesh refinement:1872
+
+Calculate error for all fields at time t = 5.0367e-02:
+  Relative error (L2-norm): 4.02194e-02
+
+________________________________________________________________________________
+
+ Time step number = 104     t = 5.03667e-02 -> t + dt = 5.08557e-02
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:1980
+  number of dofs (total) after adaptive mesh refinement:2088
+  number of dofs (total) after adaptive mesh refinement:2196
+
+Calculate error for all fields at time t = 1.0024e-01:
+  Relative error (L2-norm): 4.02036e-02
+
+________________________________________________________________________________
+
+ Time step number = 206     t = 1.00244e-01 -> t + dt = 1.00733e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2196
+  number of dofs (total) after adaptive mesh refinement:2196
+  number of dofs (total) after adaptive mesh refinement:2088
+  number of dofs (total) after adaptive mesh refinement:2196
+
+Calculate error for all fields at time t = 1.5012e-01:
+  Relative error (L2-norm): 4.01919e-02
+
+________________________________________________________________________________
+
+ Time step number = 308     t = 1.50122e-01 -> t + dt = 1.50611e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2196
+  number of dofs (total) after adaptive mesh refinement:2196
+
+Calculate error for all fields at time t = 2.0000e-01:
+  Relative error (L2-norm): 4.01796e-02
+
+________________________________________________________________________________
+
+ Time step number = 411     t = 2.00489e-01 -> t + dt = 2.00978e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2196
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2412
+  number of dofs (total) after adaptive mesh refinement:2412
+
+Calculate error for all fields at time t = 2.5037e-01:
+  Relative error (L2-norm): 4.01637e-02
+
+________________________________________________________________________________
+
+ Time step number = 513     t = 2.50367e-01 -> t + dt = 2.50856e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2520
+  number of dofs (total) after adaptive mesh refinement:2520
+  number of dofs (total) after adaptive mesh refinement:2520
+
+Calculate error for all fields at time t = 3.0024e-01:
+  Relative error (L2-norm): 4.01506e-02
+
+________________________________________________________________________________
+
+ Time step number = 615     t = 3.00244e-01 -> t + dt = 3.00733e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2196
+  number of dofs (total) after adaptive mesh refinement:2088
+  number of dofs (total) after adaptive mesh refinement:2196
+
+Calculate error for all fields at time t = 3.5012e-01:
+  Relative error (L2-norm): 4.01507e-02
+
+________________________________________________________________________________
+
+ Time step number = 717     t = 3.50122e-01 -> t + dt = 3.50611e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2088
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2304
+
+Calculate error for all fields at time t = 4.0000e-01:
+  Relative error (L2-norm): 4.01387e-02
+
+________________________________________________________________________________
+
+ Time step number = 819     t = 4.00000e-01 -> t + dt = 4.00489e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2304
+
+Calculate error for all fields at time t = 4.5037e-01:
+  Relative error (L2-norm): 4.01300e-02
+
+________________________________________________________________________________
+
+ Time step number = 922     t = 4.50367e-01 -> t + dt = 4.50856e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2412
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2412
+
+Calculate error for all fields at time t = 5.0024e-01:
+  Relative error (L2-norm): 4.01223e-02
+
+________________________________________________________________________________
+
+ Time step number = 1024    t = 5.00244e-01 -> t + dt = 5.00733e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2412
+  number of dofs (total) after adaptive mesh refinement:2196
+  number of dofs (total) after adaptive mesh refinement:2412
+
+Calculate error for all fields at time t = 5.5012e-01:
+  Relative error (L2-norm): 4.01162e-02
+
+________________________________________________________________________________
+
+ Time step number = 1126    t = 5.50122e-01 -> t + dt = 5.50611e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2412
+  number of dofs (total) after adaptive mesh refinement:2412
+  number of dofs (total) after adaptive mesh refinement:2412
+
+Calculate error for all fields at time t = 6.0000e-01:
+  Relative error (L2-norm): 4.01117e-02
+
+________________________________________________________________________________
+
+ Time step number = 1228    t = 6.00000e-01 -> t + dt = 6.00489e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2088
+  number of dofs (total) after adaptive mesh refinement:1980
+  number of dofs (total) after adaptive mesh refinement:1980
+  number of dofs (total) after adaptive mesh refinement:1872
+
+Calculate error for all fields at time t = 6.5037e-01:
+  Relative error (L2-norm): 4.01063e-02
+
+________________________________________________________________________________
+
+ Time step number = 1331    t = 6.50367e-01 -> t + dt = 6.50856e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2088
+  number of dofs (total) after adaptive mesh refinement:2304
+  number of dofs (total) after adaptive mesh refinement:2412
+
+Calculate error for all fields at time t = 7.0024e-01:
+  Relative error (L2-norm): 4.01007e-02
+
+________________________________________________________________________________
+
+ Time step number = 1433    t = 7.00244e-01 -> t + dt = 7.00733e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2412
+  number of dofs (total) after adaptive mesh refinement:2520
+  number of dofs (total) after adaptive mesh refinement:2520
+  number of dofs (total) after adaptive mesh refinement:2628
+
+Calculate error for all fields at time t = 7.5012e-01:
+  Relative error (L2-norm): 4.00976e-02
+
+________________________________________________________________________________
+
+ Time step number = 1535    t = 7.50122e-01 -> t + dt = 7.50611e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2628
+  number of dofs (total) after adaptive mesh refinement:2628
+  number of dofs (total) after adaptive mesh refinement:2736
+
+Calculate error for all fields at time t = 8.0000e-01:
+  Relative error (L2-norm): 4.00958e-02
+
+________________________________________________________________________________
+
+ Time step number = 1638    t = 8.00489e-01 -> t + dt = 8.00978e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2736
+  number of dofs (total) after adaptive mesh refinement:2952
+  number of dofs (total) after adaptive mesh refinement:3168
+
+Calculate error for all fields at time t = 8.5037e-01:
+  Relative error (L2-norm): 4.00950e-02
+
+________________________________________________________________________________
+
+ Time step number = 1740    t = 8.50367e-01 -> t + dt = 8.50856e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:3168
+  number of dofs (total) after adaptive mesh refinement:2952
+  number of dofs (total) after adaptive mesh refinement:2628
+  number of dofs (total) after adaptive mesh refinement:2520
+
+Calculate error for all fields at time t = 9.0024e-01:
+  Relative error (L2-norm): 4.00944e-02
+
+________________________________________________________________________________
+
+ Time step number = 1842    t = 9.00244e-01 -> t + dt = 9.00733e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:2520
+  number of dofs (total) after adaptive mesh refinement:2844
+  number of dofs (total) after adaptive mesh refinement:3060
+
+Calculate error for all fields at time t = 9.5012e-01:
+  Relative error (L2-norm): 4.00934e-02
+
+________________________________________________________________________________
+
+ Time step number = 1944    t = 9.50122e-01 -> t + dt = 9.50611e-01
+________________________________________________________________________________
+  number of dofs (total) after adaptive mesh refinement:3168
+  number of dofs (total) after adaptive mesh refinement:3168
+  number of dofs (total) after adaptive mesh refinement:2952
+  number of dofs (total) after adaptive mesh refinement:2844
+
+Calculate error for all fields at time t = 1.0000e+00:
+  Relative error (L2-norm): 4.00925e-02

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -227,7 +227,7 @@ Driver<dim, Number>::do_adaptive_refinement()
     }
     else
     {
-      AssertThrow(false, dealii::ExcNotImplemented());
+      AssertThrow(false, dealii::ExcMessage("Adaptive mesh refinement available only for unsteady problems."));
     }
   }
 }
@@ -252,16 +252,25 @@ Driver<dim, Number>::solve()
              application->get_parameters().amr_data.trigger_every_n_time_steps,
              time_integrator->get_number_of_time_steps()))
         {
-          // AMR is only implemented for implicit timestepping.
-          std::shared_ptr<TimeIntBDF<dim, Number>> bdf_time_integrator =
-            std::dynamic_pointer_cast<TimeIntBDF<dim, Number>>(time_integrator);
-
-          AssertThrow(bdf_time_integrator.get(),
-                      dealii::ExcMessage("Adaptive mesh refinement only implemented"
-                                         " for implicit time integration."));
-
-          mark_cells_coarsening_and_refinement(*grid->triangulation,
-                                               bdf_time_integrator->get_solution_np());
+          // Mark cells for coarsening and refinement based on the most recent solution.
+          if(application->get_parameters().temporal_discretization == TemporalDiscretization::ExplRK)
+		  {
+			std::shared_ptr<TimeIntExplRK<Number>> rk_time_integrator =
+			  std::dynamic_pointer_cast<TimeIntExplRK<Number>>(time_integrator);
+		    AssertThrow(rk_time_integrator.get(),
+	                    dealii::ExcMessage("Dynamic cast from TimeIntBase "
+	                    		           "to TimeIntExplRK not successful."));
+			mark_cells_coarsening_and_refinement(*grid->triangulation, rk_time_integrator->get_solution_np());
+		  }
+		  else
+		  {
+			std::shared_ptr<TimeIntBDF<dim, Number>> bdf_time_integrator =
+			  std::dynamic_pointer_cast<TimeIntBDF<dim, Number>>(time_integrator);
+			AssertThrow(bdf_time_integrator.get(),
+						dealii::ExcMessage("Dynamic cast from TimeIntBase "
+										   "to TimeIntBDF not successful."));
+			mark_cells_coarsening_and_refinement(*grid->triangulation, bdf_time_integrator->get_solution_np());
+		  }
 
           do_adaptive_refinement();
         }

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -227,7 +227,9 @@ Driver<dim, Number>::do_adaptive_refinement()
     }
     else
     {
-      AssertThrow(false, dealii::ExcMessage("Adaptive mesh refinement available only for unsteady problems."));
+      AssertThrow(false,
+                  dealii::ExcMessage(
+                    "Adaptive mesh refinement available only for unsteady problems."));
     }
   }
 }
@@ -253,24 +255,27 @@ Driver<dim, Number>::solve()
              time_integrator->get_number_of_time_steps()))
         {
           // Mark cells for coarsening and refinement based on the most recent solution.
-          if(application->get_parameters().temporal_discretization == TemporalDiscretization::ExplRK)
-		  {
-			std::shared_ptr<TimeIntExplRK<Number>> rk_time_integrator =
-			  std::dynamic_pointer_cast<TimeIntExplRK<Number>>(time_integrator);
-		    AssertThrow(rk_time_integrator.get(),
-	                    dealii::ExcMessage("Dynamic cast from TimeIntBase "
-	                    		           "to TimeIntExplRK not successful."));
-			mark_cells_coarsening_and_refinement(*grid->triangulation, rk_time_integrator->get_solution_np());
-		  }
-		  else
-		  {
-			std::shared_ptr<TimeIntBDF<dim, Number>> bdf_time_integrator =
-			  std::dynamic_pointer_cast<TimeIntBDF<dim, Number>>(time_integrator);
-			AssertThrow(bdf_time_integrator.get(),
-						dealii::ExcMessage("Dynamic cast from TimeIntBase "
-										   "to TimeIntBDF not successful."));
-			mark_cells_coarsening_and_refinement(*grid->triangulation, bdf_time_integrator->get_solution_np());
-		  }
+          if(application->get_parameters().temporal_discretization ==
+             TemporalDiscretization::ExplRK)
+          {
+            std::shared_ptr<TimeIntExplRK<Number>> rk_time_integrator =
+              std::dynamic_pointer_cast<TimeIntExplRK<Number>>(time_integrator);
+            AssertThrow(rk_time_integrator.get(),
+                        dealii::ExcMessage("Dynamic cast from TimeIntBase "
+                                           "to TimeIntExplRK not successful."));
+            mark_cells_coarsening_and_refinement(*grid->triangulation,
+                                                 rk_time_integrator->get_solution_np());
+          }
+          else
+          {
+            std::shared_ptr<TimeIntBDF<dim, Number>> bdf_time_integrator =
+              std::dynamic_pointer_cast<TimeIntBDF<dim, Number>>(time_integrator);
+            AssertThrow(bdf_time_integrator.get(),
+                        dealii::ExcMessage("Dynamic cast from TimeIntBase "
+                                           "to TimeIntBDF not successful."));
+            mark_cells_coarsening_and_refinement(*grid->triangulation,
+                                                 bdf_time_integrator->get_solution_np());
+          }
 
           do_adaptive_refinement();
         }

--- a/include/exadg/convection_diffusion/spatial_discretization/interface.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/interface.h
@@ -102,6 +102,15 @@ public:
   // needed for time step calculation
   virtual double
   calculate_time_step_diffusion() const = 0;
+
+  /*
+   * Prepare and interpolation in adaptive mesh refinement.
+   */
+  virtual void
+  prepare_coarsening_and_refinement(std::vector<VectorType *> & vectors) = 0;
+
+  virtual void
+  interpolate_after_coarsening_and_refinement(std::vector<VectorType *> & vectors) = 0;
 };
 } // namespace Interface
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -214,10 +214,10 @@ public:
    * Prepare and interpolation in adaptive mesh refinement.
    */
   void
-  prepare_coarsening_and_refinement(std::vector<VectorType *> & vectors);
+  prepare_coarsening_and_refinement(std::vector<VectorType *> & vectors) override;
 
   void
-  interpolate_after_coarsening_and_refinement(std::vector<VectorType *> & vectors);
+  interpolate_after_coarsening_and_refinement(std::vector<VectorType *> & vectors) override;
 
   /*
    * This function solves the linear system of equations in case of implicit time integration or

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
@@ -73,6 +73,44 @@ TimeIntExplRK<Number>::extrapolate_solution(VectorType & vector)
 }
 
 template<typename Number>
+dealii::LinearAlgebra::distributed::Vector<Number> const &
+TimeIntExplRK<Number>::get_solution_np() const
+{
+  return (this->solution_np);
+}
+
+template<typename Number>
+std::shared_ptr<std::vector<dealii::LinearAlgebra::distributed::Vector<Number> *>>
+TimeIntExplRK<Number>::get_vectors()
+{
+  std::shared_ptr<std::vector<VectorType *>> vectors =
+    std::make_shared<std::vector<VectorType *>>();
+
+  vectors->emplace_back(&this->solution_np);
+  vectors->emplace_back(&this->solution_n);
+
+  return vectors;
+}
+
+template<typename Number>
+void
+TimeIntExplRK<Number>::prepare_coarsening_and_refinement()
+{
+  std::shared_ptr<std::vector<VectorType *>> vectors = get_vectors();
+  pde_operator->prepare_coarsening_and_refinement(*vectors);
+}
+
+template<typename Number>
+void
+TimeIntExplRK<Number>::interpolate_after_coarsening_and_refinement()
+{
+  this->initialize_vectors();
+
+  std::shared_ptr<std::vector<VectorType *>> vectors = get_vectors();
+  pde_operator->interpolate_after_coarsening_and_refinement(*vectors);
+}
+
+template<typename Number>
 void
 TimeIntExplRK<Number>::initialize_vectors()
 {

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
@@ -68,7 +68,19 @@ public:
   void
   extrapolate_solution(VectorType & vector);
 
+  VectorType const &
+  get_solution_np() const;
+
+  void
+  prepare_coarsening_and_refinement() final;
+
+  void
+  interpolate_after_coarsening_and_refinement() final;
+
 private:
+  std::shared_ptr<std::vector<VectorType *>>
+  get_vectors();
+
   void
   initialize_vectors() final;
 

--- a/include/exadg/convection_diffusion/user_interface/parameters.cpp
+++ b/include/exadg/convection_diffusion/user_interface/parameters.cpp
@@ -264,10 +264,6 @@ Parameters::check() const
                 dealii::ExcMessage("Combination of adaptive mesh refinement "
                                    "and ALE formulation not implemented."));
 
-    AssertThrow(temporal_discretization == TemporalDiscretization::BDF,
-                dealii::ExcMessage("Adaptive mesh refinement only implemented"
-                                   "for implicit time integration."));
-
     AssertThrow(grid.element_type == ElementType::Hypercube,
                 dealii::ExcMessage("Adaptive mesh refinement is currently "
                                    "only supported for hypercube elements."));


### PR DESCRIPTION
Enables explicit time integration in the convection diffusion module together with adaptive mesh refinement and adds a little test case.

The test uses a static mapping already (similar to the test with the implicit time stepping). The error is a bit lower compared to the implicit test, which computes the same scenario.

I did not add `get_solution_np()` to `TimeIntBase`, which requires some dynamic casts of the `time_integrator`in the driver.