### PR TITLE
remove commented include

### DIFF
--- a/include/exadg/operators/solution_transfer.h
+++ b/include/exadg/operators/solution_transfer.h
@@ -26,7 +26,6 @@
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/grid/tria.h>
-//#include <deal.II/numerics/solution_transfer.h>
 
 namespace ExaDG
 {


### PR DESCRIPTION
I forgot this commented include in `solution_transfer.h`.