### PR TITLE
Enable sub-time-stepping for aero-acoustics

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.output
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/tests/cfl_rhs_velocity_dirichlet.output
@@ -39,6 +39,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.output
+++ b/applications/acoustic_conservation_equations/normal_incidenting_wave/tests/first_order_abc.output
@@ -39,6 +39,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
@@ -39,6 +39,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/abm3.output
@@ -126,7 +126,7 @@ List of parameters:
 Mathematical model:
   Formulation:                               SkewSymmetric
   Right-hand side:                           false
-  
+
 Physical quantities:
   Start time:                                0.0000e+00
   End time:                                  2.5254e-02
@@ -141,6 +141,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
@@ -39,6 +39,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -140,6 +141,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -241,6 +243,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -342,6 +345,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -443,6 +447,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -544,6 +549,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/skew_symmetric.output
@@ -645,6 +645,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
@@ -39,6 +39,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/strong.output
@@ -141,6 +141,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -242,6 +243,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -343,6 +345,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -444,6 +447,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -545,6 +549,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -646,6 +651,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -39,6 +39,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -140,6 +141,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -241,6 +243,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -342,6 +345,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -443,6 +447,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed
@@ -544,6 +549,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -645,6 +645,7 @@ Temporal discretization:
   Restarted simulation:                      false
   Restart:
   Write restart:                             false
+  Adaptive time stepping:                    false
 
 Spatial discretization:
   Triangulation type:                        Distributed

--- a/applications/aero_acoustic/co_rotating_vortex_pair/application.h
+++ b/applications/aero_acoustic/co_rotating_vortex_pair/application.h
@@ -111,7 +111,7 @@ private:
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
     this->param.order_time_integrator         = 2;
     this->param.start_with_low_order          = true;
-    this->param.adaptive_time_stepping        = false;
+    this->param.adaptive_time_stepping        = true;
 
     // output of solver information
     this->param.solver_info_data.interval_time = (this->param.end_time - this->param.start_time);
@@ -374,7 +374,7 @@ public:
     this->param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
     this->param.order_time_integrator           = 2;
     this->param.start_with_low_order            = false;
-    this->param.adaptive_time_stepping          = false;
+    this->param.adaptive_time_stepping          = true;
     this->param.cfl_exponent_fe_degree_velocity = 1.5;
 
     double const r           = r_0 + 0.5 * r_0;

--- a/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
+++ b/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp
@@ -88,9 +88,6 @@ Parameters::check() const
     AssertThrow(cfl_exponent_fe_degree > 0., dealii::ExcMessage("cfl_exponent_fe_degree > 0."));
   }
 
-  AssertThrow(not(adaptive_time_stepping),
-              dealii::ExcMessage("adaptive timestepping not supported"));
-
   // SPATIAL DISCRETIZATION
   grid.check();
 }
@@ -155,6 +152,9 @@ Parameters::print_parameters_temporal_discretization(dealii::ConditionalOStream 
   // restart
   print_parameter(pcout, "Restarted simulation", restarted_simulation);
   restart_data.print(pcout);
+
+  // adaptive time-stepping
+  print_parameter(pcout, "Adaptive time stepping", adaptive_time_stepping);
 }
 
 void

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -146,6 +146,8 @@ Driver<dim, Number>::solve()
       couple_fluid_to_acoustic();
     acoustic->advance_multiple_timesteps(fluid->time_integrator->get_time_step_size());
 
+    // TODO: we have to interpolate the source term also if the acoustic solver will be started
+    // during the sub-time-stepping sweep!
     fluid->advance_one_timestep_and_compute_pressure_time_derivative(
       acoustic->time_integrator->started());
   }

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -214,7 +214,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
 
   pcout << std::endl << "Throughput related to one macro time step:";
   print_throughput_unsteady(pcout,
-                            DoFs_f + sub_dt_per_macro_dt * DoFs_a,
+                            (double)DoFs_f + sub_dt_per_macro_dt * (double)DoFs_a,
                             time_solvers_side_by_side_avg,
                             acoustic->get_number_of_macro_time_steps(),
                             N_mpi_processes);

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -131,9 +131,9 @@ Driver<dim, Number>::solve()
                        application->acoustic->get_parameters().end_time) < 1.0e-12,
               dealii::ExcMessage("Acoustic and fluid simulation need the same end time."));
 
-  while(not acoustic->time_integrator->finished())
+  while(not fluid->time_integrator->finished())
   {
-    if(timer.first == false && acoustic->time_integrator->started())
+    if(timer.first == false and acoustic->time_integrator->started())
     {
       timer.first = true;
       timer.second.restart();

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -149,7 +149,7 @@ Driver<dim, Number>::solve()
     // The acoustic simulation uses explicit time-stepping while the fluid solver
     // uses implicit time-stepping. Therefore, we advance the acoustic solver to
     // t^(n+1) first and directly use the result in the fluid solver.
-    if(acoustic_starts_during_sub_stepping)
+    if(acoustic_starts_during_present_timestep)
       couple_fluid_to_acoustic();
     acoustic->advance_multiple_timesteps(fluid->time_integrator->get_time_step_size());
 

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -142,7 +142,7 @@ Driver<dim, Number>::solve()
     // To check if acoustics starts during the following sub-stepping sweep we
     // can not simply check acoustic->time_integrator->started(). Instead we
     // compute this information as follows:
-    const bool acoustic_starts_during_present_timestep =
+    bool const acoustic_starts_during_present_timestep =
       fluid->time_integrator->get_next_time() + fluid->time_integrator->get_time_step_size() >
       application->acoustic->get_parameters().start_time;
 
@@ -158,7 +158,7 @@ Driver<dim, Number>::solve()
     // sub-stepping BEFORE performing the current fluid time step we have to check if dt_{n+2}
     // is larger than the acoustic start time. We need this information BEFORE the fluid
     // time-step since we have to know if we have to compute dp/dt.
-    const bool acoustic_might_start_during_next_timestep =
+    bool const acoustic_might_start_during_next_timestep =
       fluid->time_integrator->get_next_time() + fluid->max_next_time_step_size() >
       application->acoustic->get_parameters().start_time;
 

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -208,7 +208,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
 
   dealii::types::global_dof_index const DoFs_f = fluid->pde_operator->get_number_of_dofs();
   dealii::types::global_dof_index const DoFs_a = acoustic->pde_operator->get_number_of_dofs();
-  double const sub_dt_per_macro__dt            = acoustic->get_average_number_of_sub_time_steps();
+  double const sub_dt_per_macro_dt             = acoustic->get_average_number_of_sub_time_steps();
 
   unsigned int const N_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
 

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -214,14 +214,14 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
 
   pcout << std::endl << "Throughput related to one macro time step:";
   print_throughput_unsteady(pcout,
-                            (double)DoFs_f + sub_dt_per_macro_dt * (double)DoFs_a,
+                            DoFs_f + DoFs_a,
                             time_solvers_side_by_side_avg,
                             acoustic->get_number_of_macro_time_steps(),
                             N_mpi_processes);
 
   pcout << std::endl << "Throughput related to one sub time step:";
   print_throughput_unsteady(pcout,
-                            DoFs_f + DoFs_a,
+                            (double)DoFs_f / sub_dt_per_macro_dt + (double)DoFs_a,
                             time_solvers_side_by_side_avg,
                             acoustic->get_number_of_sub_time_steps(),
                             N_mpi_processes);

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -142,7 +142,7 @@ Driver<dim, Number>::solve()
     // To check if acoustics starts during the following sub-stepping sweep we
     // can not simply check acoustic->time_integrator->started(). Instead we
     // compute this information as follows:
-    const bool acoustic_starts_during_sub_stepping =
+    const bool acoustic_starts_during_present_timestep =
       fluid->time_integrator->get_next_time() + fluid->time_integrator->get_time_step_size() >
       application->acoustic->get_parameters().start_time;
 
@@ -158,11 +158,12 @@ Driver<dim, Number>::solve()
     // sub-stepping BEFORE performing the current fluid time step we have to check if dt_{n+2}
     // is larger than the acoustic start time. We need this information BEFORE the fluid
     // time-step since we have to know if we have to compute dp/dt.
-    const bool acoustic_might_start =
+    const bool acoustic_might_start_during_next_timestep =
       fluid->time_integrator->get_next_time() + fluid->max_next_time_step_size() >
       application->acoustic->get_parameters().start_time;
 
-    fluid->advance_one_timestep_and_compute_pressure_time_derivative(acoustic_might_start);
+    fluid->advance_one_timestep_and_compute_pressure_time_derivative(
+      acoustic_might_start_during_next_timestep);
   }
 
   time_solvers_side_by_side = timer.second.wall_time();

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -181,7 +181,8 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
   fluid->time_integrator->print_iterations();
 
   pcout << std::endl << "Average number of sub-time steps Acoustic:" << std::endl;
-  pcout << "Adams-Bashforth-Moulton    " << acoustic->get_average_sub_time_steps() << std::endl;
+  pcout << "Adams-Bashforth-Moulton    " << acoustic->get_average_number_of_sub_time_steps()
+        << std::endl;
 
   // wall times
   pcout << std::endl << "Wall times:" << std::endl;
@@ -205,7 +206,7 @@ Driver<dim, Number>::print_performance_results(double const total_time) const
 
   dealii::types::global_dof_index const DoFs =
     fluid->pde_operator->get_number_of_dofs() +
-    acoustic->get_average_sub_time_steps() * acoustic->pde_operator->get_number_of_dofs();
+    acoustic->get_average_number_of_sub_time_steps() * acoustic->pde_operator->get_number_of_dofs();
 
   unsigned int const N_time_steps    = acoustic->get_number_of_global_time_steps();
   unsigned int const N_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);

--- a/include/exadg/aero_acoustic/driver.h
+++ b/include/exadg/aero_acoustic/driver.h
@@ -64,9 +64,6 @@ private:
   set_start_time() const;
 
   void
-  synchronize_time_step_size() const;
-
-  void
   couple_fluid_to_acoustic();
 
   MPI_Comm const mpi_comm;
@@ -86,6 +83,9 @@ private:
 
   // computation time
   mutable TimerTree timer_tree;
+
+  // wall time fluid and acoustic solvers ran together
+  double time_solvers_side_by_side;
 };
 
 } // namespace AeroAcoustic

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -68,6 +68,43 @@ public:
     time_integrator->setup(application->get_parameters().restarted_simulation);
   }
 
+  void
+  advance_multiple_timesteps(double const global_dt)
+  {
+    double const dt = compute_sub_time_step_size(global_dt);
+
+    // define epsilon dependent on time-step size to avoid
+    // wrong terminations of the sub-timestepping loop.
+    double eps = 0.01 * dt;
+
+    // perform time-steps until we advanced the global time step
+    unsigned int n_sub_time_steps = 0;
+    while(n_sub_time_steps * dt + eps < global_dt)
+    {
+      time_integrator->set_current_time_step_size(dt);
+      time_integrator->advance_one_timestep();
+      ++n_sub_time_steps;
+    }
+
+    if(time_integrator->started())
+    {
+      ++sub_time_steps.first;
+      sub_time_steps.second += n_sub_time_steps;
+    }
+  }
+
+  double
+  get_average_sub_time_steps() const
+  {
+    return sub_time_steps.second / sub_time_steps.first;
+  }
+
+  unsigned int
+  get_number_of_global_time_steps() const
+  {
+    return sub_time_steps.first;
+  }
+
   // grid and mapping
   std::shared_ptr<Grid<dim>>            grid;
   std::shared_ptr<dealii::Mapping<dim>> mapping;
@@ -80,6 +117,26 @@ public:
 
   // postprocessor
   std::shared_ptr<Acoustics::PostProcessorBase<dim, Number>> postprocessor;
+
+private:
+  double
+  compute_sub_time_step_size(double const global_dt)
+  {
+    double const current_dt = time_integrator->get_time_step_size();
+    if(global_dt < current_dt)
+    {
+      // in case the global time step is smaller than the acoustic timestep, simply run
+      // with global time step
+      return global_dt;
+    }
+    else
+    {
+      // otherwise, ensure that sub-timestepping ends exactly at global_dt
+      return adjust_time_step_to_hit_end_time(0.0, global_dt, current_dt);
+    }
+  }
+
+  std::pair<unsigned int /* calls */, unsigned long long /* sub_dt */> sub_time_steps;
 };
 
 

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -123,7 +123,7 @@ public:
   std::shared_ptr<Acoustics::PostProcessorBase<dim, Number>> postprocessor;
 
 private:
-  std::pair<unsigned int /* calls */, unsigned long long /* sub_dt */> sub_time_steps;
+  std::pair<unsigned int /* n_macro_dt */, unsigned long long /* n_sub_dt */> sub_time_steps;
 };
 
 

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -73,9 +73,10 @@ public:
   {
     // in case the macro time step is smaller than the acoustic timestep, simply run
     // with macro time step, otherwise, ensure that n_sub_time_steps * sub_dt = macro_dt
-    double sub_dt = time_integrator->get_time_step_size();
-    if(macro_dt > sub_dt)
-      sub_dt = adjust_time_step_to_hit_end_time(0.0, macro_dt, sub_dt);
+    double const dt = time_integrator->get_time_step_size();
+    double const sub_dt =
+      (macro_dt < dt) ? macro_dt : adjust_time_step_to_hit_end_time(0.0, macro_dt, dt);
+
 
     // define epsilon dependent on time-step size to avoid
     // wrong terminations of the sub-timestepping loop due to

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -94,7 +94,7 @@ public:
   }
 
   double
-  get_average_sub_time_steps() const
+  get_average_number_of_sub_time_steps() const
   {
     return sub_time_steps.second / sub_time_steps.first;
   }

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -78,7 +78,8 @@ public:
       sub_dt = adjust_time_step_to_hit_end_time(0.0, macro_dt, sub_dt);
 
     // define epsilon dependent on time-step size to avoid
-    // wrong terminations of the sub-timestepping loop.
+    // wrong terminations of the sub-timestepping loop due to
+    // round-off errors.
     double eps = 0.01 * sub_dt;
 
     // perform time-steps until we advanced the global time step

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -81,7 +81,7 @@ public:
     // define epsilon dependent on time-step size to avoid
     // wrong terminations of the sub-timestepping loop due to
     // round-off errors.
-    double eps = 0.01 * sub_dt;
+    double const eps = 0.01 * sub_dt;
 
     // perform time-steps until we advanced the global time step
     unsigned int n_sub_time_steps = 0;

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -102,13 +102,19 @@ public:
   double
   get_average_number_of_sub_time_steps() const
   {
-    return sub_time_steps.second / sub_time_steps.first;
+    return get_number_of_sub_time_steps() / get_number_of_macro_time_steps();
   }
 
   unsigned int
-  get_number_of_global_time_steps() const
+  get_number_of_macro_time_steps() const
   {
     return sub_time_steps.first;
+  }
+
+  unsigned int
+  get_number_of_sub_time_steps() const
+  {
+    return sub_time_steps.second;
   }
 
   // grid and mapping

--- a/include/exadg/aero_acoustic/user_interface/application_base.h
+++ b/include/exadg/aero_acoustic/user_interface/application_base.h
@@ -94,9 +94,9 @@ public:
     param.check();
 
     // Some AeroAcoustic specific Asserts
-    AssertThrow(param.adaptive_time_stepping == false,
-                dealii::ExcMessage(
-                  "Adaptive timestepping not yet implemented for aero-acoustics."));
+    AssertThrow(param.adaptive_time_stepping == true,
+                dealii::ExcMessage("Adaptive timestepping has to be enabled for aero-acoustics."));
+
     AssertThrow(param.aero_acoustic_source_term,
                 dealii::ExcMessage(
                   "aero_acoustic_source_term has to be set true for aero-acoustic computations."));

--- a/include/exadg/utilities/print_solver_results.h
+++ b/include/exadg/utilities/print_solver_results.h
@@ -145,7 +145,7 @@ print_throughput_unsteady(dealii::ConditionalOStream const & pcout,
   pcout << std::endl
         << "Throughput per time step:" << std::endl
         << "  Number of MPI processes    = " << N_mpi_processes << std::endl
-        << "  Average Degrees of freedom = " std::scientific << std::setprecision(2)<< avg_n_dofs << std::endl
+        << "  Average Degrees of freedom = " << std::scientific << std::setprecision(2)<< avg_n_dofs << std::endl
         << "  Wall time                  = " << std::scientific << std::setprecision(2) << overall_time_avg << " s" << std::endl
         << "  Time steps                 = " << std::left << N_time_steps << std::endl
         << "  Wall time per time step    = " << std::scientific << std::setprecision(2) << time_per_timestep << " s" << std::endl

--- a/include/exadg/utilities/print_solver_results.h
+++ b/include/exadg/utilities/print_solver_results.h
@@ -132,6 +132,27 @@ print_throughput_unsteady(dealii::ConditionalOStream const &    pcout,
   // clang-format on
 }
 
+inline void
+print_throughput_unsteady(dealii::ConditionalOStream const & pcout,
+                          double const                       avg_n_dofs,
+                          double const                       overall_time_avg,
+                          unsigned int const                 N_time_steps,
+                          unsigned int const                 N_mpi_processes)
+{
+  double const time_per_timestep = overall_time_avg / (double)N_time_steps;
+
+  // clang-format off
+  pcout << std::endl
+        << "Throughput per time step:" << std::endl
+        << "  Number of MPI processes    = " << N_mpi_processes << std::endl
+        << "  Average Degrees of freedom = " std::scientific << std::setprecision(2)<< avg_n_dofs << std::endl
+        << "  Wall time                  = " << std::scientific << std::setprecision(2) << overall_time_avg << " s" << std::endl
+        << "  Time steps                 = " << std::left << N_time_steps << std::endl
+        << "  Wall time per time step    = " << std::scientific << std::setprecision(2) << time_per_timestep << " s" << std::endl
+        << "  Throughput                 = " << std::scientific << std::setprecision(2) << avg_n_dofs / (time_per_timestep * N_mpi_processes) << " DoFs/s/core" << std::endl
+        << std::flush;
+  // clang-format on
+}
 
 inline void
 print_costs(dealii::ConditionalOStream const & pcout,


### PR DESCRIPTION
As indicated in https://github.com/exadg/exadg/pull/635 a few small follow-up PRs are necessary to use the aero-acoustic solver in realistic settings.

This PR adds sub-time-stepping for the aero-acoustic solver. I.e.: The fluid solver runs with its normal time step size and the acoustic solver runs multiple time steps for one fluid time-step. This heavily reduces the work that has to be performed by the fluid solver.