### PR TITLE
introduce matrix-based vmult in OperatorBase

### DIFF
--- a/applications/structure/bar/tests/quasistatic_large_strain_multigrid.output
+++ b/applications/structure/bar/tests/quasistatic_large_strain_multigrid.output
@@ -41,6 +41,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
+  Use matrix-based implementation:           false
 
 Solver:
 

--- a/applications/structure/bar/tests/steady_large_strain_multigrid.output
+++ b/applications/structure/bar/tests/steady_large_strain_multigrid.output
@@ -40,6 +40,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
+  Use matrix-based implementation:           false
 
 Solver:
 

--- a/applications/structure/bar/tests/steady_small_strain_multigrid.output
+++ b/applications/structure/bar/tests/steady_small_strain_multigrid.output
@@ -38,6 +38,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
+  Use matrix-based implementation:           false
 
 Solver:
 

--- a/applications/structure/bar/tests/unsteady_small_strain_multigrid.output
+++ b/applications/structure/bar/tests/unsteady_small_strain_multigrid.output
@@ -49,6 +49,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
+  Use matrix-based implementation:           false
 
 Solver:
 

--- a/applications/structure/bar/tests/weak_damping.output
+++ b/applications/structure/bar/tests/weak_damping.output
@@ -52,6 +52,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         1
+  Use matrix-based implementation:           false
 
 Solver:
 

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -375,8 +375,8 @@ private:
       this->param.newton_solver_data.max_iter;
     this->param.update_preconditioner_once_newton_converged = true;
 
-    this->param.use_matrix_based_implementation = false; //true;
-    this->param.sparse_matrix_type = SparseMatrixType::PETSc; // Trilinos;
+    this->param.use_matrix_based_implementation = false;                   // true;
+    this->param.sparse_matrix_type              = SparseMatrixType::PETSc; // Trilinos;
   }
 
   void

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -374,6 +374,9 @@ private:
     this->param.update_preconditioner_every_newton_iterations =
       this->param.newton_solver_data.max_iter;
     this->param.update_preconditioner_once_newton_converged = true;
+
+    this->param.use_matrix_based_implementation = false; //true;
+    this->param.sparse_matrix_type = SparseMatrixType::PETSc; // Trilinos;
   }
 
   void

--- a/applications/structure/manufactured/tests/2d.output
+++ b/applications/structure/manufactured/tests/2d.output
@@ -51,6 +51,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -168,6 +169,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -285,6 +287,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -402,6 +405,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -519,6 +523,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -636,6 +641,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -753,6 +759,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -870,6 +877,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -987,6 +995,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 

--- a/applications/structure/manufactured/tests/3d.output
+++ b/applications/structure/manufactured/tests/3d.output
@@ -51,6 +51,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -168,6 +169,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -285,6 +287,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -402,6 +405,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -519,6 +523,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -636,6 +641,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -753,6 +759,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -870,6 +877,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 
@@ -987,6 +995,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
+  Use matrix-based implementation:           false
 
 Solver:
 

--- a/include/exadg/operators/enum_types.h
+++ b/include/exadg/operators/enum_types.h
@@ -1,0 +1,38 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2021 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef INCLUDE_EXADG_OPERATORS_ENUM_TYPES_H_
+#define INCLUDE_EXADG_OPERATORS_ENUM_TYPES_H_
+
+namespace ExaDG
+{
+enum class SparseMatrixType
+{
+  Undefined,
+  Trilinos,
+  PETSc
+};
+
+}
+
+
+
+#endif /* INCLUDE_EXADG_OPERATORS_ENUM_TYPES_H_ */

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -418,6 +418,11 @@ OperatorBase<dim, Number, n_components>::apply_matrix_based(VectorType &       d
           dealii::LinearAlgebra::distributed::Vector<double> const & src_double) {
         system_matrix_trilinos.vmult(dst_double, src_double);
       });
+#else
+    AssertThrow(
+      false,
+      dealii::ExcMessage(
+        "Make sure that DEAL_II_WITH_TRILINOS is activated if you want to use SparseMatrixType::Trilinos."));
 #endif
   }
   else if(this->data.sparse_matrix_type == SparseMatrixType::PETSc)
@@ -434,6 +439,11 @@ OperatorBase<dim, Number, n_components>::apply_matrix_based(VectorType &       d
                               system_matrix_petsc.vmult(petsc_dst, petsc_src);
                             });
     }
+#else
+    AssertThrow(
+      false,
+      dealii::ExcMessage(
+        "Make sure that DEAL_II_WITH_PETSC is activated if you want to use SparseMatrixType::PETSc."));
 #endif
   }
   else

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -30,8 +30,8 @@
 #include <exadg/operators/operator_base.h>
 #include <exadg/solvers_and_preconditioners/utilities/block_jacobi_matrices.h>
 #include <exadg/solvers_and_preconditioners/utilities/invert_diagonal.h>
-#include <exadg/solvers_and_preconditioners/utilities/verify_calculation_of_diagonal.h>
 #include <exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h>
+#include <exadg/solvers_and_preconditioners/utilities/verify_calculation_of_diagonal.h>
 
 namespace ExaDG
 {

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -146,14 +146,20 @@ template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::vmult(VectorType & dst, VectorType const & src) const
 {
-  this->apply(dst, src);
+  if(this->data.use_matrix_based_vmult)
+    this->apply_matrix_based(dst, src);
+  else
+    this->apply(dst, src);
 }
 
 template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::vmult_add(VectorType & dst, VectorType const & src) const
 {
-  this->apply_add(dst, src);
+  if(this->data.use_matrix_based_vmult)
+    this->apply_matrix_based_add(dst, src);
+  else
+    this->apply_add(dst, src);
 }
 
 template<int dim, typename Number, int n_components>
@@ -304,6 +310,20 @@ OperatorBase<dim, Number, n_components>::apply_add(VectorType & dst, VectorType 
       dst.local_element(constrained_index) += src.local_element(constrained_index);
     }
   }
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::apply_matrix_based(VectorType &       dst,
+                                                            VectorType const & src) const
+{
+}
+
+template<int dim, typename Number, int n_components>
+void
+OperatorBase<dim, Number, n_components>::apply_matrix_based_add(VectorType &       dst,
+                                                                VectorType const & src) const
+{
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -30,8 +30,8 @@
 #include <exadg/operators/operator_base.h>
 #include <exadg/solvers_and_preconditioners/utilities/block_jacobi_matrices.h>
 #include <exadg/solvers_and_preconditioners/utilities/invert_diagonal.h>
-#include <exadg/solvers_and_preconditioners/utilities/petsc_operation.h>
 #include <exadg/solvers_and_preconditioners/utilities/verify_calculation_of_diagonal.h>
+#include <exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h>
 
 namespace ExaDG
 {

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -61,6 +61,7 @@ struct OperatorBaseData
     : dof_index(0),
       dof_index_inhomogeneous(dealii::numbers::invalid_unsigned_int),
       quad_index(0),
+      use_matrix_based_vmult(false),
       operator_is_singular(false),
       use_cell_based_loops(false),
       implement_block_diagonal_preconditioner_matrix_free(false),
@@ -78,6 +79,10 @@ struct OperatorBaseData
   unsigned int dof_index_inhomogeneous;
 
   unsigned int quad_index;
+
+  // this parameter can be used to use sparse matrices for the vmult() operation. The default
+  // case is to use a matrix-free implementation, i.e. use_matrix_based_vmult = false.
+  bool use_matrix_based_vmult;
 
   // Solution of linear systems of equations and preconditioning
   bool operator_is_singular;
@@ -246,6 +251,19 @@ public:
    */
   void
   apply_add(VectorType & dst, VectorType const & src) const;
+
+  /*
+   * Matrix-based version of the apply function. This function is used if use_matrix_based_vmult =
+   * true.
+   */
+  void
+  apply_matrix_based(VectorType & dst, VectorType const & src) const;
+
+  /*
+   * See function apply_matrix_based() for a description.
+   */
+  void
+  apply_matrix_based_add(VectorType & dst, VectorType const & src) const;
 
   /*
    * evaluate inhomogeneous parts of operator related to inhomogeneous boundary face integrals.

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -758,6 +758,8 @@ private:
   unsigned int n_mpi_processes;
 
   // sparse matrices for matrix-based vmult
+  mutable bool system_matrix_based_been_initialized;
+
 #ifdef DEAL_II_WITH_TRILINOS
   mutable dealii::TrilinosWrappers::SparseMatrix system_matrix_trilinos;
 #endif

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -268,6 +268,9 @@ public:
   void
   apply_add(VectorType & dst, VectorType const & src) const;
 
+  void
+  assemble_matrix_if_necessary() const;
+
   /*
    * Matrix-based version of the apply function. This function is used if use_matrix_based_vmult =
    * true.
@@ -756,11 +759,11 @@ private:
 
   // sparse matrices for matrix-based vmult
 #ifdef DEAL_II_WITH_TRILINOS
-  dealii::TrilinosWrappers::SparseMatrix system_matrix_trilinos;
+  mutable dealii::TrilinosWrappers::SparseMatrix system_matrix_trilinos;
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
-  dealii::PETScWrappers::MPI::SparseMatrix system_matrix_petsc;
+  mutable dealii::PETScWrappers::MPI::SparseMatrix system_matrix_petsc;
 
   // PETSc vector objects to avoid re-allocation in every vmult() operation
   mutable Vec petsc_vector_src;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -38,7 +38,6 @@
 #include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h>
 #include <exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h>
 #include <exadg/solvers_and_preconditioners/utilities/check_multigrid.h>
-#include <exadg/solvers_and_preconditioners/utilities/petsc_operation.h>
 #include <exadg/utilities/exceptions.h>
 
 namespace ExaDG

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -39,7 +39,7 @@
 #include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
 #include <exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h>
 #include <exadg/solvers_and_preconditioners/solvers/solver_data.h>
-#include <exadg/solvers_and_preconditioners/utilities/petsc_operation.h>
+#include <exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h>
 
 namespace ExaDG
 {

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -803,12 +803,7 @@ MultigridPreconditionerBase<dim, Number, MultigridNumber>::initialize_coarse_sol
     {
       typename MGCoarseKrylov<Operator>::AdditionalData additional_data;
 
-      if(data.coarse_problem.solver == MultigridCoarseGridSolver::CG)
-        additional_data.solver_type = KrylovSolverType::CG;
-      else if(data.coarse_problem.solver == MultigridCoarseGridSolver::GMRES)
-        additional_data.solver_type = KrylovSolverType::GMRES;
-      else
-        AssertThrow(false, dealii::ExcMessage("Not implemented."));
+      additional_data.solver_type = data.coarse_problem.solver;
 
       additional_data.solver_data          = data.coarse_problem.solver_data;
       additional_data.operator_is_singular = operator_is_singular;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -130,7 +130,7 @@ public:
       dealii::SolverCG<VectorType> solver(solver_control);
       solver.solve(system_matrix, dst, src, *this);
     }
-    else if(solver_type == Multi #endifgridCoarseGridSolver::GMRES)
+    else if(solver_type == MultigridCoarseGridSolver::GMRES)
     {
       typename dealii::SolverGMRES<VectorType>::AdditionalData gmres_data;
       gmres_data.max_n_tmp_vectors     = solver_data.max_krylov_size;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -30,8 +30,8 @@
 
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
-#include <exadg/solvers_and_preconditioners/utilities/petsc_operation.h>
 #include <exadg/utilities/print_functions.h>
+#include <exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h>
 
 namespace ExaDG
 {

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -130,7 +130,7 @@ public:
       dealii::SolverCG<VectorType> solver(solver_control);
       solver.solve(system_matrix, dst, src, *this);
     }
-    else if(solver_type == MultigridCoarseGridSolver::GMRES)
+    else if(solver_type == Multi #endifgridCoarseGridSolver::GMRES)
     {
       typename dealii::SolverGMRES<VectorType>::AdditionalData gmres_data;
       gmres_data.max_n_tmp_vectors     = solver_data.max_krylov_size;
@@ -405,6 +405,8 @@ public:
                                                                   src,
                                                                   solver_type,
                                                                   solver_data);
+#else
+      AssertThrow(false, dealii::ExcMessage("deal.II is not compiled with PETSc!"));
 #endif
     }
     else if(data.amg_type == AMGType::ML)
@@ -423,6 +425,8 @@ public:
                                                                       solver_type,
                                                                       solver_data);
         });
+#else
+      AssertThrow(false, dealii::ExcMessage("deal.II is not compiled with Trilinos!"));
 #endif
     }
     else

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -30,8 +30,8 @@
 
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
-#include <exadg/utilities/print_functions.h>
 #include <exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h>
+#include <exadg/utilities/print_functions.h>
 
 namespace ExaDG
 {

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -312,24 +312,13 @@ public:
   void
   vmult(VectorType & dst, VectorType const & src) const final
   {
-    if constexpr(std::is_same_v<Number, NumberAMG>)
-    {
-      preconditioner_amg->vmult(dst, src);
-    }
-    else
-    {
-      // create temporal vectors of type NumberAMG
-      VectorTypeAMG dst_amg;
-      dst_amg.reinit(dst, false);
-      VectorTypeAMG src_amg;
-      src_amg.reinit(src, true);
-      src_amg = src;
-
-      preconditioner_amg->vmult(dst_amg, src_amg);
-
-      // convert: NumberAMG -> Number
-      dst.copy_locally_owned_data_from(dst_amg);
-    }
+    apply_function_in_double_precision(
+      dst,
+      src,
+      [&](dealii::LinearAlgebra::distributed::Vector<double> &       dst_double,
+          dealii::LinearAlgebra::distributed::Vector<double> const & src_double) {
+        preconditioner_amg->vmult(dst_double, src_double);
+      });
   }
 
 private:

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -107,12 +107,6 @@ public:
     }
   }
 
-  dealii::TrilinosWrappers::SparseMatrix const &
-  get_system_matrix()
-  {
-    return system_matrix;
-  }
-
   void
   vmult(VectorType & dst, VectorType const & src) const override
   {
@@ -193,12 +187,6 @@ public:
     }
   }
 
-  dealii::PETScWrappers::MPI::SparseMatrix const &
-  get_system_matrix()
-  {
-    return system_matrix;
-  }
-
   void
   vmult(VectorType & dst, VectorType const & src) const override
   {
@@ -253,7 +241,7 @@ private:
     }
   }
 
-  // reference to matrix-free operator
+  // reference to MultigridOperator
   Operator const & pde_operator;
 
   BoomerData boomer_data;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -259,8 +259,8 @@ private:
   BoomerData boomer_data;
 
   // PETSc vector objects to avoid re-allocation in every vmult() operation
-  mutable VectorTypePETSc petsc_vector_src;
-  mutable VectorTypePETSc petsc_vector_dst;
+  mutable Vec petsc_vector_src;
+  mutable Vec petsc_vector_dst;
 };
 #endif
 

--- a/include/exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h
@@ -151,9 +151,9 @@ apply_function_in_double_precision(
   {
     // create temporal vectors of type double
     dealii::LinearAlgebra::distributed::Vector<double> dst_double, src_double;
-    dst_double.reinit(dst, false); // zero entries
-    src_double.reinit(src, true);  // do not zero entries
-    src_double = src;
+    dst_double.reinit(dst, true); // do not zero entries
+    src_double.reinit(src, true); // do not zero entries
+    src_double.copy_locally_owned_data_from(src);
 
     operation(dst_double, src_double);
 

--- a/include/exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/linear_algebra_utilities.h
@@ -19,8 +19,8 @@
  *  ______________________________________________________________________
  */
 
-#ifndef INCLUDE_SOLVERS_AND_PRECONDITIONERS_PETSCOPERATION_H_
-#define INCLUDE_SOLVERS_AND_PRECONDITIONERS_PETSCOPERATION_H_
+#ifndef INCLUDE_SOLVERS_AND_PRECONDITIONERS_LINEAR_ALGEBRA_UTILITIES_H_
+#define INCLUDE_SOLVERS_AND_PRECONDITIONERS_LINEAR_ALGEBRA_UTILITIES_H_
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/lac/la_parallel_vector.h>
@@ -164,4 +164,4 @@ apply_function_in_double_precision(
 
 } // namespace ExaDG
 
-#endif /* INCLUDE_SOLVERS_AND_PRECONDITIONERS_INVERTDIAGONAL_H_ */
+#endif /* INCLUDE_SOLVERS_AND_PRECONDITIONERS_LINEAR_ALGEBRA_UTILITIES_H_ */

--- a/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/petsc_operation.h
@@ -29,23 +29,17 @@ namespace ExaDG
 {
 #ifdef DEAL_II_WITH_PETSC
 /*
- * A typedef to make use of PETSc data structure clearer
- */
-typedef Vec VectorTypePETSc;
-
-/*
  *  This function wraps the copy of a PETSc object (sparse matrix,
  *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector, taking
- *  pre-allocated PETSc vector objects (with struct name `Vec`, aka
- *  VectorTypePETSc) for the temporary operations
+ *  pre-allocated PETSc vector objects (with struct name `Vec`) for the temporary operations
  */
 template<typename VectorType>
 void
 apply_petsc_operation(
   VectorType &                                                   dst,
   VectorType const &                                             src,
-  VectorTypePETSc &                                              petsc_vector_dst,
-  VectorTypePETSc &                                              petsc_vector_src,
+  Vec &                                                          petsc_vector_dst,
+  Vec &                                                          petsc_vector_src,
   std::function<void(dealii::PETScWrappers::VectorBase &,
                      dealii::PETScWrappers::VectorBase const &)> petsc_operation)
 {
@@ -72,7 +66,7 @@ apply_petsc_operation(
     AssertThrow(ierr == 0, dealii::ExcPETScError(ierr));
   }
 
-  // wrap `Vec` (aka VectorTypePETSc) into VectorBase (without copying data)
+  // wrap `Vec` into VectorBase (without copying data)
   dealii::PETScWrappers::VectorBase petsc_dst(petsc_vector_dst);
   dealii::PETScWrappers::VectorBase petsc_src(petsc_vector_src);
 
@@ -103,7 +97,7 @@ apply_petsc_operation(
 /*
  *  This function wraps the copy of a PETSc object (sparse matrix,
  *  preconditioner) with a dealii::LinearAlgebra::distributed::Vector,
- *  allocating a PETSc vectors and then calling the other function
+ *  allocating PETSc vectors and then calling the other function
  */
 template<typename VectorType>
 void
@@ -114,7 +108,7 @@ apply_petsc_operation(
   std::function<void(dealii::PETScWrappers::VectorBase &,
                      dealii::PETScWrappers::VectorBase const &)> petsc_operation)
 {
-  VectorTypePETSc petsc_vector_dst, petsc_vector_src;
+  Vec petsc_vector_dst, petsc_vector_src;
   VecCreateMPI(petsc_mpi_communicator,
                dst.get_partitioner()->locally_owned_size(),
                PETSC_DETERMINE,

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -218,10 +218,20 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
   pde_operator->initialize_dof_vector(dst);
   src = 1.0;
 
-  if(application->get_parameters().large_deformation and operator_type == OperatorType::Apply)
+  pde_operator->update_elasticity_operator(1.0, 0.0);
+
+  if(operator_type == OperatorType::Apply)
   {
-    pde_operator->initialize_dof_vector(linearization);
-    linearization = 1.0;
+    if(application->get_parameters().large_deformation)
+    {
+      pde_operator->initialize_dof_vector(linearization);
+      linearization = 1.0;
+      pde_operator->set_solution_linearization(linearization);
+    }
+    else
+    {
+      pde_operator->assemble_matrix_if_necessary_for_linear_elasticity_operator();
+    }
   }
 
   const std::function<void(void)> operator_evaluation = [&](void) {
@@ -231,7 +241,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
     }
     else if(operator_type == OperatorType::Apply)
     {
-      pde_operator->apply_elasticity_operator(dst, src, linearization, 1.0, 0.0);
+      pde_operator->apply_elasticity_operator(dst, src);
     }
   };
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -104,11 +104,13 @@ MultigridPreconditioner<dim, Number>::update()
       vector_multigrid_type_ptr  = &vector_multigrid_type_copy;
     }
 
-    // copy velocity to finest level
+    // Copy displacement vector to finest level
+    // Note: This function also re-assembles the sparse matrix in case a matrix-based implementation
+    // is used
     this->get_operator_nonlinear(this->get_number_of_levels() - 1)
       ->set_solution_linearization(*vector_multigrid_type_ptr);
 
-    // interpolate velocity from fine to coarse level
+    // interpolate displacement vector from fine to coarse level
     this->transfer_from_fine_to_coarse_levels(
       [&](unsigned int const fine_level, unsigned int const coarse_level) {
         auto const & vector_fine_level =
@@ -116,8 +118,14 @@ MultigridPreconditioner<dim, Number>::update()
         auto vector_coarse_level =
           this->get_operator_nonlinear(coarse_level)->get_solution_linearization();
         this->transfers->interpolate(fine_level, vector_coarse_level, vector_fine_level);
+        // Note: This function also re-assembles the sparse matrix in case a matrix-based
+        // implementation is used
         this->get_operator_nonlinear(coarse_level)->set_solution_linearization(vector_coarse_level);
       });
+  }
+  else // linear problems
+  {
+    pde_operator->assemble_matrix_if_necessary();
   }
 
   // Update the smoothers and the coarse grid solver. This is generic functionality implemented in

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -215,6 +215,9 @@ Operator<dim, Number>::setup_operators()
   operator_data.dof_index               = get_dof_index();
   operator_data.quad_index              = get_quad_index();
   operator_data.dof_index_inhomogeneous = get_dof_index_periodicity_and_hanging_node_constraints();
+  operator_data.use_matrix_based_vmult  = param.use_matrix_based_implementation;
+  operator_data.sparse_matrix_type      = param.sparse_matrix_type;
+
   if(not(boundary_descriptor->dirichlet_cached_bc.empty()))
   {
     AssertThrow(this->grid->triangulation->all_reference_cells_are_hyper_cube(),
@@ -252,7 +255,10 @@ Operator<dim, Number>::setup_operators()
     mass_data.dof_index               = get_dof_index();
     mass_data.dof_index_inhomogeneous = get_dof_index_periodicity_and_hanging_node_constraints();
     mass_data.quad_index              = get_quad_index();
-    mass_data.bc                      = boundary_descriptor;
+    mass_data.use_matrix_based_vmult  = param.use_matrix_based_implementation;
+    mass_data.sparse_matrix_type      = param.sparse_matrix_type;
+
+    mass_data.bc = boundary_descriptor;
 
     mass_operator.initialize(*matrix_free, affine_constraints, mass_data);
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -255,10 +255,7 @@ Operator<dim, Number>::setup_operators()
     mass_data.dof_index               = get_dof_index();
     mass_data.dof_index_inhomogeneous = get_dof_index_periodicity_and_hanging_node_constraints();
     mass_data.quad_index              = get_quad_index();
-    mass_data.use_matrix_based_vmult  = param.use_matrix_based_implementation;
-    mass_data.sparse_matrix_type      = param.sparse_matrix_type;
-
-    mass_data.bc = boundary_descriptor;
+    mass_data.bc                      = boundary_descriptor;
 
     mass_operator.initialize(*matrix_free, affine_constraints, mass_data);
 
@@ -835,8 +832,8 @@ Operator<dim, Number>::evaluate_nonlinear_residual(VectorType &       dst,
 {
   // elasticity operator: make sure that constrained degrees of freedom have been set correctly
   // before evaluating the elasticity operator.
-  elasticity_operator_nonlinear.set_scaling_factor_mass_operator(factor);
-  elasticity_operator_nonlinear.set_time(time);
+  update_elasticity_operator(factor, time);
+
   elasticity_operator_nonlinear.evaluate_nonlinear(dst, src);
 
   // dynamic problems
@@ -870,14 +867,9 @@ Operator<dim, Number>::set_solution_linearization(VectorType const & vector) con
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::apply_linearized_operator(VectorType &       dst,
-                                                 VectorType const & src,
-                                                 double const       factor,
-                                                 double const       time) const
+Operator<dim, Number>::assemble_matrix_if_necessary_for_linear_elasticity_operator() const
 {
-  elasticity_operator_nonlinear.set_scaling_factor_mass_operator(factor);
-  elasticity_operator_nonlinear.set_time(time);
-  elasticity_operator_nonlinear.vmult(dst, src);
+  elasticity_operator_linear.assemble_matrix_if_necessary();
 }
 
 template<int dim, typename Number>
@@ -887,37 +879,44 @@ Operator<dim, Number>::evaluate_elasticity_operator(VectorType &       dst,
                                                     double const       factor,
                                                     double const       time) const
 {
+  update_elasticity_operator(factor, time);
+
   if(param.large_deformation)
   {
-    elasticity_operator_nonlinear.set_scaling_factor_mass_operator(factor);
-    elasticity_operator_nonlinear.set_time(time);
     elasticity_operator_nonlinear.evaluate_nonlinear(dst, src);
   }
   else
   {
-    elasticity_operator_linear.set_scaling_factor_mass_operator(factor);
-    elasticity_operator_linear.set_time(time);
     elasticity_operator_linear.evaluate(dst, src);
   }
 }
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::apply_elasticity_operator(VectorType &       dst,
-                                                 VectorType const & src,
-                                                 VectorType const & linearization,
-                                                 double const       factor,
-                                                 double const       time) const
+Operator<dim, Number>::update_elasticity_operator(double const factor, double const time) const
 {
   if(param.large_deformation)
   {
-    set_solution_linearization(linearization);
-    apply_linearized_operator(dst, src, factor, time);
+    elasticity_operator_nonlinear.set_scaling_factor_mass_operator(factor);
+    elasticity_operator_nonlinear.set_time(time);
   }
   else
   {
     elasticity_operator_linear.set_scaling_factor_mass_operator(factor);
     elasticity_operator_linear.set_time(time);
+  }
+}
+
+template<int dim, typename Number>
+void
+Operator<dim, Number>::apply_elasticity_operator(VectorType & dst, VectorType const & src) const
+{
+  if(param.large_deformation)
+  {
+    elasticity_operator_nonlinear.vmult(dst, src);
+  }
+  else
+  {
     elasticity_operator_linear.vmult(dst, src);
   }
 }
@@ -997,8 +996,9 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   // unsteady problems
   double const scaling_factor_mass =
     compute_scaling_factor_mass(scaling_factor_acceleration, scaling_factor_velocity);
-  elasticity_operator_linear.set_scaling_factor_mass_operator(scaling_factor_mass);
-  elasticity_operator_linear.set_time(time);
+
+  update_elasticity_operator(scaling_factor_mass, time);
+  assemble_matrix_if_necessary_for_linear_elasticity_operator();
 
   linear_solver->update_preconditioner(update_preconditioner);
 

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -141,6 +141,8 @@ public:
   {
     this->scaling_factor_mass = scaling_factor_mass;
     this->time                = time;
+
+    pde_operator->update_elasticity_operator(scaling_factor_mass, time);
   }
 
   /*
@@ -150,7 +152,7 @@ public:
   void
   vmult(VectorType & dst, VectorType const & src) const
   {
-    pde_operator->apply_linearized_operator(dst, src, scaling_factor_mass, time);
+    pde_operator->apply_linearized_operator(dst, src);
   }
 
 private:
@@ -247,10 +249,7 @@ public:
   set_solution_linearization(VectorType const & vector) const;
 
   void
-  apply_linearized_operator(VectorType &       dst,
-                            VectorType const & src,
-                            double const       factor,
-                            double const       time) const;
+  assemble_matrix_if_necessary_for_linear_elasticity_operator() const;
 
   void
   evaluate_elasticity_operator(VectorType &       dst,
@@ -259,11 +258,10 @@ public:
                                double const       time) const;
 
   void
-  apply_elasticity_operator(VectorType &       dst,
-                            VectorType const & src,
-                            VectorType const & linearization,
-                            double const       factor,
-                            double const       time) const;
+  update_elasticity_operator(double const factor, double const time) const;
+
+  void
+  apply_elasticity_operator(VectorType & dst, VectorType const & src) const;
 
   /*
    * This function solves the system of equations for nonlinear problems. This function needs to

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -89,6 +89,8 @@ NonLinearOperator<dim, Number>::set_solution_linearization(VectorType const & ve
   {
     displacement_lin = vector;
     displacement_lin.update_ghost_values();
+
+    this->assemble_matrix_if_necessary();
   }
 }
 

--- a/include/exadg/structure/user_interface/parameters.cpp
+++ b/include/exadg/structure/user_interface/parameters.cpp
@@ -65,6 +65,8 @@ Parameters::Parameters()
     mapping_degree(1),
     mapping_degree_coarse_grids(1),
     degree(1),
+    use_matrix_based_implementation(false),
+    sparse_matrix_type(SparseMatrixType::Undefined),
 
     // SOLVER
     newton_solver_data(Newton::SolverData(1e4, 1.e-12, 1.e-6)),
@@ -111,6 +113,12 @@ Parameters::check() const
   grid.check();
 
   AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
+
+  if(use_matrix_based_implementation)
+  {
+    AssertThrow(sparse_matrix_type != SparseMatrixType::Undefined,
+                dealii::ExcMessage("Parameter must be defined."));
+  }
 
   // SOLVER
   AssertThrow(solver != Solver::Undefined, dealii::ExcMessage("Parameter must be defined."));
@@ -217,6 +225,13 @@ Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream c
     print_parameter(pcout, "Mapping degree coarse grids", mapping_degree_coarse_grids);
 
   print_parameter(pcout, "Polynomial degree", degree);
+
+  print_parameter(pcout, "Use matrix-based implementation", use_matrix_based_implementation);
+
+  if(use_matrix_based_implementation)
+  {
+    print_parameter(pcout, "Sparse matrix type", sparse_matrix_type);
+  }
 }
 
 void

--- a/include/exadg/structure/user_interface/parameters.h
+++ b/include/exadg/structure/user_interface/parameters.h
@@ -24,6 +24,7 @@
 
 // ExaDG
 #include <exadg/grid/grid_data.h>
+#include <exadg/operators/enum_types.h>
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/newton/newton_solver_data.h>
 #include <exadg/solvers_and_preconditioners/solvers/solver_data.h>
@@ -183,6 +184,12 @@ public:
 
   // polynomial degree of shape functions
   unsigned int degree;
+
+  // use a matrix-based implementation of linear(ized) operators
+  bool use_matrix_based_implementation;
+
+  // this parameter is only relevant if use_matrix_based_implementation == true
+  SparseMatrixType sparse_matrix_type;
 
   /**************************************************************************************/
   /*                                                                                    */


### PR DESCRIPTION
This PR aims to introduce the option to use a matrix-based `vmult()` operation in `OperatorBase`, e.g. in order to perform throughput studies with sparse matrices (instead of the usual matrix-free evaluation used in ExaDG).

This option is enabled in the present PR for the `Structure` module.

~~@richardschu Please note that with this PR, the system matrix will **not** be correctly updated when simulating a time-dependent/nonlinear problem. It will only calculate the system matrix once during setup, e.g. for throughput studies.~~

For nonlinear problems, the system matrix of the linearized operator is computed in `set_solution_linearization()` (a function that is called by the Newton solver).

For linear problems, we compute the system matrix prior to solving the linear system of equations. For time-dependent problems with constant parameters, the matrix might be calculated more often than actually needed. Upcoming PRs would have to address this in case one wants to avoid the re-assembly of the system matrix. No work is done for the usual matrix-free implementation that is used by default.

closes #682