### PR TITLE
Make compile with recent deal.II

### DIFF
--- a/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
@@ -45,15 +45,14 @@ compute_eigenvalues(Operator const &   op,
   if(operator_is_singular)
     dealii::VectorTools::subtract_mean_value(rhs);
 
-  dealii::SolverControl control(eig_n_iter, rhs.l2_norm() * 1e-5);
-  dealii::internal::PreconditionChebyshevImplementation::EigenvalueTracker eigenvalue_tracker;
+  dealii::SolverControl               control(eig_n_iter, rhs.l2_norm() * 1e-5);
+  dealii::internal::EigenvalueTracker eigenvalue_tracker;
 
   dealii::SolverCG<VectorType> solver(control);
 
-  solver.connect_eigenvalues_slot(
-    std::bind(&dealii::internal::PreconditionChebyshevImplementation::EigenvalueTracker::slot,
-              &eigenvalue_tracker,
-              std::placeholders::_1));
+  solver.connect_eigenvalues_slot(std::bind(&dealii::internal::EigenvalueTracker::slot,
+                                            &eigenvalue_tracker,
+                                            std::placeholders::_1));
 
   JacobiPreconditioner<Operator> preconditioner(op, true /* initialize */);
 


### PR DESCRIPTION
This is caused by https://github.com/dealii/dealii/pull/16742
This is an internal change and thus puts us at danger for future changes; we could alternatively try to work around the issue by manually writing the code to capture the array of eigenvalues, it will not be a big difference in code complexity here, so we might even prefer that instead.