### PR TITLE
make is_mg private in OperatorBase / ensure initialization of velocity vector in multigrid operators

### DIFF
--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
@@ -50,10 +50,7 @@ CombinedOperator<dim, Number>::initialize(
   if(operator_data.convective_problem)
   {
     convective_kernel = std::make_shared<Operators::ConvectiveKernel<dim, Number>>();
-    convective_kernel->reinit(matrix_free,
-                              data.convective_kernel_data,
-                              data.quad_index,
-                              this->is_mg);
+    convective_kernel->reinit(matrix_free, data.convective_kernel_data, data.quad_index, true);
   }
 
   if(operator_data.diffusive_problem)

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.h
@@ -71,6 +71,10 @@ private:
 public:
   CombinedOperator();
 
+  /**
+   * This function creates own kernels for the different terms of the combined PDE operator. This
+   * function is typically called when using this operator as the PDE operator in multigrid.
+   */
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              dealii::AffineConstraints<Number> const & affine_constraints,

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.h
@@ -83,7 +83,7 @@ public:
   reinit(dealii::MatrixFree<dim, Number> const & matrix_free,
          ConvectiveKernelData<dim> const &       data_in,
          unsigned int const                      quad_index,
-         bool const                              is_mg)
+         bool const                              use_own_velocity_storage)
   {
     data = data_in;
 
@@ -102,8 +102,7 @@ public:
                                                                        data.dof_index_velocity,
                                                                        quad_index);
 
-      // use own storage of velocity vector only in case of multigrid
-      if(is_mg)
+      if(use_own_velocity_storage)
       {
         velocity.reset();
         matrix_free.initialize_dof_vector(velocity.own(), data.dof_index_velocity);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -64,7 +64,7 @@ public:
          ConvectiveKernelData const &            data,
          unsigned int const                      dof_index,
          unsigned int const                      quad_index_linearized,
-         bool const                              is_mg)
+         bool const                              use_own_velocity_storage)
   {
     this->data = data;
 
@@ -84,8 +84,7 @@ public:
         std::make_shared<IntegratorFace>(matrix_free, true, dof_index, quad_index_linearized);
     }
 
-    // use own storage of velocity vector only in case of multigrid
-    if(is_mg)
+    if(use_own_velocity_storage)
     {
       velocity.reset();
       matrix_free.initialize_dof_vector(velocity.own(), dof_index);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -33,7 +33,7 @@ MomentumOperator<dim, Number>::initialize(
                                     operator_data.convective_kernel_data,
                                     operator_data.dof_index,
                                     operator_data.quad_index,
-                                    this->is_mg);
+                                    true);
   }
 
   if(operator_data.viscous_problem)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
@@ -55,6 +55,10 @@ public:
 
   MomentumOperator();
 
+  /**
+   * This function creates own kernels for the different terms of the combined PDE operator. This
+   * function is typically called when using this operator as the PDE operator in multigrid.
+   */
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              dealii::AffineConstraints<Number> const & affine_constraints,

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -432,11 +432,13 @@ protected:
    */
   IntegratorFlags integrator_flags;
 
+private:
   /*
    * Is the operator used as a multigrid level operator?
    */
   bool is_mg;
 
+protected:
   /*
    * Is the discretization based on discontinuous Galerkin method?
    */


### PR DESCRIPTION
closes #639

To improve safety, I made the member variable `is_mg` private in `OperatorBase`. (In case `is_mg` is not correctly handled in `OperatorBase`, this will at least no longer have other side effects.)