### PR TITLE
Extend deserialization rollout implicit navier stokes

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -191,6 +191,7 @@ private:
     // restart
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
+    // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -406,6 +406,7 @@ private:
     // restart
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
+    // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -141,6 +141,7 @@ private:
     // restart
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
+    // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
     this->param.restart_data.directory     = this->output_parameters.directory;
     this->param.restart_data.filename      = this->output_parameters.filename + "_restart";

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -130,6 +130,7 @@ private:
     // restart
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
+    // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -23,7 +23,7 @@
 #define APPLICATIONS_INCOMPRESSIBLE_NAVIER_STOKES_TEST_CASES_NAVIER_STOKES_MANUFACTURED_H_
 
 // ExaDG
-#include <exadg/incompressible_navier_stokes/user_interface/enum_types.h>
+#include <exadg/grid/mesh_movement_functions.h>
 
 namespace ExaDG
 {
@@ -350,6 +350,9 @@ public:
 
     prm.enter_subsection("Application");
     {
+      prm.add_parameter("MoveGrid", move_grid, "Should the grid be deformed over time?");
+      prm.add_parameter("WriteRestart", write_restart, "Should restart files be written?");
+      prm.add_parameter("ReadRestart", read_restart, "Is this a restarted simulation?");
       prm.add_parameter("IncludeConvectiveTerm",
                         include_convective_term,
                         "Include the nonlinear convective term.",
@@ -440,6 +443,10 @@ private:
                                              FormulationViscousTerm::DivergenceFormulation;
     this->param.right_hand_side          = true;
 
+    // ALE
+    this->param.ale_formulation                     = move_grid;
+    this->param.mesh_movement_type                  = MeshMovementType::Function;
+    this->param.neumann_with_variable_normal_vector = true;
 
     // PHYSICAL QUANTITIES
     this->param.start_time = start_time;
@@ -452,7 +459,7 @@ private:
     this->param.solver_type                   = SolverType::Unsteady;
     this->param.temporal_discretization       = temporal_discretization;
     this->param.calculation_of_time_step_size = TimeStepCalculation::UserSpecified;
-    this->param.time_step_size                = this->param.end_time;
+    this->param.time_step_size                = std::abs(end_time - start_time) / 1.0;
     this->param.order_time_integrator         = 2;     // 1; // 2; // 3;
     this->param.start_with_low_order          = false; // true;
 
@@ -462,6 +469,7 @@ private:
 
 
     // SPATIAL DISCRETIZATION
+    this->param.spatial_discretization      = SpatialDiscretization::L2;
     this->param.grid.triangulation_type     = TriangulationType::Distributed;
     this->param.mapping_degree              = this->param.degree_u;
     this->param.mapping_degree_coarse_grids = this->param.mapping_degree;
@@ -520,6 +528,25 @@ private:
       this->param.use_cell_based_face_loops = false;
       this->param.quad_rule_linearization   = QuadratureRuleLinearization::Standard;
     }
+
+    // RESTART
+    this->param.restarted_simulation       = read_restart;
+    this->param.restart_data.write_restart = write_restart;
+    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
+    this->param.restart_data.directory     = this->output_parameters.directory;
+    this->param.restart_data.filename      = this->output_parameters.filename + "_restart";
+    this->param.restart_data.interval_wall_time  = 1.e6;
+    this->param.restart_data.interval_time_steps = 1e8;
+
+    this->param.restart_data.degree_u                   = 5;
+    this->param.restart_data.degree_p                   = 4;
+    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
+    this->param.restart_data.spatial_discretization     = SpatialDiscretization::L2;
+    this->param.restart_data.discretization_identical   = false;
+    this->param.restart_data.consider_mapping           = false;
+    this->param.restart_data.mapping_degree             = 5;
+    this->param.restart_data.rpe_tolerance_unit_cell    = 1e-2;
+    this->param.restart_data.rpe_enforce_unique_mapping = false;
 
     // PROJECTION METHODS
 
@@ -622,6 +649,14 @@ private:
 
         dealii::GridGenerator::hyper_cube(tria, interval_start, interval_end, true);
 
+        // Save the *coarse* triangulation for later deserialization.
+        if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
+        {
+          save_coarse_triangulation<dim>(this->param.restart_data.directory,
+                                         this->param.restart_data.filename,
+                                         tria);
+        }
+
         if(vector_local_refinements.size() > 0)
           refine_local(tria, vector_local_refinements);
 
@@ -643,6 +678,26 @@ private:
                                                  this->param.mapping_degree,
                                                  this->param.mapping_degree_coarse_grids,
                                                  this->param.involves_h_multigrid());
+  }
+
+  std::shared_ptr<dealii::Function<dim>>
+  create_mesh_movement_function() final
+  {
+    std::shared_ptr<dealii::Function<dim>> mesh_motion;
+
+    MeshMovementData<dim> data;
+    data.temporal                       = MeshMovementAdvanceInTime::Sin;
+    data.shape                          = MeshMovementShape::Sin;
+    data.dimensions[0]                  = std::abs(interval_end - interval_start);
+    data.dimensions[1]                  = std::abs(interval_end - interval_start);
+    data.amplitude                      = std::abs(interval_end - interval_start) / 15.0;
+    data.period                         = std::abs(end_time - start_time);
+    data.t_start                        = start_time;
+    data.t_end                          = end_time;
+    data.spatial_number_of_oscillations = 1.0;
+    mesh_motion.reset(new CubeMeshMovementFunctions<dim>(data));
+
+    return mesh_motion;
   }
 
   void
@@ -745,6 +800,10 @@ private:
 
     return pp;
   }
+
+  bool read_restart  = false;
+  bool write_restart = false;
+  bool move_grid     = false;
 
   bool                   include_convective_term                      = true;
   bool                   pure_dirichlet_problem                       = true;

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -459,7 +459,7 @@ private:
     this->param.solver_type                   = SolverType::Unsteady;
     this->param.temporal_discretization       = temporal_discretization;
     this->param.calculation_of_time_step_size = TimeStepCalculation::UserSpecified;
-    this->param.time_step_size                = std::abs(end_time - start_time) / 1.0;
+    this->param.time_step_size                = std::abs(end_time - start_time);
     this->param.order_time_integrator         = 2;     // 1; // 2; // 3;
     this->param.start_with_low_order          = false; // true;
 
@@ -532,6 +532,7 @@ private:
     // RESTART
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
+    // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
     this->param.restart_data.directory     = this->output_parameters.directory;
     this->param.restart_data.filename      = this->output_parameters.filename + "_restart";
@@ -768,7 +769,7 @@ private:
     // write output for visualization of results
     pp_data.output_data.time_control_data.is_active        = this->output_parameters.write;
     pp_data.output_data.time_control_data.start_time       = start_time;
-    pp_data.output_data.time_control_data.trigger_interval = (end_time - start_time) / 1.0;
+    pp_data.output_data.time_control_data.trigger_interval = (end_time - start_time);
     pp_data.output_data.directory          = this->output_parameters.directory + "vtu/";
     pp_data.output_data.filename           = this->output_parameters.filename;
     pp_data.output_data.write_divergence   = true;

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/input.json
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/input.json
@@ -15,28 +15,32 @@
         "RefineTimeMax": "4"
     },
     "Application": {
-         "IncludeConvectiveTerm": "true",
-         "PureDirichletProblem": "true",
-         "StartTime": "0.0",
-         "EndTime": "0.0001",
-         "IntervalStart": "0.0",
-         "IntervalEnd": "1.0",
-         "Density": "1000.0",
-         "KinematicViscosity": "1e-6",
-         "UseGeneralizedNewtonianModel": "true",
-         "FormulationViscousTermLaplaceFormulation" : "false",
-         "TemporalDiscretization" : "BDFPressureCorrection",
-         "TreatmentOfConvectiveTermImplicit" : "true",
-         "TreatmentOfVariableViscosityImplicit" : "true",
-         "GeneralizedNewtonianViscosityMargin": "49e-6",
-         "GeneralizedNewtonianKappa": "1.0",
-         "GeneralizedNewtonianLambda": "1.0",
-         "GeneralizedNewtonianA": "2.0",
-         "GeneralizedNewtonianN": "0.5"
+        "SpatialDiscretization": "L2",
+        "MoveGrid": "false",
+        "ReadRestart": "false",
+        "WriteRestart": "false",
+        "IncludeConvectiveTerm": "true",
+        "PureDirichletProblem": "true",
+        "StartTime": "0.0",
+        "EndTime": "0.0001",
+        "IntervalStart": "0.0",
+        "IntervalEnd": "1.0",
+        "Density": "1000.0",
+        "KinematicViscosity": "1e-6",
+        "UseGeneralizedNewtonianModel": "true",
+        "FormulationViscousTermLaplaceFormulation" : "false",
+        "TemporalDiscretization" : "BDFPressureCorrection",
+        "TreatmentOfConvectiveTermImplicit" : "true",
+        "TreatmentOfVariableViscosityImplicit" : "true",
+        "GeneralizedNewtonianViscosityMargin": "49e-6",
+        "GeneralizedNewtonianKappa": "1.0",
+        "GeneralizedNewtonianLambda": "1.0",
+        "GeneralizedNewtonianA": "2.0",
+        "GeneralizedNewtonianN": "0.5"
     },
     "Output": {
         "OutputDirectory": "output/",
         "OutputName": "test",
-        "WriteOutput": "true"
+        "WriteOutput": "false"
     }
 }

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -288,7 +288,7 @@ SpatialOperator<dim, Number>::deserialize_vectors(
                                    param.restart_data.triangulation_type,
                                    mpi_comm);
 
-  // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  // Set up DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
   dealii::DoFHandler<dim> checkpoint_dof_handler_u(*checkpoint_triangulation);
   dealii::DoFHandler<dim> checkpoint_dof_handler_p(*checkpoint_triangulation);
 
@@ -327,7 +327,7 @@ SpatialOperator<dim, Number>::deserialize_vectors(
     load_vectors(checkpoint_vectors, checkpoint_dof_handlers);
     for(unsigned int i = 0; i < block_vectors.size(); ++i)
     {
-      *block_vectors[i] = checkpoint_block_vectors[i];
+      block_vectors[i]->copy_locally_owned_data_from(checkpoint_block_vectors[i]);
     }
   }
   else

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -377,7 +377,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
                                    param.restart_data.triangulation_type,
                                    mpi_comm);
 
-  // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  // Set up DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
   dealii::DoFHandler<dim> checkpoint_dof_handler(*checkpoint_triangulation);
 
   ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
@@ -405,7 +405,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
     for(unsigned int i = 0; i < vectors.size(); ++i)
     {
-      *vectors[i] = checkpoint_vectors[i];
+      vectors[i]->copy_locally_owned_data_from(checkpoint_vectors[i]);
     }
   }
   else

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -636,6 +636,8 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
 
   std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler};
 
+  // Deserialize the stored vectors associated with the previous triangulation / dof handlers,
+  // in the sequence if blocks (velocity/pressure) matching the one in `this->serialize_vectors()`.
   std::vector<VectorType>                checkpoint_vectors(vectors.size());
   std::vector<std::vector<VectorType *>> checkpoint_vectors_ptr(1);
   checkpoint_vectors_ptr[0].resize(vectors.size());

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -637,7 +637,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
   std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler};
 
   // Deserialize the stored vectors associated with the previous triangulation / dof handlers,
-  // in the sequence if blocks (velocity/pressure) matching the one in `this->serialize_vectors()`.
+  // in the sequence of blocks (velocity/pressure) matching the one in `this->serialize_vectors()`.
   std::vector<VectorType>                checkpoint_vectors(vectors.size());
   std::vector<std::vector<VectorType *>> checkpoint_vectors_ptr(1);
   checkpoint_vectors_ptr[0].resize(vectors.size());

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -624,7 +624,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
                                    param.restart_data.triangulation_type,
                                    mpi_comm);
 
-  // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  // Set up DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
   dealii::DoFHandler<dim> checkpoint_dof_handler(*checkpoint_triangulation);
 
   ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
@@ -654,7 +654,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     load_vectors(checkpoint_vectors_ptr, checkpoint_dof_handlers);
     for(unsigned int i = 0; i < vectors.size(); ++i)
     {
-      *vectors[i] = checkpoint_vectors[i];
+      vectors[i]->copy_locally_owned_data_from(checkpoint_vectors[i]);
     }
   }
   else

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -21,15 +21,18 @@
 
 // ExaDG
 #include <exadg/functions_and_boundary_conditions/interpolate.h>
+#include <exadg/grid/grid_utilities.h>
 #include <exadg/grid/mapping_dof_vector.h>
 #include <exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h>
 #include <exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h>
 #include <exadg/operators/finite_element.h>
 #include <exadg/operators/grid_related_time_step_restrictions.h>
 #include <exadg/operators/quadrature.h>
+#include <exadg/operators/solution_projection_between_triangulations.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
+#include <exadg/time_integration/restart.h>
 #include <exadg/utilities/exceptions.h>
 
 namespace ExaDG
@@ -89,26 +92,15 @@ SpatialOperatorBase<dim, Number>::initialize_dof_handler_and_constraints()
 
   fe_u_scalar = create_finite_element<dim>(param.grid.element_type, true, 1, param.degree_u);
 
-  if(param.spatial_discretization == SpatialDiscretization::L2)
-  {
-    fe_u = create_finite_element<dim>(param.grid.element_type, true, dim, param.degree_u);
-  }
-  else if(param.spatial_discretization == SpatialDiscretization::HDIV)
-  {
-    AssertThrow(
-      param.grid.element_type == ElementType::Hypercube,
-      dealii::ExcMessage(
-        "SpatialDiscretization::HDIV is currently only implemented for hypercube elements. "
-        "You might want to change the element type of the grid, or the function space, "
-        "or implement HDIV for element types other than hypercube."));
+  fe_u = setup_fe_u(param.spatial_discretization, param.grid.element_type, param.degree_u);
 
-    // The constructor of FE_RaviartThomas takes the degree in tangential direction as an
-    // argument.
-    fe_u = std::make_shared<dealii::FE_RaviartThomasNodal<dim>>(param.degree_u - 1);
-  }
-  else
+  if(param.restart_data.consider_mapping and
+     (param.restart_data.write_restart or param.restarted_simulation))
   {
-    AssertThrow(false, dealii::ExcMessage("FE not implemented."));
+    fe_mapping =
+      create_finite_element<dim>(ElementType::Hypercube, true, dim, param.mapping_degree);
+    dof_handler_mapping = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
+    dof_handler_mapping->distribute_dofs(*fe_mapping);
   }
 
   // enumerate degrees of freedom
@@ -998,6 +990,168 @@ SpatialOperatorBase<dim, Number>::prescribe_initial_conditions(VectorType & velo
 
 template<int dim, typename Number>
 void
+SpatialOperatorBase<dim, Number>::serialize_vectors(
+  std::vector<VectorType const *> vectors_velocity,
+  std::vector<VectorType const *> vectors_pressure) const
+{
+  std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler_u, &dof_handler_p};
+  std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors_velocity,
+                                                                       vectors_pressure};
+  if(param.restart_data.consider_mapping)
+  {
+    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
+                                                 param.restart_data.filename,
+                                                 vectors_per_dof_handler,
+                                                 dof_handlers,
+                                                 *this->get_mapping(),
+                                                 &(*dof_handler_mapping),
+                                                 param.mapping_degree);
+  }
+  else
+  {
+    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
+                                                 param.restart_data.filename,
+                                                 vectors_per_dof_handler,
+                                                 dof_handlers);
+  }
+}
+
+template<int dim, typename Number>
+void
+SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> vectors_velocity,
+                                                      std::vector<VectorType *> vectors_pressure)
+{
+  // Store ghost state to recover after deserialization.
+  std::vector<bool> const has_ghost_elements_velocity = get_ghost_state(vectors_velocity);
+  std::vector<bool> const has_ghost_elements_pressure = get_ghost_state(vectors_pressure);
+
+  // Load potentially unfitting checkpoint triangulation of TriangulationType.
+  std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
+    deserialize_triangulation<dim>(param.restart_data.directory,
+                                   param.restart_data.filename,
+                                   param.restart_data.triangulation_type,
+                                   mpi_comm);
+
+  // Setup DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  dealii::DoFHandler<dim> checkpoint_dof_handler_u(*checkpoint_triangulation);
+  dealii::DoFHandler<dim> checkpoint_dof_handler_p(*checkpoint_triangulation);
+
+  ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
+
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_u =
+    setup_fe_u(param.restart_data.spatial_discretization,
+               checkpoint_element_type,
+               param.restart_data.degree_u);
+
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_p =
+    create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
+
+  checkpoint_dof_handler_u.distribute_dofs(*checkpoint_fe_u);
+  checkpoint_dof_handler_p.distribute_dofs(*checkpoint_fe_p);
+
+  std::vector<dealii::DoFHandler<dim> const *> checkpoint_dof_handlers{&checkpoint_dof_handler_u,
+                                                                       &checkpoint_dof_handler_p};
+
+  // Deserialize vectors stored in triangulation, sequence matches `this->serialize_vectors()`.
+  std::vector<VectorType>                checkpoint_vectors_velocity(vectors_velocity.size());
+  std::vector<VectorType>                checkpoint_vectors_pressure(vectors_pressure.size());
+  std::vector<std::vector<VectorType *>> checkpoint_vectors(2);
+
+  for(unsigned int i = 0; i < vectors_velocity.size(); ++i)
+  {
+    checkpoint_vectors_velocity[i].reinit(checkpoint_dof_handler_u.locally_owned_dofs(), mpi_comm);
+    checkpoint_vectors[0 /* velocity */].push_back(&checkpoint_vectors_velocity[i]);
+  }
+  for(unsigned int i = 0; i < vectors_pressure.size(); ++i)
+  {
+    checkpoint_vectors_pressure[i].reinit(checkpoint_dof_handler_p.locally_owned_dofs(), mpi_comm);
+    checkpoint_vectors[1 /* pressure */].push_back(&checkpoint_vectors_pressure[i]);
+  }
+
+  if(param.restart_data.discretization_identical)
+  {
+    // DoFHandlers need to be setup with `checkpoint_triangulation`, otherwise
+    // they are identical. We can simply copy the vector contents.
+    load_vectors(checkpoint_vectors, checkpoint_dof_handlers);
+    for(unsigned int i = 0; i < vectors_velocity.size(); ++i)
+    {
+      *vectors_velocity[i] = checkpoint_vectors_velocity[i];
+    }
+    for(unsigned int i = 0; i < vectors_pressure.size(); ++i)
+    {
+      *vectors_pressure[i] = checkpoint_vectors_pressure[i];
+    }
+  }
+  else
+  {
+    // Perform global projection in case of a non-matching discretization.
+    std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&this->get_dof_handler_u(),
+                                                              &this->get_dof_handler_p()};
+
+    std::vector<std::vector<VectorType *>> vectors_per_dof_handler(2);
+    for(unsigned int i = 0; i < vectors_velocity.size(); ++i)
+    {
+      vectors_per_dof_handler[0 /* velocity */].push_back(vectors_velocity[i]);
+    }
+    for(unsigned int i = 0; i < vectors_pressure.size(); ++i)
+    {
+      vectors_per_dof_handler[1 /* pressure */].push_back(vectors_pressure[i]);
+    }
+
+    // Deserialize mapping from vector or project on reference triangulations.
+    std::shared_ptr<dealii::Mapping<dim> const> checkpoint_mapping;
+    std::shared_ptr<MappingDoFVector<dim, typename VectorType::value_type>>
+      checkpoint_mapping_dof_vector;
+    if(param.restart_data.consider_mapping)
+    {
+      dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
+      std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping =
+        create_finite_element<dim>(checkpoint_element_type,
+                                   true,
+                                   dim,
+                                   param.restart_data.mapping_degree);
+      checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
+
+      checkpoint_mapping_dof_vector = load_vectors(checkpoint_vectors,
+                                                   checkpoint_dof_handlers,
+                                                   &checkpoint_dof_handler_mapping,
+                                                   param.restart_data.mapping_degree);
+
+      checkpoint_mapping = checkpoint_mapping_dof_vector->get_mapping();
+    }
+    else
+    {
+      load_vectors(checkpoint_vectors, checkpoint_dof_handlers);
+
+      // Create dummy linear mapping since we have no mapping serialized to restore.
+      std::shared_ptr<dealii::Mapping<dim>> tmp;
+      GridUtilities::create_mapping(tmp,
+                                    get_element_type(*checkpoint_triangulation),
+                                    1 /* mapping_degree */);
+      checkpoint_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
+    }
+
+    ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
+    data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
+    data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;
+
+    ExaDG::GridToGridProjection::do_grid_to_grid_projection<dim, Number, VectorType>(
+      checkpoint_vectors,
+      checkpoint_dof_handlers,
+      checkpoint_mapping,
+      vectors_per_dof_handler,
+      dof_handlers,
+      *matrix_free,
+      data);
+  }
+
+  // Recover ghost vector state.
+  set_ghost_state(vectors_velocity, has_ghost_elements_velocity);
+  set_ghost_state(vectors_pressure, has_ghost_elements_pressure);
+}
+
+template<int dim, typename Number>
+void
 SpatialOperatorBase<dim, Number>::interpolate_analytical_solution(VectorType & velocity,
                                                                   VectorType & pressure,
                                                                   double const time) const
@@ -1030,6 +1184,38 @@ SpatialOperatorBase<dim, Number>::interpolate_stress_bc(VectorType &       stres
 
   velocity_ptr = nullptr;
   pressure_ptr = nullptr;
+}
+
+template<int dim, typename Number>
+std::shared_ptr<dealii::FiniteElement<dim>>
+SpatialOperatorBase<dim, Number>::setup_fe_u(SpatialDiscretization const spatial_discretization,
+                                             ElementType const           element_type,
+                                             unsigned int const          degree) const
+{
+  std::shared_ptr<dealii::FiniteElement<dim>> fe;
+  if(spatial_discretization == SpatialDiscretization::L2)
+  {
+    fe = create_finite_element<dim>(element_type, true, dim, degree);
+  }
+  else if(spatial_discretization == SpatialDiscretization::HDIV)
+  {
+    AssertThrow(
+      element_type == ElementType::Hypercube,
+      dealii::ExcMessage(
+        "SpatialDiscretization::HDIV is currently only implemented for hypercube elements. "
+        "You might want to change the element type of the grid, or the function space, "
+        "or implement HDIV for element types other than hypercube."));
+
+    // The constructor of FE_RaviartThomas takes the degree in tangential direction as an
+    // argument.
+    fe = std::make_shared<dealii::FE_RaviartThomasNodal<dim>>(degree - 1);
+  }
+  else
+  {
+    AssertThrow(false, dealii::ExcMessage("FE not implemented."));
+  }
+
+  return fe;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -242,12 +242,12 @@ public:
    * De-/serialization of the solution components.
    */
   void
-  serialize_vectors(std::vector<VectorType const *> vectors_velocity,
-                    std::vector<VectorType const *> vectors_pressure) const;
+  serialize_vectors(std::vector<VectorType const *> & vectors_velocity,
+                    std::vector<VectorType const *> & vectors_pressure) const;
 
   void
-  deserialize_vectors(std::vector<VectorType *> vectors_velocity,
-                      std::vector<VectorType *> vectors_pressure);
+  deserialize_vectors(std::vector<VectorType *> & vectors_velocity,
+                      std::vector<VectorType *> & vectors_pressure);
 
   /*
    * Interpolate given functions to the corresponding vectors.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -239,6 +239,17 @@ public:
                                double const time) const;
 
   /*
+   * De-/serialization of the solution components.
+   */
+  void
+  serialize_vectors(std::vector<VectorType const *> vectors_velocity,
+                    std::vector<VectorType const *> vectors_pressure) const;
+
+  void
+  deserialize_vectors(std::vector<VectorType *> vectors_velocity,
+                      std::vector<VectorType *> vectors_pressure);
+
+  /*
    * Interpolate given functions to the corresponding vectors.
    */
   void
@@ -514,10 +525,12 @@ private:
   std::shared_ptr<dealii::FiniteElement<dim>> fe_u;
   std::shared_ptr<dealii::FiniteElement<dim>> fe_p;
   std::shared_ptr<dealii::FiniteElement<dim>> fe_u_scalar;
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_mapping;
 
-  dealii::DoFHandler<dim> dof_handler_u;
-  dealii::DoFHandler<dim> dof_handler_p;
-  dealii::DoFHandler<dim> dof_handler_u_scalar;
+  dealii::DoFHandler<dim>                  dof_handler_u;
+  dealii::DoFHandler<dim>                  dof_handler_p;
+  dealii::DoFHandler<dim>                  dof_handler_u_scalar;
+  std::shared_ptr<dealii::DoFHandler<dim>> dof_handler_mapping;
 
   dealii::AffineConstraints<Number> constraint_u, constraint_p, constraint_u_scalar;
 
@@ -621,6 +634,11 @@ protected:
   dealii::ConditionalOStream pcout;
 
 private:
+  std::shared_ptr<dealii::FiniteElement<dim>>
+  setup_fe_u(SpatialDiscretization const spatial_discretization,
+             ElementType const           element_type,
+             unsigned int const          degree) const;
+
   // Minimum element length h_min required for global CFL condition.
   double
   calculate_minimum_element_length() const;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -256,17 +256,21 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
 {
+  // Setup vectors locally to read into.
+  std::vector<VectorType> vectors_velocity;
+  std::vector<VectorType> vectors_pressure;
   for(unsigned int i = 0; i < this->order; i++)
   {
-    VectorType tmp = get_velocity(i);
-    read_write_distributed_vector(tmp, ia);
-    set_velocity(tmp, i);
+    vectors_velocity.push_back(get_velocity(i));
+    vectors_pressure.push_back(get_pressure(i));
   }
+
+  std::vector<VectorType *> vectors_velocity_ptr;
+  std::vector<VectorType *> vectors_pressure_ptr;
   for(unsigned int i = 0; i < this->order; i++)
   {
-    VectorType tmp = get_pressure(i);
-    read_write_distributed_vector(tmp, ia);
-    set_pressure(tmp, i);
+    vectors_velocity_ptr.push_back(&vectors_velocity[i]);
+    vectors_pressure_ptr.push_back(&vectors_pressure[i]);
   }
 
   if(needs_vector_convective_term)
@@ -275,7 +279,7 @@ TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
     {
       for(unsigned int i = 0; i < this->order; i++)
       {
-        read_write_distributed_vector(vec_convective_term[i], ia);
+        vectors_velocity_ptr.push_back(&vec_convective_term[i]);
       }
     }
   }
@@ -284,8 +288,105 @@ TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
   {
     for(unsigned int i = 0; i < vec_grid_coordinates.size(); i++)
     {
-      read_write_distributed_vector(vec_grid_coordinates[i], ia);
+      vectors_velocity_ptr.push_back(&vec_grid_coordinates[i]);
     }
+  }
+
+  // Add vectors potentially defined in derived class.
+  std::vector<VectorType const *> vectors_velocity_add_ptr;
+  std::vector<VectorType const *> vectors_pressure_add_ptr;
+  this->get_vectors_serialization(vectors_velocity_add_ptr, vectors_pressure_add_ptr);
+  std::vector<VectorType> vectors_velocity_add;
+  std::vector<VectorType> vectors_pressure_add;
+  for(unsigned int i = 0; i < vectors_velocity_add_ptr.size(); ++i)
+  {
+    vectors_velocity_add.push_back(*vectors_velocity_add_ptr[i]);
+  }
+  for(unsigned int i = 0; i < vectors_pressure_add_ptr.size(); ++i)
+  {
+    vectors_pressure_add.push_back(*vectors_pressure_add_ptr[i]);
+  }
+  for(unsigned int i = 0; i < vectors_velocity_add.size(); ++i)
+  {
+    vectors_velocity_ptr.push_back(&vectors_velocity_add[i]);
+  }
+  for(unsigned int i = 0; i < vectors_pressure_add_ptr.size(); ++i)
+  {
+    vectors_pressure_ptr.push_back(&vectors_pressure_add[i]);
+  }
+
+  operator_base->deserialize_vectors(vectors_velocity_ptr, vectors_pressure_ptr);
+
+  // Copy contents from deserialized to used vectors.
+  for(unsigned int i = 0; i < this->order; i++)
+  {
+    set_velocity(vectors_velocity[i], i);
+  }
+  for(unsigned int i = 0; i < this->order; i++)
+  {
+    set_pressure(vectors_pressure[i], i);
+  }
+
+  this->set_vectors_deserialization(vectors_velocity_add, vectors_pressure_add);
+
+  // Remains for comparison. ##+
+  try
+  {
+    double diff_max = 0.0;
+    for(unsigned int i = 0; i < this->order; i++)
+    {
+      VectorType tmp = get_velocity(i);
+      read_write_distributed_vector(tmp, ia);
+      tmp -= get_velocity(i);
+      diff_max = std::max(diff_max, (double)tmp.linfty_norm());
+    }
+    for(unsigned int i = 0; i < this->order; i++)
+    {
+      VectorType tmp = get_pressure(i);
+      read_write_distributed_vector(tmp, ia);
+      tmp -= get_pressure(i);
+      diff_max = std::max(diff_max, (double)tmp.linfty_norm());
+    }
+
+    if(needs_vector_convective_term)
+    {
+      if(this->param.ale_formulation == false)
+      {
+        for(unsigned int i = 0; i < this->order; i++)
+        {
+          VectorType tmp;
+          tmp.reinit(vec_convective_term[i], false /* omit_zeroing_entries */);
+          read_write_distributed_vector(tmp, ia);
+          tmp -= vec_convective_term[i];
+          diff_max = std::max(diff_max, (double)tmp.linfty_norm());
+        }
+      }
+    }
+
+    if(this->param.ale_formulation)
+    {
+      for(unsigned int i = 0; i < vec_grid_coordinates.size(); i++)
+      {
+        VectorType tmp;
+        tmp.reinit(vec_grid_coordinates[i], false /* omit_zeroing_entries */);
+        read_write_distributed_vector(tmp, ia);
+        tmp -= vec_grid_coordinates[i];
+        diff_max = std::max(diff_max, (double)tmp.linfty_norm());
+      }
+    }
+
+    if(dealii::Utilities::MPI::this_mpi_process(this->mpi_comm) == 0)
+    {
+      std::cout << "|difference|_inf = " << diff_max << "\n"
+                << "(only useful for identical discretization)";
+    }
+  }
+  catch(...)
+  {
+    std::cout << "Comparison to previous serialization not possible.\n"
+              << "This can only be done with identical processor "
+              << "counts and enough data in the archives."
+              << "\n";
   }
 }
 
@@ -293,6 +394,48 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::write_restart_vectors(BoostOutputArchiveType & oa) const
 {
+  std::vector<VectorType const *> vectors_velocity;
+  std::vector<VectorType const *> vectors_pressure;
+
+  for(unsigned int i = 0; i < this->order; i++)
+  {
+    vectors_velocity.push_back(&get_velocity(i));
+    vectors_pressure.push_back(&get_pressure(i));
+  }
+
+  if(needs_vector_convective_term)
+  {
+    if(this->param.ale_formulation == false)
+    {
+      for(unsigned int i = 0; i < this->order; i++)
+      {
+        vectors_velocity.push_back(&vec_convective_term[i]);
+      }
+    }
+  }
+
+  if(this->param.ale_formulation)
+  {
+    for(unsigned int i = 0; i < vec_grid_coordinates.size(); i++)
+    {
+      vectors_velocity.push_back(&vec_grid_coordinates[i]);
+    }
+  }
+
+  // Add vectors potentially defined in derived class.
+  std::vector<VectorType const *> vectors_velocity_add;
+  std::vector<VectorType const *> vectors_pressure_add;
+  this->get_vectors_serialization(vectors_velocity_add, vectors_pressure_add);
+  vectors_velocity.insert(vectors_velocity.end(),
+                          vectors_velocity_add.begin(),
+                          vectors_velocity_add.end());
+  vectors_pressure.insert(vectors_pressure.end(),
+                          vectors_pressure_add.begin(),
+                          vectors_pressure_add.end());
+
+  operator_base->serialize_vectors(vectors_velocity, vectors_pressure);
+
+  // Remains for comparison. ##+
   for(unsigned int i = 0; i < this->order; i++)
   {
     read_write_distributed_vector(get_velocity(i), oa);
@@ -320,6 +463,29 @@ TimeIntBDF<dim, Number>::write_restart_vectors(BoostOutputArchiveType & oa) cons
       read_write_distributed_vector(vec_grid_coordinates[i], oa);
     }
   }
+}
+
+template<int dim, typename Number>
+void
+TimeIntBDF<dim, Number>::get_vectors_serialization(
+  std::vector<VectorType const *> & vectors_velocity,
+  std::vector<VectorType const *> & vectors_pressure) const
+{
+  // Overwrite this method in the derived class to attach additional vectors for serialization.
+  (void)vectors_velocity;
+  (void)vectors_pressure;
+}
+
+template<int dim, typename Number>
+void
+TimeIntBDF<dim, Number>::set_vectors_deserialization(
+  std::vector<VectorType> const & vectors_velocity,
+  std::vector<VectorType> const & vectors_pressure)
+{
+  // Overwrite this method in the derived class to process the attached vectors after
+  // deserialization.
+  (void)vectors_velocity;
+  (void)vectors_pressure;
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -110,10 +110,10 @@ protected:
   setup_derived() override;
 
   void
-  read_restart_vectors(BoostInputArchiveType & ia) override;
+  read_restart_vectors(BoostInputArchiveType & ia) final;
 
   void
-  write_restart_vectors(BoostOutputArchiveType & oa) const override;
+  write_restart_vectors(BoostOutputArchiveType & oa) const final;
 
   virtual void
   get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -115,6 +115,14 @@ protected:
   void
   write_restart_vectors(BoostOutputArchiveType & oa) const override;
 
+  virtual void
+  get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,
+                            std::vector<VectorType const *> & vectors_pressure) const;
+
+  virtual void
+  set_vectors_deserialization(std::vector<VectorType> const & vectors_velocity,
+                              std::vector<VectorType> const & vectors_pressure);
+
   void
   prepare_vectors_for_next_timestep() override;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -89,42 +89,6 @@ TimeIntBDFDualSplitting<dim, Number>::setup_derived()
 
 template<int dim, typename Number>
 void
-TimeIntBDFDualSplitting<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
-{
-  Base::read_restart_vectors(ia);
-
-  // Remains for comparison. ##+
-  double max_diff_derived = 0.0;
-  for(unsigned int i = 0; i < velocity_dbc.size(); i++)
-  {
-    VectorType tmp;
-    tmp.reinit(velocity_dbc[i], false /* omit_zeroing_entries */);
-    read_write_distributed_vector(tmp, ia);
-    tmp -= velocity_dbc[i];
-    max_diff_derived = std::max(max_diff_derived, (double)tmp.linfty_norm());
-
-    if(i == velocity_dbc.size() - 1 and
-       dealii::Utilities::MPI::this_mpi_process(tmp.get_mpi_communicator()) == 0)
-    {
-      std::cout << "max_diff_derived = " << max_diff_derived << "##+ \n";
-    }
-  }
-}
-
-template<int dim, typename Number>
-void
-TimeIntBDFDualSplitting<dim, Number>::write_restart_vectors(BoostOutputArchiveType & oa) const
-{
-  Base::write_restart_vectors(oa);
-
-  for(unsigned int i = 0; i < velocity_dbc.size(); i++)
-  {
-    read_write_distributed_vector(velocity_dbc[i], oa);
-  }
-}
-
-template<int dim, typename Number>
-void
 TimeIntBDFDualSplitting<dim, Number>::get_vectors_serialization(
   std::vector<VectorType const *> & vectors_velocity,
   std::vector<VectorType const *> & vectors_pressure) const

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -93,9 +93,21 @@ TimeIntBDFDualSplitting<dim, Number>::read_restart_vectors(BoostInputArchiveType
 {
   Base::read_restart_vectors(ia);
 
+  // Remains for comparison. ##+
+  double max_diff_derived = 0.0;
   for(unsigned int i = 0; i < velocity_dbc.size(); i++)
   {
-    read_write_distributed_vector(velocity_dbc[i], ia);
+    VectorType tmp;
+    tmp.reinit(velocity_dbc[i], false /* omit_zeroing_entries */);
+    read_write_distributed_vector(tmp, ia);
+    tmp -= velocity_dbc[i];
+    max_diff_derived = std::max(max_diff_derived, (double)tmp.linfty_norm());
+
+    if(i == velocity_dbc.size() - 1 and
+       dealii::Utilities::MPI::this_mpi_process(tmp.get_mpi_communicator()) == 0)
+    {
+      std::cout << "max_diff_derived = " << max_diff_derived << "##+ \n";
+    }
   }
 }
 
@@ -108,6 +120,34 @@ TimeIntBDFDualSplitting<dim, Number>::write_restart_vectors(BoostOutputArchiveTy
   for(unsigned int i = 0; i < velocity_dbc.size(); i++)
   {
     read_write_distributed_vector(velocity_dbc[i], oa);
+  }
+}
+
+template<int dim, typename Number>
+void
+TimeIntBDFDualSplitting<dim, Number>::get_vectors_serialization(
+  std::vector<VectorType const *> & vectors_velocity,
+  std::vector<VectorType const *> & vectors_pressure) const
+{
+  (void)vectors_pressure;
+
+  for(unsigned int i = 0; i < velocity_dbc.size(); i++)
+  {
+    vectors_velocity.push_back(&velocity_dbc[i]);
+  }
+}
+
+template<int dim, typename Number>
+void
+TimeIntBDFDualSplitting<dim, Number>::set_vectors_deserialization(
+  std::vector<VectorType> const & vectors_velocity,
+  std::vector<VectorType> const & vectors_pressure)
+{
+  (void)vectors_pressure;
+
+  for(unsigned int i = 0; i < velocity_dbc.size(); i++)
+  {
+    velocity_dbc[i] = vectors_velocity[i];
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -84,12 +84,6 @@ private:
   setup_derived() final;
 
   void
-  read_restart_vectors(BoostInputArchiveType & ia) final;
-
-  void
-  write_restart_vectors(BoostOutputArchiveType & oa) const final;
-
-  void
   get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,
                             std::vector<VectorType const *> & vectors_pressure) const final;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -90,6 +90,14 @@ private:
   write_restart_vectors(BoostOutputArchiveType & oa) const final;
 
   void
+  get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,
+                            std::vector<VectorType const *> & vectors_pressure) const final;
+
+  void
+  set_vectors_deserialization(std::vector<VectorType> const & vectors_velocity,
+                              std::vector<VectorType> const & vectors_pressure) final;
+
+  void
   do_timestep_solve() final;
 
   void

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -98,43 +98,6 @@ TimeIntBDFPressureCorrection<dim, Number>::setup_derived()
 
 template<int dim, typename Number>
 void
-TimeIntBDFPressureCorrection<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
-{
-  Base::read_restart_vectors(ia);
-
-  // Remains for comparison. ##+
-  double max_diff_derived = 0.0;
-  for(unsigned int i = 0; i < pressure_dbc.size(); i++)
-  {
-    VectorType tmp;
-    tmp.reinit(pressure_dbc[i], false /* omit_zeroing_entries */);
-    read_write_distributed_vector(tmp, ia);
-    tmp -= pressure_dbc[i];
-    max_diff_derived = std::max(max_diff_derived, (double)tmp.linfty_norm());
-
-    if(i == pressure_dbc.size() - 1 and
-       dealii::Utilities::MPI::this_mpi_process(tmp.get_mpi_communicator()) == 0)
-    {
-      std::cout << "max_diff_derived = " << max_diff_derived << "##+ \n";
-    }
-  }
-}
-
-template<int dim, typename Number>
-void
-TimeIntBDFPressureCorrection<dim, Number>::write_restart_vectors(BoostOutputArchiveType & oa) const
-{
-  Base::write_restart_vectors(oa);
-
-  // Remains for comparison. ##+
-  for(unsigned int i = 0; i < pressure_dbc.size(); i++)
-  {
-    read_write_distributed_vector(pressure_dbc[i], oa);
-  }
-}
-
-template<int dim, typename Number>
-void
 TimeIntBDFPressureCorrection<dim, Number>::get_vectors_serialization(
   std::vector<VectorType const *> & vectors_velocity,
   std::vector<VectorType const *> & vectors_pressure) const

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -93,12 +93,6 @@ private:
   initialize_former_multistep_dof_vectors() final;
 
   void
-  read_restart_vectors(BoostInputArchiveType & ia) final;
-
-  void
-  write_restart_vectors(BoostOutputArchiveType & oa) const final;
-
-  void
   get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,
                             std::vector<VectorType const *> & vectors_pressure) const final;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -99,6 +99,14 @@ private:
   write_restart_vectors(BoostOutputArchiveType & oa) const final;
 
   void
+  get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,
+                            std::vector<VectorType const *> & vectors_pressure) const final;
+
+  void
+  set_vectors_deserialization(std::vector<VectorType> const & vectors_velocity,
+                              std::vector<VectorType> const & vectors_pressure) final;
+
+  void
   initialize_pressure_on_boundary();
 
   void

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -228,7 +228,7 @@ project_vectors(
   if(not rpe_source.all_points_found())
   {
     write_points_in_dummy_triangulation(
-      integration_points_target, "./", "all_points", 0, source_dof_handler.get_mpi_communicator());
+      integration_points_target, "./", "points_all", 0, source_dof_handler.get_mpi_communicator());
 
     std::vector<dealii::Point<dim>> points_not_found;
     points_not_found.reserve(integration_points_target.size());
@@ -243,10 +243,11 @@ project_vectors(
     write_points_in_dummy_triangulation(
       points_not_found, "./", "points_not_found", 0, source_dof_handler.get_mpi_communicator());
 
-    AssertThrow(rpe_source.all_points_found(),
-                dealii::ExcMessage(
-                  "Could not interpolate source grid vector in target grid. "
-                  "Points exported to `./all_points.pvtu` and `./points_not_found.pvtu`"));
+    AssertThrow(
+      rpe_source.all_points_found(),
+      dealii::ExcMessage(
+        "Could not interpolate source grid vector in target grid. "
+        "Points exported to `./points_all_points.pvtu` and `./points_not_found_points.pvtu`"));
   }
 
   // Loop over vectors and project.


### PR DESCRIPTION
continuation of #729, #731 and #732
This extends the generalized serialization towards  incompressible Navier-Stokes solvers.
I tested with the 

`incompressible_navier_stokes/navier_stokes_manufactured`.

I tested changing the grid/FE space and ALE mapping. 
I did not yet test the `DG_Q` -> `RaviartThomasNodal` case, since there is no application with analytical solution that does not trigger the assert:

![image](https://github.com/user-attachments/assets/64f0f77c-d69f-4936-bad7-4da6124eedbd)

Also, this is roughly 350 lines on top of the rest, but the comparisons to the old path will be removed after we discussed #729.