### PR TITLE
Port preCICE integration to version 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ ENDIF()
 OPTION(EXADG_WITH_PRECICE "Use preCICE" OFF})
 IF(${EXADG_WITH_PRECICE})
     # the environment variable precice_DIR is searched by default
-    FIND_PACKAGE(precice 2.0
+    FIND_PACKAGE(precice 3.0
       HINTS ${precice_DIR} ${PRECICE_DIR} $ENV{PRECICE_DIR}
     )
     IF(NOT ${precice_FOUND})

--- a/applications/fluid_structure_interaction/perpendicular_flap/precice-config.xml
+++ b/applications/fluid_structure_interaction/perpendicular_flap/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration dimensions="2">
+<precice-configuration>
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -11,23 +11,23 @@
   <data:vector name="Displacement" />
   <data:vector name="Velocity" />
 
-  <mesh name="Fluid-Mesh-read">
+  <mesh name="Fluid-Mesh-read" dimensions="2">
     <use-data name="Velocity" />
   </mesh>
 
-  <mesh name="Fluid-Mesh-write">
+  <mesh name="Fluid-Mesh-write" dimensions="2">
     <use-data name="Stress" />
   </mesh>
 
-  <mesh name="ALE-Mesh">
+  <mesh name="ALE-Mesh" dimensions="2">
     <use-data name="Displacement" />
   </mesh>
 
-  <mesh name="Solid-Mesh-read">
+  <mesh name="Solid-Mesh-read" dimensions="2">
     <use-data name="Stress" />
   </mesh>
 
-  <mesh name="Solid-Mesh-write">
+  <mesh name="Solid-Mesh-write" dimensions="2">
     <use-data name="Displacement" />
     <use-data name="Velocity" />
   </mesh>
@@ -69,7 +69,7 @@
     </mapping:rbf>
   </participant>
 
-  <m2n:sockets from="Fluid" to="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
   <coupling-scheme:serial-explicit>
     <time-window-size value="0.01" />

--- a/applications/fluid_structure_interaction/perpendicular_flap/precice-config.xml
+++ b/applications/fluid_structure_interaction/perpendicular_flap/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,79 +7,76 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Stress" />
-    <data:vector name="Displacement" />
-    <data:vector name="Velocity" />
+  <data:vector name="Stress" />
+  <data:vector name="Displacement" />
+  <data:vector name="Velocity" />
 
-    <mesh name="Fluid-Mesh-read">
-      <use-data name="Velocity" />
-    </mesh>
+  <mesh name="Fluid-Mesh-read">
+    <use-data name="Velocity" />
+  </mesh>
 
-    <mesh name="Fluid-Mesh-write">
-      <use-data name="Stress" />
-    </mesh>
+  <mesh name="Fluid-Mesh-write">
+    <use-data name="Stress" />
+  </mesh>
 
-    <mesh name="ALE-Mesh">
-      <use-data name="Displacement" />
-    </mesh>
+  <mesh name="ALE-Mesh">
+    <use-data name="Displacement" />
+  </mesh>
 
-    <mesh name="Solid-Mesh-read">
-      <use-data name="Stress" />
-    </mesh>
+  <mesh name="Solid-Mesh-read">
+    <use-data name="Stress" />
+  </mesh>
 
-    <mesh name="Solid-Mesh-write">
-      <use-data name="Displacement" />
-      <use-data name="Velocity" />
-    </mesh>
-    
-    <participant name="Fluid">
-      <use-mesh name="Fluid-Mesh-read" provide="yes" />
-      <use-mesh name="Fluid-Mesh-write" provide="yes" />
-      <use-mesh name="ALE-Mesh" provide="yes" />
-      <use-mesh name="Solid-Mesh-write" from="Solid" />
-      <write-data name="Stress" mesh="Fluid-Mesh-write" />
-      <read-data name="Velocity" mesh="Fluid-Mesh-read" />
-      <read-data name="Displacement" mesh="ALE-Mesh" />
-      <mapping:rbf-volume-splines
-        direction="read"
-        from="Solid-Mesh-write"
-        to="Fluid-Mesh-read"
-        use-qr-decomposition="true"
-        constraint="consistent" />
-      <mapping:rbf-volume-splines
-        direction="read"
-        from="Solid-Mesh-write"
-        to="ALE-Mesh"
-        use-qr-decomposition="true"
-        constraint="consistent" />
-    </participant>
+  <mesh name="Solid-Mesh-write">
+    <use-data name="Displacement" />
+    <use-data name="Velocity" />
+  </mesh>
 
-    <participant name="Solid">
-      <use-mesh name="Solid-Mesh-read" provide="yes" />
-      <use-mesh name="Solid-Mesh-write" provide="yes" />
-      <use-mesh name="Fluid-Mesh-write" from="Fluid" />
-      <write-data name="Displacement" mesh="Solid-Mesh-write"/>
-      <write-data name="Velocity" mesh="Solid-Mesh-write" />
-      <read-data name="Stress" mesh="Solid-Mesh-read" />
-      <watch-point mesh="Solid-Mesh-write" name="Flap-Tip" coordinate="0.0;1" />
-      <mapping:rbf-volume-splines
-        direction="read"
-        from="Fluid-Mesh-write"
-        to="Solid-Mesh-read"
-        use-qr-decomposition="true"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh-read" />
+    <provide-mesh name="Fluid-Mesh-write" />
+    <provide-mesh name="ALE-Mesh" />
+    <receive-mesh name="Solid-Mesh-write" from="Solid" />
+    <write-data name="Stress" mesh="Fluid-Mesh-write" />
+    <read-data name="Velocity" mesh="Fluid-Mesh-read" />
+    <read-data name="Displacement" mesh="ALE-Mesh" />
+    <mapping:rbf
+      direction="read"
+      from="Solid-Mesh-write"
+      to="Fluid-Mesh-read"
+      constraint="consistent">
+      <basis-function:volume-splines />
+    </mapping:rbf>
+    <mapping:rbf direction="read" from="Solid-Mesh-write" to="ALE-Mesh" constraint="consistent">
+      <basis-function:volume-splines />
+    </mapping:rbf>
+  </participant>
 
-    <m2n:sockets from="Fluid" to="Solid" exchange-directory=".." />
+  <participant name="Solid">
+    <provide-mesh name="Solid-Mesh-read" />
+    <provide-mesh name="Solid-Mesh-write" />
+    <receive-mesh name="Fluid-Mesh-write" from="Fluid" />
+    <write-data name="Displacement" mesh="Solid-Mesh-write" />
+    <write-data name="Velocity" mesh="Solid-Mesh-write" />
+    <read-data name="Stress" mesh="Solid-Mesh-read" />
+    <watch-point mesh="Solid-Mesh-write" name="Flap-Tip" coordinate="0.0;1" />
+    <mapping:rbf
+      direction="read"
+      from="Fluid-Mesh-write"
+      to="Solid-Mesh-read"
+      constraint="consistent">
+      <basis-function:volume-splines />
+    </mapping:rbf>
+  </participant>
 
-    <coupling-scheme:serial-explicit>
-      <time-window-size value="0.01" />
-      <max-time value="5" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Stress" mesh="Fluid-Mesh-write" from="Fluid" to="Solid" />
-      <exchange data="Displacement" mesh="Solid-Mesh-write" from="Solid" to="Fluid" />
-      <exchange data="Velocity" mesh="Solid-Mesh-write" from="Solid" to="Fluid" />
-    </coupling-scheme:serial-explicit>
-  </solver-interface>
+  <m2n:sockets from="Fluid" to="Solid" exchange-directory=".." />
+
+  <coupling-scheme:serial-explicit>
+    <time-window-size value="0.01" />
+    <max-time value="5" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Stress" mesh="Fluid-Mesh-write" from="Fluid" to="Solid" />
+    <exchange data="Displacement" mesh="Solid-Mesh-write" from="Solid" to="Fluid" />
+    <exchange data="Velocity" mesh="Solid-Mesh-write" from="Solid" to="Fluid" />
+  </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/include/exadg/fluid_structure_interaction/precice/coupling_base.h
+++ b/include/exadg/fluid_structure_interaction/precice/coupling_base.h
@@ -33,7 +33,7 @@
 
 // preCICE
 #ifdef EXADG_WITH_PRECICE
-#  include <precice/SolverInterface.hpp>
+#  include <precice/precice.hpp>
 #endif
 
 namespace ExaDG
@@ -67,7 +67,7 @@ class CouplingBase
 public:
   CouplingBase(dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
-               std::shared_ptr<precice::SolverInterface> precice,
+               std::shared_ptr<precice::Participant> precice,
 #endif
                std::string const                mesh_name,
                dealii::types::boundary_id const surface_id);
@@ -145,7 +145,7 @@ protected:
 
   /// public precice solverinterface
 #ifdef EXADG_WITH_PRECICE
-  std::shared_ptr<precice::SolverInterface> precice;
+  std::shared_ptr<precice::Participant> precice;
 #endif
 
   /// Configuration parameters
@@ -169,7 +169,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 CouplingBase<dim, data_dim, VectorizedArrayType>::CouplingBase(
   dealii::MatrixFree<dim, double, VectorizedArrayType> const & matrix_free_,
 #ifdef EXADG_WITH_PRECICE
-  std::shared_ptr<precice::SolverInterface> precice,
+  std::shared_ptr<precice::Participant> precice,
 #endif
   std::string const                mesh_name,
   dealii::types::boundary_id const surface_id)

--- a/include/exadg/fluid_structure_interaction/precice/coupling_base.h
+++ b/include/exadg/fluid_structure_interaction/precice/coupling_base.h
@@ -104,19 +104,18 @@ public:
   write_data(dealii::LinearAlgebra::distributed::Vector<double> const & data_vector,
              std::string const &                                        data_name) = 0;
 
-
-  virtual void
-  read_block_data(std::string const & data_name) const;
+   virtual void
+  read_data(std::string const & data_name, double associated_time) const;
 
   /**
-   * @brief Queries data IDs from preCICE for the given read data name
+   * @brief Registers the the given read data name (for logging only)
    * @param read_data_name
    */
   void
   add_read_data(std::string const & read_data_name);
 
   /**
-   * @brief Queries data IDs from preCICE for the given write data name
+   * @brief Registers the the given read data name (for logging only)
    * @param write_data_name
    */
   void
@@ -152,8 +151,8 @@ protected:
   std::string const mesh_name;
 
   // Map between data ID (preCICE) and the data name
-  std::map<std::string, int> read_data_map;
-  std::map<std::string, int> write_data_map;
+  std::set<std::string> read_data_map;
+  std::set<std::string> write_data_map;
 
   dealii::types::boundary_id const dealii_boundary_surface_id;
 
@@ -195,6 +194,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 void
 CouplingBase<dim, data_dim, VectorizedArrayType>::add_read_data(std::string const & read_data_name)
 {
+  // Strictly speaking not necessary anymore, but we can keep it for debugging and logging reasons
   Assert(mesh_name != "", dealii::ExcNotInitialized());
   read_data_map.insert({read_data_name});
 }
@@ -206,7 +206,7 @@ void
 CouplingBase<dim, data_dim, VectorizedArrayType>::add_write_data(
   std::string const & write_data_name)
 {
-  // TODO: Probably not required at all
+  // Strictly speaking not necessary anymore, but we can keep it for debugging and logging reasons
   Assert(mesh_name != "", dealii::ExcNotInitialized());
   write_data_map.insert({write_data_name});
 }
@@ -233,7 +233,7 @@ CouplingBase<dim, data_dim, VectorizedArrayType>::process_coupling_mesh()
 
 template<int dim, int data_dim, typename VectorizedArrayType>
 void
-CouplingBase<dim, data_dim, VectorizedArrayType>::read_block_data(std::string const &) const
+CouplingBase<dim, data_dim, VectorizedArrayType>::read_data(std::string const &, double) const
 {
   AssertThrow(false, dealii::ExcNotImplemented());
 }

--- a/include/exadg/fluid_structure_interaction/precice/coupling_base.h
+++ b/include/exadg/fluid_structure_interaction/precice/coupling_base.h
@@ -104,7 +104,7 @@ public:
   write_data(dealii::LinearAlgebra::distributed::Vector<double> const & data_vector,
              std::string const &                                        data_name) = 0;
 
-   virtual void
+  virtual void
   read_data(std::string const & data_name, double associated_time) const;
 
   /**

--- a/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
@@ -221,7 +221,7 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::write_data(
 #ifdef EXADG_WITH_PRECICE
     // and pass them to preCICE
     this->precice->writeData(this->mesh_name, data_name, {&coupling_nodes_ids[i], 1}, write_data);
-    #else
+#else
     (void)data_name;
 #endif
   }

--- a/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
@@ -111,7 +111,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 void
 DoFCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 {
-  Assert(this->mesh_id != -1, dealii::ExcNotInitialized());
+  Assert(this->mesh_name != "", dealii::ExcNotInitialized());
 
   // In order to avoid that we define the surface multiple times when reader
   // and writer refer to the same object
@@ -182,7 +182,7 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 
       // pass node coordinates to precice
 #ifdef EXADG_WITH_PRECICE
-    int const precice_id = this->precice->setMeshVertex(this->mesh_id, nodes_position.data());
+    int const precice_id = this->precice->setMeshVertex(this->mesh_name, nodes_position);
 #else
     int const precice_id = 0;
 #endif
@@ -191,9 +191,9 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 
 #ifdef EXADG_WITH_PRECICE
   if(this->read_data_map.size() > 0)
-    this->print_info(true, this->precice->getMeshVertexSize(this->mesh_id));
+    this->print_info(true, this->precice->getMeshVertexSize(this->mesh_name));
   if(this->write_data_map.size() > 0)
-    this->print_info(false, this->precice->getMeshVertexSize(this->mesh_id));
+    this->print_info(false, this->precice->getMeshVertexSize(this->mesh_name));
 #endif
 }
 
@@ -205,8 +205,7 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::write_data(
   dealii::LinearAlgebra::distributed::Vector<double> const & data_vector,
   std::string const &                                        data_name)
 {
-  int const write_data_id = this->write_data_map.at(data_name);
-  Assert(write_data_id != -1, dealii::ExcNotInitialized());
+  Assert(data_name != "", dealii::ExcNotInitialized());
   Assert(coupling_nodes_ids.size() > 0, dealii::ExcNotInitialized());
 
   std::array<double, data_dim> write_data;

--- a/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
@@ -221,6 +221,8 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::write_data(
 #ifdef EXADG_WITH_PRECICE
     // and pass them to preCICE
     this->precice->writeData(this->mesh_name, data_name, {&coupling_nodes_ids[i], 1}, write_data);
+    #else
+    (void)data_name;
 #endif
   }
 }

--- a/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
@@ -45,7 +45,7 @@ class DoFCoupling : public CouplingBase<dim, data_dim, VectorizedArrayType>
 public:
   DoFCoupling(dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
-              std::shared_ptr<precice::SolverInterface> precice,
+              std::shared_ptr<precice::Participant> precice,
 #endif
               std::string const                mesh_name,
               dealii::types::boundary_id const surface_id,
@@ -90,7 +90,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 DoFCoupling<dim, data_dim, VectorizedArrayType>::DoFCoupling(
   dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
-  std::shared_ptr<precice::SolverInterface> precice,
+  std::shared_ptr<precice::Participant> precice,
 #endif
   std::string const                mesh_name,
   dealii::types::boundary_id const surface_id,

--- a/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/dof_coupling.h
@@ -220,16 +220,7 @@ DoFCoupling<dim, data_dim, VectorizedArrayType>::write_data(
 
 #ifdef EXADG_WITH_PRECICE
     // and pass them to preCICE
-    if constexpr(data_dim > 1)
-    {
-      this->precice->writeVectorData(write_data_id, coupling_nodes_ids[i], write_data.data());
-    }
-    else
-    {
-      this->precice->writeScalarData(write_data_id, coupling_nodes_ids[i], write_data[0]);
-    }
-#else
-    (void)write_data_id;
+    this->precice->writeData(this->mesh_name, data_name, {&coupling_nodes_ids[i], 1}, write_data);
 #endif
   }
 }

--- a/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
@@ -124,7 +124,7 @@ public:
     // initialize preCICE with initial stress data
     VectorType initial_stress;
     fluid->pde_operator->initialize_vector_velocity(initial_stress);
-    this->precice->initialize_precice(initial_stress);
+    this->precice->initialize_precice(initial_stress, this->precice_parameters.stress_data_name);
   }
 
 

--- a/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
@@ -271,16 +271,18 @@ private:
   coupling_structure_to_ale() const
   {
     // TODO: parametrize names
-    this->precice->read_block_data(this->precice_parameters.ale_mesh_name,
-                                   this->precice_parameters.displacement_data_name);
+    this->precice->read_data(this->precice_parameters.ale_mesh_name,
+                             this->precice_parameters.displacement_data_name,
+                             fluid->time_integrator->get_time_step_size());
   }
 
   void
   coupling_structure_to_fluid() const
   {
     // TODO: parametrize names
-    this->precice->read_block_data(this->precice_parameters.read_mesh_name,
-                                   this->precice_parameters.velocity_data_name);
+    this->precice->read_data(this->precice_parameters.read_mesh_name,
+                             this->precice_parameters.velocity_data_name,
+                             fluid->time_integrator->get_time_step_size());
   }
 
   void
@@ -295,8 +297,7 @@ private:
     stress_fluid *= -1.0;
     this->precice->write_data(this->precice_parameters.write_mesh_name,
                               this->precice_parameters.stress_data_name,
-                              stress_fluid,
-                              fluid->time_integrator->get_time_step_size());
+                              stress_fluid);
   }
 
   // solver

--- a/include/exadg/fluid_structure_interaction/precice/driver_solid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_solid.h
@@ -134,12 +134,10 @@ public:
       // store_solution needs to be true for compatibility
       structure->time_integrator->advance_one_timestep_partitioned_solve(is_new_time_window);
       // send displacement data to ale
-      coupling_structure_to_ale(structure->time_integrator->get_displacement_np(),
-                                structure->time_integrator->get_time_step_size());
+      coupling_structure_to_ale(structure->time_integrator->get_displacement_np());
 
       // send velocity boundary condition to fluid
-      coupling_structure_to_fluid(structure->time_integrator->get_velocity_np(),
-                                  structure->time_integrator->get_time_step_size());
+      coupling_structure_to_fluid(structure->time_integrator->get_velocity_np());
 
       // TODO: Add synchronization for the time-step size here. For now, we only allow a constant
       // time-step size
@@ -207,30 +205,27 @@ public:
 
 private:
   void
-  coupling_structure_to_ale(VectorType const & displacement_structure,
-                            double const       time_step_size) const
+  coupling_structure_to_ale(VectorType const & displacement_structure) const
   {
     this->precice->write_data(this->precice_parameters.write_mesh_name,
                               this->precice_parameters.displacement_data_name,
-                              displacement_structure,
-                              time_step_size);
+                              displacement_structure);
   }
 
   void
-  coupling_structure_to_fluid(VectorType const & velocity_structure,
-                              double const       time_step_size) const
+  coupling_structure_to_fluid(VectorType const & velocity_structure) const
   {
     this->precice->write_data(this->precice_parameters.write_mesh_name,
                               this->precice_parameters.velocity_data_name,
-                              velocity_structure,
-                              time_step_size);
+                              velocity_structure);
   }
 
   void
   coupling_fluid_to_structure() const
   {
-    this->precice->read_block_data(this->precice_parameters.read_mesh_name,
-                                   this->precice_parameters.stress_data_name);
+    this->precice->read_data(this->precice_parameters.read_mesh_name,
+                             this->precice_parameters.stress_data_name,
+                             structure->time_integrator->get_time_step_size());
   }
 
   // the solver

--- a/include/exadg/fluid_structure_interaction/precice/driver_solid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_solid.h
@@ -94,7 +94,7 @@ public:
     // initialize preCICE with initial displacement data
     VectorType displacement_structure;
     structure->pde_operator->initialize_dof_vector(displacement_structure);
-    this->precice->initialize_precice(displacement_structure);
+    this->precice->initialize_precice(displacement_structure, this->precice_parameters.displacement_data_name);
   }
 
 

--- a/include/exadg/fluid_structure_interaction/precice/driver_solid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_solid.h
@@ -94,7 +94,8 @@ public:
     // initialize preCICE with initial displacement data
     VectorType displacement_structure;
     structure->pde_operator->initialize_dof_vector(displacement_structure);
-    this->precice->initialize_precice(displacement_structure, this->precice_parameters.displacement_data_name);
+    this->precice->initialize_precice(displacement_structure,
+                                      this->precice_parameters.displacement_data_name);
   }
 
 

--- a/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
@@ -111,7 +111,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 void
 ExaDGCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 {
-  Assert(this->mesh_id != -1, dealii::ExcNotInitialized());
+  Assert(this->mesh_name != "", dealii::ExcNotInitialized());
   Assert(interface_data.get() != nullptr, dealii::ExcNotInitialized());
 
   // In order to avoid that we define the surface multiple times when reader
@@ -141,9 +141,9 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 
 #ifdef EXADG_WITH_PRECICE
   if(this->read_data_map.size() > 0)
-    this->print_info(true, this->precice->getMeshVertexSize(this->mesh_id));
+    this->print_info(true, this->precice->getMeshVertexSize(this->mesh_name));
   if(this->write_data_map.size() > 0)
-    this->print_info(false, this->precice->getMeshVertexSize(this->mesh_id));
+    this->print_info(false, this->precice->getMeshVertexSize(this->mesh_name));
 #endif
 }
 

--- a/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
@@ -133,7 +133,7 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
     // Set the vertices
 #ifdef EXADG_WITH_PRECICE
     this->precice->setMeshVertices(this->mesh_name,
-                                   {&points[0][0],points.size()},
+                                   {&points[0][0], points.size()},
                                    {&coupling_nodes_ids[start_index], points.size()});
 #endif
   }
@@ -149,9 +149,8 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 
 template<int dim, int data_dim, typename VectorizedArrayType>
 void
-ExaDGCoupling<dim, data_dim, VectorizedArrayType>::read_data(
-  std::string const & data_name,
-  double associated_time) const
+ExaDGCoupling<dim, data_dim, VectorizedArrayType>::read_data(std::string const & data_name,
+                                                             double associated_time) const
 {
   Assert(interface_data.get() != nullptr, dealii::ExcNotInitialized());
 
@@ -173,8 +172,8 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::read_data(
                               associated_time,
                               {&array_solution[0][0], array_size});
 #else
-(void)data_name;
-(void)associated_time;
+      (void)data_name;
+      (void)associated_time;
 #endif
       start_index += array_size;
     }

--- a/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
@@ -133,7 +133,7 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
     // Set the vertices
 #ifdef EXADG_WITH_PRECICE
     this->precice->setMeshVertices(this->mesh_name,
-                                   {&points[0][0], points.size()},
+                                   {&points[0][0], points.size() * dim},
                                    {&coupling_nodes_ids[start_index], points.size()});
 #endif
   }
@@ -170,7 +170,7 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::read_data(std::string const &
                               data_name,
                               {&coupling_nodes_ids[start_index], array_size},
                               associated_time,
-                              {&array_solution[0][0], array_size});
+                              {&array_solution[0][0], array_size * data_dim});
 #else
       (void)data_name;
       (void)associated_time;

--- a/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
@@ -172,6 +172,9 @@ ExaDGCoupling<dim, data_dim, VectorizedArrayType>::read_data(
                               {&coupling_nodes_ids[start_index], array_size},
                               associated_time,
                               {&array_solution[0][0], array_size});
+#else
+(void)data_name;
+(void)associated_time;
 #endif
       start_index += array_size;
     }

--- a/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/exadg_coupling.h
@@ -45,7 +45,7 @@ public:
   ExaDGCoupling(
     dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
-    std::shared_ptr<precice::SolverInterface> precice,
+    std::shared_ptr<precice::Participant> precice,
 #endif
     std::string const                                          mesh_name,
     std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_,
@@ -90,7 +90,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 ExaDGCoupling<dim, data_dim, VectorizedArrayType>::ExaDGCoupling(
   dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
-  std::shared_ptr<precice::SolverInterface> precice,
+  std::shared_ptr<precice::Participant> precice,
 #endif
   std::string const                                          mesh_name,
   std::shared_ptr<ContainerInterfaceData<rank, dim, double>> interface_data_,

--- a/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
+++ b/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
@@ -161,11 +161,17 @@ public:
   void
   write_data(std::string const & write_mesh_name,
              std::string const & write_data_name,
-             VectorType const &  write_data,
-             double const        computed_timestep_length);
+             VectorType const &  write_data);
 
+ /**
+  * @brief Read data from preCICE with the given data_name at the given relative
+  *        read time.
+  *
+  * @param data_name Name of the data field to write
+  * @param associated_time Have a look at precice::Participant::readData for a detailed explanation
+  */
   void
-  read_block_data(std::string const & mesh_name, const std::string & data_name) const;
+  read_data(std::string const & mesh_name, const std::string & data_name, double associated_time) const;
 
   /**
    * @brief is_coupling_ongoing Calls the preCICE API function isCouplingOnGoing
@@ -349,8 +355,7 @@ void
 Adapter<dim, data_dim, VectorType, VectorizedArrayType>::write_data(
   std::string const & write_mesh_name,
   std::string const & write_data_name,
-  VectorType const &  dealii_to_precice,
-  double const        computed_timestep_length)
+  VectorType const &  dealii_to_precice)
 {
 #ifdef EXADG_WITH_PRECICE
   writer.at(write_mesh_name)->write_data(dealii_to_precice, write_data_name);
@@ -358,7 +363,6 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::write_data(
   (void)write_mesh_name;
   (void)write_data_name;
   (void)dealii_to_precice;
-  (void)computed_timestep_length;
 #endif
 }
 
@@ -381,11 +385,12 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::advance(
 
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
 void
-Adapter<dim, data_dim, VectorType, VectorizedArrayType>::read_block_data(
+Adapter<dim, data_dim, VectorType, VectorizedArrayType>::read_data(
   std::string const & mesh_name,
-  std::string const & data_name) const
+  std::string const & data_name,
+  double associated_time) const
 {
-  reader.at(mesh_name)->read_block_data(data_name);
+  reader.at(mesh_name)->read_data(data_name, associated_time);
 }
 
 

--- a/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
+++ b/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
@@ -40,7 +40,7 @@
 
 // preCICE
 #ifdef EXADG_WITH_PRECICE
-#  include <precice/SolverInterface.hpp>
+#  include <precice/precice.hpp>
 #endif
 
 #include <ostream>
@@ -185,10 +185,10 @@ public:
 
 
 private:
-  // public precice solverinterface, needed in order to steer the time loop
+  // public precice participant, needed in order to steer the time loop
   // inside the solver.
 #ifdef EXADG_WITH_PRECICE
-  std::shared_ptr<precice::SolverInterface> precice;
+  std::shared_ptr<precice::Participant> precice;
 #endif
 
   /// The objects handling reading and writing data
@@ -212,12 +212,10 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::Adapter(ParameterClass 
 {
 #ifdef EXADG_WITH_PRECICE
   precice =
-    std::make_shared<precice::SolverInterface>(parameters.participant_name,
-                                               parameters.config_file,
-                                               dealii::Utilities::MPI::this_mpi_process(mpi_comm),
-                                               dealii::Utilities::MPI::n_mpi_processes(mpi_comm));
-
-  AssertThrow(dim == precice->getDimensions(), dealii::ExcInternalError());
+    std::make_shared<precice::Participant>(parameters.participant_name,
+                                           parameters.config_file,
+                                           dealii::Utilities::MPI::this_mpi_process(mpi_comm),
+                                           dealii::Utilities::MPI::n_mpi_processes(mpi_comm));
 #else
   (void)parameters;
   (void)mpi_comm;

--- a/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
+++ b/include/exadg/fluid_structure_interaction/precice/precice_adapter.h
@@ -163,15 +163,17 @@ public:
              std::string const & write_data_name,
              VectorType const &  write_data);
 
- /**
-  * @brief Read data from preCICE with the given data_name at the given relative
-  *        read time.
-  *
-  * @param data_name Name of the data field to write
-  * @param associated_time Have a look at precice::Participant::readData for a detailed explanation
-  */
+  /**
+   * @brief Read data from preCICE with the given data_name at the given relative
+   *        read time.
+   *
+   * @param data_name Name of the data field to write
+   * @param associated_time Have a look at precice::Participant::readData for a detailed explanation
+   */
   void
-  read_data(std::string const & mesh_name, const std::string & data_name, double associated_time) const;
+  read_data(std::string const & mesh_name,
+            const std::string & data_name,
+            double              associated_time) const;
 
   /**
    * @brief is_coupling_ongoing Calls the preCICE API function isCouplingOnGoing
@@ -322,7 +324,8 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::add_read_surface(
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
 void
 Adapter<dim, data_dim, VectorType, VectorizedArrayType>::initialize_precice(
-  VectorType const & dealii_to_precice, std::string const & data_name)
+  VectorType const &  dealii_to_precice,
+  std::string const & data_name)
 {
 #ifdef EXADG_WITH_PRECICE
   // if(not dealii_to_precice.has_ghost_elements())
@@ -385,10 +388,9 @@ Adapter<dim, data_dim, VectorType, VectorizedArrayType>::advance(
 
 template<int dim, int data_dim, typename VectorType, typename VectorizedArrayType>
 void
-Adapter<dim, data_dim, VectorType, VectorizedArrayType>::read_data(
-  std::string const & mesh_name,
-  std::string const & data_name,
-  double associated_time) const
+Adapter<dim, data_dim, VectorType, VectorizedArrayType>::read_data(std::string const & mesh_name,
+                                                                   std::string const & data_name,
+                                                                   double associated_time) const
 {
   reader.at(mesh_name)->read_data(data_name, associated_time);
 }

--- a/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
@@ -180,8 +180,8 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 
 #ifdef EXADG_WITH_PRECICE
       this->precice->setMeshVertices(this->mesh_name,
-                                     {unrolled_vertices.data(), active_faces},
-                                     {node_ids.data(), active_faces});
+                                     {unrolled_vertices.data(), static_cast<std::size_t>(active_faces)},
+                                     {node_ids.data(), static_cast<std::size_t>(active_faces)});
 #else
       (void)active_faces;
 #endif
@@ -292,8 +292,8 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
 #ifdef EXADG_WITH_PRECICE
         this->precice->writeData(this->mesh_name,
                                  write_data_name,
-                                 {index->data(),active_faces},
-                                 {unrolled_local_data.data(), active_faces});
+                                 {index->data(),static_cast<std::size_t>(active_faces)},
+                                 {unrolled_local_data.data(), static_cast<std::size_t>(active_faces)});
 #else
         (void)active_faces;
 #endif
@@ -303,8 +303,8 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
 #ifdef EXADG_WITH_PRECICE
         this->precice->writeData(this->mesh_name,
                                  write_data_name,
-                                 {index->data(),active_faces},
-                                 {&local_data[0], active_faces});
+                                 {index->data(),static_cast<std::size_t>(active_faces)},
+                                 {&local_data[0], static_cast<std::size_t>(active_faces)});
 #endif
       }
     }

--- a/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
@@ -91,7 +91,7 @@ private:
   void
   write_data_factory(
     dealii::LinearAlgebra::distributed::Vector<double> const &          data_vector,
-  std::string const &                                                           write_data_name,
+    std::string const &                                                 write_data_name,
     dealii::EvaluationFlags::EvaluationFlags const                      flags,
     std::function<value_type(FEFaceIntegrator &, unsigned int)> const & get_write_value);
 
@@ -180,7 +180,8 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 
 #ifdef EXADG_WITH_PRECICE
       this->precice->setMeshVertices(this->mesh_name,
-                                     {unrolled_vertices.data(), static_cast<std::size_t>(active_faces)},
+                                     {unrolled_vertices.data(),
+                                      static_cast<std::size_t>(active_faces)},
                                      {node_ids.data(), static_cast<std::size_t>(active_faces)});
 #else
       (void)active_faces;
@@ -241,7 +242,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 void
 QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
   dealii::LinearAlgebra::distributed::Vector<double> const &          data_vector,
-  std::string const &                                                           write_data_name,
+  std::string const &                                                 write_data_name,
   dealii::EvaluationFlags::EvaluationFlags const                      flags,
   std::function<value_type(FEFaceIntegrator &, unsigned int)> const & get_write_value)
 {
@@ -292,8 +293,9 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
 #ifdef EXADG_WITH_PRECICE
         this->precice->writeData(this->mesh_name,
                                  write_data_name,
-                                 {index->data(),static_cast<std::size_t>(active_faces)},
-                                 {unrolled_local_data.data(), static_cast<std::size_t>(active_faces)});
+                                 {index->data(), static_cast<std::size_t>(active_faces)},
+                                 {unrolled_local_data.data(),
+                                  static_cast<std::size_t>(active_faces)});
 #else
         (void)active_faces;
 #endif
@@ -303,7 +305,7 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
 #ifdef EXADG_WITH_PRECICE
         this->precice->writeData(this->mesh_name,
                                  write_data_name,
-                                 {index->data(),static_cast<std::size_t>(active_faces)},
+                                 {index->data(), static_cast<std::size_t>(active_faces)},
                                  {&local_data[0], static_cast<std::size_t>(active_faces)});
 #endif
       }

--- a/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
@@ -136,7 +136,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 void
 QuadCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 {
-  Assert(this->mesh_id != -1, dealii::ExcNotInitialized());
+  Assert(this->mesh_name != "", dealii::ExcNotInitialized());
 
   // In order to avoid that we define the surface multiple times when reader
   // and writer refer to the same object
@@ -179,7 +179,7 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
           unrolled_vertices[d + dim * v] = local_vertex[d][v];
 
 #ifdef EXADG_WITH_PRECICE
-      this->precice->setMeshVertices(this->mesh_id,
+      this->precice->setMeshVertices(this->mesh_name,
                                      active_faces,
                                      unrolled_vertices.data(),
                                      node_ids.data());
@@ -198,13 +198,13 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
   // Consistency check: the number of IDs we stored is equal or greater than
   // the IDs preCICE knows
   Assert(size * VectorizedArrayType::size() >=
-           static_cast<unsigned int>(this->precice->getMeshVertexSize(this->mesh_id)),
+           static_cast<unsigned int>(this->precice->getMeshVertexSize(this->mesh_name)),
          dealii::ExcInternalError());
 
   if(this->read_data_map.size() > 0)
-    this->print_info(true, this->precice->getMeshVertexSize(this->mesh_id));
+    this->print_info(true, this->precice->getMeshVertexSize(this->mesh_name));
   if(this->write_data_map.size() > 0)
-    this->print_info(false, this->precice->getMeshVertexSize(this->mesh_id));
+    this->print_info(false, this->precice->getMeshVertexSize(this->mesh_name));
 #endif
 }
 

--- a/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
@@ -43,7 +43,7 @@ class QuadCoupling : public CouplingBase<dim, data_dim, VectorizedArrayType>
 public:
   QuadCoupling(dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
-               std::shared_ptr<precice::SolverInterface> precice,
+               std::shared_ptr<precice::Participant> precice,
 #endif
                std::string const                mesh_name,
                dealii::types::boundary_id const surface_id,
@@ -113,7 +113,7 @@ template<int dim, int data_dim, typename VectorizedArrayType>
 QuadCoupling<dim, data_dim, VectorizedArrayType>::QuadCoupling(
   dealii::MatrixFree<dim, double, VectorizedArrayType> const & data,
 #ifdef EXADG_WITH_PRECICE
-  std::shared_ptr<precice::SolverInterface> precice,
+  std::shared_ptr<precice::Participant> precice,
 #endif
   std::string const                mesh_name,
   dealii::types::boundary_id const surface_id,

--- a/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
@@ -181,7 +181,7 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::define_coupling_mesh()
 #ifdef EXADG_WITH_PRECICE
       this->precice->setMeshVertices(this->mesh_name,
                                      {unrolled_vertices.data(),
-                                      static_cast<std::size_t>(active_faces)},
+                                      static_cast<std::size_t>(active_faces * dim)},
                                      {node_ids.data(), static_cast<std::size_t>(active_faces)});
 #else
       (void)active_faces;
@@ -295,7 +295,7 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
                                  write_data_name,
                                  {index->data(), static_cast<std::size_t>(active_faces)},
                                  {unrolled_local_data.data(),
-                                  static_cast<std::size_t>(active_faces)});
+                                  static_cast<std::size_t>(active_faces * data_dim) });
 #else
         (void)active_faces;
 #endif

--- a/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
+++ b/include/exadg/fluid_structure_interaction/precice/quad_coupling.h
@@ -245,7 +245,7 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
   dealii::EvaluationFlags::EvaluationFlags const                      flags,
   std::function<value_type(FEFaceIntegrator &, unsigned int)> const & get_write_value)
 {
-  Assert(write_data_id != -1, dealii::ExcNotInitialized());
+  Assert(write_data_name != "", dealii::ExcNotInitialized());
   Assert(coupling_nodes_ids.size() > 0, dealii::ExcNotInitialized());
   // Similar as in define_coupling_mesh
   FEFaceIntegrator phi(this->matrix_free, true, mf_dof_index, mf_quad_index);
@@ -253,6 +253,7 @@ QuadCoupling<dim, data_dim, VectorizedArrayType>::write_data_factory(
   // In order to unroll the vectorization
   std::array<double, data_dim * VectorizedArrayType::size()> unrolled_local_data;
   (void)unrolled_local_data;
+  (void)write_data_name;
 
   auto index = coupling_nodes_ids.begin();
 


### PR DESCRIPTION
Since a while already, preCICE version 3 is released. This is a braking release with a couple of changes.

The new interface uses `std::span` to interface with user-provided vectors, which becomes a bit ugly in the current implementations, as we don't use and pass over full vectors, but we use a static array and only pass the 'active' over to preCICE, necessitating to specify the span range manually. I kept in this way to make this migration a pure technical one.

While running the test case for the preCICE coupling, the fluid solver segfaulted at timestep number two somehwere in ExaDG. Since I don't have Trilinos compiled into my local deal.II, I tried using `MultigridCoarseGridPreconditioner::PointJacobi` (the AMG requires Trilinos). My best guess is that this causes trouble in the SolverCG (this is at least, where the segfault stems from).

preCICE version 3 now also supports a proper time interpolation for coupling data. Therefore, I have to update the porting later on to make this work with ExaDG. Maybe I will open an issue on this, as I am not sure (a) where the BDF time integrator evaluates the spatial operator in time, i.e., at which time the coupling data has to be retrieved from preCICE and (b) where the time-step size calculation takes place in ExaDG and how to synchronize it with preCICE.

Still, I would first consider to pursue the technical update before adding new features.