### PR TITLE
Fix parameter misuse for TemporalDiscretization::InterpolateAnalyticalSolution

### DIFF
--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -637,8 +637,14 @@ Parameters::involves_h_multigrid() const
       }
     }
   }
+  // TODO: we currently treat TemporalDiscretization::InterpolateAnalyticalSolution as a splitting
+  // scheme, since the implementation creates a spatial operator related to the pressure-correction
+  // scheme in case of InterpolateAnalyticalSolution. This is only a temporary solution and we need
+  // to write a separate class SpatialOperatorInterpolateAnalyticalSolution that does not create
+  // preconditioners (including multigrid)
   else if(temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme or
-          temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
+          temporal_discretization == TemporalDiscretization::BDFPressureCorrection or
+          temporal_discretization == TemporalDiscretization::InterpolateAnalyticalSolution)
   {
     // pressure step is the same for both time discretization schemes
     if(involves_h_multigrid_pressure_step())
@@ -663,9 +669,6 @@ Parameters::involves_h_multigrid() const
         use_global_coarsening = true;
       }
     }
-  }
-  else if(temporal_discretization == TemporalDiscretization::InterpolateAnalyticalSolution)
-  {
   }
   else
   {


### PR DESCRIPTION
This replaces PR #669. The present PR is also related to issue #664.

I see the problem here: https://github.com/exadg/exadg/blob/d216d419a25726843b7ac34b21bac391945ba6cd/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h#L74-L82

Creating a pressure-correction spatial operator wants to create multigrid preconditioners. However, the function `Parameters::involves_h_multigrid()` returns false for `TemporalDiscretization::InterpolateAnalyticalSolution` in the current implementation. I would currently argue that this is kind of a misuse/hack of `IncNS::Parameters` in combination with the `Driver` class and cannot be expected to work as expected.

The present PR aims to make the code consistent with the "hack" of creating `OperatorPressureCorrection` if `TemporalDiscretization::InterpolateAnalyticalSolution`. To have a clean solution of this problem, we need to implement a new class `OperatorInterpolateAnalyticalSolution` (deriving from `SpatialOperatorBase`) that does not want to create/initialize any preconditioners (including multigrid).