### PR TITLE
fix component number in default OperatorBase::get_constant_modes()

### DIFF
--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -271,12 +271,12 @@ public:
     if(dof_handler.has_level_dofs())
     {
       constant_modes = dealii::DoFTools::extract_level_constant_modes(
-        0, dof_handler, dealii::ComponentMask(1 /* single component */, true));
+        0, dof_handler, dealii::ComponentMask(n_components, true));
     }
     else
     {
       constant_modes = dealii::DoFTools::extract_constant_modes(
-        dof_handler, dealii::ComponentMask(1 /* single component */, true));
+        dof_handler, dealii::ComponentMask(n_components, true));
     }
   }
 


### PR DESCRIPTION
this is a bug in the current master that I just found when running the `pressure_wave` example with Poisson ALE mapping. In that case, the mapping is constructed with a Laplace with `dim` components, which leads to an assert in  `dealii::DoFTools::extract_constant_modes()`. Mistakenly I thought this code path was tested, but we never setup an AMG solver using `n_components != 1` in any of the tests apart from the cases where we override `OperatorBase::get_constant_modes()` (that is, in the `structure` module). The component mask should have the size of the currently used components, where those set to `true` are respected in the `extract_level_constant_modes()`. Hence, the initially expected behavior for `n_components != 1` is  achieved with the present PR.