### PR TITLE
Fix preprocessor directive of conditional PETSc code in operator base

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -2120,12 +2120,12 @@ OperatorBase<dim, Number, n_components>::compute_factorized_additive_schwarz_mat
 {
 #ifdef DEAL_II_WITH_TRILINOS
   internal_compute_factorized_additive_schwarz_matrices<dealii::TrilinosWrappers::SparseMatrix>();
-#elif DEAL_II_WITH_PETSC
+#elif defined(DEAL_II_WITH_PETSC)
   internal_compute_factorized_additive_schwarz_matrices<dealii::PETScWrappers::MPI::SparseMatrix>();
 #else
   AssertThrow(
     n_mpi_processes == 1,
-    ExcMessage(
+    dealii::ExcMessage(
       "If you want to use this function in parallel you have to compile deal.II with either "
       "Trilinos or Petsc support for distributed sparse matrices."));
   internal_compute_factorized_additive_schwarz_matrices<dealii::SparseMatrix>();


### PR DESCRIPTION
... to make the code compile with PETSc, but without Trilinos.

The `DEAL_II_WITH_` defines are not equal to any true or false per se, just PP defines. 