### PR TITLE
Enable matrix-based evaluation in Poisson throughput studies

### DIFF
--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -34,6 +34,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         1
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -124,6 +125,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         2
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -214,6 +216,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         3
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -304,6 +307,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         4
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -394,6 +398,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         5
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -484,6 +489,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         6
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -574,6 +580,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         7
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -664,6 +671,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         8
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -754,6 +762,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         9
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -844,6 +853,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         10
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -934,6 +944,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         11
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -1024,6 +1035,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         12
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -1077,7 +1089,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.58640e-11
+  Relative error (L2-norm): 4.58597e-11
 
 
 
@@ -1114,6 +1126,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         13
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -1167,7 +1180,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.25200e-11
+  Relative error (L2-norm): 4.25103e-11
 
 
 
@@ -1204,6 +1217,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         14
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -1257,7 +1271,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 2.43664e-12
+  Relative error (L2-norm): 2.51762e-12
 
 
 
@@ -1294,6 +1308,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         15
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -1347,4 +1362,4 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 1.54768e-12
+  Relative error (L2-norm): 1.90388e-12

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -34,6 +34,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         1
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -124,6 +125,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         2
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -214,6 +216,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         3
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -304,6 +307,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         4
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -394,6 +398,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         5
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -484,6 +489,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         6
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -574,6 +580,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         7
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -34,6 +34,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         1
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -124,6 +125,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         2
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -214,6 +216,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         3
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -304,6 +307,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         4
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -394,6 +398,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         5
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -484,6 +489,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         6
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG
@@ -574,6 +580,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         7
   IP factor:                                 1.0000e+00
+  Use matrix-based implementation:           false
 
 Solver:
   Solver:                                    CG

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -82,6 +82,9 @@ private:
     this->param.spatial_discretization = SpatialDiscretization::DG;
     this->param.IP_factor              = 1.0e0;
 
+    this->param.use_matrix_based_implementation = false;
+    this->param.sparse_matrix_type              = SparseMatrixType::Trilinos;
+
     // SOLVER
     this->param.solver         = LinearSolver::CG;
     this->param.preconditioner = Preconditioner::None;

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -237,9 +237,11 @@ Operator<dim, n_components, Number>::setup_operators()
 
     laplace_operator_data.quad_index_gauss_lobatto = get_quad_index_gauss_lobatto();
   }
-  laplace_operator_data.bc                    = boundary_descriptor;
-  laplace_operator_data.use_cell_based_loops  = param.enable_cell_based_face_loops;
-  laplace_operator_data.kernel_data.IP_factor = param.IP_factor;
+  laplace_operator_data.bc                     = boundary_descriptor;
+  laplace_operator_data.use_cell_based_loops   = param.enable_cell_based_face_loops;
+  laplace_operator_data.kernel_data.IP_factor  = param.IP_factor;
+  laplace_operator_data.use_matrix_based_vmult = param.use_matrix_based_implementation;
+  laplace_operator_data.sparse_matrix_type     = param.sparse_matrix_type;
   laplace_operator.initialize(*matrix_free, affine_constraints, laplace_operator_data);
 
   // rhs operator

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -244,6 +244,8 @@ Operator<dim, n_components, Number>::setup_operators()
   laplace_operator_data.sparse_matrix_type     = param.sparse_matrix_type;
   laplace_operator.initialize(*matrix_free, affine_constraints, laplace_operator_data);
 
+  laplace_operator.assemble_matrix_if_necessary();
+
   // rhs operator
   if(param.right_hand_side)
   {

--- a/include/exadg/poisson/user_interface/parameters.cpp
+++ b/include/exadg/poisson/user_interface/parameters.cpp
@@ -40,6 +40,8 @@ Parameters::Parameters()
     spatial_discretization(SpatialDiscretization::Undefined),
     degree(1),
     IP_factor(1.0),
+    use_matrix_based_implementation(false),
+    sparse_matrix_type(SparseMatrixType::Undefined),
 
     // SOLVER
     solver(LinearSolver::Undefined),
@@ -63,6 +65,12 @@ Parameters::check() const
               dealii::ExcMessage("parameter must be defined."));
 
   AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
+
+  if(use_matrix_based_implementation)
+  {
+    AssertThrow(sparse_matrix_type != SparseMatrixType::Undefined,
+                dealii::ExcMessage("Parameter must be defined."));
+  }
 
   // SOLVER
   AssertThrow(solver != LinearSolver::Undefined, dealii::ExcMessage("parameter must be defined."));
@@ -123,6 +131,13 @@ Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream c
 
   if(spatial_discretization == SpatialDiscretization::DG)
     print_parameter(pcout, "IP factor", IP_factor);
+
+  print_parameter(pcout, "Use matrix-based implementation", use_matrix_based_implementation);
+
+  if(use_matrix_based_implementation)
+  {
+    print_parameter(pcout, "Sparse matrix type", sparse_matrix_type);
+  }
 }
 
 void

--- a/include/exadg/poisson/user_interface/parameters.h
+++ b/include/exadg/poisson/user_interface/parameters.h
@@ -23,6 +23,7 @@
 #define INCLUDE_LAPLACE_INPUT_PARAMETERS_H_
 
 #include <exadg/grid/grid_data.h>
+#include <exadg/operators/enum_types.h>
 #include <exadg/poisson/user_interface/enum_types.h>
 #include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/solvers/solver_data.h>
@@ -94,6 +95,12 @@ public:
   // Symmetric interior penalty Galerkin (SIPG) discretization
   // interior penalty parameter scaling factor: default value is 1.0
   double IP_factor;
+
+  // use a matrix-based implementation of linear(ized) operators
+  bool use_matrix_based_implementation;
+
+  // this parameter is only relevant if use_matrix_based_implementation == true
+  SparseMatrixType sparse_matrix_type;
 
 
   /**************************************************************************************/


### PR DESCRIPTION
Matrix-based code is currently not working correctly, see also issue #702