### PR TITLE
include missing <limits> header in `utilities/numbers.h`

### DIFF
--- a/include/exadg/utilities/numbers.h
+++ b/include/exadg/utilities/numbers.h
@@ -22,6 +22,8 @@
 #ifndef INCLUDE_EXADG_UTILITIES_NUMBERS_H_
 #define INCLUDE_EXADG_UTILITIES_NUMBERS_H_
 
+#include <limits>
+
 namespace ExaDG
 {
 namespace types


### PR DESCRIPTION
I couldnt compile on Fritz without adding the STL `<limits>` header