### PR TITLE
make vector_fine_level in convDiff and iNS MG preconditioners const ref

### DIFF
--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -157,8 +157,8 @@ MultigridPreconditioner<dim, Number>::update()
     // interpolate velocity from fine to coarse level
     this->transfer_from_fine_to_coarse_levels(
       [&](unsigned int const fine_level, unsigned int const coarse_level) {
-        auto & vector_fine_level   = this->get_operator(fine_level)->get_velocity();
-        auto   vector_coarse_level = this->get_operator(coarse_level)->get_velocity();
+        auto const & vector_fine_level   = this->get_operator(fine_level)->get_velocity();
+        auto         vector_coarse_level = this->get_operator(coarse_level)->get_velocity();
         transfers_velocity->interpolate(fine_level, vector_coarse_level, vector_fine_level);
         this->get_operator(coarse_level)->set_velocity_copy(vector_coarse_level);
       });

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -143,8 +143,8 @@ MultigridPreconditioner<dim, Number>::update()
     // interpolate velocity from fine to coarse level
     this->transfer_from_fine_to_coarse_levels(
       [&](unsigned int const fine_level, unsigned int const coarse_level) {
-        auto & vector_fine_level   = this->get_operator(fine_level)->get_velocity();
-        auto   vector_coarse_level = this->get_operator(coarse_level)->get_velocity();
+        auto const & vector_fine_level   = this->get_operator(fine_level)->get_velocity();
+        auto         vector_coarse_level = this->get_operator(coarse_level)->get_velocity();
         this->transfers->interpolate(fine_level, vector_coarse_level, vector_fine_level);
         this->get_operator(coarse_level)->set_velocity_copy(vector_coarse_level);
       });


### PR DESCRIPTION
I forgot to change code sections similar to the one covered in #581.
I checked all appearances of `transfer_from_fine_to_coarse_levels`:

1: `solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h:244`
2: `incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp:104`
3: `incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp:144`
4: `structure/preconditioners/multigrid_preconditioner.cpp:112`
5: `convection_diffusion/preconditioners/multigrid_preconditioner.cpp:158`

1: this is the definition
2: Here, two (a coarse and a fine) vectors are created on purpose (see [code snippet](https://github.com/exadg/exadg/blob/5327f3a10b40d9146c92563e0b80b27760ca3c5e/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp#L101-L116)).
3: addressed here
4: considered in #581 
5: addressed here
