### PR TITLE
Fix bug in time dependent acoustic boundary conditions

### DIFF
--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.json
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.json
@@ -22,7 +22,7 @@
         "UserSpecifiedTimeStepSize": "1.0e-4",
         "OrderTimeIntegrator": "2",
         "RuntimeInNumberOfPeriods": "0.25",
-        "Modes": "2.0"
+        "Modes": "1.5"
     },
     "Output": {
         "OutputDirectory": "output/vibrating_membrane/",

--- a/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
+++ b/applications/acoustic_conservation_equations/vibrating_membrane/tests/weak.output
@@ -27,7 +27,7 @@ Mathematical model:
 
 Physical quantities:
   Start time:                                0.0000e+00
-  End time:                                  2.5254e-02
+  End time:                                  3.3672e-02
   Speed of sound:                            7.0000e+00
 
 Temporal discretization:
@@ -84,7 +84,7 @@ Calculation of time step size:
 Starting time loop ...
 
 Calculate error for pressure at time t = 0.0000e+00:
-  Absolute error (L2-norm): 1.80554e-01
+  Absolute error (L2-norm): 1.09728e-01
 
 Calculate error for velocity at time t = 0.0000e+00:
   Absolute error (L2-norm): 0.00000e+00
@@ -94,11 +94,11 @@ ________________________________________________________________________________
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-04
 ________________________________________________________________________________
 
-Calculate error for pressure at time t = 2.5300e-02:
-  Absolute error (L2-norm): 1.56490e-02
+Calculate error for pressure at time t = 3.3700e-02:
+  Absolute error (L2-norm): 4.68986e-02
 
-Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 2.83242e-02
+Calculate error for velocity at time t = 3.3700e-02:
+  Absolute error (L2-norm): 1.38719e-02
 
 
 
@@ -128,7 +128,7 @@ Mathematical model:
 
 Physical quantities:
   Start time:                                0.0000e+00
-  End time:                                  2.5254e-02
+  End time:                                  3.3672e-02
   Speed of sound:                            7.0000e+00
 
 Temporal discretization:
@@ -185,7 +185,7 @@ Calculation of time step size:
 Starting time loop ...
 
 Calculate error for pressure at time t = 0.0000e+00:
-  Absolute error (L2-norm): 1.57067e-02
+  Absolute error (L2-norm): 6.65003e-03
 
 Calculate error for velocity at time t = 0.0000e+00:
   Absolute error (L2-norm): 0.00000e+00
@@ -195,11 +195,11 @@ ________________________________________________________________________________
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-04
 ________________________________________________________________________________
 
-Calculate error for pressure at time t = 2.5300e-02:
-  Absolute error (L2-norm): 8.03504e-03
+Calculate error for pressure at time t = 3.3700e-02:
+  Absolute error (L2-norm): 2.69809e-03
 
-Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 1.68592e-03
+Calculate error for velocity at time t = 3.3700e-02:
+  Absolute error (L2-norm): 6.57061e-04
 
 
 
@@ -229,7 +229,7 @@ Mathematical model:
 
 Physical quantities:
   Start time:                                0.0000e+00
-  End time:                                  2.5254e-02
+  End time:                                  3.3672e-02
   Speed of sound:                            7.0000e+00
 
 Temporal discretization:
@@ -286,7 +286,7 @@ Calculation of time step size:
 Starting time loop ...
 
 Calculate error for pressure at time t = 0.0000e+00:
-  Absolute error (L2-norm): 1.39272e-03
+  Absolute error (L2-norm): 4.45586e-04
 
 Calculate error for velocity at time t = 0.0000e+00:
   Absolute error (L2-norm): 0.00000e+00
@@ -296,11 +296,11 @@ ________________________________________________________________________________
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-04
 ________________________________________________________________________________
 
-Calculate error for pressure at time t = 2.5300e-02:
-  Absolute error (L2-norm): 7.77314e-04
+Calculate error for pressure at time t = 3.3700e-02:
+  Absolute error (L2-norm): 2.00796e-04
 
-Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 1.32258e-04
+Calculate error for velocity at time t = 3.3700e-02:
+  Absolute error (L2-norm): 5.10435e-05
 
 
 
@@ -330,7 +330,7 @@ Mathematical model:
 
 Physical quantities:
   Start time:                                0.0000e+00
-  End time:                                  2.5254e-02
+  End time:                                  3.3672e-02
   Speed of sound:                            7.0000e+00
 
 Temporal discretization:
@@ -387,7 +387,7 @@ Calculation of time step size:
 Starting time loop ...
 
 Calculate error for pressure at time t = 0.0000e+00:
-  Absolute error (L2-norm): 1.05702e-04
+  Absolute error (L2-norm): 2.53327e-05
 
 Calculate error for velocity at time t = 0.0000e+00:
   Absolute error (L2-norm): 0.00000e+00
@@ -397,11 +397,11 @@ ________________________________________________________________________________
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-04
 ________________________________________________________________________________
 
-Calculate error for pressure at time t = 2.5300e-02:
-  Absolute error (L2-norm): 5.18740e-05
+Calculate error for pressure at time t = 3.3700e-02:
+  Absolute error (L2-norm): 1.19597e-05
 
-Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 1.09897e-05
+Calculate error for velocity at time t = 3.3700e-02:
+  Absolute error (L2-norm): 2.89105e-06
 
 
 
@@ -431,7 +431,7 @@ Mathematical model:
 
 Physical quantities:
   Start time:                                0.0000e+00
-  End time:                                  2.5254e-02
+  End time:                                  3.3672e-02
   Speed of sound:                            7.0000e+00
 
 Temporal discretization:
@@ -488,7 +488,7 @@ Calculation of time step size:
 Starting time loop ...
 
 Calculate error for pressure at time t = 0.0000e+00:
-  Absolute error (L2-norm): 6.78907e-06
+  Absolute error (L2-norm): 1.21871e-06
 
 Calculate error for velocity at time t = 0.0000e+00:
   Absolute error (L2-norm): 0.00000e+00
@@ -498,11 +498,11 @@ ________________________________________________________________________________
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-04
 ________________________________________________________________________________
 
-Calculate error for pressure at time t = 2.5300e-02:
-  Absolute error (L2-norm): 6.14288e-06
+Calculate error for pressure at time t = 3.3700e-02:
+  Absolute error (L2-norm): 3.23599e-06
 
-Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 7.67662e-07
+Calculate error for velocity at time t = 3.3700e-02:
+  Absolute error (L2-norm): 2.88955e-07
 
 
 
@@ -532,7 +532,7 @@ Mathematical model:
 
 Physical quantities:
   Start time:                                0.0000e+00
-  End time:                                  2.5254e-02
+  End time:                                  3.3672e-02
   Speed of sound:                            7.0000e+00
 
 Temporal discretization:
@@ -589,7 +589,7 @@ Calculation of time step size:
 Starting time loop ...
 
 Calculate error for pressure at time t = 0.0000e+00:
-  Absolute error (L2-norm): 3.76329e-07
+  Absolute error (L2-norm): 5.06161e-08
 
 Calculate error for velocity at time t = 0.0000e+00:
   Absolute error (L2-norm): 0.00000e+00
@@ -599,11 +599,11 @@ ________________________________________________________________________________
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-04
 ________________________________________________________________________________
 
-Calculate error for pressure at time t = 2.5300e-02:
-  Absolute error (L2-norm): 5.07805e-06
+Calculate error for pressure at time t = 3.3700e-02:
+  Absolute error (L2-norm): 3.18551e-06
 
-Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 4.23885e-08
+Calculate error for velocity at time t = 3.3700e-02:
+  Absolute error (L2-norm): 2.48798e-07
 
 
 
@@ -633,7 +633,7 @@ Mathematical model:
 
 Physical quantities:
   Start time:                                0.0000e+00
-  End time:                                  2.5254e-02
+  End time:                                  3.3672e-02
   Speed of sound:                            7.0000e+00
 
 Temporal discretization:
@@ -690,7 +690,7 @@ Calculation of time step size:
 Starting time loop ...
 
 Calculate error for pressure at time t = 0.0000e+00:
-  Absolute error (L2-norm): 1.83214e-08
+  Absolute error (L2-norm): 1.84673e-09
 
 Calculate error for velocity at time t = 0.0000e+00:
   Absolute error (L2-norm): 0.00000e+00
@@ -700,8 +700,8 @@ ________________________________________________________________________________
  Time step number = 1       t = 0.00000e+00 -> t + dt = 1.00000e-04
 ________________________________________________________________________________
 
-Calculate error for pressure at time t = 2.5300e-02:
-  Absolute error (L2-norm): 5.07362e-06
+Calculate error for pressure at time t = 3.3700e-02:
+  Absolute error (L2-norm): 3.19000e-06
 
-Calculate error for velocity at time t = 2.5300e-02:
-  Absolute error (L2-norm): 2.37661e-09
+Calculate error for velocity at time t = 3.3700e-02:
+  Absolute error (L2-norm): 2.49803e-07

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
@@ -251,13 +251,13 @@ public:
   void
   evaluate(BlockVectorType & dst, BlockVectorType const & src, double const time) const
   {
-    do_evaluate(dst, src, true, time);
+    do_evaluate(dst, src, time, true);
   }
 
   void
   evaluate_add(BlockVectorType & dst, BlockVectorType const & src, double const time) const
   {
-    do_evaluate(dst, src, false, time);
+    do_evaluate(dst, src, time, true);
   }
 
 private:


### PR DESCRIPTION
I misplaced two function arguments which led to a bug for time-dependent boundary conditions. 

I fixed the placement of the arguments and adjusted a test case such that the BC is time-dependent. Before, the domain had its boundaries exactly where the analytical pressure solution was 0 during the whole simulation and therefore, the bug was not visible in any test case.