### PR TITLE
Enable DualSplitting and Pressure Correction for Simplex Elements

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -596,10 +596,7 @@ OperatorDualSplitting<dim, Number>::local_interpolate_velocity_dirichlet_bc_boun
   Range const & face_range) const
 {
   unsigned int const dof_index = this->get_dof_index_velocity();
-  AssertThrow(
-    matrix_free.get_dof_handler(dof_index).get_triangulation().all_reference_cells_are_hyper_cube(),
-    dealii::ExcMessage("This function is only implemented for hypercube elements."));
-  unsigned int const quad_index = this->get_quad_index_velocity_gauss_lobatto();
+  unsigned int const quad_index = this->get_quad_index_velocity_nodal_points();
 
   FaceIntegratorU integrator(matrix_free, true, dof_index, quad_index);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -227,10 +227,7 @@ OperatorPressureCorrection<dim, Number>::local_interpolate_pressure_dirichlet_bc
   Range const & face_range) const
 {
   unsigned int const dof_index = this->get_dof_index_pressure();
-  AssertThrow(
-    matrix_free.get_dof_handler(dof_index).get_triangulation().all_reference_cells_are_hyper_cube(),
-    dealii::ExcMessage("This function is only implemented for hypercube elements."));
-  unsigned int const quad_index = this->get_quad_index_pressure_gauss_lobatto();
+  unsigned int const quad_index = this->get_quad_index_pressure_nodal_points();
 
   FaceIntegratorP integrator(matrix_free, true, dof_index, quad_index);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -169,10 +169,10 @@ protected:
   get_quad_index_velocity_overintegration() const;
 
   unsigned int
-  get_quad_index_velocity_gauss_lobatto() const;
+  get_quad_index_velocity_nodal_points() const;
 
   unsigned int
-  get_quad_index_pressure_gauss_lobatto() const;
+  get_quad_index_pressure_nodal_points() const;
 
   unsigned int
   get_quad_index_velocity_linearized() const;
@@ -514,8 +514,8 @@ private:
   std::string const quad_index_u                 = "velocity";
   std::string const quad_index_p                 = "pressure";
   std::string const quad_index_u_overintegration = "velocity_overintegration";
-  std::string const quad_index_u_gauss_lobatto   = "velocity_gauss_lobatto";
-  std::string const quad_index_p_gauss_lobatto   = "pressure_gauss_lobatto";
+  std::string const quad_index_u_nodal_points    = "velocity_nodal_points";
+  std::string const quad_index_p_nodal_points    = "pressure_nodal_points";
 
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -548,13 +548,6 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
                                    "nonlinear regarding the unknown velocity field) is currently "
                                    "not implemented for the dual splitting scheme."));
   }
-
-  // SIMPLEX ELEMENTS
-  if(grid.element_type == ElementType::Simplex)
-  {
-    AssertThrow(temporal_discretization == TemporalDiscretization::BDFCoupledSolution,
-                dealii::ExcMessage("Only BDFCoupledSolution is supported for simplex elements."));
-  }
 }
 
 bool


### PR DESCRIPTION
This PR adds simplex support for the Dirichlet boundary functions of the `DualSplitting` and the `PressureCorrection` time integrators. Therefore a new Quadrature is introduced to (see [here](https://github.com/dealii/dealii/pull/17205)) which has support on the unit support points of the face, so the boundary function can be evaluated at the correct locations. The `integrate` function is used to make sure that the values are mapped to the corresponding entries in the DoF vector.
I am open for suggestions how to test this (and after testing I would like to clean up the duplicated code).
