### PR TITLE
Use overintegration only for implicit convective problem

### DIFF
--- a/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/include/postprocessor.h
@@ -101,7 +101,7 @@ public:
         mean_velocity_calculator.reset(
           new MeanVelocityCalculator<dim, Number>(pde_operator.get_matrix_free(),
                                                   pde_operator.get_dof_index_velocity(),
-                                                  pde_operator.get_quad_index_velocity_linear(),
+                                                  pde_operator.get_quad_index_velocity_standard(),
                                                   pp_data_fda.mean_velocity_data,
                                                   this->mpi_comm));
       }

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/include/postprocessor.h
@@ -61,7 +61,7 @@ public:
 
     energy_calculator.setup(pde_operator.get_matrix_free(),
                             pde_operator.get_dof_index_velocity(),
-                            pde_operator.get_quad_index_velocity_linear(),
+                            pde_operator.get_quad_index_velocity_standard(),
                             energy_data);
   }
 

--- a/applications/incompressible_navier_stokes/periodic_hill/include/postprocessor.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/postprocessor.h
@@ -71,7 +71,7 @@ public:
     mean_velocity_calculator.reset(
       new MeanVelocityCalculator<dim, Number>(pde_operator.get_matrix_free(),
                                               pde_operator.get_dof_index_velocity(),
-                                              pde_operator.get_quad_index_velocity_linear(),
+                                              pde_operator.get_quad_index_velocity_standard(),
                                               my_pp_data.mean_velocity_data,
                                               this->mpi_comm));
 

--- a/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
+++ b/include/exadg/fluid_structure_interaction/precice/driver_fluid.h
@@ -76,7 +76,7 @@ public:
         this->precice_parameters.write_data_type,
         fluid->pde_operator->get_matrix_free(),
         fluid->pde_operator->get_dof_index_velocity(),
-        fluid->pde_operator->get_quad_index_velocity_linear());
+        fluid->pde_operator->get_quad_index_velocity_standard());
     }
 
     // structure to ALE

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -80,7 +80,7 @@ PostProcessor<dim, Number>::setup(Operator const & pde_operator)
                                  pde_operator.get_matrix_free(),
                                  pde_operator.get_dof_index_velocity(),
                                  pde_operator.get_dof_index_pressure(),
-                                 pde_operator.get_quad_index_velocity_linear(),
+                                 pde_operator.get_quad_index_velocity_standard(),
                                  pp_data.lift_and_drag_data);
 
   pressure_difference_calculator.setup(pde_operator.get_dof_handler_p(),
@@ -89,13 +89,13 @@ PostProcessor<dim, Number>::setup(Operator const & pde_operator)
 
   div_and_mass_error_calculator.setup(pde_operator.get_matrix_free(),
                                       pde_operator.get_dof_index_velocity(),
-                                      pde_operator.get_quad_index_velocity_linear(),
+                                      pde_operator.get_quad_index_velocity_standard(),
                                       pp_data.mass_data);
 
   kinetic_energy_calculator.setup(pde_operator,
                                   pde_operator.get_matrix_free(),
                                   pde_operator.get_dof_index_velocity(),
-                                  pde_operator.get_quad_index_velocity_linear(),
+                                  pde_operator.get_quad_index_velocity_standard(),
                                   pp_data.kinetic_energy_data);
 
   kinetic_energy_spectrum_calculator.setup(pde_operator.get_matrix_free(),

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -437,7 +437,7 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_velocity_block()
   {
     InverseMassOperatorData inverse_mass_operator_data;
     inverse_mass_operator_data.dof_index  = this->get_dof_index_velocity();
-    inverse_mass_operator_data.quad_index = this->get_quad_index_velocity_linear();
+    inverse_mass_operator_data.quad_index = this->get_quad_index_velocity_standard();
     inverse_mass_operator_data.parameters = this->param.inverse_mass_preconditioner;
 
     preconditioner_momentum =

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -170,7 +170,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_convective_term_bound
 {
   unsigned int const dof_index_velocity = this->get_dof_index_velocity();
   unsigned int const dof_index_pressure = this->get_dof_index_pressure();
-  unsigned int const quad_index         = this->get_quad_index_velocity_nonlinear();
+  unsigned int const quad_index         = this->get_quad_index_velocity_overintegration();
 
   FaceIntegratorU velocity(matrix_free, true, dof_index_velocity, quad_index);
   FaceIntegratorP pressure(matrix_free, true, dof_index_pressure, quad_index);
@@ -274,7 +274,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_numerical_time_derivative_
 {
   unsigned int dof_index_velocity  = this->get_dof_index_velocity();
   unsigned int dof_index_pressure  = this->get_dof_index_pressure();
-  unsigned int quad_index_velocity = this->get_quad_index_velocity_linear();
+  unsigned int quad_index_velocity = this->get_quad_index_velocity_standard();
 
   FaceIntegratorU integrator_velocity(data, true, dof_index_velocity, quad_index_velocity);
   FaceIntegratorP integrator_pressure(data, true, dof_index_pressure, quad_index_velocity);
@@ -411,7 +411,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_convective_add_boundary_fa
 {
   unsigned int const dof_index_velocity = this->get_dof_index_velocity();
   unsigned int const dof_index_pressure = this->get_dof_index_pressure();
-  unsigned int const quad_index         = this->get_quad_index_velocity_nonlinear();
+  unsigned int const quad_index         = this->get_quad_index_velocity_overintegration();
 
   FaceIntegratorU velocity(matrix_free, true, dof_index_velocity, quad_index);
   FaceIntegratorP pressure(matrix_free, true, dof_index_pressure, quad_index);
@@ -506,7 +506,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_viscous_add_boundary_face(
 {
   unsigned int const dof_index_velocity = this->get_dof_index_velocity();
   unsigned int const dof_index_pressure = this->get_quad_index_pressure();
-  unsigned int const quad_index         = this->get_quad_index_velocity_linear();
+  unsigned int const quad_index         = this->get_quad_index_velocity_standard();
 
   FaceIntegratorU omega(matrix_free, true, dof_index_velocity, quad_index);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -266,7 +266,7 @@ OperatorProjectionMethods<dim, Number>::setup_momentum_preconditioner()
   {
     InverseMassOperatorData inverse_mass_operator_data;
     inverse_mass_operator_data.dof_index  = this->get_dof_index_velocity();
-    inverse_mass_operator_data.quad_index = this->get_quad_index_velocity_linear();
+    inverse_mass_operator_data.quad_index = this->get_quad_index_velocity_standard();
     inverse_mass_operator_data.parameters = this->param.inverse_mass_preconditioner;
 
     momentum_preconditioner =

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -356,7 +356,8 @@ SpatialOperatorBase<dim, Number>::fill_matrix_free_data(
   matrix_free_data.insert_quadrature(*quadrature_p, field + quad_index_p);
   std::shared_ptr<dealii::Quadrature<dim>> quadrature_u_overintegration =
     create_quadrature<dim>(param.grid.element_type, param.degree_u + (param.degree_u + 2) / 2);
-  matrix_free_data.insert_quadrature(*quadrature_u_overintegration, field + quad_index_u_nonlinear);
+  matrix_free_data.insert_quadrature(*quadrature_u_overintegration,
+                                     field + quad_index_u_overintegration);
 
   // TODO create these quadrature rules only when needed
   matrix_free_data.insert_quadrature(dealii::QGaussLobatto<1>(param.degree_u + 1),
@@ -374,8 +375,8 @@ SpatialOperatorBase<dim, Number>::initialize_dirichlet_cached_bc()
   if(not(boundary_descriptor->velocity->dirichlet_cached_bc.empty()))
   {
     std::vector<unsigned int> quad_indices;
-    quad_indices.emplace_back(get_quad_index_velocity_linear());
-    quad_indices.emplace_back(get_quad_index_velocity_nonlinear());
+    quad_indices.emplace_back(get_quad_index_velocity_standard());
+    quad_indices.emplace_back(get_quad_index_velocity_overintegration());
     quad_indices.emplace_back(get_quad_index_velocity_gauss_lobatto());
 
     interface_data_dirichlet_cached = std::make_shared<ContainerInterfaceData<1, dim, double>>();
@@ -395,12 +396,12 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   // mass operator
   MassOperatorData<dim> mass_operator_data;
   mass_operator_data.dof_index  = get_dof_index_velocity();
-  mass_operator_data.quad_index = get_quad_index_velocity_linear();
+  mass_operator_data.quad_index = get_quad_index_velocity_standard();
   mass_operator.initialize(*matrix_free, constraint_u, mass_operator_data);
 
   InverseMassOperatorDataHdiv inverse_mass_data_hdiv;
   inverse_mass_data_hdiv.dof_index  = get_dof_index_velocity();
-  inverse_mass_data_hdiv.quad_index = get_quad_index_velocity_linear();
+  inverse_mass_data_hdiv.quad_index = get_quad_index_velocity_standard();
   inverse_mass_data_hdiv.parameters = this->param.inverse_mass_operator_hdiv;
 
   inverse_mass_hdiv.initialize(*matrix_free, constraint_u, inverse_mass_data_hdiv);
@@ -410,14 +411,14 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   {
     InverseMassOperatorData inverse_mass_operator_data_velocity;
     inverse_mass_operator_data_velocity.dof_index  = get_dof_index_velocity();
-    inverse_mass_operator_data_velocity.quad_index = get_quad_index_velocity_linear();
+    inverse_mass_operator_data_velocity.quad_index = get_quad_index_velocity_standard();
     inverse_mass_operator_data_velocity.parameters = param.inverse_mass_operator;
     inverse_mass_velocity.initialize(*matrix_free, inverse_mass_operator_data_velocity);
   }
   // inverse mass operator velocity scalar
   InverseMassOperatorData inverse_mass_operator_data_velocity_scalar;
   inverse_mass_operator_data_velocity_scalar.dof_index  = get_dof_index_velocity_scalar();
-  inverse_mass_operator_data_velocity_scalar.quad_index = get_quad_index_velocity_linear();
+  inverse_mass_operator_data_velocity_scalar.quad_index = get_quad_index_velocity_standard();
   inverse_mass_operator_data_velocity_scalar.parameters = param.inverse_mass_operator;
   inverse_mass_velocity_scalar.initialize(*matrix_free, inverse_mass_operator_data_velocity_scalar);
 
@@ -426,7 +427,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   rhs_data.dof_index = get_dof_index_velocity();
   if(param.boussinesq_term)
     rhs_data.dof_index_scalar = matrix_free_data->get_dof_index(dof_index_temperature);
-  rhs_data.quad_index                                = get_quad_index_velocity_linear();
+  rhs_data.quad_index                                = get_quad_index_velocity_standard();
   rhs_data.kernel_data.f                             = field_functions->right_hand_side;
   rhs_data.kernel_data.boussinesq_term               = param.boussinesq_term;
   rhs_data.kernel_data.boussinesq_dynamic_part_only  = param.boussinesq_dynamic_part_only;
@@ -440,7 +441,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   GradientOperatorData<dim> gradient_operator_data;
   gradient_operator_data.dof_index_velocity   = get_dof_index_velocity();
   gradient_operator_data.dof_index_pressure   = get_dof_index_pressure();
-  gradient_operator_data.quad_index           = get_quad_index_velocity_linear();
+  gradient_operator_data.quad_index           = get_quad_index_velocity_standard();
   gradient_operator_data.integration_by_parts = param.gradp_integrated_by_parts;
   gradient_operator_data.formulation          = param.gradp_formulation;
   gradient_operator_data.use_boundary_data    = param.gradp_use_boundary_data;
@@ -451,7 +452,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   DivergenceOperatorData<dim> divergence_operator_data;
   divergence_operator_data.dof_index_velocity   = get_dof_index_velocity();
   divergence_operator_data.dof_index_pressure   = get_dof_index_pressure();
-  divergence_operator_data.quad_index           = get_quad_index_velocity_linear();
+  divergence_operator_data.quad_index           = get_quad_index_velocity_standard();
   divergence_operator_data.integration_by_parts = param.divu_integrated_by_parts;
   divergence_operator_data.formulation          = param.divu_formulation;
   divergence_operator_data.use_boundary_data    = param.divu_use_boundary_data;
@@ -479,7 +480,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   convective_operator_data.dof_index            = get_dof_index_velocity();
   convective_operator_data.quad_index           = this->get_quad_index_velocity_linearized();
   convective_operator_data.use_cell_based_loops = param.use_cell_based_face_loops;
-  convective_operator_data.quad_index_nonlinear = get_quad_index_velocity_nonlinear();
+  convective_operator_data.quad_index_nonlinear = get_quad_index_velocity_overintegration();
   convective_operator_data.bc                   = boundary_descriptor->velocity;
   convective_operator.initialize(*matrix_free,
                                  constraint_dummy,
@@ -498,7 +499,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   viscous_kernel->reinit(*matrix_free,
                          viscous_kernel_data,
                          get_dof_index_velocity(),
-                         get_quad_index_velocity_linear());
+                         get_quad_index_velocity_standard());
 
   // initialize and check turbulence model data
   if(param.turbulence_model_data.is_active)
@@ -523,7 +524,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   viscous_operator_data.kernel_data          = viscous_kernel_data;
   viscous_operator_data.bc                   = boundary_descriptor->velocity;
   viscous_operator_data.dof_index            = get_dof_index_velocity();
-  viscous_operator_data.quad_index           = get_quad_index_velocity_linear();
+  viscous_operator_data.quad_index           = get_quad_index_velocity_standard();
   viscous_operator_data.use_cell_based_loops = param.use_cell_based_face_loops;
   viscous_operator.initialize(*matrix_free,
                               constraint_dummy,
@@ -577,13 +578,13 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
     div_penalty_kernel = std::make_shared<Operators::DivergencePenaltyKernel<dim, Number>>();
     div_penalty_kernel->reinit(*matrix_free,
                                get_dof_index_velocity(),
-                               get_quad_index_velocity_linear(),
+                               get_quad_index_velocity_standard(),
                                div_penalty_data);
 
     // Operator
     DivergencePenaltyData operator_data;
     operator_data.dof_index  = get_dof_index_velocity();
-    operator_data.quad_index = get_quad_index_velocity_linear();
+    operator_data.quad_index = get_quad_index_velocity_standard();
 
     div_penalty_operator.initialize(*matrix_free, operator_data, div_penalty_kernel);
   }
@@ -602,13 +603,13 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
     conti_penalty_kernel = std::make_shared<Operators::ContinuityPenaltyKernel<dim, Number>>();
     conti_penalty_kernel->reinit(*matrix_free,
                                  get_dof_index_velocity(),
-                                 get_quad_index_velocity_linear(),
+                                 get_quad_index_velocity_standard(),
                                  kernel_data);
 
     // Operator
     ContinuityPenaltyData<dim> operator_data;
     operator_data.dof_index         = get_dof_index_velocity();
-    operator_data.quad_index        = get_quad_index_velocity_linear();
+    operator_data.quad_index        = get_quad_index_velocity_standard();
     operator_data.use_boundary_data = param.continuity_penalty_use_boundary_data;
     operator_data.bc                = this->boundary_descriptor->velocity;
 
@@ -629,7 +630,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
       data.use_boundary_data      = param.continuity_penalty_use_boundary_data;
       data.bc                     = this->boundary_descriptor->velocity;
       data.dof_index              = get_dof_index_velocity();
-      data.quad_index             = get_quad_index_velocity_linear();
+      data.quad_index             = get_quad_index_velocity_standard();
       data.use_cell_based_loops   = param.use_cell_based_face_loops;
       data.implement_block_diagonal_preconditioner_matrix_free =
         param.implement_block_diagonal_preconditioner_matrix_free;
@@ -651,23 +652,23 @@ SpatialOperatorBase<dim, Number>::initialize_calculators_for_derived_quantities(
 {
   vorticity_calculator.initialize(*matrix_free,
                                   get_dof_index_velocity(),
-                                  get_quad_index_velocity_linear());
+                                  get_quad_index_velocity_standard());
   divergence_calculator.initialize(*matrix_free,
                                    get_dof_index_velocity(),
                                    get_dof_index_velocity_scalar(),
-                                   get_quad_index_velocity_linear());
+                                   get_quad_index_velocity_standard());
   shear_rate_calculator.initialize(*matrix_free,
                                    get_dof_index_velocity(),
                                    get_dof_index_velocity_scalar(),
-                                   get_quad_index_velocity_linear());
+                                   get_quad_index_velocity_standard());
   magnitude_calculator.initialize(*matrix_free,
                                   get_dof_index_velocity(),
                                   get_dof_index_velocity_scalar(),
-                                  get_quad_index_velocity_linear());
+                                  get_quad_index_velocity_standard());
   q_criterion_calculator.initialize(*matrix_free,
                                     get_dof_index_velocity(),
                                     get_dof_index_velocity_scalar(),
-                                    get_quad_index_velocity_linear(),
+                                    get_quad_index_velocity_standard(),
                                     false /*compressible_flow*/);
 }
 
@@ -774,7 +775,7 @@ SpatialOperatorBase<dim, Number>::get_dof_index_velocity_scalar() const
 
 template<int dim, typename Number>
 unsigned int
-SpatialOperatorBase<dim, Number>::get_quad_index_velocity_linear() const
+SpatialOperatorBase<dim, Number>::get_quad_index_velocity_standard() const
 {
   return matrix_free_data->get_quad_index(field + quad_index_u);
 }
@@ -788,9 +789,9 @@ SpatialOperatorBase<dim, Number>::get_quad_index_pressure() const
 
 template<int dim, typename Number>
 unsigned int
-SpatialOperatorBase<dim, Number>::get_quad_index_velocity_nonlinear() const
+SpatialOperatorBase<dim, Number>::get_quad_index_velocity_overintegration() const
 {
-  return matrix_free_data->get_quad_index(field + quad_index_u_nonlinear);
+  return matrix_free_data->get_quad_index(field + quad_index_u_overintegration);
 }
 
 template<int dim, typename Number>
@@ -813,19 +814,19 @@ SpatialOperatorBase<dim, Number>::get_quad_index_velocity_linearized() const
 {
   if(param.quad_rule_linearization == QuadratureRuleLinearization::Standard)
   {
-    return get_quad_index_velocity_linear();
+    return get_quad_index_velocity_standard();
   }
   else if(param.quad_rule_linearization == QuadratureRuleLinearization::Overintegration32k)
   {
     if(param.implicit_convective_problem())
-      return get_quad_index_velocity_nonlinear();
+      return get_quad_index_velocity_overintegration();
     else
-      return get_quad_index_velocity_linear();
+      return get_quad_index_velocity_standard();
   }
   else
   {
     AssertThrow(false, dealii::ExcMessage("Not implemented"));
-    return get_quad_index_velocity_nonlinear();
+    return get_quad_index_velocity_overintegration();
   }
 }
 
@@ -1068,7 +1069,7 @@ SpatialOperatorBase<dim, Number>::calculate_time_step_cfl_global() const
   return calculate_time_step_cfl_local<dim, Number>(
     *matrix_free,
     get_dof_index_velocity(),
-    get_quad_index_velocity_linear(),
+    get_quad_index_velocity_standard(),
     velocity_field,
     param.start_time /* will not be used (ConstantFunction) */,
     param.degree_u,
@@ -1087,7 +1088,7 @@ SpatialOperatorBase<dim, Number>::calculate_time_step_cfl(VectorType const & vel
 
   return calculate_time_step_cfl_local<dim, Number>(*matrix_free,
                                                     get_dof_index_velocity(),
-                                                    get_quad_index_velocity_linear(),
+                                                    get_quad_index_velocity_standard(),
                                                     velocity,
                                                     param.degree_u,
                                                     param.cfl_exponent_fe_degree_velocity,
@@ -1105,7 +1106,7 @@ SpatialOperatorBase<dim, Number>::calculate_cfl_from_time_step(VectorType &     
                              *grid->triangulation,
                              *matrix_free,
                              get_dof_index_velocity(),
-                             get_quad_index_velocity_linear(),
+                             get_quad_index_velocity_standard(),
                              velocity,
                              time_step_size,
                              param.degree_u,
@@ -1292,7 +1293,7 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
   rhs_operator.initialize(*matrix_free,
                           get_dof_index_velocity(),
                           get_dof_index_velocity_scalar(),
-                          get_quad_index_velocity_linear());
+                          get_quad_index_velocity_standard());
   VectorType rhs;
   initialize_vector_velocity_scalar(rhs);
   rhs_operator.apply(rhs, src);
@@ -1300,7 +1301,7 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
   // setup Laplace operator for scalar velocity vector
   Poisson::LaplaceOperatorData<0, dim> laplace_operator_data;
   laplace_operator_data.dof_index  = get_dof_index_velocity_scalar();
-  laplace_operator_data.quad_index = get_quad_index_velocity_linear();
+  laplace_operator_data.quad_index = get_quad_index_velocity_standard();
 
   std::shared_ptr<Poisson::BoundaryDescriptor<0, dim>> boundary_descriptor_streamfunction;
   boundary_descriptor_streamfunction = std::make_shared<Poisson::BoundaryDescriptor<0, dim>>();
@@ -1645,7 +1646,7 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
     {
       InverseMassOperatorData inverse_mass_operator_data;
       inverse_mass_operator_data.dof_index  = get_dof_index_velocity();
-      inverse_mass_operator_data.quad_index = get_quad_index_velocity_linear();
+      inverse_mass_operator_data.quad_index = get_quad_index_velocity_standard();
       inverse_mass_operator_data.parameters = param.inverse_mass_preconditioner;
 
       preconditioner_projection =

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -817,7 +817,7 @@ SpatialOperatorBase<dim, Number>::get_quad_index_velocity_linearized() const
   }
   else if(param.quad_rule_linearization == QuadratureRuleLinearization::Overintegration32k)
   {
-    if(param.nonlinear_problem_has_to_be_solved())
+    if(param.implicit_convective_problem())
       return get_quad_index_velocity_nonlinear();
     else
       return get_quad_index_velocity_linear();

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -156,7 +156,7 @@ public:
   get_dof_index_pressure() const;
 
   unsigned int
-  get_quad_index_velocity_linear() const;
+  get_quad_index_velocity_standard() const;
 
   unsigned int
   get_quad_index_pressure() const;
@@ -166,7 +166,7 @@ protected:
   get_dof_index_velocity_scalar() const;
 
   unsigned int
-  get_quad_index_velocity_nonlinear() const;
+  get_quad_index_velocity_overintegration() const;
 
   unsigned int
   get_quad_index_velocity_gauss_lobatto() const;
@@ -511,11 +511,11 @@ private:
   std::string const dof_index_p        = "pressure";
   std::string const dof_index_u_scalar = "velocity_scalar";
 
-  std::string const quad_index_u               = "velocity";
-  std::string const quad_index_p               = "pressure";
-  std::string const quad_index_u_nonlinear     = "velocity_nonlinear";
-  std::string const quad_index_u_gauss_lobatto = "velocity_gauss_lobatto";
-  std::string const quad_index_p_gauss_lobatto = "pressure_gauss_lobatto";
+  std::string const quad_index_u                 = "velocity";
+  std::string const quad_index_p                 = "pressure";
+  std::string const quad_index_u_overintegration = "velocity_overintegration";
+  std::string const quad_index_u_gauss_lobatto   = "velocity_gauss_lobatto";
+  std::string const quad_index_p_gauss_lobatto   = "pressure_gauss_lobatto";
 
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -412,7 +412,7 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
     }
   }
 
-  if(viscosity_is_variable() and nonlinear_problem_has_to_be_solved())
+  if(nonlinear_viscous_problem())
     AssertThrow(quad_rule_linearization == QuadratureRuleLinearization::Standard,
                 dealii::ExcMessage(
                   "Only the standard integration rule is supported for variable viscosity. "

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -412,11 +412,13 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
     }
   }
 
-  if(nonlinear_viscous_problem())
+  if(viscous_problem() and viscosity_is_variable())
+  {
     AssertThrow(quad_rule_linearization == QuadratureRuleLinearization::Standard,
                 dealii::ExcMessage(
                   "Only the standard integration rule is supported for variable viscosity. "
                   "Variable viscosity with multiple integration rules is not yet implemented."));
+  }
 
   // PROJECTION METHODS
   if(preconditioner_momentum == MomentumPreconditioner::Multigrid)

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -457,6 +457,9 @@ public:
   // be the same. Hence, although this parameter speeds up the operator evaluation (i.e.
   // the wall time per iteration), it is unclear whether a lower order quadrature rule
   // really allows to achieve a more efficient method overall.
+  // Note that if the convective term is not involved in the momentum operator, this
+  // parameter does not have any effect and the standard quadrature rule will be used
+  // for the momentum operator.
   QuadratureRuleLinearization quad_rule_linearization;
 
   /**************************************************************************************/


### PR DESCRIPTION
... and not for nonlinear viscous problem.

@richardschu I think when we extended the meaning of `Parameters::nonlinear_problem_has_to_be_solved()` (which now becomes also true for nonlinear viscous problems), we didn't realize that this implies that an over-integration quad-rule will be used for the momentum operator according to the current implementation (even if no convection is involved).

Indeed, we have an assert in the `Parameter` class currently ensuring that we use the standard quad-rule for variable-viscosity problems, but still I consider the implementation in `SpatialOperatorBase` a "bug", i.e. removing the assert in `Parameters` could lead to (unrecognized) unexpected behavior.

Of course, one could also debate if `param.quad_rule_linearization` will define once and for all the chosen quad-rule, i.e. to actually remove the if-else-statement in `SpatalOperatorBase`

```bash
    if(param.implicit_convective_problem())
      return get_quad_index_velocity_nonlinear();
    else
      return get_quad_index_velocity_linear();
```
by
```bash
      return get_quad_index_velocity_nonlinear();
```

However, the downside would be that if one switches between an explicit and an implicit version of the convective term in an application (which happens quite often in my opinion), one would always have to adjust the parameter `param.quad_rule_linearization`. Hence, the current implementation provides somewhat more automation and will not use over-integration if one can determine from the parameters that the convective term is actually not involved in the momentum operator. So I would keep this if-statement in the implementation. The current documentation has not been clear about this, so I also extend the documentation in the present PR, so that the documentation is in line with the implementation.

I encountered this "bug" during PR #673, so it would be good to discuss/merge the present PR soon and then use this in #673.