### PR TITLE
Extend deserialization rollout implicit

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -196,6 +196,15 @@ private:
     this->param.restart_data.interval_time_steps = 1e8;
     this->param.restart_data.filename =
       this->output_parameters.directory + this->output_parameters.filename + "_restart";
+
+    this->param.restart_data.degree_u                   = 5;
+    this->param.restart_data.degree_p                   = 5;
+    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
+    this->param.restart_data.discretization_identical   = false;
+    this->param.restart_data.consider_mapping           = true;
+    this->param.restart_data.mapping_degree             = 2;
+    this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;
+    this->param.restart_data.rpe_enforce_unique_mapping = false;
   }
 
   void
@@ -214,6 +223,13 @@ private:
         for(const auto & face : tria.active_face_iterators())
           if(face->at_boundary())
             face->set_boundary_id(1);
+
+        // Save the *coarse* triangulation for later deserialization.
+        if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
+        {
+          save_coarse_triangulation<dim, dealii::Triangulation<dim>>(
+            this->param.restart_data.filename, tria);
+        }
 
         tria.refine_global(global_refinements);
       };
@@ -301,9 +317,10 @@ private:
     return (2.0 * dealii::numbers::PI / xi);
   }
 
-  double const start_time    = 0.0;
-  bool         write_restart = false;
-  bool         read_restart  = false;
+  double const start_time = 0.0;
+
+  bool read_restart  = false;
+  bool write_restart = false;
 };
 
 } // namespace Acoustics

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -360,6 +360,19 @@ public:
   {
   }
 
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+      prm.add_parameter("WriteRestart", write_restart, "Should restart files be written?");
+      prm.add_parameter("ReadRestart", read_restart, "Is this a restarted simulation?");
+    }
+    prm.leave_subsection();
+  }
+
 private:
   void
   set_parameters() final
@@ -391,11 +404,22 @@ private:
     this->param.exponent_fe_degree_viscous    = 4.0;
 
     // restart
-    this->param.restarted_simulation       = false;
-    this->param.restart_data.write_restart = false;
-    this->param.restart_data.interval_time = 0.5;
+    this->param.restarted_simulation       = read_restart;
+    this->param.restart_data.write_restart = write_restart;
+    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
     this->param.restart_data.filename =
       this->output_parameters.directory + this->output_parameters.filename + "_restart";
+    this->param.restart_data.interval_wall_time  = 1.e6;
+    this->param.restart_data.interval_time_steps = 1e8;
+
+    this->param.restart_data.degree_u                   = 6;
+    this->param.restart_data.degree_p                   = 6;
+    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
+    this->param.restart_data.discretization_identical   = false;
+    this->param.restart_data.consider_mapping           = true;
+    this->param.restart_data.mapping_degree             = 6;
+    this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;
+    this->param.restart_data.rpe_enforce_unique_mapping = false;
 
     // output of solver information
     this->param.solver_info_data.interval_time = (end_time - start_time) / 10;
@@ -453,6 +477,13 @@ private:
 
       dealii::GridTools::collect_periodic_faces(tria, 0 + 10, 1 + 10, 1, periodic_face_pairs);
       tria.add_periodicity(periodic_face_pairs);
+
+      // Save the *coarse* triangulation for later deserialization.
+      if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
+      {
+        save_coarse_triangulation<dim, dealii::Triangulation<dim>>(
+          this->param.restart_data.filename, tria);
+      }
 
       tria.refine_global(global_refinements);
     };
@@ -525,6 +556,9 @@ private:
 
   double const start_time = 0.0;
   double const end_time   = 0.75;
+
+  bool read_restart  = false;
+  bool write_restart = false;
 };
 
 } // namespace CompNS

--- a/applications/compressible_navier_stokes/manufactured_solution/input.json
+++ b/applications/compressible_navier_stokes/manufactured_solution/input.json
@@ -15,10 +15,12 @@
         "RefineTimeMax": "0"
     },
     "Application": {
+        "ReadRestart": "false",
+        "WriteRestart": "false"
     },
     "Output": {
         "OutputDirectory": "output/manufactured_solution/",
         "OutputName": "test",
-        "WriteOutput": "false"
+        "WriteOutput": "true"
     }
 }

--- a/applications/compressible_navier_stokes/manufactured_solution/input.json
+++ b/applications/compressible_navier_stokes/manufactured_solution/input.json
@@ -21,6 +21,6 @@
     "Output": {
         "OutputDirectory": "output/manufactured_solution/",
         "OutputName": "test",
-        "WriteOutput": "true"
+        "WriteOutput": "false"
     }
 }

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -96,6 +96,9 @@ public:
                         enable_adaptivity,
                         "Enable adaptive mesh refinement.",
                         dealii::Patterns::Bool());
+      prm.add_parameter("WriteRestart", write_restart, "Should restart files be written?");
+      prm.add_parameter("ReadRestart", read_restart, "Is this a restarted simulation?");
+      prm.add_parameter("ApplyManifold", apply_manifold, "Apply the `DeformedCubeManifold`?");
     }
     prm.leave_subsection();
   }
@@ -121,8 +124,8 @@ private:
     this->param.treatment_of_convective_term = TreatmentOfConvectiveTerm::Implicit;
     this->param.start_with_low_order         = false;
 
-    //    this->param.temporal_discretization      = TemporalDiscretization::ExplRK;
-    //    this->param.time_integrator_rk           = TimeIntegratorRK::ExplRK3Stage7Reg2;
+    // this->param.temporal_discretization      = TemporalDiscretization::ExplRK;
+    // this->param.time_integrator_rk           = TimeIntegratorRK::ExplRK3Stage7Reg2;
 
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
     this->param.adaptive_time_stepping        = false;
@@ -130,16 +133,28 @@ private:
     this->param.cfl                           = 0.25;
     this->param.exponent_fe_degree_convection = 1.5;
 
-    // restart
-    this->param.restart_data.write_restart = false;
-    this->param.restart_data.filename      = "output_conv_diff/rotating_hill";
-    this->param.restart_data.interval_time = 0.4;
-
-
     // SPATIAL DISCRETIZATION
     this->param.grid.triangulation_type     = TriangulationType::Distributed;
     this->param.mapping_degree              = this->param.degree;
     this->param.mapping_degree_coarse_grids = this->param.mapping_degree;
+
+    // restart
+    this->param.restarted_simulation       = read_restart;
+    this->param.restart_data.write_restart = write_restart;
+    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
+    this->param.restart_data.filename =
+      this->output_parameters.directory + this->output_parameters.filename + "_restart";
+    this->param.restart_data.interval_wall_time  = 1.e6;
+    this->param.restart_data.interval_time_steps = 1e8;
+
+    this->param.restart_data.degree_u                   = 5;
+    this->param.restart_data.degree_p                   = 5;
+    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
+    this->param.restart_data.discretization_identical   = false;
+    this->param.restart_data.consider_mapping           = true;
+    this->param.restart_data.mapping_degree             = this->param.mapping_degree;
+    this->param.restart_data.rpe_tolerance_unit_cell    = 1e-2;
+    this->param.restart_data.rpe_enforce_unique_mapping = false;
 
     this->param.enable_adaptivity = enable_adaptivity;
 
@@ -215,11 +230,18 @@ private:
         dealii::GridGenerator::hyper_cube(tria, left, right);
 
         // For AMR, we want to consider a mapping as well.
-        if(this->param.enable_adaptivity)
+        if(apply_manifold)
         {
           unsigned int const frequency   = 1;
           double const       deformation = (right - left) * 0.1;
           apply_deformed_cube_manifold(tria, left, right, deformation, frequency);
+        }
+
+        // Save the *coarse* triangulation for later deserialization.
+        if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
+        {
+          save_coarse_triangulation<dim, dealii::Triangulation<dim>>(
+            this->param.restart_data.filename, tria);
         }
 
         tria.refine_global(global_refinements);
@@ -289,6 +311,9 @@ private:
   double const right = +1.0;
 
   bool enable_adaptivity = false;
+  bool write_restart     = false;
+  bool read_restart      = false;
+  bool apply_manifold    = false;
 };
 
 } // namespace ConvDiff

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -229,7 +229,7 @@ private:
         // hypercube volume is [left,right]^dim
         dealii::GridGenerator::hyper_cube(tria, left, right);
 
-        // For AMR, we want to consider a mapping as well.
+        // Consider a mapped interior of the grid if desired.
         if(apply_manifold)
         {
           unsigned int const frequency   = 1;

--- a/applications/convection_diffusion/rotating_hill/input.json
+++ b/applications/convection_diffusion/rotating_hill/input.json
@@ -15,7 +15,10 @@
         "RefineTimeMax": "0"
     },
     "Application": {
-        "EnableAdaptivity": "true"
+        "EnableAdaptivity": "true",
+        "ReadRestart": "false",
+        "WriteRestart": "false",
+        "ApplyManifold": "true"
     },
     "Output": {
         "OutputDirectory": "output/rotating_hill/",

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.json
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.json
@@ -18,7 +18,7 @@
         "EnableAdaptivity": "false",
         "ReadRestart": "false",
         "WriteRestart": "false",
-        "ApplyManifold": "true"
+        "ApplyManifold": "false"
     },
     "Output": {
         "OutputDirectory": "output/rotating_hill/",

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.json
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.json
@@ -15,6 +15,10 @@
         "RefineTimeMax": "0"
     },
     "Application": {
+        "EnableAdaptivity": "false",
+        "ReadRestart": "false",
+        "WriteRestart": "false",
+        "ApplyManifold": "true"
     },
     "Output": {
         "OutputDirectory": "output/rotating_hill/",

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int_amr.json
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int_amr.json
@@ -15,7 +15,10 @@
         "RefineTimeMax": "0"
     },
     "Application": {
-        "EnableAdaptivity": "true"
+        "EnableAdaptivity": "true",
+        "ReadRestart": "false",
+        "WriteRestart": "false",
+        "ApplyManifold": "true"
     },
     "Output": {
         "OutputDirectory": "output/rotating_hill/",

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -60,6 +60,19 @@ public:
   {
   }
 
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+      prm.add_parameter("WriteRestart", write_restart, "Should restart files be written?");
+      prm.add_parameter("ReadRestart", read_restart, "Is this a restarted simulation?");
+    }
+    prm.leave_subsection();
+  }
+
 private:
   void
   set_parameters() final
@@ -113,6 +126,24 @@ private:
     // NUMERICAL PARAMETERS
     this->param.use_combined_operator                   = true;
     this->param.store_analytical_velocity_in_dof_vector = false;
+
+    // restart
+    this->param.restarted_simulation       = read_restart;
+    this->param.restart_data.write_restart = write_restart;
+    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
+    this->param.restart_data.filename =
+      this->output_parameters.directory + this->output_parameters.filename + "_restart";
+    this->param.restart_data.interval_wall_time  = 1.e6;
+    this->param.restart_data.interval_time_steps = 1e8;
+
+    this->param.restart_data.degree_u                   = 7;
+    this->param.restart_data.degree_p                   = 7;
+    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
+    this->param.restart_data.discretization_identical   = false;
+    this->param.restart_data.consider_mapping           = false;
+    this->param.restart_data.mapping_degree             = this->param.mapping_degree;
+    this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;
+    this->param.restart_data.rpe_enforce_unique_mapping = false;
   }
 
   void
@@ -143,6 +174,13 @@ private:
             if((std::fabs(cell.face(f)->center()(0) - right) < 1e-12))
               cell.face(f)->set_boundary_id(1);
           }
+        }
+
+        // Save the *coarse* triangulation for later deserialization.
+        if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
+        {
+          save_coarse_triangulation<dim, dealii::Triangulation<dim>>(
+            this->param.restart_data.filename, tria);
         }
 
         tria.refine_global(global_refinements);
@@ -235,6 +273,9 @@ private:
   double const right = +1.0;
 
   bool const ale = false;
+
+  bool read_restart  = false;
+  bool write_restart = false;
 };
 
 } // namespace ConvDiff

--- a/applications/convection_diffusion/sine_wave/input.json
+++ b/applications/convection_diffusion/sine_wave/input.json
@@ -15,6 +15,8 @@
         "RefineTimeMax": "0"
     },
     "Application": {
+        "ReadRestart": "false",
+        "WriteRestart": "false"
     },
     "Output": {
         "OutputDirectory": "output/sine_wave/",

--- a/include/exadg/acoustic_conservation_equations/driver.cpp
+++ b/include/exadg/acoustic_conservation_equations/driver.cpp
@@ -77,7 +77,7 @@ Driver<dim, Number>::setup()
     postprocessor->setup(*pde_operator);
 
     // create and setup time integrator
-    time_integrator = std::make_shared<TimeIntAdamsBashforthMoulton<Number>>(
+    time_integrator = std::make_shared<TimeIntAdamsBashforthMoulton<dim, Number>>(
       pde_operator, application->get_parameters(), postprocessor, mpi_comm, is_test);
     time_integrator->setup(application->get_parameters().restarted_simulation);
   }

--- a/include/exadg/acoustic_conservation_equations/driver.h
+++ b/include/exadg/acoustic_conservation_equations/driver.h
@@ -119,7 +119,7 @@ private:
    */
 
   // unsteady solver
-  std::shared_ptr<TimeIntAdamsBashforthMoulton<Number>> time_integrator;
+  std::shared_ptr<TimeIntAdamsBashforthMoulton<dim, Number>> time_integrator;
 
   /*
    * Computation time (wall clock time).

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/interface.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/interface.h
@@ -31,10 +31,11 @@ namespace Acoustics
 {
 namespace Interface
 {
-template<typename Number>
+template<int dim, typename Number>
 class SpatialOperator
 {
 public:
+  using VectorType      = dealii::LinearAlgebra::distributed::Vector<Number>;
   using BlockVectorType = dealii::LinearAlgebra::distributed::BlockVector<Number>;
 
   virtual ~SpatialOperator() = default;
@@ -51,6 +52,13 @@ public:
   // time integration: evaluate
   virtual void
   evaluate(BlockVectorType & dst, BlockVectorType const & src, double const time) const = 0;
+
+  // required for restart functionality
+  virtual void
+  serialize_vectors(std::vector<BlockVectorType const *> block_vectors) const = 0;
+
+  virtual void
+  deserialize_vectors(std::vector<BlockVectorType *> block_vectors) const = 0;
 
   virtual double
   calculate_time_step_cfl() const = 0;

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -24,10 +24,12 @@
 
 // ExaDG
 #include <exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h>
+#include <exadg/grid/grid_utilities.h>
 #include <exadg/grid/mapping_dof_vector.h>
 #include <exadg/operators/finite_element.h>
 #include <exadg/operators/grid_related_time_step_restrictions.h>
 #include <exadg/operators/quadrature.h>
+#include <exadg/time_integration/restart.h>
 #include <exadg/utilities/exceptions.h>
 
 namespace ExaDG
@@ -43,7 +45,7 @@ SpatialOperator<dim, Number>::SpatialOperator(
   Parameters const &                             parameters_in,
   std::string const &                            field_in,
   MPI_Comm const &                               mpi_comm_in)
-  : Interface::SpatialOperator<Number>(),
+  : Interface::SpatialOperator<dim, Number>(),
     grid(grid_in),
     mapping(mapping_in),
     boundary_descriptor(boundary_descriptor_in),
@@ -240,6 +242,133 @@ dealii::DoFHandler<dim> const &
 SpatialOperator<dim, Number>::get_dof_handler_u() const
 {
   return dof_handler_u;
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::serialize_vectors(
+  std::vector<BlockVectorType const *> block_vectors) const
+{
+  std::vector<dealii::DoFHandler<dim> const *> dof_handlers(2);
+  dof_handlers.at(block_index_velocity) = &this->get_dof_handler_u();
+  dof_handlers.at(block_index_pressure) = &this->get_dof_handler_p();
+
+  std::vector<std::vector<VectorType const *>> vectors_per_dof_handler =
+    get_vectors_per_block<VectorType const, BlockVectorType const>(block_vectors);
+
+  if(param.restart_data.consider_mapping)
+  {
+    store_vectors_in_triangulation_and_serialize(
+      param.restart_data.filename,
+      vectors_per_dof_handler,
+      dof_handlers,
+      *this->get_mapping(),
+      &this->get_dof_handler_u() /* dof_handler_mapping */,
+      param.mapping_degree);
+  }
+  else
+  {
+    store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
+                                                 vectors_per_dof_handler,
+                                                 dof_handlers);
+  }
+}
+
+template<int dim, typename Number>
+void
+SpatialOperator<dim, Number>::deserialize_vectors(
+  std::vector<BlockVectorType *> block_vectors) const
+{
+  // Store ghost state to recover after deserialization.
+  std::vector<bool> const has_ghost_elements = get_ghost_state(block_vectors);
+
+  // Load potentially unfitting checkpoint triangulation of TriangulationType.
+  std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
+    deserialize_triangulation<dim>(this->get_dof_handler_u().get_triangulation(),
+                                   param.restart_data.filename,
+                                   param.restart_data.triangulation_type,
+                                   mpi_comm);
+
+  // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  dealii::DoFHandler<dim> checkpoint_dof_handler_u(*checkpoint_triangulation);
+  dealii::DoFHandler<dim> checkpoint_dof_handler_p(*checkpoint_triangulation);
+  ElementType             checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_u =
+    create_finite_element<dim>(checkpoint_element_type, true, dim, param.restart_data.degree_u);
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_p =
+    create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
+  checkpoint_dof_handler_u.distribute_dofs(*checkpoint_fe_u);
+  checkpoint_dof_handler_p.distribute_dofs(*checkpoint_fe_p);
+  std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers(2);
+  checkpoint_dof_handlers[block_index_velocity] = &checkpoint_dof_handler_u;
+  checkpoint_dof_handlers[block_index_pressure] = &checkpoint_dof_handler_p;
+
+  // Deserialize vectors stored in triangulation, sequence matches `this->serialize_vectors()`.
+  std::vector<BlockVectorType> checkpoint_block_vectors =
+    get_block_vectors_from_dof_handlers<dim, BlockVectorType>(block_vectors.size(),
+                                                              checkpoint_dof_handlers);
+
+  std::vector<std::vector<VectorType *>> checkpoint_vectors =
+    get_vectors_per_block<VectorType, BlockVectorType>(checkpoint_block_vectors);
+
+  if(param.restart_data.discretization_identical)
+  {
+    // DoFHandlers need to be setup with `checkpoint_triangulation`, otherwise
+    // they are identical. We can simply copy the vector contents.
+    load_vectors(checkpoint_vectors, checkpoint_dof_handlers);
+    for(unsigned int i = 0; i < block_vectors.size(); ++i)
+    {
+      *block_vectors[i] = checkpoint_block_vectors[i];
+    }
+  }
+  else
+  {
+    // Perform global projection in case of a non-matching discretization.
+    std::vector<dealii::DoFHandler<dim> const *> dof_handlers(2);
+    dof_handlers.at(block_index_velocity) = &this->get_dof_handler_u();
+    dof_handlers.at(block_index_pressure) = &this->get_dof_handler_p();
+
+    std::vector<std::vector<VectorType *>> vectors_per_dof_handler =
+      get_vectors_per_block<VectorType, BlockVectorType>(block_vectors);
+
+    // Deserialize mapping from vector or project on reference trianuglations.
+    std::shared_ptr<dealii::Mapping<dim> const> target_mapping;
+    std::shared_ptr<dealii::Mapping<dim>>       checkpoint_mapping;
+    if(param.restart_data.consider_mapping)
+    {
+      target_mapping     = this->get_mapping();
+      checkpoint_mapping = load_vectors(checkpoint_vectors,
+                                        checkpoint_dof_handlers,
+                                        &checkpoint_dof_handler_u /* dof_handler_mapping */,
+                                        param.restart_data.mapping_degree);
+    }
+    else
+    {
+      load_vectors(checkpoint_vectors, checkpoint_dof_handlers);
+
+      // Create dummy linear mappings since we have no mapping serialized to restore.
+      GridUtilities::create_mapping(checkpoint_mapping,
+                                    get_element_type(*checkpoint_triangulation),
+                                    1 /* mapping_degree */);
+      std::shared_ptr<dealii::Mapping<dim>> tmp;
+      GridUtilities::create_mapping(tmp,
+                                    get_element_type(dof_handlers.at(0)->get_triangulation()),
+                                    1 /* mapping_degree */);
+      target_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
+    }
+
+    grid_to_grid_projection(checkpoint_vectors,
+                            checkpoint_dof_handlers,
+                            checkpoint_mapping,
+                            vectors_per_dof_handler,
+                            dof_handlers,
+                            target_mapping,
+                            param.restart_data.rpe_tolerance_unit_cell,
+                            param.restart_data.rpe_enforce_unique_mapping);
+  }
+
+  // Recover ghost vector state.
+  set_ghost_state(block_vectors, has_ghost_elements);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -292,7 +292,7 @@ SpatialOperator<dim, Number>::deserialize_vectors(
   // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
   dealii::DoFHandler<dim> checkpoint_dof_handler_u(*checkpoint_triangulation);
   dealii::DoFHandler<dim> checkpoint_dof_handler_p(*checkpoint_triangulation);
-  ElementType             checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+  ElementType const       checkpoint_element_type = get_element_type(*checkpoint_triangulation);
   std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_u =
     create_finite_element<dim>(checkpoint_element_type, true, dim, param.restart_data.degree_u);
   std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_p =
@@ -336,7 +336,7 @@ SpatialOperator<dim, Number>::deserialize_vectors(
     std::vector<std::vector<VectorType *>> vectors_per_dof_handler =
       get_vectors_per_block<VectorType, BlockVectorType>(block_vectors);
 
-    // Deserialize mapping from vector or project on reference trianuglations.
+    // Deserialize mapping from vector or project on reference triangulations.
     std::shared_ptr<dealii::Mapping<dim> const> target_mapping;
     std::shared_ptr<dealii::Mapping<dim>>       checkpoint_mapping;
     if(param.restart_data.consider_mapping)

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -308,8 +308,13 @@ SpatialOperator<dim, Number>::deserialize_vectors(
     get_block_vectors_from_dof_handlers<dim, BlockVectorType>(block_vectors.size(),
                                                               checkpoint_dof_handlers);
 
+  std::vector<BlockVectorType *> checkpoint_block_vectors_ptr;
+  for(unsigned int i = 0; i < checkpoint_block_vectors.size(); ++i)
+  {
+    checkpoint_block_vectors_ptr.push_back(&checkpoint_block_vectors[i]);
+  }
   std::vector<std::vector<VectorType *>> checkpoint_vectors =
-    get_vectors_per_block<VectorType, BlockVectorType>(checkpoint_block_vectors);
+    get_vectors_per_block<VectorType, BlockVectorType>(checkpoint_block_vectors_ptr);
 
   if(param.restart_data.discretization_identical)
   {

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
@@ -53,10 +53,10 @@ namespace Acoustics
  * already scaled by the density rho * u.
  */
 template<int dim, typename Number>
-class SpatialOperator : public Interface::SpatialOperator<Number>
+class SpatialOperator : public Interface::SpatialOperator<dim, Number>
 {
-  using BlockVectorType = typename Interface::SpatialOperator<Number>::BlockVectorType;
-  using VectorType      = dealii::LinearAlgebra::distributed::Vector<Number>;
+  using VectorType      = typename Interface::SpatialOperator<dim, Number>::VectorType;
+  using BlockVectorType = typename Interface::SpatialOperator<dim, Number>::BlockVectorType;
 
 public:
   static unsigned int const block_index_pressure = 0;
@@ -133,6 +133,12 @@ public:
 
   dealii::DoFHandler<dim> const &
   get_dof_handler_u() const;
+
+  void
+  serialize_vectors(std::vector<BlockVectorType const *> block_vectors) const final;
+
+  void
+  deserialize_vectors(std::vector<BlockVectorType *> block_vectors) const final;
 
   dealii::AffineConstraints<Number> const &
   get_constraint_p() const;

--- a/include/exadg/acoustic_conservation_equations/time_integration/time_int_abm.h
+++ b/include/exadg/acoustic_conservation_equations/time_integration/time_int_abm.h
@@ -32,18 +32,19 @@ namespace ExaDG
 {
 namespace Acoustics
 {
-template<typename Number>
+template<int dim, typename Number>
 class TimeIntAdamsBashforthMoulton
-  : public TimeIntAdamsBashforthMoultonBase<Interface::SpatialOperator<Number>,
+  : public TimeIntAdamsBashforthMoultonBase<Interface::SpatialOperator<dim, Number>,
                                             dealii::LinearAlgebra::distributed::BlockVector<Number>>
 {
 public:
-  TimeIntAdamsBashforthMoulton(std::shared_ptr<Interface::SpatialOperator<Number>> pde_operator_in,
-                               Parameters const &                                  param_in,
-                               std::shared_ptr<PostProcessorInterface<Number>>     postprocessor_in,
-                               MPI_Comm const &                                    mpi_comm_in,
-                               bool const                                          is_test_in)
-    : TimeIntAdamsBashforthMoultonBase<Interface::SpatialOperator<Number>,
+  TimeIntAdamsBashforthMoulton(
+    std::shared_ptr<Interface::SpatialOperator<dim, Number>> pde_operator_in,
+    Parameters const &                                       param_in,
+    std::shared_ptr<PostProcessorInterface<Number>>          postprocessor_in,
+    MPI_Comm const &                                         mpi_comm_in,
+    bool const                                               is_test_in)
+    : TimeIntAdamsBashforthMoultonBase<Interface::SpatialOperator<dim, Number>,
                                        dealii::LinearAlgebra::distributed::BlockVector<Number>>(
         pde_operator_in,
         param_in.start_time,

--- a/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
+++ b/include/exadg/aero_acoustic/single_field_solvers/acoustics.h
@@ -62,7 +62,7 @@ public:
     postprocessor->setup(*pde_operator);
 
     // initialize time integrator
-    time_integrator = std::make_shared<Acoustics::TimeIntAdamsBashforthMoulton<Number>>(
+    time_integrator = std::make_shared<Acoustics::TimeIntAdamsBashforthMoulton<dim, Number>>(
       pde_operator, application->get_parameters(), postprocessor, mpi_comm, is_test);
 
     time_integrator->setup(application->get_parameters().restarted_simulation);
@@ -125,7 +125,7 @@ public:
   std::shared_ptr<Acoustics::SpatialOperator<dim, Number>> pde_operator;
 
   // temporal discretization
-  std::shared_ptr<Acoustics::TimeIntAdamsBashforthMoulton<Number>> time_integrator;
+  std::shared_ptr<Acoustics::TimeIntAdamsBashforthMoulton<dim, Number>> time_integrator;
 
   // postprocessor
   std::shared_ptr<Acoustics::PostProcessorBase<dim, Number>> postprocessor;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/interface.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/interface.h
@@ -48,6 +48,13 @@ public:
   virtual void
   initialize_dof_vector(VectorType & src) const = 0;
 
+  // required for restart functionality
+  virtual void
+  serialize_vectors(std::vector<VectorType const *> const & vectors) const = 0;
+
+  virtual void
+  deserialize_vectors(std::vector<VectorType *> const & vectors) = 0;
+
   // time integration: prescribe initial conditions
   virtual void
   prescribe_initial_conditions(VectorType & src, double const evaluation_time) const = 0;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -28,6 +28,7 @@
 #include <exadg/operators/finite_element.h>
 #include <exadg/operators/grid_related_time_step_restrictions.h>
 #include <exadg/operators/quadrature.h>
+#include <exadg/time_integration/restart.h>
 
 namespace ExaDG
 {
@@ -75,6 +76,15 @@ Operator<dim, Number>::initialize_dof_handler_and_constraints()
   dof_handler.distribute_dofs(*fe);
   dof_handler_vector.distribute_dofs(*fe_vector);
   dof_handler_scalar.distribute_dofs(*fe_scalar);
+
+  if(param.restart_data.consider_mapping and
+     (param.restarted_simulation or param.restart_data.write_restart))
+  {
+    fe_mapping =
+      create_finite_element<dim>(ElementType::Hypercube, true, dim, param.mapping_degree);
+    dof_handler_mapping = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
+    dof_handler_mapping->distribute_dofs(*fe_mapping);
+  }
 
   constraint.close();
 
@@ -343,16 +353,118 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const & vectors) const
 {
-  // ##+
-  (void)vectors;
+  std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+  std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
+  if(param.restart_data.consider_mapping)
+  {
+    store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
+                                                 vectors_per_dof_handler,
+                                                 dof_handlers,
+                                                 this->get_mapping(),
+                                                 &(*dof_handler_mapping),
+                                                 param.mapping_degree);
+  }
+  else
+  {
+    store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
+                                                 vectors_per_dof_handler,
+                                                 dof_handlers);
+  }
 }
 
 template<int dim, typename Number>
 void
 Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vectors)
 {
-  // ##+
-  vectors.at(0)->add(1.2345);
+  // Store ghost state to recover after deserialization.
+  std::vector<bool> const has_ghost_elements = get_ghost_state(vectors);
+
+  // Load potentially unfitting checkpoint triangulation of TriangulationType.
+  std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
+    deserialize_triangulation<dim>(dof_handler.get_triangulation(),
+                                   param.restart_data.filename,
+                                   param.restart_data.triangulation_type,
+                                   mpi_comm);
+
+  // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  dealii::DoFHandler<dim> checkpoint_dof_handler(*checkpoint_triangulation);
+  dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
+
+  ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe =
+    create_finite_element<dim>(checkpoint_element_type, true, dim + 2, param.restart_data.degree_u);
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping = create_finite_element<dim>(
+    checkpoint_element_type, true, dim, param.restart_data.mapping_degree);
+
+  checkpoint_dof_handler.distribute_dofs(*checkpoint_fe);
+  checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
+
+  std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler};
+
+  std::vector<VectorType>                checkpoint_vectors(vectors.size());
+  std::vector<std::vector<VectorType *>> checkpoint_vectors_ptr(1);
+  checkpoint_vectors_ptr[0].resize(vectors.size());
+  for(unsigned int i = 0; i < vectors.size(); ++i)
+  {
+    checkpoint_vectors[i].reinit(checkpoint_dof_handler.locally_owned_dofs(), mpi_comm);
+    checkpoint_vectors_ptr[0][i] = &checkpoint_vectors[i];
+  }
+
+  if(param.restart_data.discretization_identical)
+  {
+    // DoFHandlers need to be setup with `checkpoint_triangulation`, otherwise
+    // they are identical. We can simply copy the vector contents.
+    load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
+    for(unsigned int i = 0; i < vectors.size(); ++i)
+    {
+      *vectors[i] = checkpoint_vectors[i];
+    }
+  }
+  else
+  {
+    // Perform global projection in case of a non-matching discretization.
+    std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+    std::vector<std::vector<VectorType *>>       vectors_per_dof_handler{vectors};
+
+    // Deserialize mapping from vector or project on reference trianuglations.
+    std::shared_ptr<dealii::Mapping<dim> const> target_mapping;
+    std::shared_ptr<dealii::Mapping<dim>>       checkpoint_mapping;
+    if(param.restart_data.consider_mapping)
+    {
+      target_mapping     = mapping;
+      checkpoint_mapping = load_vectors(checkpoint_vectors_ptr,
+                                        checkpoint_dof_handlers,
+                                        &checkpoint_dof_handler_mapping,
+                                        param.restart_data.mapping_degree);
+    }
+    else
+    {
+      load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
+
+      // Create dummy linear mappings since we have no mapping serialized to restore.
+      GridUtilities::create_mapping(checkpoint_mapping,
+                                    get_element_type(*checkpoint_triangulation),
+                                    1 /* mapping_degree */);
+      std::shared_ptr<dealii::Mapping<dim>> tmp;
+      GridUtilities::create_mapping(tmp,
+                                    get_element_type(dof_handlers.at(0)->get_triangulation()),
+                                    1 /* mapping_degree */);
+      target_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
+    }
+
+    grid_to_grid_projection(checkpoint_vectors_ptr,
+                            checkpoint_dof_handlers,
+                            checkpoint_mapping,
+                            vectors_per_dof_handler,
+                            dof_handlers,
+                            target_mapping,
+                            param.restart_data.rpe_tolerance_unit_cell,
+                            param.restart_data.rpe_enforce_unique_mapping);
+  }
+
+  // Recover ghost vector state.
+  set_ghost_state(vectors, has_ghost_elements);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -341,6 +341,22 @@ Operator<dim, Number>::prescribe_initial_conditions(VectorType & src, double con
 
 template<int dim, typename Number>
 void
+Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const & vectors) const
+{
+  // ##+
+  (void)vectors;
+}
+
+template<int dim, typename Number>
+void
+Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vectors)
+{
+  // ##+
+  vectors.at(0)->add(1.2345);
+}
+
+template<int dim, typename Number>
+void
 Operator<dim, Number>::evaluate(VectorType & dst, VectorType const & src, Number const time) const
 {
   dealii::Timer timer;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -89,6 +89,13 @@ public:
   void
   initialize_dof_vector_dim_components(VectorType & src) const;
 
+  // required for restart functionality
+  void
+  serialize_vectors(std::vector<VectorType const *> const & vectors) const final;
+
+  void
+  deserialize_vectors(std::vector<VectorType *> const & vectors) final;
+
   // set initial conditions
   void
   prescribe_initial_conditions(VectorType & src, double const time) const final;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -250,6 +250,10 @@ private:
   std::string const quad_index_overintegration_conv = "overintegration_conv";
   std::string const quad_index_overintegration_vis  = "overintegration_vis";
 
+  // required for de-/serialization
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_mapping;
+  std::shared_ptr<dealii::DoFHandler<dim>>    dof_handler_mapping;
+
   std::string const quad_index_l2_projections = quad_index_standard;
   // alternative: use more accurate over-integration strategy
   //  std::string const quad_index_l2_projections = quad_index_overintegration_conv;

--- a/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.cpp
@@ -121,6 +121,20 @@ TimeIntExplRK<Number>::initialize_solution()
   pde_operator->prescribe_initial_conditions(this->solution_n, this->time);
 }
 
+template<typename Number>
+void
+TimeIntExplRK<Number>::read_restart_vectors(std::vector<VectorType *> const & vectors)
+{
+  pde_operator->deserialize_vectors(vectors);
+}
+
+template<typename Number>
+void
+TimeIntExplRK<Number>::write_restart_vectors(std::vector<VectorType const *> const & vectors) const
+{
+  pde_operator->serialize_vectors(vectors);
+}
+
 /*
  *  calculate time step size
  */

--- a/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.h
+++ b/include/exadg/compressible_navier_stokes/time_integration/time_int_explicit_runge_kutta.h
@@ -75,6 +75,12 @@ private:
   initialize_solution() final;
 
   void
+  read_restart_vectors(std::vector<VectorType *> const & vectors) final;
+
+  void
+  write_restart_vectors(std::vector<VectorType const *> const & vectors) const final;
+
+  void
   detect_instabilities() const;
 
   void

--- a/include/exadg/convection_diffusion/spatial_discretization/interface.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/interface.h
@@ -80,6 +80,13 @@ public:
   virtual void
   project_velocity(VectorType & velocity, double const time) const = 0;
 
+  // required for restart functionality
+  virtual void
+  serialize_vectors(std::vector<VectorType const *> const & vectors) const = 0;
+
+  virtual void
+  deserialize_vectors(std::vector<VectorType *> const & vectors) = 0;
+
   // time integration: prescribe initial conditions
   virtual void
   prescribe_initial_conditions(VectorType & src, double const evaluation_time) const = 0;
@@ -152,6 +159,19 @@ public:
   initialize_dof_vector_velocity(VectorType & src) const
   {
     pde_operator->initialize_dof_vector_velocity(src);
+  }
+
+  // are these really needed? ##+
+  void
+  serialize_vectors(std::vector<VectorType const *> const & vectors) const
+  {
+    pde_operator->serialize_vectors(vectors);
+  }
+
+  void
+  deserialize_vectors(std::vector<VectorType *> const & vectors)
+  {
+    pde_operator->deserialize_vectors(vectors);
   }
 
 private:

--- a/include/exadg/convection_diffusion/spatial_discretization/interface.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/interface.h
@@ -161,19 +161,6 @@ public:
     pde_operator->initialize_dof_vector_velocity(src);
   }
 
-  // are these really needed? ##+
-  void
-  serialize_vectors(std::vector<VectorType const *> const & vectors) const
-  {
-    pde_operator->serialize_vectors(vectors);
-  }
-
-  void
-  deserialize_vectors(std::vector<VectorType *> const & vectors)
-  {
-    pde_operator->deserialize_vectors(vectors);
-  }
-
 private:
   std::shared_ptr<ConvDiff::Interface::Operator<Number>> pde_operator;
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -35,6 +35,7 @@
 #include <exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h>
+#include <exadg/time_integration/restart.h>
 
 namespace ExaDG
 {
@@ -72,6 +73,19 @@ Operator<dim, Number>::Operator(
     dof_handler_velocity = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
   }
 
+  if(param.degree)
+  {
+    fe_velocity = create_finite_element<dim>(ElementType::Hypercube, true, dim, param.degree);
+    dof_handler_velocity = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
+  }
+
+  if(needs_dof_handler_mapping())
+  {
+    fe_mapping =
+      create_finite_element<dim>(ElementType::Hypercube, true, dim, param.mapping_degree);
+    dof_handler_mapping = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
+  }
+
   initialize_dof_handler_and_constraints();
 
   pcout << std::endl
@@ -94,6 +108,11 @@ Operator<dim, Number>::initialize_dof_handler_and_constraints()
   if(needs_own_dof_handler_velocity())
   {
     dof_handler_velocity->distribute_dofs(*fe_velocity);
+  }
+
+  if(needs_dof_handler_mapping())
+  {
+    dof_handler_mapping->distribute_dofs(*fe_mapping);
   }
 
   affine_constraints.close();
@@ -587,16 +606,118 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const & vectors) const
 {
-  // ##+
-  (void)vectors;
+  if(param.temporal_discretization == TemporalDiscretization::ExplRK)
+  {
+    std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+    if(param.restart_data.consider_mapping)
+    {
+      store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
+                                                   vectors,
+                                                   dof_handlers,
+                                                   *this->get_mapping(),
+                                                   &(*dof_handler_mapping),
+                                                   param.mapping_degree);
+    }
+    else
+    {
+      store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
+                                                   vectors,
+                                                   dof_handlers);
+    }
+  }
+  else
+  {
+    AssertThrow(false, dealii::ExcNotImplemented());
+  }
 }
 
 template<int dim, typename Number>
 void
 Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vectors)
 {
-  // ##+
-  vectors.at(0)->add(1.2345);
+  if(param.temporal_discretization == TemporalDiscretization::ExplRK)
+  {
+    // Store ghost state to recover after deserialization.
+    std::vector<bool> const has_ghost_elements = get_ghost_state(vectors);
+
+    // Load potentially unfitting checkpoint triangulation of TriangulationType.
+    std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
+      deserialize_triangulation<dim>(dof_handler.get_triangulation(),
+                                     param.restart_data.filename,
+                                     param.restart_data.triangulation_type,
+                                     mpi_comm);
+
+    // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+    dealii::DoFHandler<dim> checkpoint_dof_handler(*checkpoint_triangulation);
+    ElementType const       checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+    std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe =
+      create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
+    checkpoint_dof_handler.distribute_dofs(*checkpoint_fe);
+    std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler};
+
+    if(param.restart_data.discretization_identical)
+    {
+      // DoFHandlers need to be setup with `checkpoint_triangulation`, otherwise
+      // they are identical. We can load the contents into the vectors.
+      load_vectors(vectors, checkpoint_dof_handlers);
+    }
+    else
+    {
+      // Perform global projection in case of a non-matching discretization.
+      std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+
+      // Deserialize mapping from vector or project on reference trianuglations.
+      std::shared_ptr<dealii::Mapping<dim> const> target_mapping;
+      std::shared_ptr<dealii::Mapping<dim>>       checkpoint_mapping;
+
+      std::vector<VectorType>   checkpoint_vectors(vectors.size);
+      std::vector<VectorType *> checkpoint_vectors_ptr(vectors.size);
+      for(unsigned int i = 0; i < vectors.size(); ++i)
+      {
+        checkpoint_vectors[i].reinit(checkpoint_dof_handler.locally_owned_dofs, mpi_comm);
+        checkpoint_vectors[i] = &checkpoint_vectors[i];
+      }
+
+      if(param.restart_data.consider_mapping)
+      {
+        target_mapping     = this->get_mapping();
+        checkpoint_mapping = load_vectors(checkpoint_vectors,
+                                          checkpoint_dof_handlers,
+                                          &(*dof_handler_mapping),
+                                          param.restart_data.mapping_degree);
+      }
+      else
+      {
+        load_vectors(checkpoint_vectors, checkpoint_dof_handlers);
+
+        // Create dummy linear mappings since we have no mapping serialized to restore.
+        GridUtilities::create_mapping(checkpoint_mapping,
+                                      get_element_type(*checkpoint_triangulation),
+                                      1 /* mapping_degree */);
+        std::shared_ptr<dealii::Mapping<dim>> tmp;
+        GridUtilities::create_mapping(tmp,
+                                      get_element_type(dof_handlers.at(0)->get_triangulation()),
+                                      1 /* mapping_degree */);
+        target_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
+      }
+
+      grid_to_grid_projection(checkpoint_vectors,
+                              checkpoint_dof_handlers,
+                              checkpoint_mapping,
+                              vectors,
+                              dof_handlers,
+                              target_mapping,
+                              param.restart_data.rpe_tolerance_unit_cell,
+                              param.restart_data.rpe_enforce_unique_mapping);
+    }
+
+    // Recover ghost vector state.
+    set_ghost_state(vectors, has_ghost_elements);
+  }
+  else
+  {
+    AssertThrow(false, dealii::ExcNotImplemented());
+  }
 }
 
 template<int dim, typename Number>
@@ -1014,6 +1135,14 @@ bool
 Operator<dim, Number>::needs_own_dof_handler_velocity() const
 {
   return param.analytical_velocity_field and param.store_analytical_velocity_in_dof_vector;
+}
+
+template<int dim, typename Number>
+bool
+Operator<dim, Number>::needs_dof_handler_mapping() const
+{
+  return param.restart_data.consider_mapping and
+         (param.restart_data.write_restart or param.restarted_simulation);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -585,6 +585,22 @@ Operator<dim, Number>::project_velocity(VectorType & velocity, double const time
 
 template<int dim, typename Number>
 void
+Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const & vectors) const
+{
+  // ##+
+  (void)vectors;
+}
+
+template<int dim, typename Number>
+void
+Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vectors)
+{
+  // ##+
+  vectors.at(0)->add(1.2345);
+}
+
+template<int dim, typename Number>
+void
 Operator<dim, Number>::prescribe_initial_conditions(VectorType & src, double const time) const
 {
   field_functions->initial_solution->set_time(time);

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -600,29 +600,22 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const & vectors) const
 {
-  if(param.temporal_discretization == TemporalDiscretization::ExplRK)
+  std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+  std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
+  if(param.restart_data.consider_mapping)
   {
-    std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
-    std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
-    if(param.restart_data.consider_mapping)
-    {
-      store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
-                                                   vectors_per_dof_handler,
-                                                   dof_handlers,
-                                                   *this->get_mapping(),
-                                                   &(*dof_handler_mapping),
-                                                   param.mapping_degree);
-    }
-    else
-    {
-      store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
-                                                   vectors_per_dof_handler,
-                                                   dof_handlers);
-    }
+    store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
+                                                 vectors_per_dof_handler,
+                                                 dof_handlers,
+                                                 *this->get_mapping(),
+                                                 &(*dof_handler_mapping),
+                                                 param.mapping_degree);
   }
   else
   {
-    AssertThrow(false, dealii::ExcNotImplemented());
+    store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
+                                                 vectors_per_dof_handler,
+                                                 dof_handlers);
   }
 }
 
@@ -630,102 +623,95 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vectors)
 {
-  if(param.temporal_discretization == TemporalDiscretization::ExplRK)
+  // Store ghost state to recover after deserialization.
+  std::vector<bool> const has_ghost_elements = get_ghost_state(vectors);
+
+  // Load potentially unfitting checkpoint triangulation of TriangulationType.
+  std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
+    deserialize_triangulation<dim>(dof_handler.get_triangulation(),
+                                   param.restart_data.filename,
+                                   param.restart_data.triangulation_type,
+                                   mpi_comm);
+
+  // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  dealii::DoFHandler<dim> checkpoint_dof_handler(*checkpoint_triangulation);
+  dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
+
+  ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe =
+    create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping = create_finite_element<dim>(
+    checkpoint_element_type, true, dim, param.restart_data.mapping_degree);
+
+  checkpoint_dof_handler.distribute_dofs(*checkpoint_fe);
+  checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
+
+  std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler};
+
+  std::vector<VectorType>                checkpoint_vectors(vectors.size());
+  std::vector<std::vector<VectorType *>> checkpoint_vectors_ptr(1);
+  checkpoint_vectors_ptr[0].resize(vectors.size());
+  for(unsigned int i = 0; i < vectors.size(); ++i)
   {
-    // Store ghost state to recover after deserialization.
-    std::vector<bool> const has_ghost_elements = get_ghost_state(vectors);
+    checkpoint_vectors[i].reinit(checkpoint_dof_handler.locally_owned_dofs(), mpi_comm);
+    checkpoint_vectors_ptr[0][i] = &checkpoint_vectors[i];
+  }
 
-    // Load potentially unfitting checkpoint triangulation of TriangulationType.
-    std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
-      deserialize_triangulation<dim>(dof_handler.get_triangulation(),
-                                     param.restart_data.filename,
-                                     param.restart_data.triangulation_type,
-                                     mpi_comm);
-
-    // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
-    dealii::DoFHandler<dim> checkpoint_dof_handler(*checkpoint_triangulation);
-    dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
-
-    ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
-
-    std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe =
-      create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
-    std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping = create_finite_element<dim>(
-      checkpoint_element_type, true, dim, param.restart_data.mapping_degree);
-
-    checkpoint_dof_handler.distribute_dofs(*checkpoint_fe);
-    checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
-
-    std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler};
-
-    std::vector<VectorType>                checkpoint_vectors(vectors.size());
-    std::vector<std::vector<VectorType *>> checkpoint_vectors_ptr(1);
-    checkpoint_vectors_ptr[0].resize(vectors.size());
+  if(param.restart_data.discretization_identical)
+  {
+    // DoFHandlers need to be setup with `checkpoint_triangulation`, otherwise
+    // they are identical. We can simply copy the vector contents.
+    load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
     for(unsigned int i = 0; i < vectors.size(); ++i)
     {
-      checkpoint_vectors[i].reinit(checkpoint_dof_handler.locally_owned_dofs(), mpi_comm);
-      checkpoint_vectors_ptr[0][i] = &checkpoint_vectors[i];
+      *vectors[i] = checkpoint_vectors[i];
     }
-
-    if(param.restart_data.discretization_identical)
-    {
-      // DoFHandlers need to be setup with `checkpoint_triangulation`, otherwise
-      // they are identical. We can simply copy the vector contents.
-      load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
-      for(unsigned int i = 0; i < vectors.size(); ++i)
-      {
-        *vectors[i] = checkpoint_vectors[i];
-      }
-    }
-    else
-    {
-      // Perform global projection in case of a non-matching discretization.
-      std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
-      std::vector<std::vector<VectorType *>>       vectors_per_dof_handler{vectors};
-
-      // Deserialize mapping from vector or project on reference trianuglations.
-      std::shared_ptr<dealii::Mapping<dim> const> target_mapping;
-      std::shared_ptr<dealii::Mapping<dim>>       checkpoint_mapping;
-      if(param.restart_data.consider_mapping)
-      {
-        target_mapping     = this->get_mapping();
-        checkpoint_mapping = load_vectors(checkpoint_vectors_ptr,
-                                          checkpoint_dof_handlers,
-                                          &checkpoint_dof_handler_mapping,
-                                          param.restart_data.mapping_degree);
-      }
-      else
-      {
-        load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
-
-        // Create dummy linear mappings since we have no mapping serialized to restore.
-        GridUtilities::create_mapping(checkpoint_mapping,
-                                      get_element_type(*checkpoint_triangulation),
-                                      1 /* mapping_degree */);
-        std::shared_ptr<dealii::Mapping<dim>> tmp;
-        GridUtilities::create_mapping(tmp,
-                                      get_element_type(dof_handlers.at(0)->get_triangulation()),
-                                      1 /* mapping_degree */);
-        target_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
-      }
-
-      grid_to_grid_projection(checkpoint_vectors_ptr,
-                              checkpoint_dof_handlers,
-                              checkpoint_mapping,
-                              vectors_per_dof_handler,
-                              dof_handlers,
-                              target_mapping,
-                              param.restart_data.rpe_tolerance_unit_cell,
-                              param.restart_data.rpe_enforce_unique_mapping);
-    }
-
-    // Recover ghost vector state.
-    set_ghost_state(vectors, has_ghost_elements);
   }
   else
   {
-    AssertThrow(false, dealii::ExcNotImplemented());
+    // Perform global projection in case of a non-matching discretization.
+    std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+    std::vector<std::vector<VectorType *>>       vectors_per_dof_handler{vectors};
+
+    // Deserialize mapping from vector or project on reference trianuglations.
+    std::shared_ptr<dealii::Mapping<dim> const> target_mapping;
+    std::shared_ptr<dealii::Mapping<dim>>       checkpoint_mapping;
+    if(param.restart_data.consider_mapping)
+    {
+      target_mapping     = this->get_mapping();
+      checkpoint_mapping = load_vectors(checkpoint_vectors_ptr,
+                                        checkpoint_dof_handlers,
+                                        &checkpoint_dof_handler_mapping,
+                                        param.restart_data.mapping_degree);
+    }
+    else
+    {
+      load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
+
+      // Create dummy linear mappings since we have no mapping serialized to restore.
+      GridUtilities::create_mapping(checkpoint_mapping,
+                                    get_element_type(*checkpoint_triangulation),
+                                    1 /* mapping_degree */);
+      std::shared_ptr<dealii::Mapping<dim>> tmp;
+      GridUtilities::create_mapping(tmp,
+                                    get_element_type(dof_handlers.at(0)->get_triangulation()),
+                                    1 /* mapping_degree */);
+      target_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
+    }
+
+    grid_to_grid_projection(checkpoint_vectors_ptr,
+                            checkpoint_dof_handlers,
+                            checkpoint_mapping,
+                            vectors_per_dof_handler,
+                            dof_handlers,
+                            target_mapping,
+                            param.restart_data.rpe_tolerance_unit_cell,
+                            param.restart_data.rpe_enforce_unique_mapping);
   }
+
+  // Recover ghost vector state.
+  set_ghost_state(vectors, has_ghost_elements);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -73,12 +73,6 @@ Operator<dim, Number>::Operator(
     dof_handler_velocity = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
   }
 
-  if(param.degree)
-  {
-    fe_velocity = create_finite_element<dim>(ElementType::Hypercube, true, dim, param.degree);
-    dof_handler_velocity = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
-  }
-
   if(needs_dof_handler_mapping())
   {
     fe_mapping =

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -609,10 +609,11 @@ Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const &
   if(param.temporal_discretization == TemporalDiscretization::ExplRK)
   {
     std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+    std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
     if(param.restart_data.consider_mapping)
     {
       store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
-                                                   vectors,
+                                                   vectors_per_dof_handler,
                                                    dof_handlers,
                                                    *this->get_mapping(),
                                                    &(*dof_handler_mapping),
@@ -621,7 +622,7 @@ Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const &
     else
     {
       store_vectors_in_triangulation_and_serialize(param.restart_data.filename,
-                                                   vectors,
+                                                   vectors_per_dof_handler,
                                                    dof_handlers);
     }
   }
@@ -649,46 +650,59 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
 
     // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
     dealii::DoFHandler<dim> checkpoint_dof_handler(*checkpoint_triangulation);
-    ElementType const       checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+    dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
+
+    ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+
     std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe =
       create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
+    std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping = create_finite_element<dim>(
+      checkpoint_element_type, true, dim, param.restart_data.mapping_degree);
+
     checkpoint_dof_handler.distribute_dofs(*checkpoint_fe);
+    checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
+
     std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler};
+
+    std::vector<VectorType>                checkpoint_vectors(vectors.size());
+    std::vector<std::vector<VectorType *>> checkpoint_vectors_ptr(1);
+    checkpoint_vectors_ptr[0].resize(vectors.size());
+    for(unsigned int i = 0; i < vectors.size(); ++i)
+    {
+      checkpoint_vectors[i].reinit(checkpoint_dof_handler.locally_owned_dofs(), mpi_comm);
+      checkpoint_vectors_ptr[0][i] = &checkpoint_vectors[i];
+    }
 
     if(param.restart_data.discretization_identical)
     {
       // DoFHandlers need to be setup with `checkpoint_triangulation`, otherwise
-      // they are identical. We can load the contents into the vectors.
-      load_vectors(vectors, checkpoint_dof_handlers);
+      // they are identical. We can simply copy the vector contents.
+      load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
+      for(unsigned int i = 0; i < vectors.size(); ++i)
+      {
+        *vectors[i] = checkpoint_vectors[i];
+      }
     }
     else
     {
       // Perform global projection in case of a non-matching discretization.
       std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
+      std::vector<std::vector<VectorType *>>       vectors_per_dof_handler{vectors};
 
       // Deserialize mapping from vector or project on reference trianuglations.
       std::shared_ptr<dealii::Mapping<dim> const> target_mapping;
       std::shared_ptr<dealii::Mapping<dim>>       checkpoint_mapping;
-
-      std::vector<VectorType>   checkpoint_vectors(vectors.size);
-      std::vector<VectorType *> checkpoint_vectors_ptr(vectors.size);
-      for(unsigned int i = 0; i < vectors.size(); ++i)
-      {
-        checkpoint_vectors[i].reinit(checkpoint_dof_handler.locally_owned_dofs, mpi_comm);
-        checkpoint_vectors[i] = &checkpoint_vectors[i];
-      }
-
       if(param.restart_data.consider_mapping)
       {
         target_mapping     = this->get_mapping();
-        checkpoint_mapping = load_vectors(checkpoint_vectors,
+        checkpoint_mapping = load_vectors(checkpoint_vectors_ptr,
                                           checkpoint_dof_handlers,
-                                          &(*dof_handler_mapping),
+                                          &checkpoint_dof_handler_mapping,
                                           param.restart_data.mapping_degree);
       }
       else
       {
-        load_vectors(checkpoint_vectors, checkpoint_dof_handlers);
+        load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
 
         // Create dummy linear mappings since we have no mapping serialized to restore.
         GridUtilities::create_mapping(checkpoint_mapping,
@@ -701,10 +715,10 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
         target_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
       }
 
-      grid_to_grid_projection(checkpoint_vectors,
+      grid_to_grid_projection(checkpoint_vectors_ptr,
                               checkpoint_dof_handlers,
                               checkpoint_mapping,
-                              vectors,
+                              vectors_per_dof_handler,
                               dof_handlers,
                               target_mapping,
                               param.restart_data.rpe_tolerance_unit_cell,

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -331,6 +331,9 @@ private:
   bool
   needs_own_dof_handler_velocity() const;
 
+  bool
+  needs_dof_handler_mapping() const;
+
   std::string
   get_quad_name() const;
 
@@ -396,6 +399,12 @@ private:
    */
   std::shared_ptr<dealii::FiniteElement<dim>> fe;
   dealii::DoFHandler<dim>                     dof_handler;
+
+  /*
+   * De-/serialization of the mapping requires a vector-valued `dealii::DofHandler`.
+   */
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_mapping;
+  std::shared_ptr<dealii::DoFHandler<dim>>    dof_handler_mapping;
 
   /*
    * Numerical velocity field.

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -117,6 +117,15 @@ public:
   project_velocity(VectorType & velocity, double const time) const final;
 
   /*
+   * De-/serialize the vectors given.
+   */
+  void
+  serialize_vectors(std::vector<VectorType const *> const & vectors) const final;
+
+  void
+  deserialize_vectors(std::vector<VectorType *> const & vectors) final;
+
+  /*
    * Prescribe initial conditions using a specified analytical function.
    */
   void

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -430,9 +430,11 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
 {
+  std::vector<VectorType *> vectors;
+
   for(unsigned int i = 0; i < this->order; i++)
   {
-    read_write_distributed_vector(solution[i], ia);
+    vectors.push_back(&solution[i]);
   }
 
   if(param.convective_problem() and
@@ -442,7 +444,7 @@ TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
     {
       for(unsigned int i = 0; i < this->order; i++)
       {
-        read_write_distributed_vector(vec_convective_term[i], ia);
+        vectors.push_back(&vec_convective_term[i]);
       }
     }
   }
@@ -451,8 +453,64 @@ TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
   {
     for(unsigned int i = 0; i < vec_grid_coordinates.size(); i++)
     {
-      read_write_distributed_vector(vec_grid_coordinates[i], ia);
+      vectors.push_back(&vec_grid_coordinates[i]);
     }
+  }
+
+  pde_operator->deserialize_vectors(vectors);
+
+  // Remains for comparison.
+  try
+  {
+    VectorType tmp;
+    tmp.reinit(solution[0], false /* omit_zeroing_entries */);
+    double diff_max = 0.0;
+    for(unsigned int i = 0; i < this->order; i++)
+    {
+      tmp = 0.0;
+      read_write_distributed_vector(tmp, ia);
+      tmp -= solution[i];
+      diff_max = std::max(diff_max, (double)tmp.linfty_norm());
+    }
+
+    if(param.convective_problem() and
+       param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
+    {
+      if(this->param.ale_formulation == false)
+      {
+        for(unsigned int i = 0; i < this->order; i++)
+        {
+          tmp = 0.0;
+          read_write_distributed_vector(tmp, ia);
+          tmp -= vec_convective_term[i];
+          diff_max = std::max(diff_max, (double)tmp.linfty_norm());
+        }
+      }
+    }
+
+    if(this->param.ale_formulation)
+    {
+      for(unsigned int i = 0; i < vec_grid_coordinates.size(); i++)
+      {
+        tmp = 0.0;
+        read_write_distributed_vector(tmp, ia);
+        tmp -= vec_grid_coordinates[i];
+        diff_max = std::max(diff_max, (double)tmp.linfty_norm());
+      }
+    }
+
+    if(dealii::Utilities::MPI::this_mpi_process(tmp.get_mpi_communicator()) == 0)
+    {
+      std::cout << "|difference|_inf = " << diff_max << "\n"
+                << "(only useful for identical discretization)";
+    }
+  }
+  catch(...)
+  {
+    std::cout << "Comparison to previous serialization not possible.\n"
+              << "This can only be done with identical processor "
+              << "counts and enough data in the archives."
+              << "\n";
   }
 }
 
@@ -460,6 +518,36 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::write_restart_vectors(BoostOutputArchiveType & oa) const
 {
+  std::vector<VectorType const *> vectors;
+
+  for(unsigned int i = 0; i < this->order; i++)
+  {
+    vectors.push_back(&solution[i]);
+  }
+
+  if(param.convective_problem() and
+     param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
+  {
+    if(this->param.ale_formulation == false)
+    {
+      for(unsigned int i = 0; i < this->order; i++)
+      {
+        vectors.push_back(&vec_convective_term[i]);
+      }
+    }
+  }
+
+  if(this->param.ale_formulation)
+  {
+    for(unsigned int i = 0; i < vec_grid_coordinates.size(); i++)
+    {
+      vectors.push_back(&vec_grid_coordinates[i]);
+    }
+  }
+
+  pde_operator->serialize_vectors(vectors);
+
+  // Remains for comparison.
   for(unsigned int i = 0; i < this->order; i++)
   {
     read_write_distributed_vector(solution[i], oa);

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.cpp
@@ -331,6 +331,20 @@ TimeIntExplRK<Number>::initialize_time_integrator()
 }
 
 template<typename Number>
+void
+TimeIntExplRK<Number>::read_restart_vectors(std::vector<VectorType *> const & vectors)
+{
+  pde_operator->deserialize_vectors(vectors);
+}
+
+template<typename Number>
+void
+TimeIntExplRK<Number>::write_restart_vectors(std::vector<VectorType const *> const & vectors) const
+{
+  pde_operator->serialize_vectors(vectors);
+}
+
+template<typename Number>
 bool
 TimeIntExplRK<Number>::print_solver_info() const
 {

--- a/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_explicit_runge_kutta.h
@@ -93,6 +93,12 @@ private:
   void
   initialize_time_integrator() final;
 
+  void
+  read_restart_vectors(std::vector<VectorType *> const & vectors) final;
+
+  void
+  write_restart_vectors(std::vector<VectorType const *> const & vectors) const final;
+
   std::shared_ptr<Interface::Operator<Number>> pde_operator;
 
   std::shared_ptr<OperatorExplRK<Number>> expl_rk_operator;

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -386,6 +386,8 @@ store_vectors_in_triangulation_and_serialize(
 
   if(not vector_initialized)
   {
+    std::cout << "more expensive vector setup ##+\n";
+
     // More expensive setup extracting the `dealii::IndexSet`.
     dealii::IndexSet const & locally_owned_dofs = dof_handler_mapping->locally_owned_dofs();
     dealii::IndexSet const   locally_relevant_dofs =
@@ -400,6 +402,11 @@ store_vectors_in_triangulation_and_serialize(
   mapping_dof_vector.fill_grid_coordinates_vector(mapping,
                                                   vector_grid_coordinates,
                                                   *dof_handler_mapping);
+
+  std::cout << "dof_handler_mapping->n_dofs() = " << dof_handler_mapping->n_dofs() << "##+ \n";
+  std::cout << "vector_grid_coordinates.size() = " << vector_grid_coordinates.size() << "##+ \n";
+  std::cout << "vector_grid_coordinates.linfty_norm() = " << vector_grid_coordinates.linfty_norm()
+            << "##+ \n";
 
   // Attach vector holding mapping and corresponding `dof_handler_mapping`.
   std::vector<std::vector<VectorType const *>> vectors_per_dof_handler_extended =

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -27,6 +27,7 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 
@@ -35,6 +36,7 @@
 #include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
+#include <deal.II/grid/manifold.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
@@ -417,6 +419,82 @@ store_vectors_in_triangulation_and_serialize(
 }
 
 /**
+ * Utility function to copy over manifolds from one triangulation to another
+ * after deserializing. We modify `triangulation_old`, since this is the one
+ * deserialized. Currently, `manifold_id`s are preserved, while manifolds
+ * themselves are not. Match them if we can do so in an unambiguous manner.
+ */
+template<typename TriangulationTypeOld, typename TriangulationTypeNew>
+inline void
+copy_manifolds_after_serialization(TriangulationTypeOld &       triangulation_old,
+                                   TriangulationTypeNew const & triangulation_new)
+{
+  std::vector<dealii::types::manifold_id> ids_old = triangulation_old.get_manifold_ids();
+  std::vector<dealii::types::manifold_id> ids_new = triangulation_new.get_manifold_ids();
+
+  AssertThrow(ids_old.size() == ids_new.size(),
+              dealii::ExcMessage("Number of manifolds in old and new triangulations differ."));
+
+  std::sort(ids_old.begin(), ids_old.end());
+  std::sort(ids_new.begin(), ids_new.end());
+  std::vector<dealii::types::manifold_id> intersection;
+  std::set_intersection(ids_old.begin(),
+                        ids_old.end(),
+                        ids_new.begin(),
+                        ids_new.end(),
+                        std::back_inserter(intersection));
+
+  // Copy over matching manifolds.
+  for(unsigned int i = 0; i < intersection.size(); ++i)
+  {
+    triangulation_old.reset_manifold(intersection[i]);
+    triangulation_old.set_manifold(intersection[i],
+                                   triangulation_new.get_manifold(intersection[i]));
+  }
+
+  if(intersection.size() < ids_old.size() or intersection.size() < ids_new.size())
+  {
+    std::vector<dealii::types::manifold_id> ids_old_without_new;
+    std::vector<dealii::types::manifold_id> ids_new_without_old;
+    std::set_difference(ids_old.begin(),
+                        ids_old.end(),
+                        ids_new.begin(),
+                        ids_new.end(),
+                        std::inserter(ids_old_without_new, ids_old_without_new.begin()));
+    std::set_difference(ids_new.begin(),
+                        ids_new.end(),
+                        ids_old.begin(),
+                        ids_old.end(),
+                        std::inserter(ids_new_without_old, ids_new_without_old.begin()));
+
+    if(ids_old_without_new.size() == 1 and ids_new_without_old.size() == 1)
+    {
+      // We have exactly one manifold not identified, but also one manifold left to copy.
+      // Note: this should not be necessary, it might hint at an inconsistency in the setup.
+      dealii::types::manifold_id manifold_id = ids_old_without_new[0];
+
+      if(dealii::Utilities::MPI::this_mpi_process(triangulation_new.get_communicator()) == 0)
+      {
+        std::cout << "manifold_id " << ids_new_without_old[0]
+                  << " from current (new) grid not matched,\n"
+                     "but copied using manifold_id "
+                  << manifold_id << " from old grid.\n";
+      }
+
+      triangulation_old.reset_manifold(manifold_id);
+      triangulation_old.set_manifold(manifold_id,
+                                     triangulation_new.get_manifold(ids_new_without_old[0]));
+    }
+    else
+    {
+      AssertThrow(false,
+                  dealii::ExcMessage("Failed to assign manifolds between triangulations "
+                                     "due to non-matching `manifold_id`s."));
+    }
+  }
+}
+
+/**
  * Utility function to deserialize the stored triangulation.
  */
 template<int dim, typename TriangulationTypeDeserialize>
@@ -434,15 +512,7 @@ deserialize_triangulation(TriangulationTypeDeserialize const & triangulation_new
     triangulation_old = std::make_shared<dealii::Triangulation<dim>>();
     triangulation_old->load(filename_base + ".triangulation");
 
-    // In case the coarse triangulation has manifolds assigned, copy them.
-    // We assume here that the `dealii::Manifold`s to be copied are exactly the same.
-    for(dealii::types::manifold_id const manifold_id : triangulation_new.get_manifold_ids())
-    {
-      if(manifold_id != dealii::numbers::flat_manifold_id)
-      {
-        triangulation_old->set_manifold(manifold_id, triangulation_new.get_manifold(manifold_id));
-      }
-    }
+    copy_manifolds_after_serialization(*triangulation_old, triangulation_new);
   }
   else if(triangulation_type == TriangulationType::Distributed)
   {
@@ -469,15 +539,8 @@ deserialize_triangulation(TriangulationTypeDeserialize const & triangulation_new
     tmp->copy_triangulation(coarse_triangulation);
     coarse_triangulation.clear();
 
-    // In case the coarse triangulation has manifolds assigned, copy them.
-    // We assume here that the `dealii::Manifold`s to be copied are exactly the same.
-    for(dealii::types::manifold_id const manifold_id : triangulation_new.get_manifold_ids())
-    {
-      if(manifold_id != dealii::numbers::flat_manifold_id)
-      {
-        tmp->set_manifold(manifold_id, triangulation_new.get_manifold(manifold_id));
-      }
-    }
+    copy_manifolds_after_serialization(*tmp, triangulation_new);
+
     tmp->load(filename_base + ".triangulation");
 
     triangulation_old = std::dynamic_pointer_cast<dealii::Triangulation<dim>>(tmp);
@@ -490,15 +553,7 @@ deserialize_triangulation(TriangulationTypeDeserialize const & triangulation_new
       std::make_shared<dealii::parallel::fullydistributed::Triangulation<dim>>(mpi_communicator);
     tmp->load(filename_base + ".triangulation");
 
-    // In case the coarse triangulation has manifolds assigned, copy them.
-    // We assume here that the `dealii::Manifold`s to be copied are exactly the same.
-    for(dealii::types::manifold_id const manifold_id : triangulation_new.get_manifold_ids())
-    {
-      if(manifold_id != dealii::numbers::flat_manifold_id)
-      {
-        tmp->set_manifold(manifold_id, triangulation_new.get_manifold(manifold_id));
-      }
-    }
+    copy_manifolds_after_serialization(*tmp, triangulation_new);
 
     triangulation_old = std::dynamic_pointer_cast<dealii::Triangulation<dim>>(tmp);
   }

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -186,36 +186,6 @@ get_vectors_per_block(std::vector<BlockVectorType *> const & block_vectors)
   return vectors_per_block;
 }
 
-/**
- * Same as above but input argument is a vector of BlockVectors.
- * Return type is a vector of vector of pointers, i.e, unchanged.
- */
-template<typename VectorType, typename BlockVectorType>
-std::vector<std::vector<VectorType *>>
-get_vectors_per_block(std::vector<BlockVectorType> & block_vectors)
-{
-  unsigned int const n_blocks = block_vectors.at(0).n_blocks();
-  for(unsigned int i = 0; i < block_vectors.size(); ++i)
-  {
-    AssertThrow(block_vectors[i].n_blocks() == n_blocks,
-                dealii::ExcMessage("Provided number of blocks per "
-                                   "BlockVector must be equal."));
-  }
-
-  std::vector<std::vector<VectorType *>> vectors_per_block;
-  for(unsigned int i = 0; i < n_blocks; ++i)
-  {
-    std::vector<VectorType *> vectors;
-    for(unsigned int j = 0; j < block_vectors.size(); ++j)
-    {
-      vectors.push_back(&block_vectors[j].block(i));
-    }
-    vectors_per_block.push_back(vectors);
-  }
-
-  return vectors_per_block;
-}
-
 /** Utility function to setup a BlockVector given a vector
  * of DoFHandlers only containing owned DoFs. This can be used
  * in combination with `get_vectors_per_block()` to obtain vectors

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -386,8 +386,6 @@ store_vectors_in_triangulation_and_serialize(
 
   if(not vector_initialized)
   {
-    std::cout << "more expensive vector setup ##+\n";
-
     // More expensive setup extracting the `dealii::IndexSet`.
     dealii::IndexSet const & locally_owned_dofs = dof_handler_mapping->locally_owned_dofs();
     dealii::IndexSet const   locally_relevant_dofs =
@@ -402,11 +400,6 @@ store_vectors_in_triangulation_and_serialize(
   mapping_dof_vector.fill_grid_coordinates_vector(mapping,
                                                   vector_grid_coordinates,
                                                   *dof_handler_mapping);
-
-  std::cout << "dof_handler_mapping->n_dofs() = " << dof_handler_mapping->n_dofs() << "##+ \n";
-  std::cout << "vector_grid_coordinates.size() = " << vector_grid_coordinates.size() << "##+ \n";
-  std::cout << "vector_grid_coordinates.linfty_norm() = " << vector_grid_coordinates.linfty_norm()
-            << "##+ \n";
 
   // Attach vector holding mapping and corresponding `dof_handler_mapping`.
   std::vector<std::vector<VectorType const *>> vectors_per_dof_handler_extended =
@@ -672,11 +665,11 @@ assemble_projection_rhs(
         {
           tmp[0][i] = values;
         }
-        else if constexpr(n_components == dim)
+        else
         {
-          for(unsigned int d = 0; d < n_components; ++d)
+          for(unsigned int c = 0; c < n_components; ++c)
           {
-            tmp[d][i] = values[d];
+            tmp[c][i] = values[c];
           }
         }
       }
@@ -860,31 +853,48 @@ grid_to_grid_projection(
     unsigned int const n_components = target_dof_handlers[i]->get_fe().n_components();
     if(n_components == 1)
     {
-      project_vectors<dim, Number, 1 /* n_components */>(source_vectors_per_dof_handler.at(i),
-                                                         *source_dof_handlers.at(i),
-                                                         source_mapping,
-                                                         target_vectors_per_dof_handler.at(i),
-                                                         *target_dof_handlers.at(i),
-                                                         matrix_free,
-                                                         empty_constraints,
-                                                         i /* dof_index */,
-                                                         i /* quad_index */,
-                                                         rpe_tolerance_unit_cell,
-                                                         rpe_enforce_unique_mapping);
+      project_vectors<dim, Number, 1 /* n_components */, VectorType>(
+        source_vectors_per_dof_handler.at(i),
+        *source_dof_handlers.at(i),
+        source_mapping,
+        target_vectors_per_dof_handler.at(i),
+        *target_dof_handlers.at(i),
+        matrix_free,
+        empty_constraints,
+        i /* dof_index */,
+        i /* quad_index */,
+        rpe_tolerance_unit_cell,
+        rpe_enforce_unique_mapping);
     }
     else if(n_components == dim)
     {
-      project_vectors<dim, Number, dim /* n_components */>(source_vectors_per_dof_handler.at(i),
-                                                           *source_dof_handlers.at(i),
-                                                           source_mapping,
-                                                           target_vectors_per_dof_handler.at(i),
-                                                           *target_dof_handlers.at(i),
-                                                           matrix_free,
-                                                           empty_constraints,
-                                                           i /* dof_index */,
-                                                           i /* quad_index */,
-                                                           rpe_tolerance_unit_cell,
-                                                           rpe_enforce_unique_mapping);
+      project_vectors<dim, Number, dim /* n_components */, VectorType>(
+        source_vectors_per_dof_handler.at(i),
+        *source_dof_handlers.at(i),
+        source_mapping,
+        target_vectors_per_dof_handler.at(i),
+        *target_dof_handlers.at(i),
+        matrix_free,
+        empty_constraints,
+        i /* dof_index */,
+        i /* quad_index */,
+        rpe_tolerance_unit_cell,
+        rpe_enforce_unique_mapping);
+    }
+    else if(n_components == dim + 2)
+    {
+      project_vectors<dim, Number, dim + 2 /* n_components */, VectorType>(
+        source_vectors_per_dof_handler.at(i),
+        *source_dof_handlers.at(i),
+        source_mapping,
+        target_vectors_per_dof_handler.at(i),
+        *target_dof_handlers.at(i),
+        matrix_free,
+        empty_constraints,
+        i /* dof_index */,
+        i /* quad_index */,
+        rpe_tolerance_unit_cell,
+        rpe_enforce_unique_mapping);
     }
     else
     {

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -32,8 +32,25 @@
 
 // deal.II
 #include <deal.II/base/mpi.h>
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/tria.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/matrix_free/fe_point_evaluation.h>
+#include <deal.II/numerics/vector_tools.h>
+
+// ExaDG
+#include <exadg/grid/grid_data.h>
+#include <exadg/grid/grid_utilities.h>
+#include <exadg/grid/mapping_dof_vector.h>
+#include <exadg/matrix_free/matrix_free_data.h>
+#include <exadg/operators/mapping_flags.h>
+#include <exadg/operators/mass_operator.h>
+#include <exadg/operators/quadrature.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
 
 namespace ExaDG
 {
@@ -135,6 +152,767 @@ read_write_distributed_vector(VectorType & vector, BoostArchiveType & archive)
      std::is_same<BoostArchiveType, boost::archive::binary_iarchive>::value)
   {
     print_vector_l2_norm(vector);
+  }
+}
+
+/** Utility function to convert a vector of block vector pointers into a
+ * vector of vectors of VectorType pointers, where all vectors from each
+ * individual block are summarized in a std::vector.
+ * This is useful for solution transfer and serialization.
+ */
+template<typename VectorType, typename BlockVectorType>
+std::vector<std::vector<VectorType *>>
+get_vectors_per_block(std::vector<BlockVectorType *> const & block_vectors)
+{
+  unsigned int const n_blocks = block_vectors.at(0)->n_blocks();
+  for(unsigned int i = 0; i < block_vectors.size(); ++i)
+  {
+    AssertThrow(block_vectors[i]->n_blocks() == n_blocks,
+                dealii::ExcMessage("Provided number of blocks per "
+                                   "BlockVector must be equal."));
+  }
+
+  std::vector<std::vector<VectorType *>> vectors_per_block;
+  for(unsigned int i = 0; i < n_blocks; ++i)
+  {
+    std::vector<VectorType *> vectors;
+    for(unsigned int j = 0; j < block_vectors.size(); ++j)
+    {
+      vectors.push_back(&block_vectors[j]->block(i));
+    }
+    vectors_per_block.push_back(vectors);
+  }
+
+  return vectors_per_block;
+}
+
+/**
+ * Same as above but input argument is a vector of BlockVectors.
+ * Return type is a vector of vector of pointers, i.e, unchanged.
+ */
+template<typename VectorType, typename BlockVectorType>
+std::vector<std::vector<VectorType *>>
+get_vectors_per_block(std::vector<BlockVectorType> & block_vectors)
+{
+  unsigned int const n_blocks = block_vectors.at(0).n_blocks();
+  for(unsigned int i = 0; i < block_vectors.size(); ++i)
+  {
+    AssertThrow(block_vectors[i].n_blocks() == n_blocks,
+                dealii::ExcMessage("Provided number of blocks per "
+                                   "BlockVector must be equal."));
+  }
+
+  std::vector<std::vector<VectorType *>> vectors_per_block;
+  for(unsigned int i = 0; i < n_blocks; ++i)
+  {
+    std::vector<VectorType *> vectors;
+    for(unsigned int j = 0; j < block_vectors.size(); ++j)
+    {
+      vectors.push_back(&block_vectors[j].block(i));
+    }
+    vectors_per_block.push_back(vectors);
+  }
+
+  return vectors_per_block;
+}
+
+/** Utility function to setup a BlockVector given a vector
+ * of DoFHandlers only containing owned DoFs. This can be used
+ * in combination with `get_vectors_per_block()` to obtain vectors
+ * of VectorType pointers as required for `dealii::SolutionTransfer`.
+ */
+template<int dim, typename BlockVectorType>
+std::vector<BlockVectorType>
+get_block_vectors_from_dof_handlers(
+  unsigned int const                                        n_vectors,
+  std::vector<dealii::DoFHandler<dim, dim> const *> const & dof_handlers)
+{
+  unsigned int const n_blocks = dof_handlers.size();
+
+  // Setup first BlockVector
+  BlockVectorType block_vector(n_blocks);
+  for(unsigned int i = 0; i < n_blocks; ++i)
+  {
+    block_vector.block(i).reinit(dof_handlers[i]->locally_owned_dofs(),
+                                 dof_handlers[i]->get_communicator());
+  }
+  block_vector.collect_sizes();
+
+  std::vector<BlockVectorType> block_vectors(n_vectors, block_vector);
+
+  return block_vectors;
+}
+
+template<typename VectorType>
+std::vector<bool>
+get_ghost_state(std::vector<VectorType *> const & vectors)
+{
+  std::vector<bool> has_ghost_elements(vectors.size());
+  for(unsigned int i = 0; i < has_ghost_elements.size(); ++i)
+  {
+    has_ghost_elements[i] = vectors[i]->has_ghost_elements();
+  }
+  return has_ghost_elements;
+}
+
+template<typename VectorType>
+void
+set_ghost_state(std::vector<VectorType *> const & vectors,
+                std::vector<bool> const &         had_ghost_elements)
+{
+  AssertThrow(vectors.size() == had_ghost_elements.size(),
+              dealii::ExcMessage("Vector sizes do not match."));
+
+  for(unsigned int i = 0; i < had_ghost_elements.size(); ++i)
+  {
+    if(had_ghost_elements[i])
+    {
+      vectors[i]->update_ghost_values();
+    }
+    else
+    {
+      vectors[i]->zero_out_ghost_values();
+    }
+  }
+}
+
+/**
+ * Utility function to serialize a `dealii::Triangulation`. This is only implemented for the
+ * serial case since we only require the coarsest triangulation to be read from file when
+ * deserializing into a `dealii::parallel::distributed::Triangulation`.
+ */
+template<int dim, typename TriangulationType>
+inline void
+save_coarse_triangulation(std::string const &       filename_base,
+                          TriangulationType const & triangulation)
+{
+  if constexpr(std::is_same<std::remove_cv_t<TriangulationType>,
+                            dealii::parallel::distributed::Triangulation<dim, dim>>::value or
+               std::is_same<std::remove_cv_t<TriangulationType>,
+                            dealii::parallel::fullydistributed::Triangulation<dim, dim>>::value)
+  {
+    AssertThrow(false,
+                dealii::ExcMessage("Only TriangulationType::Serial, i.e., "
+                                   "dealii::Triangulation<dim> supported."));
+  }
+
+  std::string const filename = filename_base + ".coarse_triangulation";
+  if(dealii::Utilities::MPI::this_mpi_process(triangulation.get_communicator()) == 0)
+  {
+    // Serialization only creates a single file, move with one process only.
+    rename_restart_files(filename + ".info");
+    rename_restart_files(filename + "_triangulation.data");
+
+    // For `dealii::Triangulation` the triangulation is the same for all processes.
+    triangulation.save(filename);
+  }
+}
+
+/**
+ * Utility function to store a std::vector<VectorType> in a triangulation and serialize.
+ * We assume that the Triangulation(s) linked to the DoFHandlers are all identical.
+ * Note also that the sequence of vectors and DoFHandlers here and in
+ * deserialize_triangulation_and_load_vectors() *must* be identical.
+ * This function does not consider a mapping to be stored, if it is
+ * not provided within the `dof_handlers` (and hence treated like all other vectors).
+ */
+template<int dim, typename VectorType>
+inline void
+store_vectors_in_triangulation_and_serialize(
+  std::string const &                                       filename_base,
+  std::vector<std::vector<VectorType const *>> const &      vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim, dim> const *> const & dof_handlers)
+{
+  AssertThrow(vectors_per_dof_handler.size() > 0,
+              dealii::ExcMessage("No vectors to store in triangulation."));
+  AssertThrow(vectors_per_dof_handler.size() == dof_handlers.size(),
+              dealii::ExcMessage("Number of vectors of vectors and DoFHandlers do not match."));
+  auto const & triangulation = dof_handlers.at(0)->get_triangulation();
+
+  // Check if all the Triangulation(s) associated with the DoFHandlers point to the same object.
+  for(unsigned int i = 1; i < dof_handlers.size(); ++i)
+  {
+    AssertThrow(&dof_handlers[i]->get_triangulation() == &triangulation,
+                dealii::ExcMessage("Triangulations of DoFHandlers are not identical."));
+  }
+
+  // Loop over the DoFHandlers and store the vectors in the triangulation.
+  std::vector<std::shared_ptr<dealii::parallel::distributed::SolutionTransfer<dim, VectorType>>>
+    solution_transfers;
+  for(unsigned int i = 0; i < dof_handlers.size(); ++i)
+  {
+    for(unsigned int j = 0; j < vectors_per_dof_handler[i].size(); ++j)
+    {
+      print_vector_l2_norm(*vectors_per_dof_handler[i][j]);
+    }
+    solution_transfers.push_back(
+      std::make_shared<dealii::parallel::distributed::SolutionTransfer<dim, VectorType>>(
+        *dof_handlers[i]));
+    solution_transfers[i]->prepare_for_serialization(vectors_per_dof_handler[i]);
+  }
+
+  // Serialize the triangulation keeping a maximum of two snapshots.
+  std::string const filename = filename_base + ".triangulation";
+  if(dealii::Utilities::MPI::this_mpi_process(dof_handlers[0]->get_communicator()) == 0)
+  {
+    // Serialization only creates a single file, move with one process only.
+    rename_restart_files(filename);
+    rename_restart_files(filename + ".info");
+    rename_restart_files(filename + "_fixed.data");
+    rename_restart_files(filename + "_triangulation.data");
+  }
+
+  // Collective call for serialization.
+  triangulation.save(filename);
+}
+
+/**
+ * Same as the function above, but the mapping is stored for tensor-product elements
+ * as one of the vectors, while for any other element type, we ignore the mapping in
+ * the projection when deserializing.
+ */
+template<int dim, typename VectorType>
+inline void
+store_vectors_in_triangulation_and_serialize(
+  std::string const &                                       filename_base,
+  std::vector<std::vector<VectorType const *>> const &      vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim, dim> const *> const & dof_handlers,
+  dealii::Mapping<dim> const &                              mapping,
+  dealii::DoFHandler<dim> const *                           dof_handler_mapping,
+  unsigned int const                                        mapping_degree)
+{
+  AssertThrow(vectors_per_dof_handler.size() > 0,
+              dealii::ExcMessage("No vectors to store in triangulation."));
+  AssertThrow(vectors_per_dof_handler.size() == dof_handlers.size(),
+              dealii::ExcMessage("Number of vectors of vectors and DoFHandlers do not match."));
+
+  auto const & triangulation = dof_handlers.at(0)->get_triangulation();
+
+  // Check if all the Triangulation(s) associated with the DoFHandlers point to the same object.
+  for(unsigned int i = 1; i < dof_handlers.size(); ++i)
+  {
+    AssertThrow(&dof_handlers[i]->get_triangulation() == &triangulation,
+                dealii::ExcMessage("Triangulations of DoFHandlers are not identical."));
+  }
+
+  AssertThrow(triangulation.all_reference_cells_are_hyper_cube(),
+              dealii::ExcMessage("Serialization including mapping not "
+                                 "supported for non-hypercube cell types."));
+
+  // Initialize vector to hold grid coordinates.
+  bool       vector_initialized = false;
+  VectorType vector_grid_coordinates;
+  for(unsigned int i = 0; i < dof_handlers.size(); ++i)
+  {
+    if(dof_handlers[i] == dof_handler_mapping and not vector_initialized)
+    {
+      // Cheaper setup if we already have a vector given in the input arguments.
+      vector_grid_coordinates.reinit(*vectors_per_dof_handler[i][0],
+                                     true /* omit_zeroing_entries */);
+      vector_initialized = true;
+      break;
+    }
+  }
+
+  if(not vector_initialized)
+  {
+    // More expensive setup extracting the `dealii::IndexSet`.
+    dealii::IndexSet const & locally_owned_dofs = dof_handler_mapping->locally_owned_dofs();
+    dealii::IndexSet const   locally_relevant_dofs =
+      dealii::DoFTools::extract_locally_relevant_dofs(*dof_handler_mapping);
+    vector_grid_coordinates.reinit(locally_owned_dofs,
+                                   locally_relevant_dofs,
+                                   dof_handler_mapping->get_communicator());
+  }
+
+  // Fill vector with mapping.
+  MappingDoFVector<dim, typename VectorType::value_type> mapping_dof_vector(mapping_degree);
+  mapping_dof_vector.fill_grid_coordinates_vector(mapping,
+                                                  vector_grid_coordinates,
+                                                  *dof_handler_mapping);
+
+  // Attach vector holding mapping and corresponding `dof_handler_mapping`.
+  std::vector<std::vector<VectorType const *>> vectors_per_dof_handler_extended =
+    vectors_per_dof_handler;
+  std::vector<VectorType const *> tmp = {&vector_grid_coordinates};
+  vectors_per_dof_handler_extended.push_back(tmp);
+
+  std::vector<dealii::DoFHandler<dim, dim> const *> dof_handlers_extended = dof_handlers;
+  dof_handlers_extended.push_back(dof_handler_mapping);
+
+  // Use utility function that ignores the mapping.
+  store_vectors_in_triangulation_and_serialize(filename_base,
+                                               vectors_per_dof_handler_extended,
+                                               dof_handlers_extended);
+}
+
+/**
+ * Utility function to deserialize the stored triangulation.
+ */
+template<int dim, typename TriangulationTypeDeserialize>
+inline std::shared_ptr<dealii::Triangulation<dim>>
+deserialize_triangulation(TriangulationTypeDeserialize const & triangulation_new,
+                          std::string const &                  filename_base,
+                          TriangulationType const              triangulation_type,
+                          MPI_Comm const &                     mpi_communicator)
+{
+  std::shared_ptr<dealii::Triangulation<dim>> triangulation_old;
+
+  // Deserialize the checkpointed triangulation,
+  if(triangulation_type == TriangulationType::Serial)
+  {
+    triangulation_old = std::make_shared<dealii::Triangulation<dim>>();
+    triangulation_old->load(filename_base + ".triangulation");
+
+    // In case the coarse triangulation has manifolds assigned, copy them.
+    // We assume here that the `dealii::Manifold`s to be copied are exactly the same.
+    for(dealii::types::manifold_id const manifold_id : triangulation_new.get_manifold_ids())
+    {
+      if(manifold_id != dealii::numbers::flat_manifold_id)
+      {
+        triangulation_old->set_manifold(manifold_id, triangulation_new.get_manifold(manifold_id));
+      }
+    }
+  }
+  else if(triangulation_type == TriangulationType::Distributed)
+  {
+    // Deserialize the coarse triangulation to be stored by the user
+    // during `create_grid` in the respective application.
+    dealii::Triangulation<dim, dim> coarse_triangulation;
+    try
+    {
+      coarse_triangulation.load(filename_base + ".coarse_triangulation");
+    }
+    catch(...)
+    {
+      AssertThrow(false,
+                  dealii::ExcMessage(
+                    "Deserializing coarse triangulation expected in\n" + filename_base +
+                    ".coarse_triangulation\n"
+                    "make sure to store the coarse grid during `create_grid`\n"
+                    "in the respective application.h using TriangulationType::Serial."));
+    }
+
+    std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> tmp =
+      std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(mpi_communicator);
+
+    tmp->copy_triangulation(coarse_triangulation);
+    coarse_triangulation.clear();
+
+    // In case the coarse triangulation has manifolds assigned, copy them.
+    // We assume here that the `dealii::Manifold`s to be copied are exactly the same.
+    for(dealii::types::manifold_id const manifold_id : triangulation_new.get_manifold_ids())
+    {
+      if(manifold_id != dealii::numbers::flat_manifold_id)
+      {
+        tmp->set_manifold(manifold_id, triangulation_new.get_manifold(manifold_id));
+      }
+    }
+    tmp->load(filename_base + ".triangulation");
+
+    triangulation_old = std::dynamic_pointer_cast<dealii::Triangulation<dim>>(tmp);
+  }
+  else if(triangulation_type == TriangulationType::FullyDistributed)
+  {
+    // Note that the number of MPI processes the triangulation was
+    // saved with cannot change and hence autopartitioning is disabled.
+    std::shared_ptr<dealii::parallel::fullydistributed::Triangulation<dim>> tmp =
+      std::make_shared<dealii::parallel::fullydistributed::Triangulation<dim>>(mpi_communicator);
+    tmp->load(filename_base + ".triangulation");
+
+    // In case the coarse triangulation has manifolds assigned, copy them.
+    // We assume here that the `dealii::Manifold`s to be copied are exactly the same.
+    for(dealii::types::manifold_id const manifold_id : triangulation_new.get_manifold_ids())
+    {
+      if(manifold_id != dealii::numbers::flat_manifold_id)
+      {
+        tmp->set_manifold(manifold_id, triangulation_new.get_manifold(manifold_id));
+      }
+    }
+
+    triangulation_old = std::dynamic_pointer_cast<dealii::Triangulation<dim>>(tmp);
+  }
+  else
+  {
+    AssertThrow(false, dealii::ExcMessage("TriangulationType not supported."));
+  }
+
+  return triangulation_old;
+}
+
+/**
+ * Utility function to load vectors via `dealii::SolutionTransfer`
+ * assuming the `Triangulation` the `DoFHandler` was initialized with
+ * actually stores the related data.
+ */
+template<int dim, typename VectorType>
+inline void
+load_vectors(std::vector<std::vector<VectorType *>> &                  vectors_per_dof_handler,
+             std::vector<dealii::DoFHandler<dim, dim> const *> const & dof_handlers)
+{
+  // The DoFHandlers and vectors are already initialized and
+  // ``vectors_per_dof_handler`` contain only owned DoFs.
+  AssertThrow(vectors_per_dof_handler.size() > 0,
+              dealii::ExcMessage("No vectors to load into from triangulation."));
+  AssertThrow(vectors_per_dof_handler.size() == dof_handlers.size(),
+              dealii::ExcMessage("Number of vectors of vectors and DoFHandlers do not match."));
+
+  // Loop over the DoFHandlers and load the vectors stored in
+  // the triangulation the DoFHandlers were initialized with.
+  for(unsigned int i = 0; i < dof_handlers.size(); ++i)
+  {
+    dealii::parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
+      *dof_handlers[i]);
+    solution_transfer.deserialize(vectors_per_dof_handler[i]);
+
+    for(unsigned int j = 0; j < vectors_per_dof_handler[i].size(); ++j)
+    {
+      print_vector_l2_norm(*vectors_per_dof_handler[i][j]);
+    }
+  }
+}
+
+/**
+ * Same as the above function, but consider for a mapping added as an additional vector
+ * added during `store_vectors_in_triangulation_and_serialize()`.
+ */
+template<int dim, typename VectorType>
+inline std::shared_ptr<dealii::Mapping<dim>>
+load_vectors(std::vector<std::vector<VectorType *>> &                  vectors_per_dof_handler,
+             std::vector<dealii::DoFHandler<dim, dim> const *> const & dof_handlers,
+             dealii::DoFHandler<dim> const *                           dof_handler_mapping,
+             unsigned int const                                        mapping_degree)
+{
+  // We need a collective call to `SolutionTransfer::deserialize()` with all vectors in a
+  // single container. Hence, create a mapping vector and add a pointer to the input argument.
+  dealii::IndexSet const & locally_owned_dofs = dof_handler_mapping->locally_owned_dofs();
+  dealii::IndexSet const & locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(*dof_handler_mapping);
+  VectorType vector_grid_coordinates(locally_owned_dofs,
+                                     locally_relevant_dofs,
+                                     dof_handler_mapping->get_communicator());
+
+  // Standard utility function, sequence as in `store_vectors_in_triangulation_and_serialize()`.
+  std::vector<std::vector<VectorType *>> vectors_per_dof_handler_extended = vectors_per_dof_handler;
+  std::vector<VectorType *>              tmp = {&vector_grid_coordinates};
+  vectors_per_dof_handler_extended.push_back(tmp);
+  std::vector<dealii::DoFHandler<dim, dim> const *> dof_handlers_extended = dof_handlers;
+  dof_handlers_extended.push_back(dof_handler_mapping);
+
+  load_vectors(vectors_per_dof_handler_extended, dof_handlers_extended);
+
+  // Reconstruct the mapping given the deserialized grid coordinate vector.
+  std::shared_ptr<dealii::Mapping<dim>> mapping;
+  GridUtilities::create_mapping(mapping,
+                                get_element_type(dof_handler_mapping->get_triangulation()),
+                                mapping_degree);
+  MappingDoFVector<dim, typename VectorType::value_type> mapping_dof_vector(mapping_degree);
+  mapping_dof_vector.fill_grid_coordinates_vector(*mapping,
+                                                  vector_grid_coordinates,
+                                                  *dof_handler_mapping);
+
+  return mapping;
+}
+
+/**
+ * Utility function to collect integration points via `dealii::FEEvaluation`.
+ */
+template<int dim, int n_components, typename Number>
+inline std::vector<dealii::Point<dim>>
+collect_integration_points(
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  unsigned int const                                                       dof_index,
+  unsigned int                                                             quad_index)
+{
+  CellIntegrator<dim, n_components, Number> fe_eval(matrix_free, dof_index, quad_index);
+
+  // Conservative estimate for the number of points.
+  std::vector<dealii::Point<dim>> integration_points;
+  integration_points.reserve(
+    matrix_free.get_dof_handler(dof_index).get_triangulation().n_active_cells() *
+    fe_eval.n_q_points);
+
+  for(unsigned int cell_batch_idx = 0; cell_batch_idx < matrix_free.n_cell_batches();
+      ++cell_batch_idx)
+  {
+    fe_eval.reinit(cell_batch_idx);
+    for(const unsigned int q : fe_eval.quadrature_point_indices())
+    {
+      dealii::Point<dim, dealii::VectorizedArray<Number>> const cell_batch_points =
+        fe_eval.quadrature_point(q);
+      for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); ++i)
+      {
+        dealii::Point<dim> p;
+        for(unsigned int d = 0; d < dim; ++d)
+        {
+          p[d] = cell_batch_points[d][i];
+        }
+        integration_points.push_back(p);
+      }
+    }
+  }
+
+  return integration_points;
+}
+
+/**
+ * Utility function to compute the right hand side of a projection with values given in integration
+ * points obtained via `collect_integration_points()`.
+ */
+template<int dim, int n_components, typename Number, typename VectorType>
+inline VectorType
+assemble_projection_rhs(
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  CellIntegrator<dim, n_components, Number> &                              fe_eval,
+  std::vector<
+    typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const &
+                     values_source_in_q_points_target,
+  unsigned int const dof_index)
+{
+  VectorType system_rhs;
+  matrix_free.initialize_dof_vector(system_rhs, dof_index);
+
+  unsigned int idx_q_point = 0;
+
+  for(unsigned int cell_batch_idx = 0; cell_batch_idx < matrix_free.n_cell_batches();
+      ++cell_batch_idx)
+  {
+    fe_eval.reinit(cell_batch_idx);
+    for(unsigned int const q : fe_eval.quadrature_point_indices())
+    {
+      dealii::Tensor<1, n_components, dealii::VectorizedArray<Number>> tmp;
+
+      for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); ++i)
+      {
+        typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type const
+          values = values_source_in_q_points_target[idx_q_point];
+
+        // Increment index into `values_source_in_q_points_target` which is dictated
+        // by `integration_points_target`, i.e., `collect_integration_points()`.
+        ++idx_q_point;
+
+        if constexpr(n_components == 1)
+        {
+          tmp[0][i] = values;
+        }
+        else if constexpr(n_components == dim)
+        {
+          for(unsigned int d = 0; d < n_components; ++d)
+          {
+            tmp[d][i] = values[d];
+          }
+        }
+      }
+
+      fe_eval.submit_value(tmp, q);
+    }
+    fe_eval.integrate(dealii::EvaluationFlags::values);
+    fe_eval.distribute_local_to_global(system_rhs);
+  }
+  system_rhs.compress(dealii::VectorOperation::add);
+
+  return system_rhs;
+}
+
+/**
+ * Utilitiy function to project vectors from a source to a target triangulation
+ * via `dealii::RemotePointEvaluation`, matrix-free mass operator evaluation
+ * and a Jacobi-preconditioned CG solver.
+ */
+template<int dim, typename Number, int n_components, typename VectorType>
+inline void
+project_vectors(
+  std::vector<VectorType *> const &                                        source_vectors,
+  dealii::DoFHandler<dim> const &                                          source_dof_handler,
+  std::shared_ptr<dealii::Mapping<dim>> const &                            source_mapping,
+  std::vector<VectorType *> const &                                        target_vectors,
+  dealii::DoFHandler<dim> const &                                          target_dof_handler,
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & target_matrix_free,
+  dealii::AffineConstraints<Number> const &                                constraints,
+  unsigned int const                                                       dof_index,
+  unsigned int const                                                       quad_index,
+  double const &                                                           rpe_tolerance_unit_cell,
+  bool const rpe_enforce_unique_mapping)
+{
+  // Setup operator and preconditioner outside of the loop since the operator remains unchanged.
+  MassOperatorData<dim> mass_operator_data;
+  mass_operator_data.dof_index  = dof_index;
+  mass_operator_data.quad_index = quad_index;
+
+  MassOperator<dim, n_components, Number> mass_operator;
+  mass_operator.initialize(target_matrix_free, constraints, mass_operator_data);
+
+  JacobiPreconditioner<MassOperator<dim, n_components, Number>> jacobi_preconditioner(
+    mass_operator, true /* initialize_preconditioner */);
+
+  // Setup RemotePointEvaluation since the `source_vectors` all live on the same triangulation.
+  typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData rpe_data(
+    rpe_tolerance_unit_cell,
+    rpe_enforce_unique_mapping,
+    0 /* rtree_level */,
+    {} /* marked_vertices */);
+
+  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe_source(rpe_data);
+
+  // The sequence of integration points follows from the sequence of points as encountered during
+  // cell batch loop.
+  std::vector<dealii::Point<dim>> integration_points_target =
+    collect_integration_points<dim, n_components, Number>(target_matrix_free,
+                                                          dof_index,
+                                                          quad_index);
+
+  rpe_source.reinit(integration_points_target,
+                    source_dof_handler.get_triangulation(),
+                    *source_mapping);
+  AssertThrow(rpe_source.all_points_found(),
+              dealii::ExcMessage("Could not interpolate source grid vector in target grid."));
+
+  CellIntegrator<dim, n_components, Number> fe_eval(target_matrix_free, dof_index, quad_index);
+
+  // Loop over vectors and project.
+  for(unsigned int i = 0; i < target_vectors.size(); ++i)
+  {
+    // Evaluate the source vector at the target integration points.
+    VectorType const & source_vector = *source_vectors.at(i);
+    source_vector.update_ghost_values();
+
+    std::vector<
+      typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const
+      values_source_in_q_points_target = dealii::VectorTools::point_values<n_components>(
+        rpe_source, source_dof_handler, source_vector, dealii::VectorTools::EvaluationFlags::avg);
+
+    // Assemble right hand side vector for the projection.
+    VectorType system_rhs = assemble_projection_rhs<dim, n_components, Number, VectorType>(
+      target_matrix_free, fe_eval, values_source_in_q_points_target, dof_index);
+
+    // CG solver for global projection.
+    unsigned int constexpr max_iter      = 10000;
+    double const                 abs_tol = 1e-16 * system_rhs.l2_norm();
+    double const                 rel_tol = 1e-12;
+    dealii::ReductionControl     reduction_control(max_iter, abs_tol, rel_tol);
+    dealii::SolverCG<VectorType> solver_cg(reduction_control);
+
+    VectorType sol;
+    sol.reinit(system_rhs, false /* omit_zeroing_entries */);
+
+    solver_cg.solve(mass_operator, sol, system_rhs, jacobi_preconditioner);
+
+    *target_vectors[i] = sol;
+
+    if(dealii::Utilities::MPI::this_mpi_process(target_dof_handler.get_communicator()) == 0)
+    {
+      std::cout << "    global projection required " << reduction_control.last_step()
+                << " CG iterations.\n";
+    }
+  }
+}
+
+/**
+ * Utility function to perform grid-to-grid projection using `dealii::RemotePointEvaluation`.
+ * We assume we only have a single `dealii::FiniteElement` per `dealii::DoFHandler`.
+ * The VectorType template argument is assumed no to be of `BlockVector` type.
+ * Note that this function initializes a complete `dealii::MatrixFree` object and hence
+ */
+template<int dim, typename VectorType>
+inline void
+grid_to_grid_projection(
+  std::vector<std::vector<VectorType *>> const &       source_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & source_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim>> const &        source_mapping,
+  std::vector<std::vector<VectorType *>> &             target_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & target_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  target_mapping,
+  double const &                                       rpe_tolerance_unit_cell,
+  bool const                                           rpe_enforce_unique_mapping)
+{
+  // Check input dimensions.
+  AssertThrow(source_vectors_per_dof_handler.size() == source_dof_handlers.size(),
+              dealii::ExcMessage("First dimension of source vector of vectors "
+                                 "has to match source DoFHandler count."));
+  AssertThrow(target_vectors_per_dof_handler.size() == target_dof_handlers.size(),
+              dealii::ExcMessage("First dimension of target vector of vectors "
+                                 "has to match target DoFHandler count."));
+  AssertThrow(source_dof_handlers.size() == target_dof_handlers.size(),
+              dealii::ExcMessage("Target and source DoFHandler counts have to match"));
+  AssertThrow(source_vectors_per_dof_handler.size() > 0,
+              dealii::ExcMessage("Vector of source vectors empty."));
+  for(unsigned int i = 0; i < source_vectors_per_dof_handler.size(); ++i)
+  {
+    AssertThrow(source_vectors_per_dof_handler[i].size() ==
+                  target_vectors_per_dof_handler.at(i).size(),
+                dealii::ExcMessage("Vectors of source and target vectors need to have same size."));
+  }
+
+  // Setup `dealii::MatrixFree` object with multiple `dealii::DoFHandler`.
+  using Number = typename VectorType::value_type;
+  MatrixFreeData<dim, Number> matrix_free_data;
+
+  MappingFlags mapping_flags;
+  mapping_flags.cells =
+    dealii::update_quadrature_points | dealii::update_values | dealii::update_JxW_values;
+  matrix_free_data.append_mapping_flags(mapping_flags);
+
+  dealii::AffineConstraints<Number> empty_constraints;
+  empty_constraints.clear();
+  empty_constraints.close();
+  for(unsigned int i = 0; i < target_dof_handlers.size(); ++i)
+  {
+    matrix_free_data.insert_dof_handler(target_dof_handlers[i], std::to_string(i));
+    matrix_free_data.insert_constraint(&empty_constraints, std::to_string(i));
+
+    ElementType element_type = get_element_type(target_dof_handlers[i]->get_triangulation());
+
+    std::shared_ptr<dealii::Quadrature<dim>> quadrature =
+      create_quadrature<dim>(element_type, target_dof_handlers[i]->get_fe().degree + 2);
+
+    matrix_free_data.insert_quadrature(*quadrature, std::to_string(i));
+  }
+
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> matrix_free;
+  matrix_free.reinit(*target_mapping,
+                     matrix_free_data.get_dof_handler_vector(),
+                     matrix_free_data.get_constraint_vector(),
+                     matrix_free_data.get_quadrature_vector(),
+                     matrix_free_data.data);
+
+  // Project vectors per `dealii::DoFHandler`.
+  for(unsigned int i = 0; i < target_dof_handlers.size(); ++i)
+  {
+    unsigned int const n_components = target_dof_handlers[i]->get_fe().n_components();
+    if(n_components == 1)
+    {
+      project_vectors<dim, Number, 1 /* n_components */>(source_vectors_per_dof_handler.at(i),
+                                                         *source_dof_handlers.at(i),
+                                                         source_mapping,
+                                                         target_vectors_per_dof_handler.at(i),
+                                                         *target_dof_handlers.at(i),
+                                                         matrix_free,
+                                                         empty_constraints,
+                                                         i /* dof_index */,
+                                                         i /* quad_index */,
+                                                         rpe_tolerance_unit_cell,
+                                                         rpe_enforce_unique_mapping);
+    }
+    else if(n_components == dim)
+    {
+      project_vectors<dim, Number, dim /* n_components */>(source_vectors_per_dof_handler.at(i),
+                                                           *source_dof_handlers.at(i),
+                                                           source_mapping,
+                                                           target_vectors_per_dof_handler.at(i),
+                                                           *target_dof_handlers.at(i),
+                                                           matrix_free,
+                                                           empty_constraints,
+                                                           i /* dof_index */,
+                                                           i /* quad_index */,
+                                                           rpe_tolerance_unit_cell,
+                                                           rpe_enforce_unique_mapping);
+    }
+    else
+    {
+      AssertThrow(n_components == 1 or n_components == dim,
+                  dealii::ExcMessage("The current number of components is not"
+                                     "supported in `grid_to_grid_projection()`."));
+    }
   }
 }
 

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -756,9 +756,10 @@ project_vectors(
       target_matrix_free, fe_eval, values_source_in_q_points_target, dof_index);
 
     // CG solver for global projection.
-    unsigned int constexpr max_iter      = 10000;
-    double const                 abs_tol = 1e-16 * system_rhs.l2_norm();
-    double const                 rel_tol = 1e-12;
+    unsigned int constexpr max_iter = 10000;
+    double const abs_tol            = 1e-16 * system_rhs.l2_norm();
+    double constexpr rel_tol        = 1e-12;
+
     dealii::ReductionControl     reduction_control(max_iter, abs_tol, rel_tol);
     dealii::SolverCG<VectorType> solver_cg(reduction_control);
 
@@ -778,10 +779,11 @@ project_vectors(
 }
 
 /**
- * Utility function to perform grid-to-grid projection using `dealii::RemotePointEvaluation`.
- * We assume we only have a single `dealii::FiniteElement` per `dealii::DoFHandler`.
- * The VectorType template argument is assumed no to be of `BlockVector` type.
- * Note that this function initializes a complete `dealii::MatrixFree` object and hence
+ * Utility function to perform grid-to-grid projection using `dealii::RemotePointEvaluation`. We
+ * assume we only have a single `dealii::FiniteElement` per `dealii::DoFHandler`. The VectorType
+ * template argument is assumed not to be of `BlockVector` type. Note that this function initializes
+ * `dealii::MatrixFree` and `dealii::RemotePointEvaluation` object and hence should be used with
+ * caution.
  */
 template<int dim, typename VectorType>
 inline void
@@ -813,7 +815,7 @@ grid_to_grid_projection(
                 dealii::ExcMessage("Vectors of source and target vectors need to have same size."));
   }
 
-  // Setup `dealii::MatrixFree` object with multiple `dealii::DoFHandler`.
+  // Setup `dealii::MatrixFree` object with multiple `dealii::DoFHandler`s.
   using Number = typename VectorType::value_type;
   MatrixFreeData<dim, Number> matrix_free_data;
 
@@ -880,7 +882,7 @@ grid_to_grid_projection(
     else
     {
       AssertThrow(n_components == 1 or n_components == dim,
-                  dealii::ExcMessage("The current number of components is not"
+                  dealii::ExcMessage("The requested number of components is not"
                                      "supported in `grid_to_grid_projection()`."));
     }
   }

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -29,6 +29,7 @@
 #include <deal.II/base/conditional_ostream.h>
 
 // ExaDG
+#include <exadg/grid/grid_data.h>
 #include <exadg/utilities/numbers.h>
 #include <exadg/utilities/print_functions.h>
 
@@ -42,7 +43,15 @@ struct RestartData
       interval_wall_time(std::numeric_limits<double>::max()),
       interval_time_steps(std::numeric_limits<unsigned int>::max()),
       filename("restart"),
-      counter(1)
+      counter(1),
+      degree_u(dealii::numbers::invalid_unsigned_int),
+      degree_p(dealii::numbers::invalid_unsigned_int),
+      triangulation_type(TriangulationType::Serial),
+      discretization_identical(false),
+      consider_mapping(false),
+      mapping_degree(dealii::numbers::invalid_unsigned_int),
+      rpe_tolerance_unit_cell(1e-12),
+      rpe_enforce_unique_mapping(false)
   {
   }
 
@@ -99,6 +108,33 @@ struct RestartData
 
   // counter needed do decide when to write restart
   mutable unsigned int counter;
+
+  // Finite element degree used when restart data was written (relevant for restart run only).
+  unsigned int degree_u;
+  unsigned int degree_p;
+
+  // TriangulationType used when restart data was written (relevant for restart run only).
+  TriangulationType triangulation_type;
+
+  // The discretization used when writing the restart data was identical to the current one
+  // (after calling `ApplicationBase::create_grid()`). Note that this includes the finite
+  // element, uniform and adaptive refinement, and the TriangulationType, *but* one might
+  // consider a different number of MPI ranks for `dealii::parallel::distributed::Triangulation``
+  // without the need for the otherwise necessary global projection.
+  bool discretization_identical;
+
+  // The mapping of the triangulation should be de-/serialized as well to consider for a mapped
+  // geometry at serialization and during deserialization. This is option toggles storing the
+  // mapping via a displacement vector *and* reading it back in. Hence, this parameter needs to
+  // match in serialization/deserialization runs.
+  bool consider_mapping;
+
+  // The `mapping_degree` considered when storing or reading the grid.
+  unsigned int mapping_degree;
+
+  // Parameters for `dealii::RemotePointEvaluation` used for grid-to-grid projection.
+  double rpe_tolerance_unit_cell;
+  bool   rpe_enforce_unique_mapping;
 };
 
 } // namespace ExaDG

--- a/include/exadg/time_integration/time_int_abm_base.h
+++ b/include/exadg/time_integration/time_int_abm_base.h
@@ -223,18 +223,68 @@ private:
   void
   read_restart_vectors(BoostInputArchiveType & ia) final
   {
-    read_write_distributed_vector(solution, ia);
-    read_write_distributed_vector(prediction, ia);
-
+    std::vector<VectorType *> vectors{&solution, &prediction};
     for(unsigned int i = 0; i < vec_evaluated_operators.size(); ++i)
     {
-      read_write_distributed_vector(vec_evaluated_operators[i], ia);
+      vectors.push_back(&vec_evaluated_operators[i]);
+    }
+
+    pde_operator->deserialize_vectors(vectors);
+
+    // Remains for comparison.
+    try
+    {
+      VectorType solution_compare(solution);
+      VectorType prediction_compare(prediction);
+
+      read_write_distributed_vector(solution_compare, ia);
+      read_write_distributed_vector(prediction_compare, ia);
+
+      std::vector<VectorType> vec_evaluated_operators_compare = vec_evaluated_operators;
+      for(unsigned int i = 0; i < vec_evaluated_operators.size(); ++i)
+      {
+        read_write_distributed_vector(vec_evaluated_operators_compare[i], ia);
+      }
+
+      solution_compare -= solution;
+      prediction_compare -= prediction;
+      double diff_max = std::max(solution_compare.linfty_norm(), prediction_compare.linfty_norm());
+      for(unsigned int i = 0; i < vec_evaluated_operators.size(); ++i)
+      {
+        vec_evaluated_operators_compare[i] -= vec_evaluated_operators[i];
+        vec_evaluated_operators_compare[i] *=
+          solution.linfty_norm() / vec_evaluated_operators[i].linfty_norm();
+        diff_max =
+          std::max(static_cast<double>(vec_evaluated_operators_compare[i].linfty_norm()), diff_max);
+      }
+
+      if(dealii::Utilities::MPI::this_mpi_process(solution.get_mpi_communicator()) == 0)
+      {
+        std::cout << "|difference|_inf = " << diff_max << "\n"
+                  << "(only useful for identical discretization)";
+      }
+    }
+    catch(...)
+    {
+      std::cout << "Comparison to previous serialization not possible.\n"
+                << "This can only be done with identical processor "
+                << "counts and enough data in the archives."
+                << "\n";
     }
   }
 
   void
   write_restart_vectors(BoostOutputArchiveType & oa) const final
   {
+    std::vector<VectorType const *> vectors{&solution, &prediction};
+    for(unsigned int i = 0; i < vec_evaluated_operators.size(); ++i)
+    {
+      vectors.push_back(&vec_evaluated_operators[i]);
+    }
+
+    pde_operator->serialize_vectors(vectors);
+
+    // Remains for comparison.
     read_write_distributed_vector(solution, oa);
     read_write_distributed_vector(prediction, oa);
 

--- a/include/exadg/time_integration/time_int_explicit_runge_kutta_base.cpp
+++ b/include/exadg/time_integration/time_int_explicit_runge_kutta_base.cpp
@@ -148,6 +148,10 @@ TimeIntExplRKBase<Number>::do_write_restart(std::string const & filename) const
   oa & time_step;
 
   // 4. solution vectors
+  std::vector<VectorType const *> vectors{&solution_n};
+  this->write_restart_vectors(vectors);
+
+  // Remains for comparison.
   read_write_distributed_vector(solution_n, oa);
 
   write_restart_file(oss, filename);
@@ -183,7 +187,51 @@ TimeIntExplRKBase<Number>::do_read_restart(std::ifstream & in)
   ia & time_step;
 
   // 4. solution vectors
-  read_write_distributed_vector(solution_n, ia);
+  std::vector<VectorType *> vectors{&solution_n};
+  this->read_restart_vectors(vectors);
+
+  // Remains for comparison.
+  try
+  {
+    VectorType solution_n_compare(solution_n);
+    read_write_distributed_vector(solution_n_compare, ia);
+
+    solution_n_compare -= solution_n;
+    double diff_max = solution_n_compare.linfty_norm();
+    if(dealii::Utilities::MPI::this_mpi_process(solution_n.get_mpi_communicator()) == 0)
+    {
+      std::cout << "|difference|_inf = " << diff_max << "\n"
+                << "(only useful for identical discretization)";
+    }
+  }
+  catch(...)
+  {
+    std::cout << "Comparison to previous serialization not possible.\n"
+              << "This can only be done with identical processor "
+              << "counts and enough data in the archives."
+              << "\n";
+  }
+}
+
+template<typename Number>
+void
+TimeIntExplRKBase<Number>::read_restart_vectors(std::vector<VectorType *> const & vectors)
+{
+  (void)vectors;
+  AssertThrow(false,
+              dealii::ExcMessage("Overwrite this method in the derived "
+                                 "class to enable de-/serialization."));
+}
+
+template<typename Number>
+void
+TimeIntExplRKBase<Number>::write_restart_vectors(
+  std::vector<VectorType const *> const & vectors) const
+{
+  (void)vectors;
+  AssertThrow(false,
+              dealii::ExcMessage("Overwrite this method in the derived "
+                                 "class to enable de-/serialization."));
 }
 
 // instantiations

--- a/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
+++ b/include/exadg/time_integration/time_int_explicit_runge_kutta_base.h
@@ -99,6 +99,12 @@ private:
 
   void
   do_read_restart(std::ifstream & in) final;
+
+  virtual void
+  read_restart_vectors(std::vector<VectorType *> const & vectors);
+
+  virtual void
+  write_restart_vectors(std::vector<VectorType const *> const & vectors) const;
 };
 
 } // namespace ExaDG


### PR DESCRIPTION
continuation of #729 and #731
This extends the generalized serialization towards **implicit** solvers in the **convection diffusion** module.
I tested with the 

`convection_diffusion/rotating_hill`: implicit time integration now and adaptive mesh refinement

application; with two cores I get:
before serialization:
![image](https://github.com/user-attachments/assets/6dc87738-be9d-44af-b211-6b7dd5dabed8)

after deserialization, where I use the same manifold, but no adaptive refinement (completely new grid and domain decomposition essentially):

![image](https://github.com/user-attachments/assets/3117cd50-a48f-47d6-9011-ded86ac88f8a)

end of the simulation:

![image](https://github.com/user-attachments/assets/7ba2875d-d2d9-4223-b079-e3c2e9b342b4)

error increases marginally, see:
[left the restarted run, right the solution with adaptively refined grid]
![image](https://github.com/user-attachments/assets/dfbb978b-b051-4411-a1da-8c48958c98b9)

This is draft until we figured out how to/if we need to reshape #729