### PR TITLE
CG: distribute periodicity and hanging node constraints

### DIFF
--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -499,6 +499,7 @@ Operator<dim, n_components, Number>::solve(VectorType &       sol,
   {
     laplace_operator.set_time(time);
     laplace_operator.set_inhomogeneous_boundary_values(sol);
+    affine_constraints_periodicity_and_hanging_nodes.distribute(sol);
   }
 
   return n_iterations;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -796,6 +796,7 @@ Operator<dim, Number>::compute_initial_acceleration(VectorType &       initial_a
     // Set initial acceleration for the Dirichlet degrees of freedom so that the initial
     // acceleration is also correct on the Dirichlet boundary
     mass_operator.set_inhomogeneous_boundary_values(initial_acceleration);
+    affine_constraints_periodicity_and_hanging_nodes.distribute(initial_acceleration);
   }
 }
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -935,6 +935,7 @@ Operator<dim, Number>::solve_nonlinear(VectorType &       sol,
   // set inhomogeneous Dirichlet values in order to evaluate the nonlinear residual correctly
   elasticity_operator_nonlinear.set_time(time);
   elasticity_operator_nonlinear.set_inhomogeneous_boundary_values(sol);
+  affine_constraints_periodicity_and_hanging_nodes.distribute(sol);
 
   // call Newton solver
   Newton::UpdateData update;
@@ -1002,6 +1003,7 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   // Set Dirichlet degrees of freedom according to Dirichlet boundary condition.
   elasticity_operator_linear.set_time(time);
   elasticity_operator_linear.set_inhomogeneous_boundary_values(sol);
+  affine_constraints_periodicity_and_hanging_nodes.distribute(sol);
 
   return iterations;
 }


### PR DESCRIPTION
fixes #650 
For the structure module, similar problems might appear. Maybe no one solved structure problems with hanging nodes or periodic constraints yet? There, it would actually impact the performance of the nonlinear solver I believe, as we distribute constraints on the linearization vector. I did not test the changes in the structure module yet, but I doubt any of these consider hanging nodes anyways. ~Will test manually and then update here. Until then, this is on `do not merge`~ (tests for structure module done in #690).