### PR TITLE
Linearly implicit convective term for incompressible flows

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -172,14 +172,14 @@ OperatorCoupled<dim, Number>::solve_linear_problem(BlockVectorType &       dst,
                                                    bool const &            update_preconditioner,
                                                    double const &          scaling_factor_mass)
 {
-  // TODO: linearly implicit convective term
-  (void)transport_velocity;
-
   // Update momentum operator
   // We do not need to set the time here, because time affects the operator only in the form of
   // boundary conditions. The result of such boundary condition evaluations is handed over to this
   // function via the vector src.
   this->momentum_operator.set_scaling_factor_mass_operator(scaling_factor_mass);
+
+  // linearly implicit convective term
+  this->momentum_operator.set_solution_linearization(transport_velocity);
 
   linear_solver->update_preconditioner(update_preconditioner);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -179,7 +179,11 @@ OperatorCoupled<dim, Number>::solve_linear_problem(BlockVectorType &       dst,
   this->momentum_operator.set_scaling_factor_mass_operator(scaling_factor_mass);
 
   // linearly implicit convective term
-  this->momentum_operator.set_solution_linearization(transport_velocity);
+  if(this->param.convective_problem() and
+     this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+  {
+    this->momentum_operator.set_solution_linearization(transport_velocity);
+  }
 
   linear_solver->update_preconditioner(update_preconditioner);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -205,9 +205,9 @@ OperatorCoupled<dim, Number>::rhs_linear_problem(BlockVectorType &  dst,
   if(this->param.convective_problem() and
      this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
   {
-    // TODO: compute inhomogeneous contributions of linearly implicit convective term
-    (void)transport_velocity;
-    AssertThrow(false, dealii::ExcMessage("not implemented."));
+    this->convective_operator.set_velocity_ptr(transport_velocity);
+    this->convective_operator.set_time(time);
+    this->convective_operator.rhs_add(dst.block(0));
   }
 
   if(this->param.apply_penalty_terms_in_postprocessing_step == false)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -259,10 +259,10 @@ public:
    * can be omitted for steady problems.
    */
   unsigned int
-  solve_linear_stokes_problem(BlockVectorType &       dst,
-                              BlockVectorType const & src,
-                              bool const &            update_preconditioner,
-                              double const &          scaling_factor_mass = 1.0);
+  solve_linear_problem(BlockVectorType &       dst,
+                       BlockVectorType const & src,
+                       bool const &            update_preconditioner,
+                       double const &          scaling_factor_mass = 1.0);
 
   /*
    * Convective term treated implicitly: solve non-linear system of equations
@@ -313,7 +313,7 @@ public:
    * problems.
    */
   void
-  rhs_stokes_problem(BlockVectorType & dst, double const & time = 0.0) const;
+  rhs_linear_problem(BlockVectorType & dst, double const & time = 0.0) const;
 
   /*
    * Block preconditioner

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -261,6 +261,7 @@ public:
   unsigned int
   solve_linear_problem(BlockVectorType &       dst,
                        BlockVectorType const & src,
+                       VectorType const &      transport_velocity,
                        bool const &            update_preconditioner,
                        double const &          scaling_factor_mass = 1.0);
 
@@ -313,7 +314,9 @@ public:
    * problems.
    */
   void
-  rhs_linear_problem(BlockVectorType & dst, double const & time = 0.0) const;
+  rhs_linear_problem(BlockVectorType &  dst,
+                     VectorType const & transport_velocity,
+                     double const &     time = 0.0) const;
 
   /*
    * Block preconditioner

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -115,7 +115,7 @@ OperatorPressureCorrection<dim, Number>::evaluate_nonlinear_residual_steady(
     dst_u *= -1.0;
   }
 
-  if(this->param.implicit_convective_problem())
+  if(this->param.implicit_nonlinear_convective_problem())
   {
     this->convective_operator.evaluate_nonlinear_operator_add(dst_u, src_u, time);
   }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -489,7 +489,11 @@ OperatorProjectionMethods<dim, Number>::solve_linear_momentum_equation(
   this->momentum_operator.set_scaling_factor_mass_operator(scaling_factor_mass);
 
   // linearly implicit convective term
-  this->momentum_operator.set_solution_linearization(transport_velocity);
+  if(this->param.convective_problem() and
+     this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+  {
+    this->momentum_operator.set_solution_linearization(transport_velocity);
+  }
 
   this->momentum_linear_solver->update_preconditioner(update_preconditioner);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -483,17 +483,13 @@ OperatorProjectionMethods<dim, Number>::solve_linear_momentum_equation(
   bool const &       update_preconditioner,
   double const &     scaling_factor_mass)
 {
-  // TODO: linearly implicit convective term
-  (void)transport_velocity;
-
   // We do not need to set the time here, because time affects the operator only in the form of
   // boundary conditions. The result of such boundary condition evaluations is handed over to this
   // function via the vector rhs.
   this->momentum_operator.set_scaling_factor_mass_operator(scaling_factor_mass);
 
-  // Note that there is no need to set the evaluation time for the momentum_operator
-  // because this function is only called if the convective term is not considered
-  // in the momentum_operator (Stokes eq. or explicit treatment of convective term).
+  // linearly implicit convective term
+  this->momentum_operator.set_solution_linearization(transport_velocity);
 
   this->momentum_linear_solver->update_preconditioner(update_preconditioner);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -417,6 +417,18 @@ OperatorProjectionMethods<dim, Number>::rhs_add_viscous_term(VectorType & dst,
 
 template<int dim, typename Number>
 void
+OperatorProjectionMethods<dim, Number>::rhs_add_convective_term(
+  VectorType &       dst,
+  VectorType const & transport_velocity,
+  double const       time) const
+{
+  this->convective_operator.set_velocity_ptr(transport_velocity);
+  this->convective_operator.set_time(time);
+  this->convective_operator.rhs_add(dst);
+}
+
+template<int dim, typename Number>
+void
 OperatorProjectionMethods<dim, Number>::do_rhs_ppe_laplace_add(VectorType &   dst,
                                                                double const & time) const
 {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -467,9 +467,13 @@ unsigned int
 OperatorProjectionMethods<dim, Number>::solve_linear_momentum_equation(
   VectorType &       solution,
   VectorType const & rhs,
+  VectorType const & transport_velocity,
   bool const &       update_preconditioner,
   double const &     scaling_factor_mass)
 {
+  // TODO: linearly implicit convective term
+  (void)transport_velocity;
+
   // We do not need to set the time here, because time affects the operator only in the form of
   // boundary conditions. The result of such boundary condition evaluations is handed over to this
   // function via the vector rhs.
@@ -530,7 +534,7 @@ OperatorProjectionMethods<dim, Number>::evaluate_nonlinear_residual(
   this->mass_operator.apply_scale(dst, scaling_factor_mass, src);
 
   // implicitly treated convective term
-  if(this->param.implicit_convective_problem())
+  if(this->param.implicit_nonlinear_convective_problem())
   {
     this->convective_operator.evaluate_nonlinear_operator_add(dst, src, time);
   }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -167,6 +167,7 @@ public:
   unsigned int
   solve_linear_momentum_equation(VectorType &       solution,
                                  VectorType const & rhs,
+                                 VectorType const & transport_velocity,
                                  bool const &       update_preconditioner,
                                  double const &     scaling_factor_mass);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.h
@@ -179,6 +179,16 @@ public:
   rhs_add_viscous_term(VectorType & dst, double const time) const;
 
   /*
+   * This function evaluates the rhs-contribution of the convective term and adds the result to the
+   * dst-vector. This functions is only used for a "linearly implicit formulation" of the convective
+   * term.
+   */
+  void
+  rhs_add_convective_term(VectorType &       dst,
+                          VectorType const & transport_velocity,
+                          double const       time) const;
+
+  /*
    * Momentum step is a non-linear system of equations
    */
   std::tuple<unsigned int, unsigned int>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -427,7 +427,7 @@ ConvectiveOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) c
 
     if(operator_data.kernel_data.formulation == FormulationConvectiveTerm::DivergenceFormulation)
     {
-      tensor flux = kernel->get_volume_flux_linearized_divergence_formulation(delta_u, q);
+      tensor flux = kernel->get_volume_flux_divergence_formulation(delta_u, q);
 
       integrator.submit_gradient(flux, q);
     }
@@ -436,8 +436,7 @@ ConvectiveOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) c
     {
       tensor grad_delta_u = integrator.get_gradient(q);
 
-      vector flux =
-        kernel->get_volume_flux_linearized_convective_formulation(delta_u, grad_delta_u, q);
+      vector flux = kernel->get_volume_flux_convective_formulation(delta_u, grad_delta_u, q);
 
       integrator.submit_value(flux, q);
     }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -104,28 +104,6 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator_add(VectorType &   
 
 template<int dim, typename Number>
 void
-ConvectiveOperator<dim, Number>::rhs(VectorType & dst) const
-{
-  (void)dst;
-
-  AssertThrow(false,
-              dealii::ExcMessage(
-                "The function rhs() does not make sense for the convective operator."));
-}
-
-template<int dim, typename Number>
-void
-ConvectiveOperator<dim, Number>::rhs_add(VectorType & dst) const
-{
-  (void)dst;
-
-  AssertThrow(false,
-              dealii::ExcMessage(
-                "The function rhs_add() does not make sense for the convective operator."));
-}
-
-template<int dim, typename Number>
-void
 ConvectiveOperator<dim, Number>::evaluate(VectorType & dst, VectorType const & src) const
 {
   (void)dst;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -167,7 +167,7 @@ ConvectiveOperator<dim, Number>::cell_loop_nonlinear_operator(
   {
     integrator.reinit(cell);
 
-    // Strictly speaking, the variable integrator_flags refers to the linearized operator, but
+    // Strictly speaking, the variable integrator_flags refers to the linear operator, but
     // integrator_flags is also valid for the nonlinear operator.
     integrator.gather_evaluate(src, this->integrator_flags.cell_evaluate);
 
@@ -211,7 +211,7 @@ ConvectiveOperator<dim, Number>::face_loop_nonlinear_operator(
     integrator_m.reinit(face);
     integrator_p.reinit(face);
 
-    // Strictly speaking, the variable integrator_flags refers to the linearized operator, but
+    // Strictly speaking, the variable integrator_flags refers to the linear operator, but
     // integrator_flags is also valid for the nonlinear operator.
     integrator_m.gather_evaluate(src, this->integrator_flags.face_evaluate);
 
@@ -254,7 +254,7 @@ ConvectiveOperator<dim, Number>::boundary_face_loop_nonlinear_operator(
   {
     integrator_m.reinit(face);
 
-    // Strictly speaking, the variable integrator_flags refers to the linearized operator, but
+    // Strictly speaking, the variable integrator_flags refers to the linear operator, but
     // integrator_flags is also valid for the nonlinear operator.
     integrator_m.gather_evaluate(src, this->integrator_flags.face_evaluate);
 
@@ -462,7 +462,7 @@ ConvectiveOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
 
     vector normal_m = integrator_m.get_normal_vector(q);
 
-    std::tuple<vector, vector> flux = kernel->calculate_flux_linearized_interior_and_neighbor(
+    std::tuple<vector, vector> flux = kernel->calculate_flux_linear_operator_interior_and_neighbor(
       u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
 
     integrator_m.submit_value(std::get<0>(flux) /* flux_m */, q);
@@ -488,7 +488,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrato
     vector normal_m = integrator_m.get_normal_vector(q);
 
     vector flux =
-      kernel->calculate_flux_linearized_interior(u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
+      kernel->calculate_flux_linear_operator_interior(u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
 
     integrator_m.submit_value(flux, q);
   }
@@ -508,7 +508,8 @@ ConvectiveOperator<dim, Number>::do_face_int_integral_cell_based(
     // TODO
     // Accessing exterior data is currently not available in deal.II/matrixfree.
     // Hence, we simply use the interior value, but note that the diagonal and block-diagonal
-    // are not calculated exactly.
+    // are not calculated exactly. Note that the present implementation also does not take
+    // into account boundary conditions on boundary faces.
     vector u_p = u_m;
 
     vector delta_u_m = integrator_m.get_value(q);
@@ -517,7 +518,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral_cell_based(
     vector normal_m = integrator_m.get_normal_vector(q);
 
     vector flux =
-      kernel->calculate_flux_linearized_interior(u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
+      kernel->calculate_flux_linear_operator_interior(u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
 
     integrator_m.submit_value(flux, q);
   }
@@ -541,7 +542,7 @@ ConvectiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
     vector normal_p = -integrator_p.get_normal_vector(q);
 
     vector flux =
-      kernel->calculate_flux_linearized_interior(u_p, u_m, delta_u_p, delta_u_m, normal_p, q);
+      kernel->calculate_flux_linear_operator_interior(u_p, u_m, delta_u_p, delta_u_m, normal_p, q);
 
     integrator_p.submit_value(flux, q);
   }
@@ -564,23 +565,41 @@ ConvectiveOperator<dim, Number>::do_boundary_integral(
 
   for(unsigned int q = 0; q < integrator.n_q_points; ++q)
   {
-    vector u_m = kernel->get_velocity_m(q);
-    vector u_p = calculate_exterior_value_nonlinear(u_m,
-                                                    q,
-                                                    integrator,
-                                                    boundary_type,
-                                                    operator_data.kernel_data.type_dirichlet_bc,
-                                                    boundary_id,
-                                                    operator_data.bc,
-                                                    this->time);
-
     vector delta_u_m = integrator.get_value(q);
     vector delta_u_p =
       kernel->calculate_exterior_value_linearized(delta_u_m, q, integrator, boundary_type);
 
+    vector u_m = kernel->get_velocity_m(q);
+    vector u_p;
+
+    if(operator_data.kernel_data.temporal_treatment == TreatmentOfConvectiveTerm::Implicit)
+    {
+      u_p = calculate_exterior_value_nonlinear(u_m,
+                                               q,
+                                               integrator,
+                                               boundary_type,
+                                               operator_data.kernel_data.type_dirichlet_bc,
+                                               boundary_id,
+                                               operator_data.bc,
+                                               this->time);
+    }
+    else if(operator_data.kernel_data.temporal_treatment ==
+            TreatmentOfConvectiveTerm::LinearlyImplicit)
+    {
+      // for a linearly implicit treatment of the convective term, we do not impose boundary
+      // conditions for the transport velocity u. Boundary conditions are only imposed for the
+      // solution variable denoted here as "value_m" and "value_p".
+      u_p = u_m;
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcMessage("not implemented"));
+    }
+
+
     vector normal_m = integrator.get_normal_vector(q);
 
-    vector flux = kernel->calculate_flux_linearized_boundary(
+    vector flux = kernel->calculate_flux_linear_operator_boundary(
       u_m, u_p, delta_u_m, delta_u_p, normal_m, boundary_type, q);
 
     integrator.submit_value(flux, q);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -827,7 +827,11 @@ public:
 private:
   ConvectiveKernelData data;
 
+  // linearization velocity for nonlinear problems or transport velocity for "linearly implicit
+  // formulation" of convective term
   lazy_ptr<VectorType> velocity;
+
+  // grid velocity for ALE problems
   lazy_ptr<VectorType> grid_velocity;
 
   std::shared_ptr<IntegratorCell> integrator_velocity;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -927,63 +927,6 @@ public:
     flux = outflow_indicator * flux;
   }
 
-  /*
-   * Velocity:
-   *
-   *  Linearized convective operator (= homogeneous operator):
-   *  Dirichlet boundary: delta_u⁺ = - delta_u⁻ or 0
-   *  Neumann boundary:   delta_u⁺ = + delta_u⁻
-   *  symmetry boundary:  delta_u⁺ = delta_u⁻ - 2 (delta_u⁻*n)n
-   */
-  inline DEAL_II_ALWAYS_INLINE //
-    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>
-    calculate_exterior_value_linearized(
-      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> & delta_uM,
-      unsigned int const                                        q,
-      FaceIntegrator<dim, dim, Number> &                        integrator,
-      BoundaryTypeU const &                                     boundary_type) const
-  {
-    // element e⁺
-    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> delta_uP;
-
-    if(boundary_type == BoundaryTypeU::Dirichlet or boundary_type == BoundaryTypeU::DirichletCached)
-    {
-      if(data.type_dirichlet_bc == TypeDirichletBCs::Mirror)
-      {
-        delta_uP = -delta_uM;
-      }
-      else if(data.type_dirichlet_bc == TypeDirichletBCs::Direct)
-      {
-        // delta_uP = 0
-        // do nothing, delta_uP is already initialized with zero
-      }
-      else
-      {
-        AssertThrow(
-          false,
-          dealii::ExcMessage(
-            "Type of imposition of Dirichlet BC's for convective term is not implemented."));
-      }
-    }
-    else if(boundary_type == BoundaryTypeU::Neumann)
-    {
-      delta_uP = delta_uM;
-    }
-    else if(boundary_type == BoundaryTypeU::Symmetry)
-    {
-      dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normalM =
-        integrator.get_normal_vector(q);
-      delta_uP = delta_uM - 2. * (delta_uM * normalM) * normalM;
-    }
-    else
-    {
-      AssertThrow(false,
-                  dealii::ExcMessage("Boundary type of face is invalid or not implemented."));
-    }
-
-    return delta_uP;
-  }
-
 private:
   ConvectiveKernelData data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -314,14 +314,12 @@ MomentumOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) con
       if(operator_data.convective_kernel_data.formulation ==
          FormulationConvectiveTerm::DivergenceFormulation)
       {
-        gradient_flux +=
-          convective_kernel->get_volume_flux_linearized_divergence_formulation(value, q);
+        gradient_flux += convective_kernel->get_volume_flux_divergence_formulation(value, q);
       }
       else if(operator_data.convective_kernel_data.formulation ==
               FormulationConvectiveTerm::ConvectiveFormulation)
       {
-        value_flux +=
-          convective_kernel->get_volume_flux_linearized_convective_formulation(value, gradient, q);
+        value_flux += convective_kernel->get_volume_flux_convective_formulation(value, gradient, q);
       }
       else
       {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -460,11 +460,12 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   divergence_operator.initialize(*matrix_free, divergence_operator_data);
 
   // convective operator
-  convective_kernel_data.formulation       = param.formulation_convective_term;
-  convective_kernel_data.upwind_factor     = param.upwind_factor;
-  convective_kernel_data.use_outflow_bc    = param.use_outflow_bc_convective_term;
-  convective_kernel_data.type_dirichlet_bc = param.type_dirichlet_bc_convective;
-  convective_kernel_data.ale               = param.ale_formulation;
+  convective_kernel_data.formulation        = param.formulation_convective_term;
+  convective_kernel_data.temporal_treatment = param.treatment_of_convective_term;
+  convective_kernel_data.upwind_factor      = param.upwind_factor;
+  convective_kernel_data.use_outflow_bc     = param.use_outflow_bc_convective_term;
+  convective_kernel_data.type_dirichlet_bc  = param.type_dirichlet_bc_convective;
+  convective_kernel_data.ale                = param.ale_formulation;
   convective_kernel = std::make_shared<Operators::ConvectiveKernel<dim, Number>>();
   convective_kernel->reinit(*matrix_free,
                             convective_kernel_data,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -534,16 +534,9 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   // Momentum operator
   MomentumOperatorData<dim> data;
 
-  data.unsteady_problem = unsteady_problem_has_to_be_solved();
-  if(param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
-  {
-    data.convective_problem = false;
-  }
-  else
-  {
-    data.convective_problem = param.implicit_convective_problem();
-  }
-  data.viscous_problem = param.viscous_problem();
+  data.unsteady_problem   = unsteady_problem_has_to_be_solved();
+  data.convective_problem = param.non_explicit_convective_problem();
+  data.viscous_problem    = param.viscous_problem();
 
   data.convective_kernel_data = convective_kernel_data;
   data.viscous_kernel_data    = viscous_kernel_data;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -811,7 +811,7 @@ SpatialOperatorBase<dim, Number>::get_quad_index_velocity_linearized() const
   }
   else if(param.quad_rule_linearization == QuadratureRuleLinearization::Overintegration32k)
   {
-    if(param.implicit_convective_problem())
+    if(param.non_explicit_convective_problem())
       return get_quad_index_velocity_overintegration();
     else
       return get_quad_index_velocity_standard();

--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
@@ -178,10 +178,10 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
   else // linear problem
   {
     // calculate rhs vector
-    pde_operator->rhs_stokes_problem(rhs_vector, time);
+    pde_operator->rhs_linear_problem(rhs_vector, time);
 
     // solve coupled system of equations
-    unsigned int const n_iter = pde_operator->solve_linear_stokes_problem(
+    unsigned int const n_iter = pde_operator->solve_linear_problem(
       solution, rhs_vector, this->param.update_preconditioner_coupled, time);
 
     if(print_solver_info(time, unsteady_problem) and not(this->is_test))

--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
@@ -177,12 +177,16 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
   }
   else // linear problem
   {
+    // linearly implicit convective term does not make sense for steady problems, but we need to
+    // pass a vector to the functions rhs_linear_problem() and solve_linear_problem()
+    VectorType transport_velocity;
+
     // calculate rhs vector
-    pde_operator->rhs_linear_problem(rhs_vector, time);
+    pde_operator->rhs_linear_problem(rhs_vector, transport_velocity, time);
 
     // solve coupled system of equations
     unsigned int const n_iter = pde_operator->solve_linear_problem(
-      solution, rhs_vector, this->param.update_preconditioner_coupled, time);
+      solution, rhs_vector, transport_velocity, this->param.update_preconditioner_coupled, time);
 
     if(print_solver_info(time, unsteady_problem) and not(this->is_test))
       print_solver_info_linear(pcout, n_iter, timer.wall_time());

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -259,11 +259,11 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
       pde_operator->evaluate_add_body_force_term(rhs, this->get_next_time());
 
     // Add the convective term to the right-hand side of the equations
-    // if the convective term is treated explicitly (additive decomposition):
-    // add extrapolation of convective term to the rhs (-> minus sign!)
+    // if the convective term is treated explicitly
     if(this->param.convective_problem() and
        this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
     {
+      // add extrapolation of convective term to the rhs (-> minus sign!)
       for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
         rhs.add(-this->extra.get_beta(i), this->vec_convective_term[i]);
     }
@@ -295,16 +295,16 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
     BlockVectorType rhs_vector;
     pde_operator->initialize_block_vector_velocity_pressure(rhs_vector);
 
-    // calculate rhs vector for the Stokes problem, i.e., the convective term is neglected in this
-    // step
+    // calculate rhs vector for the linear problem, with contributions from the convective term for
+    // a linearly implicit formulation
     pde_operator->rhs_linear_problem(rhs_vector, this->get_next_time());
 
     // Add the convective term to the right-hand side of the equations
-    // if the convective term is treated explicitly (additive decomposition):
-    // add extrapolation of convective term to the rhs (-> minus sign!)
+    // if the convective term is treated explicitly
     if(this->param.convective_problem() and
        this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
     {
+      // add extrapolation of convective term to the rhs (-> minus sign!)
       for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
         rhs_vector.block(0).add(-this->extra.get_beta(i), this->vec_convective_term[i]);
     }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -300,7 +300,6 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
       transport_velocity = solution_np.block(0);
     }
 
-
     BlockVectorType rhs_vector;
     pde_operator->initialize_block_vector_velocity_pressure(rhs_vector);
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -297,7 +297,7 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
 
     // calculate rhs vector for the Stokes problem, i.e., the convective term is neglected in this
     // step
-    pde_operator->rhs_stokes_problem(rhs_vector, this->get_next_time());
+    pde_operator->rhs_linear_problem(rhs_vector, this->get_next_time());
 
     // Add the convective term to the right-hand side of the equations
     // if the convective term is treated explicitly (additive decomposition):
@@ -313,10 +313,10 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
     pde_operator->apply_mass_operator_add(rhs_vector.block(0), sum_alphai_ui);
 
     unsigned int const n_iter =
-      pde_operator->solve_linear_stokes_problem(solution_np,
-                                                rhs_vector,
-                                                update_preconditioner,
-                                                this->get_scaling_factor_time_derivative_term());
+      pde_operator->solve_linear_problem(solution_np,
+                                         rhs_vector,
+                                         update_preconditioner,
+                                         this->get_scaling_factor_time_derivative_term());
 
     iterations.first += 1;
     std::get<1>(iterations.second) += n_iter;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -820,15 +820,28 @@ TimeIntBDFDualSplitting<dim, Number>::rhs_viscous(VectorType &       rhs,
     // for a nonlinear problem, inhomogeneous contributions are taken into account when evaluating
     // the nonlinear residual
 
-    // compensate for explicit convective term
     if(this->param.convective_problem())
     {
+      // compensate for explicit convective term taken into account in the first sub-step of the
+      // dual-splitting scheme
       for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
         rhs.add(this->extra.get_beta(i), this->vec_convective_term[i]);
     }
   }
   else
   {
+    if(this->param.convective_problem() and
+       this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+    {
+      // compensate for explicit convective term taken into account in the first sub-step of the
+      // dual-splitting scheme
+      for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
+        rhs.add(this->extra.get_beta(i), this->vec_convective_term[i]);
+
+      // TODO: compute inhomogeneous contributions of linearly implicit convective term
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
+    }
+
     /*
      *  II. inhomogeneous parts of boundary face integrals of viscous operator
      */

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -773,7 +773,9 @@ TimeIntBDFDualSplitting<dim, Number>::viscous_step()
       VectorType transport_velocity;
       if(this->param.convective_problem() and
          this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+      {
         transport_velocity = velocity_np;
+      }
 
       /*
        *  Calculate the right-hand side of the linear system of equations.

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -822,7 +822,7 @@ TimeIntBDFDualSplitting<dim, Number>::rhs_viscous(VectorType &       rhs,
                                                   VectorType const & transport_velocity) const
 {
   /*
-   *  I. apply mass operator
+   *  apply mass operator
    */
   pde_operator->apply_mass_operator(rhs, velocity_mass_operator);
   rhs *= this->bdf.get_gamma0() / this->get_time_step_size();
@@ -850,13 +850,12 @@ TimeIntBDFDualSplitting<dim, Number>::rhs_viscous(VectorType &       rhs,
       for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
         rhs.add(this->extra.get_beta(i), this->vec_convective_term[i]);
 
-      // TODO: compute inhomogeneous contributions of linearly implicit convective term
-      (void)transport_velocity;
-      AssertThrow(false, dealii::ExcMessage("not implemented."));
+      // compute inhomogeneous contributions of linearly implicit convective term
+      pde_operator->rhs_add_convective_term(rhs, transport_velocity, this->get_next_time());
     }
 
     /*
-     *  II. inhomogeneous parts of boundary face integrals of viscous operator
+     *  inhomogeneous parts of boundary face integrals of viscous operator
      */
     pde_operator->rhs_add_viscous_term(rhs, this->get_next_time());
   }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -128,7 +128,9 @@ private:
   viscous_step();
 
   void
-  rhs_viscous(VectorType & rhs, VectorType const & velocity_rhs) const;
+  rhs_viscous(VectorType &       rhs,
+              VectorType const & velocity_mass_operator,
+              VectorType const & transport_velocity) const;
 
   void
   solve_steady_problem() final;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -496,22 +496,29 @@ TimeIntBDFPressureCorrection<dim, Number>::rhs_momentum(VectorType & rhs)
    *  Convective term formulated explicitly (additive decomposition):
    *  Evaluate convective term and add extrapolation of convective term to the rhs
    */
-  if(this->param.convective_problem() and
-     this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
+  if(this->param.convective_problem())
   {
-    if(this->param.ale_formulation)
+    if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
     {
-      for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
+      if(this->param.ale_formulation)
       {
-        // in a general setting, we only know the boundary conditions at time t_{n+1}
-        pde_operator->evaluate_convective_term(this->vec_convective_term[i],
-                                               velocity[i],
-                                               this->get_next_time());
+        for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
+        {
+          // in a general setting, we only know the boundary conditions at time t_{n+1}
+          pde_operator->evaluate_convective_term(this->vec_convective_term[i],
+                                                 velocity[i],
+                                                 this->get_next_time());
+        }
       }
+
+      for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
+        rhs.add(-this->extra.get_beta(i), this->vec_convective_term[i]);
     }
 
-    for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
-      rhs.add(-this->extra.get_beta(i), this->vec_convective_term[i]);
+    if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+    {
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
+    }
   }
 
   /*

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -528,15 +528,12 @@ TimeIntBDFPressureCorrection<dim, Number>::rhs_momentum(VectorType &       rhs,
 
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
     {
-      // TODO: compute inhomogeneous contributions of linearly implicit convective term
-      (void)transport_velocity;
-      AssertThrow(false, dealii::ExcMessage("not implemented."));
+      pde_operator->rhs_add_convective_term(rhs, transport_velocity, this->get_next_time());
     }
   }
 
   /*
-   *  calculate sum (alpha_i/dt * u_i): This term is relevant for both the explicit
-   *  and the implicit formulation of the convective term
+   *  calculate sum (alpha_i/dt * u_i) and apply mass operator to this vector
    */
   VectorType sum_alphai_ui(velocity[0]);
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -341,7 +341,7 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
   timer.restart();
 
   // in case we need to iteratively solve a linear or nonlinear system of equations
-  if(this->param.viscous_problem() or this->param.implicit_convective_problem())
+  if(this->param.viscous_problem() or this->param.non_explicit_convective_problem())
   {
     // Extrapolate old solutions to get a good initial estimate for the solver.
     if(this->use_extrapolation)
@@ -388,7 +388,8 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
        *  to the next, i.e., it does not depend on the current solution of the nonlinear solver)
        */
       VectorType rhs(velocity_np);
-      rhs_momentum(rhs);
+      VectorType transport_velocity_dummy;
+      rhs_momentum(rhs, transport_velocity_dummy);
 
       // solve non-linear system of equations
       auto const iter = pde_operator->solve_nonlinear_momentum_equation(
@@ -413,17 +414,25 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
     }
     else // linear problem
     {
-      AssertThrow(this->param.viscous_problem(), dealii::ExcMessage("Should not arrive here."));
+      // linearly implicit convective term: use extrapolated/stored velocity as transport velocity
+      VectorType transport_velocity;
+      if(this->param.convective_problem() and
+         this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+        transport_velocity = velocity_np;
 
       /*
        *  Calculate the right-hand side of the linear system of equations.
        */
       VectorType rhs(velocity_np);
-      rhs_momentum(rhs);
+      rhs_momentum(rhs, transport_velocity);
 
       // solve linear system of equations
       unsigned int n_iter = pde_operator->solve_linear_momentum_equation(
-        velocity_np, rhs, update_preconditioner, this->get_scaling_factor_time_derivative_term());
+        velocity_np,
+        rhs,
+        transport_velocity,
+        update_preconditioner,
+        this->get_scaling_factor_time_derivative_term());
 
       iterations_momentum.first += 1;
       std::get<1>(iterations_momentum.second) += n_iter;
@@ -438,14 +447,15 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
     if(this->store_solution)
       velocity_momentum_last_iter = velocity_np;
   }
-  else // no viscous term and no implicit convective term, i.e. we only need to invert the mass
-       // matrix
+  else // no viscous term and no (linearly) implicit convective term, i.e. we only need to invert
+       // the mass matrix
   {
     /*
      *  Calculate the right-hand side vector.
      */
     VectorType rhs(velocity_np);
-    rhs_momentum(rhs);
+    VectorType transport_velocity_dummy;
+    rhs_momentum(rhs, transport_velocity_dummy);
 
     pde_operator->apply_inverse_mass_operator(velocity_np, rhs);
     velocity_np *= this->get_time_step_size() / this->bdf.get_gamma0();
@@ -462,7 +472,8 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
 
 template<int dim, typename Number>
 void
-TimeIntBDFPressureCorrection<dim, Number>::rhs_momentum(VectorType & rhs)
+TimeIntBDFPressureCorrection<dim, Number>::rhs_momentum(VectorType &       rhs,
+                                                        VectorType const & transport_velocity)
 {
   rhs = 0.0;
 
@@ -517,6 +528,8 @@ TimeIntBDFPressureCorrection<dim, Number>::rhs_momentum(VectorType & rhs)
 
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
     {
+      // TODO: compute inhomogeneous contributions of linearly implicit convective term
+      (void)transport_velocity;
       AssertThrow(false, dealii::ExcMessage("not implemented."));
     }
   }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -418,7 +418,9 @@ TimeIntBDFPressureCorrection<dim, Number>::momentum_step()
       VectorType transport_velocity;
       if(this->param.convective_problem() and
          this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+      {
         transport_velocity = velocity_np;
+      }
 
       /*
        *  Calculate the right-hand side of the linear system of equations.

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -110,7 +110,7 @@ private:
   momentum_step();
 
   void
-  rhs_momentum(VectorType & rhs);
+  rhs_momentum(VectorType & rhs, VectorType const & transport_velocity);
 
   void
   pressure_step(VectorType & pressure_increment);

--- a/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
@@ -136,7 +136,8 @@ enum class TreatmentOfConvectiveTerm
 {
   Undefined,
   Explicit,
-  Implicit
+  Implicit,
+  LinearlyImplicit
 };
 
 /*

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -308,6 +308,14 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
   {
     AssertThrow(treatment_of_convective_term != TreatmentOfConvectiveTerm::Undefined,
                 dealii::ExcMessage("parameter must be defined"));
+
+    if(treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
+    {
+      AssertThrow(
+        nonlinear_viscous_problem() == false,
+        dealii::ExcMessage(
+          "The combination of a linearly implicit convective term and a nonlinear viscous term is currently not implemented. Choose e.g. an implicit formulation of the convective term."));
+    }
   }
 
   AssertThrow(calculation_of_time_step_size != TimeStepCalculation::Undefined,

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -590,7 +590,23 @@ Parameters::viscosity_is_variable() const
 }
 
 bool
-Parameters::implicit_convective_problem() const
+Parameters::non_explicit_convective_problem() const
+{
+  if(convective_problem())
+  {
+    if(solver_type == SolverType::Steady or
+       (solver_type == SolverType::Unsteady and
+        (treatment_of_convective_term != TreatmentOfConvectiveTerm::Explicit)))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool
+Parameters::implicit_nonlinear_convective_problem() const
 {
   if(convective_problem())
   {
@@ -615,7 +631,7 @@ Parameters::nonlinear_viscous_problem() const
 bool
 Parameters::nonlinear_problem_has_to_be_solved() const
 {
-  return (implicit_convective_problem() or nonlinear_viscous_problem());
+  return (implicit_nonlinear_convective_problem() or nonlinear_viscous_problem());
 }
 
 bool
@@ -669,7 +685,7 @@ Parameters::involves_h_multigrid() const
     }
 
     // momentum step
-    if(viscous_problem() or implicit_convective_problem())
+    if(viscous_problem() or non_explicit_convective_problem())
     {
       if(involves_h_multigrid_momentum_step())
       {
@@ -1085,7 +1101,7 @@ Parameters::print_parameters_dual_splitting(dealii::ConditionalOStream const & p
   print_parameters_projection_step(pcout);
 
   // momentum step
-  if(viscous_problem() or implicit_convective_problem())
+  if(viscous_problem() or non_explicit_convective_problem())
   {
     print_parameters_momentum_step(pcout);
   }

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -264,6 +264,11 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
       dealii::ExcMessage(
         "ALE formulation only implemented for equations that include the convective operator, "
         "e.g., ALE is currently not available for the Stokes equations."));
+
+    AssertThrow(
+      treatment_of_convective_term != TreatmentOfConvectiveTerm::LinearlyImplicit,
+      dealii::ExcMessage(
+        "ALE formulation is currently not implemented for a linearly implicit convective term."));
   }
 
   // PHYSICAL QUANTITIES

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -452,17 +452,19 @@ public:
 
   // Quadrature rule used to integrate the linearized convective term. This parameter is
   // therefore only relevant if linear systems of equations have to be solved involving
-  // the convective term. For reasons of computational efficiency, it might be advantageous
-  // to use a standard quadrature rule for the linearized problem in order to speed up
+  // the convective term. The quadrature rule specified by this parameter is also used in
+  // case of a linearly implicit formulation of the convective term.
+  // Note that if the convective term is not involved in the momentum operator, this
+  // parameter does not have any effect and the standard quadrature rule will be used
+  // for the momentum operator.
+  // For reasons of computational efficiency, it might be advantageous to use a standard
+  // quadrature rule for the linear(ized) momentum operator in order to speed up
   // the computation. However, it was found that choosing a lower order quadrature rule
   // for the linearized problem only, increases the number of iterations significantly. It
   // was found that the quadrature rules used for the nonlinear and linear problems should
   // be the same. Hence, although this parameter speeds up the operator evaluation (i.e.
   // the wall time per iteration), it is unclear whether a lower order quadrature rule
   // really allows to achieve a more efficient method overall.
-  // Note that if the convective term is not involved in the momentum operator, this
-  // parameter does not have any effect and the standard quadrature rule will be used
-  // for the momentum operator.
   QuadratureRuleLinearization quad_rule_linearization;
 
   /**************************************************************************************/

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -61,7 +61,10 @@ public:
   viscosity_is_variable() const;
 
   bool
-  implicit_convective_problem() const;
+  non_explicit_convective_problem() const;
+
+  bool
+  implicit_nonlinear_convective_problem() const;
 
   bool
   nonlinear_viscous_problem() const;


### PR DESCRIPTION
This PR introduces another formulation of the convective term called `TreatmentOfConvectiveTerm::LinearlyImplicit`, i.e. for this new formulation 

- the nonlinear convective term $F(u,u)$ is replaced by $F(\hat{u},u)$, where $\hat{u}=\sum_i \beta_i u_{n-i}$ is an extrapolation of the velocity from previous time steps. 

The motivation is
- to overcome the CFL-type time step restriction for explicit convective terms, and
- to avoid an outer iteration needed for nonlinear problems, e.g. Newton (which for fully implicit formulations of the convective term often causes a noticeable increase in costs).