### PR TITLE
Make sure to initialize multigrid preconditioner for steady linear structure

### DIFF
--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -58,7 +58,7 @@ MultigridPreconditioner<dim, Number>::initialize(
                    false /*operator_is_singular*/,
                    dirichlet_bc,
                    dirichlet_bc_component_mask,
-                   false /* initialize_preconditioners */);
+                   nonlinear == false /* initialize_preconditioners */);
 }
 
 template<int dim, typename Number>


### PR DESCRIPTION
This addresses another issue I found in the context of the errors reported in #666 and #664, which is that the multigrid preconditioner did not set up its constituents (in particular the diagonals of the Jacobi/Chebyshev smoother) for the case that we used a steady linear elasticity problem as typical for our FSI problems, see e.g. https://github.com/exadg/exadg/blob/27a6077e7c503487399fa218aecdb966a5c95f81/applications/fluid_structure_interaction/cylinder_with_flag/application.h#L671-L679 or similarly https://github.com/exadg/exadg/blob/27a6077e7c503487399fa218aecdb966a5c95f81/applications/fluid_structure_interaction/perpendicular_flap/application.h#L531-L537 Reflecting to how we set up the Poisson solver, https://github.com/exadg/exadg/blob/27a6077e7c503487399fa218aecdb966a5c95f81/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp#L55-L62 we also need to make sure to build everything for the preconditioner choice that does not call the respective `update()` function. @davidscn @jh66637 it would be great if you could check this and see if this or adaptations of this help in your case.