### PR TITLE
Fix manifold ids for flow past sphere

### DIFF
--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -423,8 +423,6 @@ private:
 
       create_triangulation(tria);
 
-      tria.set_all_manifold_ids(0);
-
       // vectors of manifold_ids and face_ids
       unsigned int const        manifold_id_start = 10;
       std::vector<unsigned int> manifold_ids;
@@ -976,8 +974,6 @@ private:
       (void)vector_local_refinements;
 
       create_triangulation_structure(tria);
-
-      tria.set_all_manifold_ids(0);
 
       // vectors of manifold_ids and face_ids
       unsigned int const        manifold_id_start = 10;

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -346,8 +346,6 @@ private:
 
         create_triangulation(tria);
 
-        tria.set_all_manifold_ids(0);
-
         for(auto cell : tria.cell_iterators())
         {
           for(auto const & f : cell->face_indices())
@@ -720,8 +718,6 @@ public:
         (void)vector_local_refinements;
 
         create_triangulation(tria);
-
-        tria.set_all_manifold_ids(0);
 
         for(auto cell : tria.cell_iterators())
         {

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -319,8 +319,6 @@ private:
       /*
        *  MANIFOLDS
        */
-      tria.set_all_manifold_ids(0);
-
       // first fill vectors of manifold_ids and face_ids
       std::vector<unsigned int> manifold_ids;
       std::vector<unsigned int> face_ids;

--- a/applications/incompressible_navier_stokes/fda_benchmark/include/grid.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/grid.h
@@ -218,7 +218,6 @@ create_grid_and_set_boundary_ids_nozzle(
    *  MANIFOLDS
    */
   dealii::Triangulation<dim> * current_tria = &triangulation;
-  current_tria->set_all_manifold_ids(0);
 
   // first fill vectors of manifold_ids and face_ids
   std::vector<unsigned int> manifold_ids;
@@ -465,8 +464,6 @@ create_grid_and_set_boundary_ids_precursor(
   /*
    *  MANIFOLDS
    */
-  tria.set_all_manifold_ids(0);
-
   // first fill vectors of manifold_ids and face_ids
   std::vector<unsigned int> manifold_ids;
   std::vector<unsigned int> face_ids;

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/include/grid.h
@@ -232,8 +232,6 @@ do_create_coarse_triangulation(dealii::Triangulation<2> & tria, bool const compu
     if(compute_in_2d)
     {
       // set manifold ID's
-      tria.set_all_manifold_ids(0);
-
       for(auto cell : tria.cell_iterators())
       {
         if(MANIFOLD_TYPE == ManifoldType::SurfaceManifold)
@@ -381,8 +379,6 @@ do_create_coarse_triangulation(dealii::Triangulation<2> & tria, bool const compu
     if(compute_in_2d)
     {
       // set manifold ID's
-      tria.set_all_manifold_ids(0);
-
       for(auto cell : tria.cell_iterators())
       {
         if(MANIFOLD_TYPE == ManifoldType::SurfaceManifold)
@@ -518,8 +514,6 @@ do_create_coarse_triangulation(dealii::Triangulation<2> & tria, bool const compu
     if(compute_in_2d)
     {
       // set manifold ID's
-      tria.set_all_manifold_ids(0);
-
       for(auto cell : tria.cell_iterators())
       {
         if(MANIFOLD_TYPE == ManifoldType::VolumeManifold)
@@ -631,8 +625,6 @@ do_create_coarse_triangulation(dealii::Triangulation<2> & tria, bool const compu
     if(compute_in_2d)
     {
       // set manifold ID's
-      tria.set_all_manifold_ids(0);
-
       for(auto cell : tria.cell_iterators())
       {
         if(MANIFOLD_TYPE == ManifoldType::VolumeManifold)
@@ -696,8 +688,6 @@ do_create_coarse_triangulation(dealii::Triangulation<3> & tria)
     dealii::GridGenerator::extrude_triangulation(tria_2d, 3, H, tria);
 
     // set manifold ID's
-    tria.set_all_manifold_ids(0);
-
     if(MANIFOLD_TYPE == ManifoldType::SurfaceManifold)
     {
       for(auto cell : tria.cell_iterators())
@@ -756,8 +746,6 @@ do_create_coarse_triangulation(dealii::Triangulation<3> & tria)
     dealii::GridGenerator::extrude_triangulation(tria_2d, 3, H, tria);
 
     // set manifold ID's
-    tria.set_all_manifold_ids(0);
-
     if(MANIFOLD_TYPE == ManifoldType::SurfaceManifold)
     {
       for(auto cell : tria.cell_iterators())
@@ -815,8 +803,6 @@ do_create_coarse_triangulation(dealii::Triangulation<3> & tria)
     dealii::GridGenerator::extrude_triangulation(tria_2d, 2, H, tria);
 
     // set manifold ID's
-    tria.set_all_manifold_ids(0);
-
     if(MANIFOLD_TYPE == ManifoldType::VolumeManifold)
     {
       for(auto cell : tria.cell_iterators())
@@ -867,8 +853,6 @@ do_create_coarse_triangulation(dealii::Triangulation<3> & tria)
     dealii::GridGenerator::extrude_triangulation(tria_2d, 2, H, tria);
 
     // set manifold ID's
-    tria.set_all_manifold_ids(0);
-
     if(MANIFOLD_TYPE == ManifoldType::VolumeManifold)
     {
       for(auto cell : tria.cell_iterators())

--- a/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
@@ -146,7 +146,7 @@ create_sphere_grid(dealii::Triangulation<dim> & tria,
 
   dealii::GridGenerator::merge_triangulations({&tria1, &tria2, &tria3, &tria4}, tria_ser);
   tria_ser.reset_all_manifolds();
-  tria.set_all_manifold_ids(0);
+  tria_ser.set_all_manifold_ids(dealii::numbers::flat_manifold_id);
 
   // Set cells near sphere to spherical manifold for first round of refinement
   for(auto const & cell : tria_ser.active_cell_iterators())

--- a/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/include/grid.h
@@ -145,8 +145,6 @@ create_sphere_grid(dealii::Triangulation<dim> & tria,
     tria4, {1, 1, 1}, lower_left, upper_right, false);
 
   dealii::GridGenerator::merge_triangulations({&tria1, &tria2, &tria3, &tria4}, tria_ser);
-  tria_ser.reset_all_manifolds();
-  tria_ser.set_all_manifold_ids(dealii::numbers::flat_manifold_id);
 
   // Set cells near sphere to spherical manifold for first round of refinement
   for(auto const & cell : tria_ser.active_cell_iterators())


### PR DESCRIPTION
Related to #664: This fixes the initial setup of the flow-past-sphere case. However, I believe this does not address the issue that @jh66637 saw in the first place.