### PR TITLE
Fix setup order of aeroacoustic application and ensure blend in start time < blend in end time

### DIFF
--- a/applications/aero_acoustic/co_rotating_vortex_pair/application.h
+++ b/applications/aero_acoustic/co_rotating_vortex_pair/application.h
@@ -793,15 +793,6 @@ public:
   {
   }
 
-private:
-  void
-  set_single_field_solvers(std::string input_file, MPI_Comm const & comm) final
-  {
-    this->acoustic =
-      std::make_shared<AcousticsAeroAcoustic::Application<dim, Number>>(input_file, comm);
-    this->fluid = std::make_shared<FluidAeroAcoustic::Application<dim, Number>>(input_file, comm);
-  }
-
   void
   set_field_functions() final
   {
@@ -812,6 +803,15 @@ private:
 
     this->field_functions->analytical_aero_acoustic_source_term =
       std::make_shared<AnalyticalSourceTerm<dim>>(source_term_with_convection, intensity, r_0, r_c);
+  }
+
+private:
+  void
+  set_single_field_solvers(std::string input_file, MPI_Comm const & comm) final
+  {
+    this->acoustic =
+      std::make_shared<AcousticsAeroAcoustic::Application<dim, Number>>(input_file, comm);
+    this->fluid = std::make_shared<FluidAeroAcoustic::Application<dim, Number>>(input_file, comm);
   }
 
   void

--- a/applications/aero_acoustic/co_rotating_vortex_pair/application.h
+++ b/applications/aero_acoustic/co_rotating_vortex_pair/application.h
@@ -658,6 +658,9 @@ public:
   BlendInFunction(double const blend_in_start, double const blend_in_end)
     : Utilities::SpatialAwareFunction<dim>(1, 0.0), start(blend_in_start), end(blend_in_end)
   {
+    AssertThrow(start < end,
+                dealii::ExcMessage(
+                  "End of blend in has to be smaller compared to start of blend in."));
   }
 
   double
@@ -798,8 +801,9 @@ public:
   {
     this->field_functions->source_term_blend_in =
       std::make_shared<BlendInFunction<dim>>(this->acoustic->get_parameters().start_time,
-                                             0.1 * (this->acoustic->get_parameters().end_time -
-                                                    this->acoustic->get_parameters().start_time));
+                                             this->acoustic->get_parameters().start_time +
+                                               0.1 * (this->acoustic->get_parameters().end_time -
+                                                      this->acoustic->get_parameters().start_time));
 
     this->field_functions->analytical_aero_acoustic_source_term =
       std::make_shared<AnalyticalSourceTerm<dim>>(source_term_with_convection, intensity, r_0, r_c);

--- a/applications/aero_acoustic/co_rotating_vortex_pair/application.h
+++ b/applications/aero_acoustic/co_rotating_vortex_pair/application.h
@@ -794,8 +794,12 @@ public:
   Application(std::string input_file, MPI_Comm const & comm)
     : ApplicationBase<dim, Number>(input_file, comm)
   {
+    this->acoustic =
+      std::make_shared<AcousticsAeroAcoustic::Application<dim, Number>>(input_file, comm);
+    this->fluid = std::make_shared<FluidAeroAcoustic::Application<dim, Number>>(input_file, comm);
   }
 
+private:
   void
   set_field_functions() final
   {
@@ -807,15 +811,6 @@ public:
 
     this->field_functions->analytical_aero_acoustic_source_term =
       std::make_shared<AnalyticalSourceTerm<dim>>(source_term_with_convection, intensity, r_0, r_c);
-  }
-
-private:
-  void
-  set_single_field_solvers(std::string input_file, MPI_Comm const & comm) final
-  {
-    this->acoustic =
-      std::make_shared<AcousticsAeroAcoustic::Application<dim, Number>>(input_file, comm);
-    this->fluid = std::make_shared<FluidAeroAcoustic::Application<dim, Number>>(input_file, comm);
   }
 
   void

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -51,9 +51,6 @@ Driver<dim, Number>::setup()
 
   pcout << std::endl << "Setting up aero-acoustic solver:" << std::endl;
 
-  // setup application
-  application->setup();
-
   // setup acoustic solver
   {
     dealii::Timer timer_local;
@@ -72,7 +69,8 @@ Driver<dim, Number>::setup()
     timer_tree.insert({"AeroAcoustic", "Setup", "Fluid"}, timer_local.wall_time());
   }
 
-  application->set_field_functions();
+  // setup application
+  application->setup();
 
   setup_volume_coupling();
 

--- a/include/exadg/aero_acoustic/driver.cpp
+++ b/include/exadg/aero_acoustic/driver.cpp
@@ -72,6 +72,8 @@ Driver<dim, Number>::setup()
     timer_tree.insert({"AeroAcoustic", "Setup", "Fluid"}, timer_local.wall_time());
   }
 
+  application->set_field_functions();
+
   setup_volume_coupling();
 
   timer_tree.insert({"AeroAcoustic", "Setup"}, timer.wall_time());

--- a/include/exadg/aero_acoustic/user_interface/application_base.h
+++ b/include/exadg/aero_acoustic/user_interface/application_base.h
@@ -331,16 +331,17 @@ public:
     parameters.print(pcout, "List of parameters for aero-acoustic solver");
 
     field_functions = std::make_shared<FieldFunctions<dim>>();
-    set_field_functions();
   }
+
+  // has to be called after the setup of acoustic and fluid member because we want to have
+  // access to them
+  virtual void
+  set_field_functions() = 0;
 
   virtual void
   add_parameters(dealii::ParameterHandler & prm)
   {
     parameters.add_parameters(prm, "AeroAcoustic");
-
-    acoustic->add_parameters(prm);
-    fluid->add_parameters(prm);
   }
 
   Parameters parameters;
@@ -361,9 +362,6 @@ private:
 
   virtual void
   set_single_field_solvers(std::string input_file, MPI_Comm const & comm) = 0;
-
-  virtual void
-  set_field_functions() = 0;
 
   std::string const          parameter_file;
   MPI_Comm const             mpi_comm;

--- a/include/exadg/aero_acoustic/user_interface/application_base.h
+++ b/include/exadg/aero_acoustic/user_interface/application_base.h
@@ -324,24 +324,22 @@ public:
   void
   setup()
   {
-    set_single_field_solvers(parameter_file, mpi_comm);
-
     parse_parameters();
     parameters.check();
     parameters.print(pcout, "List of parameters for aero-acoustic solver");
 
+    // field functions
     field_functions = std::make_shared<FieldFunctions<dim>>();
+    set_field_functions();
   }
-
-  // has to be called after the setup of acoustic and fluid member because we want to have
-  // access to them
-  virtual void
-  set_field_functions() = 0;
 
   virtual void
   add_parameters(dealii::ParameterHandler & prm)
   {
     parameters.add_parameters(prm, "AeroAcoustic");
+
+    acoustic->add_parameters(prm);
+    fluid->add_parameters(prm);
   }
 
   Parameters parameters;
@@ -352,6 +350,9 @@ public:
   std::shared_ptr<FieldFunctions<dim>> field_functions;
 
 private:
+  virtual void
+  set_field_functions() = 0;
+
   void
   parse_parameters()
   {
@@ -359,9 +360,6 @@ private:
     add_parameters(prm);
     prm.parse_input(parameter_file, "", true, true);
   }
-
-  virtual void
-  set_single_field_solvers(std::string input_file, MPI_Comm const & comm) = 0;
 
   std::string const          parameter_file;
   MPI_Comm const             mpi_comm;


### PR DESCRIPTION
The setup of the aero-acoustic application was broken. We make use of the acoustic and the fluid application during the setup of the aero-acoustic field functions, so we have to set up acoustic and fluid before the setup of the field functions.

Besides this, I found that there is a typo setting the end time of the blend-in function. I fixed the end time and added asserts to ensure the end time is > the start time.