### PR TITLE
refactor matrix init in OperatorBase

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -44,8 +44,7 @@ OperatorBase<dim, Number, n_components>::OperatorBase()
     is_dg(true),
     data(OperatorBaseData()),
     level(dealii::numbers::invalid_unsigned_int),
-    n_mpi_processes(0),
-    system_matrix_based_been_initialized(false)
+    n_mpi_processes(0)
 {
 }
 
@@ -86,6 +85,40 @@ OperatorBase<dim, Number, n_components>::reinit(
     this->matrix_free->get_dof_handler(this->data.dof_index);
 
   n_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(dof_handler.get_communicator());
+
+  // initialize matrix
+  if(this->data.use_matrix_based_vmult)
+  {
+    dealii::DoFHandler<dim> const & dof_handler =
+      this->matrix_free->get_dof_handler(this->data.dof_index);
+
+    if(this->data.sparse_matrix_type == SparseMatrixType::Trilinos)
+    {
+#ifdef DEAL_II_WITH_TRILINOS
+      init_system_matrix(system_matrix_trilinos, dof_handler.get_communicator());
+#else
+      AssertThrow(
+        false,
+        dealii::ExcMessage(
+          "Make sure that DEAL_II_WITH_TRILINOS is activated if you want to use SparseMatrixType::Trilinos."));
+#endif
+    }
+    else if(this->data.sparse_matrix_type == SparseMatrixType::PETSc)
+    {
+#ifdef DEAL_II_WITH_PETSC
+      init_system_matrix(system_matrix_petsc, dof_handler.get_communicator());
+#else
+      AssertThrow(
+        false,
+        dealii::ExcMessage(
+          "Make sure that DEAL_II_WITH_PETSC is activated if you want to use SparseMatrixType::PETSc."));
+#endif
+    }
+    else
+    {
+      AssertThrow(false, dealii::ExcMessage("not implemented."));
+    }
+  }
 }
 
 template<int dim, typename Number, int n_components>
@@ -320,42 +353,6 @@ OperatorBase<dim, Number, n_components>::assemble_matrix_if_necessary() const
 {
   if(this->data.use_matrix_based_vmult)
   {
-    // initialize matrix
-    if(not(system_matrix_based_been_initialized))
-    {
-      dealii::DoFHandler<dim> const & dof_handler =
-        this->matrix_free->get_dof_handler(this->data.dof_index);
-
-      if(this->data.sparse_matrix_type == SparseMatrixType::Trilinos)
-      {
-#ifdef DEAL_II_WITH_TRILINOS
-        init_system_matrix(system_matrix_trilinos, dof_handler.get_communicator());
-#else
-        AssertThrow(
-          false,
-          dealii::ExcMessage(
-            "Make sure that DEAL_II_WITH_TRILINOS is activated if you want to use SparseMatrixType::Trilinos."));
-#endif
-      }
-      else if(this->data.sparse_matrix_type == SparseMatrixType::PETSc)
-      {
-#ifdef DEAL_II_WITH_PETSC
-        init_system_matrix(system_matrix_petsc, dof_handler.get_communicator());
-#else
-        AssertThrow(
-          false,
-          dealii::ExcMessage(
-            "Make sure that DEAL_II_WITH_PETSC is activated if you want to use SparseMatrixType::PETSc."));
-#endif
-      }
-      else
-      {
-        AssertThrow(false, dealii::ExcMessage("not implemented."));
-      }
-
-      system_matrix_based_been_initialized = true;
-    }
-
     // calculate matrix
     if(this->data.sparse_matrix_type == SparseMatrixType::Trilinos)
     {

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -758,7 +758,6 @@ private:
   unsigned int n_mpi_processes;
 
   // sparse matrices for matrix-based vmult
-  mutable bool system_matrix_based_been_initialized;
 
 #ifdef DEAL_II_WITH_TRILINOS
   mutable dealii::TrilinosWrappers::SparseMatrix system_matrix_trilinos;


### PR DESCRIPTION
A change that would be helpful to realize what is described in comment https://github.com/exadg/exadg/pull/709#issuecomment-2474001550 (using the same matrix for the operator itself and an AMG preconditioner based on that operator).

Since we get rid of a member variable of `OperatorBase` in the present PR, this change might be considered useful in any case.