### PR TITLE
Change initialize sequence

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -83,9 +83,9 @@ MultigridPreconditionerBase<dim, Number, MultigridNumber>::initialize(
 
   this->initialize_matrix_free_objects();
 
-  this->initialize_transfer_operators();
-
   this->initialize_operators();
+
+  this->initialize_transfer_operators();
 
   this->initialize_smoothers(initialize_preconditioners);
 


### PR DESCRIPTION
I have a bit of a chicken-egg problem in my code because of this initialize sequence change in https://github.com/exadg/exadg/pull/599

The problem is that my operator modifies the constraints and therefore also the matrix-free object and setting up the transfer correctly works only after the final matrix-free object is set up.

https://github.com/exadg/exadg/pull/599/files#r1401973099 states that this sequence change should not affect anything and also does not change the logic of initializing things dependent on `initialize_preconditioners`.