### PR TITLE
make sure that variable viscosity is updated

### DIFF
--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
@@ -142,7 +142,7 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
   }
 
   // explicit viscosity update
-  if(this->param.viscosity_is_variable() and
+  if(this->param.viscous_problem() and this->param.viscosity_is_variable() and
      this->param.treatment_of_variable_viscosity == TreatmentOfVariableViscosity::Explicit)
   {
     dealii::Timer timer_viscosity_update;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -177,7 +177,7 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
   }
 
   // explicit viscosity update
-  if(this->param.viscosity_is_variable() and
+  if(this->viscous_problem() and this->param.viscosity_is_variable() and
      this->param.treatment_of_variable_viscosity == TreatmentOfVariableViscosity::Explicit)
   {
     dealii::Timer timer_viscosity_update;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -177,7 +177,7 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
   }
 
   // explicit viscosity update
-  if(this->viscous_problem() and this->param.viscosity_is_variable() and
+  if(this->param.viscous_problem() and this->param.viscosity_is_variable() and
      this->param.treatment_of_variable_viscosity == TreatmentOfVariableViscosity::Explicit)
   {
     dealii::Timer timer_viscosity_update;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -715,7 +715,7 @@ TimeIntBDFDualSplitting<dim, Number>::viscous_step()
     /*
      *  update variable viscosity
      */
-    if(this->viscous_problem() and this->param.viscosity_is_variable() and
+    if(this->param.viscous_problem() and this->param.viscosity_is_variable() and
        this->param.treatment_of_variable_viscosity == TreatmentOfVariableViscosity::Explicit)
     {
       dealii::Timer timer_viscosity_update;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -360,7 +360,7 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
     /*
      *  update variable viscosity
      */
-    if(this->viscous_problem() and this->param.viscosity_is_variable() and
+    if(this->param.viscous_problem() and this->param.viscosity_is_variable() and
        this->param.treatment_of_variable_viscosity == TreatmentOfVariableViscosity::Explicit)
     {
       dealii::Timer timer_viscosity_update;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -357,6 +357,24 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
       velocity_np = velocity_momentum_last_iter;
     }
 
+    /*
+     *  update variable viscosity
+     */
+    if(this->viscous_problem() and this->param.viscosity_is_variable() and
+       this->param.treatment_of_variable_viscosity == TreatmentOfVariableViscosity::Explicit)
+    {
+      dealii::Timer timer_viscosity_update;
+      timer_viscosity_update.restart();
+
+      pde_operator->update_viscosity(velocity_np);
+
+      if(this->print_solver_info() and not(this->is_test))
+      {
+        this->pcout << std::endl << "Update of variable viscosity:";
+        print_wall_time(this->pcout, timer_viscosity_update.wall_time());
+      }
+    }
+
     bool const update_preconditioner =
       this->param.update_preconditioner_momentum and
       ((this->time_step_number - 1) % this->param.update_preconditioner_momentum_every_time_steps ==
@@ -396,27 +414,6 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
     else // linear problem
     {
       AssertThrow(this->param.viscous_problem(), dealii::ExcMessage("Should not arrive here."));
-
-      /*
-       *  update variable viscosity prior to calculation of rhs_momentum
-       */
-      if(this->param.viscosity_is_variable())
-      {
-        AssertThrow(this->param.treatment_of_variable_viscosity ==
-                      TreatmentOfVariableViscosity::Explicit,
-                    dealii::ExcMessage("Should not arrive here."));
-
-        dealii::Timer timer_viscosity_update;
-        timer_viscosity_update.restart();
-
-        pde_operator->update_viscosity(velocity_np);
-
-        if(this->print_solver_info() and not(this->is_test))
-        {
-          this->pcout << std::endl << "Update of variable viscosity:";
-          print_wall_time(this->pcout, timer_viscosity_update.wall_time());
-        }
-      }
 
       /*
        *  Calculate the right-hand side of the linear system of equations.


### PR DESCRIPTION
This PR fixes two things:

- Make sure that variable viscosity is updated if we solve a nonlinear problem but the variable viscosity is treated explicitly in case of pressure-correction scheme and dual-splitting scheme.  (If the variable viscosity is treated implicitly, the update happens in `evaluate_nonlinear_residual()` (with an if-statement) and should be fine.)

- In the coupled solver, an `if(this->param.viscous_problem() ...)` was missing in my opinion