### PR TITLE
make sure that matrices are assembled for multigrid with matrix-based implementation

### DIFF
--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -76,8 +76,11 @@ MultigridPreconditioner<dim, Number, n_components>::update()
 
     this->update_matrix_free_objects();
 
-    this->for_all_levels(
-      [&](unsigned int const level) { get_operator(level)->update_penalty_parameter(); });
+    // update operators
+    this->for_all_levels([&](unsigned int const level) {
+      get_operator(level)->update_penalty_parameter();
+      get_operator(level)->assemble_matrix_if_necessary();
+    });
 
     // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
     // functionality implemented in the base class.

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -44,6 +44,8 @@ LaplaceOperator<dim, Number, n_components>::initialize(
   kernel.reinit(matrix_free, data.kernel_data, data.dof_index);
 
   this->integrator_flags = kernel.get_integrator_flags(this->is_dg);
+
+  this->assemble_matrix_if_necessary();
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -244,8 +244,6 @@ Operator<dim, n_components, Number>::setup_operators()
   laplace_operator_data.sparse_matrix_type     = param.sparse_matrix_type;
   laplace_operator.initialize(*matrix_free, affine_constraints, laplace_operator_data);
 
-  laplace_operator.assemble_matrix_if_necessary();
-
   // rhs operator
   if(param.right_hand_side)
   {


### PR DESCRIPTION
Currently, this PR only addresses the Poisson module.