### PR TITLE
Added missing includes.

### DIFF
--- a/include/exadg/utilities/enum_utilities.h
+++ b/include/exadg/utilities/enum_utilities.h
@@ -22,6 +22,8 @@
 #ifndef INCLUDE_EXADG_UTILITIES_ENUM_UTILITIES_H_
 #define INCLUDE_EXADG_UTILITIES_ENUM_UTILITIES_H_
 
+#include <vector>
+
 #include <boost/algorithm/string/join.hpp>
 #include <magic_enum/magic_enum.hpp>
 

--- a/include/exadg/utilities/print_functions.h
+++ b/include/exadg/utilities/print_functions.h
@@ -24,6 +24,7 @@
 
 // C/C++
 #include <iomanip>
+#include <iostream>
 
 // deal.II
 #include <deal.II/base/conditional_ostream.h>


### PR DESCRIPTION
I tried to compile with `gcc 14.1.1` which complained about missing includes.

```
In file included from .../exadg/include/exadg/time_integration/restart_data.h:33,
                 from .../exadg/include/exadg/time_integration/time_int_base.h:38,
                 from .../exadg/include/exadg/time_integration/time_int_base.cpp:22:
.../exadg/include/exadg/utilities/print_functions.h: In function ‘void ExaDG::print_write_output_time(double, unsigned int, bool, ompi_communicator_t* const&)’:
.../exadg/include/exadg/utilities/print_functions.h:124:41: error: ‘cout’ is not a member of ‘std’
  124 |   dealii::ConditionalOStream pcout(std::cout,
      |                                         ^~~~
.../exadg/include/exadg/utilities/print_functions.h:34:1: note: ‘std::cout’ is defined in header ‘<iostream>’; this is probably fixable by adding ‘#include <iostream>’
   33 | #include <exadg/utilities/enum_utilities.h>
  +++ |+#include <iostream>
   34 | 
```

```
In file included from .../exadg/include/exadg/acoustic_conservation_equations/user_interface/enum_types.h:24,
                 from .../exadg/include/exadg/acoustic_conservation_equations/user_interface/parameters.h:29,
                 from .../exadg/include/exadg/acoustic_conservation_equations/user_interface/parameters.cpp:26:
.../exadg/include/exadg/utilities/enum_utilities.h: In function ‘std::string ExaDG::Utilities::serialized_string()’:
.../exadg/include/exadg/utilities/enum_utilities.h:60:8: error: ‘vector’ is not a member of ‘std’
   60 |   std::vector<std::string> const enums_strings_vec(enum_strings.begin(), enum_strings.end());
      |        ^~~~~~
.../exadg/include/exadg/utilities/enum_utilities.h:27:1: note: ‘std::vector’ is defined in header ‘<vector>’; this is probably fixable by adding ‘#include <vector>’
   26 | #include <magic_enum/magic_enum.hpp>
  +++ |+#include <vector>
   27 | 
```