### PR TITLE
introduce `grid_to_grid_projection()` and related test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ SET(TARGET_SRC
      include/exadg/operators/operator_base.cpp
      include/exadg/operators/mass_operator.cpp
      include/exadg/operators/rhs_operator.cpp
+     include/exadg/operators/solution_projection_between_triangulations.cpp
      include/exadg/operators/navier_stokes_calculators.cpp
      # Poisson equation
      include/exadg/poisson/user_interface/parameters.cpp

--- a/include/exadg/operators/solution_projection_between_triangulations.cpp
+++ b/include/exadg/operators/solution_projection_between_triangulations.cpp
@@ -1,0 +1,361 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// C/C++
+#include <algorithm>
+
+// deal.II
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/matrix_free/fe_point_evaluation.h>
+#include <deal.II/numerics/vector_tools.h>
+
+// ExaDG
+#include <exadg/matrix_free/matrix_free_data.h>
+#include <exadg/operators/inverse_mass_operator.h>
+#include <exadg/operators/mapping_flags.h>
+#include <exadg/operators/quadrature.h>
+#include <exadg/operators/solution_projection_between_triangulations.h>
+#include <exadg/postprocessor/write_output.h>
+
+namespace ExaDG
+{
+namespace GridToGridProjection
+{
+template<int dim, int n_components, typename Number>
+std::vector<dealii::Point<dim>>
+collect_integration_points(
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  unsigned int const                                                       dof_index,
+  unsigned int const                                                       quad_index)
+{
+  CellIntegrator<dim, n_components, Number> fe_eval(matrix_free, dof_index, quad_index);
+
+  // Conservative estimate for the number of points.
+  std::vector<dealii::Point<dim>> integration_points;
+  integration_points.reserve(
+    matrix_free.get_dof_handler(dof_index).get_triangulation().n_active_cells() *
+    fe_eval.n_q_points);
+
+  for(unsigned int cell_batch_idx = 0; cell_batch_idx < matrix_free.n_cell_batches();
+      ++cell_batch_idx)
+  {
+    fe_eval.reinit(cell_batch_idx);
+    for(const unsigned int q : fe_eval.quadrature_point_indices())
+    {
+      dealii::Point<dim, dealii::VectorizedArray<Number>> const cell_batch_points =
+        fe_eval.quadrature_point(q);
+      for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); ++i)
+      {
+        dealii::Point<dim> p;
+        for(unsigned int d = 0; d < dim; ++d)
+        {
+          p[d] = cell_batch_points[d][i];
+        }
+        integration_points.push_back(p);
+      }
+    }
+  }
+
+  return integration_points;
+}
+
+template<int dim, int n_components, typename Number, typename VectorType>
+VectorType
+assemble_projection_rhs(
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  std::vector<
+    typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const &
+                     values_source_in_q_points_target,
+  unsigned int const dof_index,
+  unsigned int const quad_index)
+{
+  VectorType system_rhs;
+  matrix_free.initialize_dof_vector(system_rhs, dof_index);
+
+  CellIntegrator<dim, n_components, Number> fe_eval(matrix_free, dof_index, quad_index);
+
+  unsigned int idx_q_point = 0;
+
+  for(unsigned int cell_batch_idx = 0; cell_batch_idx < matrix_free.n_cell_batches();
+      ++cell_batch_idx)
+  {
+    fe_eval.reinit(cell_batch_idx);
+    for(unsigned int const q : fe_eval.quadrature_point_indices())
+    {
+      dealii::Tensor<1, n_components, dealii::VectorizedArray<Number>> tmp;
+
+      for(unsigned int i = 0; i < dealii::VectorizedArray<Number>::size(); ++i)
+      {
+        typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type const
+          values = values_source_in_q_points_target[idx_q_point];
+
+        // Increment index into `values_source_in_q_points_target`, meaning that the sequence of
+        // function values in integration points need to match the particular sequence here.
+        ++idx_q_point;
+
+        if constexpr(n_components == 1)
+        {
+          tmp[0][i] = values;
+        }
+        else
+        {
+          for(unsigned int c = 0; c < n_components; ++c)
+          {
+            tmp[c][i] = values[c];
+          }
+        }
+      }
+
+      fe_eval.submit_value(tmp, q);
+    }
+    fe_eval.integrate(dealii::EvaluationFlags::values);
+    fe_eval.distribute_local_to_global(system_rhs);
+  }
+  system_rhs.compress(dealii::VectorOperation::add);
+
+  return system_rhs;
+}
+
+template<int dim, typename Number, int n_components, typename VectorType>
+void
+project_vectors(
+  std::vector<VectorType *> const &                                        source_vectors,
+  dealii::DoFHandler<dim> const &                                          source_dof_handler,
+  std::shared_ptr<dealii::Mapping<dim> const> const &                      source_mapping,
+  std::vector<VectorType *> const &                                        target_vectors,
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & target_matrix_free,
+  dealii::AffineConstraints<Number> const &                                constraints,
+  unsigned int const                                                       dof_index,
+  unsigned int const                                                       quad_index,
+  GridToGridProjectionData<dim> const &                                    data)
+{
+  // Setup inverse mass operator.
+  InverseMassOperatorData<Number> inverse_mass_operator_data;
+  inverse_mass_operator_data.dof_index                      = dof_index;
+  inverse_mass_operator_data.quad_index                     = quad_index;
+  inverse_mass_operator_data.parameters.preconditioner      = PreconditionerMass::PointJacobi;
+  inverse_mass_operator_data.parameters.solver_data         = data.solver_data;
+  inverse_mass_operator_data.parameters.implementation_type = data.inverse_mass_type;
+
+  InverseMassOperator<dim, n_components, Number> inverse_mass_operator;
+  inverse_mass_operator.initialize(target_matrix_free, inverse_mass_operator_data);
+
+  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe_source(data.rpe_data);
+
+  // The sequence of integration points follows from the sequence of points as encountered during
+  // cell batch loop.
+  std::vector<dealii::Point<dim>> integration_points_target =
+    collect_integration_points<dim, n_components, Number>(target_matrix_free,
+                                                          dof_index,
+                                                          quad_index);
+
+  rpe_source.reinit(integration_points_target,
+                    source_dof_handler.get_triangulation(),
+                    *source_mapping);
+
+  if(not rpe_source.all_points_found())
+  {
+    write_points_in_dummy_triangulation(
+      integration_points_target, "./", "all_points", 0, source_dof_handler.get_communicator());
+
+    std::vector<dealii::Point<dim>> points_not_found;
+    points_not_found.reserve(integration_points_target.size());
+    for(unsigned int i = 0; i < integration_points_target.size(); ++i)
+    {
+      if(not rpe_source.point_found(i))
+      {
+        points_not_found.push_back(integration_points_target[i]);
+      }
+    }
+
+    write_points_in_dummy_triangulation(
+      points_not_found, "./", "points_not_found", 0, source_dof_handler.get_communicator());
+
+    AssertThrow(rpe_source.all_points_found(),
+                dealii::ExcMessage(
+                  "Could not interpolate source grid vector in target grid. "
+                  "Points exported to `./all_points.pvtu` and `./points_not_found.pvtu`"));
+  }
+
+  // Loop over vectors and project.
+  for(unsigned int i = 0; i < target_vectors.size(); ++i)
+  {
+    // Evaluate the source vector at the target integration points.
+    VectorType const & source_vector = *source_vectors.at(i);
+    source_vector.update_ghost_values();
+
+    std::vector<
+      typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const
+      values_source_in_q_points_target = dealii::VectorTools::point_values<n_components>(
+        rpe_source, source_dof_handler, source_vector, dealii::VectorTools::EvaluationFlags::avg);
+
+    // Assemble right hand side vector for the projection.
+    VectorType system_rhs = assemble_projection_rhs<dim, n_components, Number, VectorType>(
+      target_matrix_free, values_source_in_q_points_target, dof_index, quad_index);
+
+    // Solve linear system starting from zero initial guess.
+    VectorType sol;
+    sol.reinit(system_rhs, false /* omit_zeroing_entries */);
+
+    inverse_mass_operator.apply(sol, system_rhs);
+
+    // Copy solution to target vector.
+    *target_vectors[i] = sol;
+  }
+}
+
+template<int dim, typename Number, typename VectorType>
+void
+do_grid_to_grid_projection(
+  std::vector<std::vector<VectorType *>> const &       source_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & source_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  source_mapping,
+  std::vector<std::vector<VectorType *>> &             target_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & target_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  target_mapping,
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  GridToGridProjectionData<dim> const &                                    data)
+{
+  // Check input dimensions.
+  AssertThrow(source_vectors_per_dof_handler.size() == source_dof_handlers.size(),
+              dealii::ExcMessage("First dimension of source vector of vectors "
+                                 "has to match source DoFHandler count."));
+  AssertThrow(target_vectors_per_dof_handler.size() == target_dof_handlers.size(),
+              dealii::ExcMessage("First dimension of target vector of vectors "
+                                 "has to match target DoFHandler count."));
+  AssertThrow(source_dof_handlers.size() == target_dof_handlers.size(),
+              dealii::ExcMessage("Target and source DoFHandler counts have to match"));
+  AssertThrow(source_vectors_per_dof_handler.size() > 0,
+              dealii::ExcMessage("Vector of source vectors empty."));
+  for(unsigned int i = 0; i < source_vectors_per_dof_handler.size(); ++i)
+  {
+    AssertThrow(source_vectors_per_dof_handler[i].size() ==
+                  target_vectors_per_dof_handler.at(i).size(),
+                dealii::ExcMessage("Vectors of source and target vectors need to have same size."));
+  }
+
+  // Project vectors per `dealii::DoFHandler`.
+  for(unsigned int i = 0; i < target_dof_handlers.size(); ++i)
+  {
+    unsigned int const n_components = target_dof_handlers[i]->get_fe().n_components();
+    if(n_components == 1)
+    {
+      project_vectors<dim, Number, 1 /* n_components */, VectorType>(
+        source_vectors_per_dof_handler.at(i),
+        *source_dof_handlers.at(i),
+        source_mapping,
+        target_vectors_per_dof_handler.at(i),
+        matrix_free,
+        matrix_free.get_affine_constraints(i),
+        i /* dof_index */,
+        i /* quad_index */,
+        data);
+    }
+    else if(n_components == dim)
+    {
+      project_vectors<dim, Number, dim /* n_components */, VectorType>(
+        source_vectors_per_dof_handler.at(i),
+        *source_dof_handlers.at(i),
+        source_mapping,
+        target_vectors_per_dof_handler.at(i),
+        matrix_free,
+        matrix_free.get_affine_constraints(i),
+        i /* dof_index */,
+        i /* quad_index */,
+        data);
+    }
+    else if(n_components == dim + 2)
+    {
+      project_vectors<dim, Number, dim + 2 /* n_components */, VectorType>(
+        source_vectors_per_dof_handler.at(i),
+        *source_dof_handlers.at(i),
+        source_mapping,
+        target_vectors_per_dof_handler.at(i),
+        matrix_free,
+        matrix_free.get_affine_constraints(i),
+        i /* dof_index */,
+        i /* quad_index */,
+        data);
+    }
+    else
+    {
+      AssertThrow(n_components == 1 or n_components == dim,
+                  dealii::ExcMessage("The requested number of components is not"
+                                     "supported in `grid_to_grid_projection()`."));
+    }
+  }
+}
+
+template<int dim, typename Number, typename VectorType>
+void
+grid_to_grid_projection(
+  std::vector<std::vector<VectorType *>> const &       source_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & source_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  source_mapping,
+  std::vector<std::vector<VectorType *>> &             target_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & target_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  target_mapping,
+  GridToGridProjectionData<dim> const &                data)
+{
+  // Setup a single `dealii::MatrixFree` object with multiple `dealii::DoFHandler`s.
+  MatrixFreeData<dim, Number> matrix_free_data;
+
+  MappingFlags mapping_flags;
+  mapping_flags.cells =
+    dealii::update_quadrature_points | dealii::update_values | dealii::update_JxW_values;
+  matrix_free_data.append_mapping_flags(mapping_flags);
+
+  dealii::AffineConstraints<Number> empty_constraints;
+  empty_constraints.clear();
+  empty_constraints.close();
+  for(unsigned int i = 0; i < target_dof_handlers.size(); ++i)
+  {
+    matrix_free_data.insert_dof_handler(target_dof_handlers[i], std::to_string(i));
+    matrix_free_data.insert_constraint(&empty_constraints, std::to_string(i));
+
+    ElementType element_type = get_element_type(target_dof_handlers[i]->get_triangulation());
+
+    std::shared_ptr<dealii::Quadrature<dim>> quadrature = create_quadrature<dim>(
+      element_type, target_dof_handlers[i]->get_fe().degree + data.additional_quadrature_points);
+
+    matrix_free_data.insert_quadrature(*quadrature, std::to_string(i));
+  }
+
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> matrix_free;
+  matrix_free.reinit(*target_mapping,
+                     matrix_free_data.get_dof_handler_vector(),
+                     matrix_free_data.get_constraint_vector(),
+                     matrix_free_data.get_quadrature_vector(),
+                     matrix_free_data.data);
+
+  do_grid_to_grid_projection<dim, Number, VectorType>(source_vectors_per_dof_handler,
+                                                      source_dof_handlers,
+                                                      source_mapping,
+                                                      target_vectors_per_dof_handler,
+                                                      target_dof_handlers,
+                                                      target_mapping,
+                                                      matrix_free,
+                                                      data);
+}
+
+} // namespace GridToGridProjection
+} // namespace ExaDG

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -1,0 +1,150 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_OPERATORS_SOLUTION_PROJECTION_BETWEEN_TRIANGULATIONS_H_
+#define EXADG_OPERATORS_SOLUTION_PROJECTION_BETWEEN_TRIANGULATIONS_H_
+
+// deal.II
+#include <deal.II/base/mpi_remote_point_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+
+// ExaDG
+#include <exadg/matrix_free/integrators.h>
+#include <exadg/operators/inverse_mass_parameters.h>
+
+namespace ExaDG
+{
+namespace GridToGridProjection
+{
+// Parameters controlling the grid-to-grid projection.
+template<int dim>
+struct GridToGridProjectionData
+{
+  GridToGridProjectionData()
+    : rpe_data(),
+      solver_data(),
+      preconditioner(PreconditionerMass::PointJacobi),
+      inverse_mass_type(InverseMassType::MatrixfreeOperator),
+      additional_quadrature_points(1),
+      is_test(false)
+  {
+  }
+
+  void
+  print(dealii::ConditionalOStream const & pcout) const
+  {
+    print_parameter(pcout, "RPE tolerance", rpe_data.tolerance);
+    print_parameter(pcout, "RPE enforce unique mapping", rpe_data.enforce_unique_mapping);
+    print_parameter(pcout, "RPE rtree level", rpe_data.rtree_level);
+  }
+
+  typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData::AdditionalData
+                     rpe_data;
+  SolverData         solver_data;
+  PreconditionerMass preconditioner;
+  InverseMassType    inverse_mass_type;
+
+  // Number of additional integration points used for sampling the source grid.
+  // The default `additional_quadrature_points = 1` considers `fe_degree + 1` quadrature points in
+  // 1D using the `fe_degree` of the target grid's finite element.
+  unsigned int additional_quadrature_points;
+
+  // Toggle iteration count and timing output.
+  bool is_test;
+};
+
+/**
+ * Utility function to collect integration points in the particular sequence they are encountered
+ * in.
+ */
+template<int dim, int n_components, typename Number>
+std::vector<dealii::Point<dim>>
+collect_integration_points(
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  unsigned int const                                                       dof_index,
+  unsigned int const                                                       quad_index);
+
+/**
+ * Utility function to compute the right hand side of a projection (mass matrix solve)
+ * with values given in integration points in the particular sequence they are encountered in.
+ */
+template<int dim, int n_components, typename Number, typename VectorType>
+VectorType
+assemble_projection_rhs(
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  std::vector<
+    typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const &
+                     values_source_in_q_points_target,
+  unsigned int const dof_index,
+  unsigned int const quad_index);
+
+/**
+ * Utilitiy function to project vectors from a source to a target triangulation via
+ * matrix-free mass operator evaluation and preconditioned CG solver.
+ */
+template<int dim, typename Number, int n_components, typename VectorType>
+void
+project_vectors(
+  std::vector<VectorType *> const &                                        source_vectors,
+  dealii::DoFHandler<dim> const &                                          source_dof_handler,
+  std::shared_ptr<dealii::Mapping<dim> const> const &                      source_mapping,
+  std::vector<VectorType *> const &                                        target_vectors,
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & target_matrix_free,
+  dealii::AffineConstraints<Number> const &                                constraints,
+  unsigned int const                                                       dof_index,
+  unsigned int const                                                       quad_index,
+  GridToGridProjectionData<dim> const &                                    data);
+
+/**
+ * Utility function to perform matrix-free grid-to-grid projection. We assume we only have a single
+ * `dealii::FiniteElement` per `dealii::DoFHandler`. This function creates a `MatrixFree` object.
+ */
+template<int dim, typename Number, typename VectorType>
+void
+grid_to_grid_projection(
+  std::vector<std::vector<VectorType *>> const &       source_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & source_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  source_mapping,
+  std::vector<std::vector<VectorType *>> &             target_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & target_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  target_mapping,
+  GridToGridProjectionData<dim> const &                data);
+
+/**
+ * Same as the function above, but relies on a suitable `MatrixFree` object input argument.
+ * We assume that the `MatrixFree` object
+ * */
+template<int dim, typename Number, typename VectorType>
+void
+do_grid_to_grid_projection(
+  std::vector<std::vector<VectorType *>> const &       source_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & source_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  source_mapping,
+  std::vector<std::vector<VectorType *>> &             target_vectors_per_dof_handler,
+  std::vector<dealii::DoFHandler<dim> const *> const & target_dof_handlers,
+  std::shared_ptr<dealii::Mapping<dim> const> const &  target_mapping,
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & matrix_free,
+  GridToGridProjectionData<dim> const &                                    data);
+
+} // namespace GridToGridProjection
+} // namespace ExaDG
+
+#endif /* EXADG_OPERATORS_SOLUTION_PROJECTION_BETWEEN_TRIANGULATIONS_H_ */

--- a/include/exadg/postprocessor/error_calculation.cpp
+++ b/include/exadg/postprocessor/error_calculation.cpp
@@ -177,7 +177,8 @@ ErrorCalculator<dim, Number>::do_evaluate(VectorType const & solution_vector, do
                                             time,
                                             dealii::VectorTools::L2_norm,
                                             error_data.spatially_weight_error,
-                                            error_data.weight);
+                                            error_data.weight,
+                                            error_data.additional_quadrature_points);
 
   dealii::ConditionalOStream pcout(std::cout,
                                    dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0);
@@ -223,7 +224,8 @@ ErrorCalculator<dim, Number>::do_evaluate(VectorType const & solution_vector, do
                                               time,
                                               dealii::VectorTools::H1_seminorm,
                                               error_data.spatially_weight_error,
-                                              error_data.weight);
+                                              error_data.weight,
+                                              error_data.additional_quadrature_points);
 
     dealii::ConditionalOStream pcout(std::cout,
                                      dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0);

--- a/include/exadg/postprocessor/error_calculation.h
+++ b/include/exadg/postprocessor/error_calculation.h
@@ -43,6 +43,7 @@ struct ErrorCalculationData
       write_errors_to_file(false),
       spatially_weight_error(false),
       weight(nullptr),
+      additional_quadrature_points(3),
       directory("output/"),
       name("all fields")
   {
@@ -84,6 +85,8 @@ struct ErrorCalculationData
   bool spatially_weight_error;
   // Weight used to compute spatially weighted error.
   std::shared_ptr<dealii::Function<dim>> weight;
+  // Number of quadrature points in 1D: fe_degree + additional_quadrature_points
+  unsigned int additional_quadrature_points;
 
   // directory and name (used as filename and as identifier for screen output)
   std::string directory;

--- a/tests/utilities/grid_to_grid_projection.cc
+++ b/tests/utilities/grid_to_grid_projection.cc
@@ -1,0 +1,688 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// deal.II
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_raviart_thomas.h>
+#include <deal.II/fe/mapping_fe.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/matrix_free/fe_point_evaluation.h>
+#include <deal.II/numerics/vector_tools.h>
+
+// ExaDG
+#include <exadg/grid/grid_data.h>
+#include <exadg/operators/finite_element.h>
+#include <exadg/operators/solution_projection_between_triangulations.h>
+#include <exadg/postprocessor/error_calculation.h>
+#include <exadg/postprocessor/write_output.h>
+#include <exadg/utilities/numbers.h>
+#include <exadg/operators/solution_projection_between_triangulations.cpp> // temporary
+
+using namespace ExaDG;
+
+template<int dim, int n_components>
+class SampleFunction : public dealii::Function<dim>
+{
+public:
+  SampleFunction(double scale) : dealii::Function<dim>(n_components), scale(scale)
+  {
+  }
+
+  virtual double
+  value(dealii::Point<dim> const & p, unsigned int const component = 0) const override;
+
+private:
+  double scale;
+};
+
+template<int dim, int n_components>
+double
+SampleFunction<dim, n_components>::value(dealii::Point<dim> const & p,
+                                         unsigned int const         component) const
+{
+  if(component == 0)
+  {
+    return scale * (1.1 + std::sin(0.75 * p[0]));
+  }
+  else if(component == 1)
+  {
+    return scale * (1.1 + std::sin(1.0 * p[1]));
+  }
+  else if(component == 2)
+  {
+    if constexpr(dim == 3)
+    {
+      return scale * (1.1 + std::sin(0.5 * p[2]));
+    }
+  }
+
+  return 0.0;
+}
+
+template<int dim, int n_components>
+class GridToGridProjector
+{
+  using VectorType = dealii::LinearAlgebra::distributed::Vector<double>;
+
+public:
+  GridToGridProjector(bool const        vector_target_is_RT_else_DGQ,
+                      bool const        vector_source_is_RT_else_DGQ,
+                      ElementType const element_type);
+
+  void
+  run();
+
+  void
+  setup();
+
+private:
+  void
+  project();
+
+  void
+  check();
+
+  MPI_Comm                   mpi_comm;
+  dealii::ConditionalOStream pcout;
+
+  bool const        vector_target_is_RT_else_DGQ;
+  bool const        vector_source_is_RT_else_DGQ;
+  ElementType const element_type;
+
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_target;
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_source;
+
+  std::shared_ptr<dealii::Mapping<dim> const> mapping;
+
+  dealii::parallel::fullydistributed::Triangulation<dim> tria_source;
+  dealii::parallel::fullydistributed::Triangulation<dim> tria_target;
+
+  dealii::DoFHandler<dim> dof_handler_target_continuous;
+  dealii::DoFHandler<dim> dof_handler_source_continuous;
+  dealii::DoFHandler<dim> dof_handler_target;
+  dealii::DoFHandler<dim> dof_handler_source;
+
+  std::vector<VectorType> vectors_target_continuous;
+  std::vector<VectorType> vectors_source_continuous;
+  std::vector<VectorType> vectors_target;
+  std::vector<VectorType> vectors_source;
+
+  static unsigned int constexpr fe_degree_source  = 3;
+  static unsigned int constexpr fe_degree_target  = 2;
+  static unsigned int constexpr fe_degree_mapping = 2;
+
+  static bool constexpr export_vectors = false;
+};
+
+template<int dim, int n_components>
+GridToGridProjector<dim, n_components>::GridToGridProjector(bool const vector_target_is_RT_else_DGQ,
+                                                            bool const vector_source_is_RT_else_DGQ,
+                                                            ElementType const element_type)
+  : mpi_comm(MPI_COMM_WORLD),
+    pcout(std::cout, (dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)),
+    vector_target_is_RT_else_DGQ(vector_target_is_RT_else_DGQ),
+    vector_source_is_RT_else_DGQ(vector_source_is_RT_else_DGQ),
+    element_type(element_type),
+    tria_source(mpi_comm),
+    tria_target(mpi_comm)
+{
+}
+
+template<int dim, int n_components>
+void
+GridToGridProjector<dim, n_components>::setup()
+{
+  // Initialize finite elements
+  pcout << "  element_type == ElementType::Hypercube : " << (element_type == ElementType::Hypercube)
+        << "\n"
+        << "  dim                          = " << dim << "\n"
+        << "  n_components                 = " << n_components << "\n"
+        << "  vector_target_is_RT_else_DGQ = " << vector_target_is_RT_else_DGQ << "\n"
+        << "  vector_source_is_RT_else_DGQ = " << vector_source_is_RT_else_DGQ << "\n";
+
+  bool const raviart_thomas_used = vector_source_is_RT_else_DGQ or vector_target_is_RT_else_DGQ;
+  AssertThrow(element_type == ElementType::Hypercube or not raviart_thomas_used,
+              dealii::ExcMessage("Cannot use Raviart-Thomas elements on non-hypercube cells."));
+  AssertThrow(not raviart_thomas_used or n_components == dim,
+              dealii::ExcMessage(
+                "Raviart-Thomas elements can only be used for dim == n_components."));
+
+  if(n_components == 1 or not vector_target_is_RT_else_DGQ)
+  {
+    fe_target = create_finite_element<dim>(element_type, true, n_components, fe_degree_target);
+  }
+  else
+  {
+    fe_target = std::make_shared<dealii::FE_RaviartThomasNodal<dim>>(fe_degree_target - 1);
+  }
+
+  if(n_components == 1 or not vector_source_is_RT_else_DGQ)
+  {
+    fe_source = create_finite_element<dim>(element_type, true, n_components, fe_degree_source);
+  }
+  else
+  {
+    fe_source = std::make_shared<dealii::FE_RaviartThomasNodal<dim>>(fe_degree_source - 1);
+  }
+
+  // Create grids (dim == 2 and dim == 3) with a manifold attached and no merged patches for
+  // Raviart-Thomas. The target grid is inscribed in the source grid, but the inner radii match to
+  // test curved boundaries.
+  double const radius            = 0.5;
+  double const radius_shift      = radius * 0.1;
+  double const halve_edge_length = 0.75;
+  double const length            = 1.5;
+  {
+    auto const construction_data = dealii::TriangulationDescription::Utilities::
+      create_description_from_triangulation_in_groups<dim, dim>(
+        [&](dealii::Triangulation<dim> & tria_serial) {
+          if(element_type == ElementType::Hypercube)
+          {
+            dealii::GridGenerator::hyper_cube_with_cylindrical_hole(
+              tria_serial, radius + radius_shift, halve_edge_length, length, 2, true);
+            if constexpr(dim == 2)
+            {
+              dealii::PolarManifold<dim> const manifold;
+              tria_source.set_manifold(0, manifold);
+              tria_target.set_manifold(0, manifold);
+            }
+            else if constexpr(dim == 3)
+            {
+              dealii::CylindricalManifold<dim> const manifold(2 /* z-axis */);
+              tria_source.set_manifold(0, manifold);
+              tria_target.set_manifold(0, manifold);
+            }
+            tria_serial.refine_global(2);
+          }
+          else
+          {
+            dealii::Triangulation<dim> tria_hypercube;
+            dealii::GridGenerator::hyper_cube_with_cylindrical_hole(
+              tria_hypercube, radius + radius_shift, halve_edge_length, length, 2, true);
+            tria_hypercube.refine_global(2);
+            dealii::GridGenerator::convert_hypercube_to_simplex_mesh(tria_hypercube, tria_serial);
+          }
+        },
+        [](dealii::Triangulation<dim> & tria_serial,
+           MPI_Comm const               mpi_communicator,
+           unsigned int const /* group_size */) {
+          dealii::GridTools::partition_triangulation(
+            dealii::Utilities::MPI::n_mpi_processes(mpi_communicator), tria_serial);
+        },
+        mpi_comm,
+        1);
+
+    tria_target.create_triangulation(construction_data);
+  }
+  {
+    auto const construction_data = dealii::TriangulationDescription::Utilities::
+      create_description_from_triangulation_in_groups<dim, dim>(
+        [&](dealii::Triangulation<dim> & tria_serial) {
+          if(element_type == ElementType::Hypercube)
+          {
+            dealii::GridGenerator::hyper_cube_with_cylindrical_hole(
+              tria_serial, radius, halve_edge_length * 1.2, length, 2, true);
+            if constexpr(dim == 2)
+            {
+              dealii::PolarManifold<dim> const manifold;
+              tria_source.set_manifold(0, manifold);
+              tria_target.set_manifold(0, manifold);
+            }
+            else if constexpr(dim == 3)
+            {
+              dealii::CylindricalManifold<dim> const manifold(2 /* z-axis */);
+              tria_source.set_manifold(0, manifold);
+              tria_target.set_manifold(0, manifold);
+            }
+            tria_serial.refine_global(2);
+          }
+          else
+          {
+            dealii::Triangulation<dim> tria_hypercube;
+            dealii::GridGenerator::hyper_cube_with_cylindrical_hole(
+              tria_hypercube, radius, halve_edge_length * 1.2, length, 2, true);
+            tria_hypercube.refine_global(2);
+            dealii::GridGenerator::convert_hypercube_to_simplex_mesh(tria_hypercube, tria_serial);
+          }
+        },
+        [](dealii::Triangulation<dim> & tria_serial,
+           MPI_Comm const               mpi_communicator,
+           unsigned int const /* group_size */) {
+          dealii::GridTools::partition_triangulation(
+            dealii::Utilities::MPI::n_mpi_processes(mpi_communicator), tria_serial);
+        },
+        mpi_comm,
+        1);
+
+    tria_source.create_triangulation(construction_data);
+  }
+
+  // Construction via description necessitates reconstruction of the manifold.
+  if constexpr(dim == 2)
+  {
+    dealii::PolarManifold<dim> const manifold;
+    tria_source.set_manifold(0, manifold);
+    tria_target.set_manifold(0, manifold);
+  }
+  else if constexpr(dim == 3)
+  {
+    dealii::CylindricalManifold<dim> const manifold(2 /* z-axis */);
+    tria_source.set_manifold(0, manifold);
+    tria_target.set_manifold(0, manifold);
+  }
+
+  // Create identity mapping depending on cell type.
+  if(element_type == ElementType::Hypercube)
+  {
+    mapping = std::make_shared<dealii::MappingFE<dim> const>(dealii::FE_Q<dim>(fe_degree_mapping));
+  }
+  else
+  {
+    mapping =
+      std::make_shared<dealii::MappingFE<dim> const>(dealii::FE_SimplexP<dim>(fe_degree_mapping));
+  }
+
+  // Distribute DoFs.
+  dof_handler_target.reinit(tria_target);
+  dof_handler_target.distribute_dofs(*fe_target);
+  dof_handler_source.reinit(tria_source);
+  dof_handler_source.distribute_dofs(*fe_source);
+
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_target_continuous =
+    create_finite_element<dim>(element_type, false, n_components, fe_degree_target);
+  dof_handler_target_continuous.reinit(tria_target);
+  dof_handler_target_continuous.distribute_dofs(*fe_target_continuous);
+
+  std::shared_ptr<dealii::FiniteElement<dim>> fe_source_continuous =
+    create_finite_element<dim>(element_type, false, n_components, fe_degree_source);
+  dof_handler_source_continuous.reinit(tria_source);
+  dof_handler_source_continuous.distribute_dofs(*fe_source_continuous);
+
+  pcout << "  Number of degrees of freedom:\n"
+        << "    TARGET: " << dof_handler_target.n_dofs() << "\n"
+        << "            " << dof_handler_target_continuous.n_dofs() << " (continuous)\n"
+        << "    SOURCE: " << dof_handler_source.n_dofs() << "\n"
+        << "            " << dof_handler_source_continuous.n_dofs() << " (continuous)\n";
+
+  // Setup/fill vectors.
+  {
+    dealii::IndexSet const rel_dofs =
+      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_target);
+    VectorType tmp(dof_handler_target.locally_owned_dofs(), rel_dofs, mpi_comm);
+    vectors_target.push_back(tmp);
+    vectors_target.push_back(tmp);
+    vectors_target.push_back(tmp);
+  }
+  {
+    dealii::IndexSet const rel_dofs =
+      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_target_continuous);
+    VectorType tmp(dof_handler_target_continuous.locally_owned_dofs(), rel_dofs, mpi_comm);
+    vectors_target_continuous.push_back(tmp);
+    vectors_target_continuous.push_back(tmp);
+  }
+  {
+    dealii::IndexSet const rel_dofs =
+      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_source);
+    VectorType tmp(dof_handler_source.locally_owned_dofs(), rel_dofs, mpi_comm);
+    dealii::VectorTools::interpolate(dof_handler_source,
+                                     SampleFunction<dim, n_components>(1.0 /* scale */),
+                                     tmp);
+    vectors_source.push_back(tmp);
+    tmp *= 1.0e3;
+    vectors_source.push_back(tmp);
+  }
+  {
+    dealii::IndexSet const rel_dofs =
+      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_source_continuous);
+    VectorType tmp(dof_handler_source_continuous.locally_owned_dofs(), rel_dofs, mpi_comm);
+    dealii::VectorTools::interpolate(dof_handler_source_continuous,
+                                     SampleFunction<dim, n_components>(1.0 /* scale */),
+                                     tmp);
+    vectors_source_continuous.push_back(tmp);
+    tmp *= 1.0e2;
+    vectors_source_continuous.push_back(tmp);
+    tmp *= 1.0e-3;
+    vectors_source_continuous.push_back(tmp);
+  }
+}
+
+template<int dim, int n_components>
+void
+GridToGridProjector<dim, n_components>::project()
+{
+  // Output vectors in source.
+  if constexpr(export_vectors)
+  {
+    OutputDataBase output_data;
+    output_data.directory = "./";
+    output_data.filename  = "source_vectors";
+    output_data.degree    = element_type == ElementType::Hypercube ? 3 : 1;
+
+    VectorWriter<dim, VectorType::value_type> vector_writer(output_data,
+                                                            0 /* output_counter */,
+                                                            mpi_comm);
+    std::vector<bool>                         component_is_part_of_vector(n_components, true);
+    if(n_components == 1)
+    {
+      component_is_part_of_vector[0] = false;
+    }
+
+    std::string elem_str = element_type == ElementType::Hypercube ? "hypercube" : "simplex";
+    for(unsigned int i = 0; i < vectors_source.size(); ++i)
+    {
+      std::vector<std::string> component_names(n_components,
+                                               "source_" + std::to_string(i) + "_" + elem_str);
+      vector_writer.add_data_vector(vectors_source[i],
+                                    dof_handler_source,
+                                    component_names,
+                                    component_is_part_of_vector);
+    }
+    for(unsigned int i = 0; i < vectors_source_continuous.size(); ++i)
+    {
+      std::vector<std::string> component_names(n_components,
+                                               "source_continuous" + std::to_string(i) + "_" +
+                                                 elem_str);
+      vector_writer.add_data_vector(vectors_source_continuous[i],
+                                    dof_handler_source_continuous,
+                                    component_names,
+                                    component_is_part_of_vector);
+    }
+  }
+
+  // Project source vectors onto target grids:
+  // vectors_source_continupus -> vectors_target (3 vectors)
+  // vectors_source -> vectors_target_continuous (2 vectors)
+  std::vector<dealii::DoFHandler<dim> const *> source_dof_handlers(
+    {&dof_handler_source_continuous, &dof_handler_source});
+  std::vector<dealii::DoFHandler<dim> const *> target_dof_handlers(
+    {&dof_handler_target, &dof_handler_target_continuous});
+
+  std::vector<std::vector<VectorType *>> source_vectors_per_dof_handler;
+  {
+    std::vector<VectorType *> tmp;
+    for(unsigned int i = 0; i < vectors_source_continuous.size(); ++i)
+    {
+      tmp.push_back(&vectors_source_continuous[i]);
+    }
+    source_vectors_per_dof_handler.push_back(tmp);
+  }
+  {
+    std::vector<VectorType *> tmp;
+    for(unsigned int i = 0; i < vectors_source.size(); ++i)
+    {
+      tmp.push_back(&vectors_source[i]);
+    }
+    source_vectors_per_dof_handler.push_back(tmp);
+  }
+
+  std::vector<std::vector<VectorType *>> target_vectors_per_dof_handler;
+  {
+    std::vector<VectorType *> tmp;
+    for(unsigned int i = 0; i < vectors_target.size(); ++i)
+    {
+      tmp.push_back(&vectors_target[i]);
+    }
+    target_vectors_per_dof_handler.push_back(tmp);
+  }
+  {
+    std::vector<VectorType *> tmp;
+    for(unsigned int i = 0; i < vectors_target_continuous.size(); ++i)
+    {
+      tmp.push_back(&vectors_target_continuous[i]);
+    }
+    target_vectors_per_dof_handler.push_back(tmp);
+  }
+
+  GridToGridProjection::GridToGridProjectionData<dim> data;
+  data.solver_data.max_iter = 1000;
+  data.solver_data.abs_tol  = 1.0e-12;
+  data.solver_data.rel_tol  = 1.0e-8;
+
+  data.rpe_data.tolerance              = 1e-6;
+  data.rpe_data.enforce_unique_mapping = false;
+  data.rpe_data.rtree_level            = 0;
+
+  data.additional_quadrature_points = 1;
+
+  data.is_test = true;
+
+  bool all_dg = true;
+  for(unsigned int i = 0; i < target_dof_handlers.size(); ++i)
+  {
+    bool is_dg = target_dof_handlers[i]->get_fe().dofs_per_vertex == 0;
+    if(not is_dg)
+    {
+      all_dg = false;
+    }
+  }
+
+  data.preconditioner = PreconditionerMass::PointJacobi;
+  if(all_dg)
+  {
+    if(element_type == ElementType::Hypercube)
+    {
+      data.inverse_mass_type = InverseMassType::MatrixfreeOperator;
+    }
+    else
+    {
+      data.inverse_mass_type = InverseMassType::ElementwiseKrylovSolver;
+    }
+  }
+  else
+  {
+    data.inverse_mass_type = InverseMassType::GlobalKrylovSolver;
+  }
+
+  GridToGridProjection::grid_to_grid_projection<dim, VectorType::value_type, VectorType>(
+    source_vectors_per_dof_handler,
+    source_dof_handlers,
+    mapping,
+    target_vectors_per_dof_handler,
+    target_dof_handlers,
+    mapping,
+    data);
+}
+
+template<int dim, int n_components>
+void
+GridToGridProjector<dim, n_components>::check()
+{
+  // Output vectors in target.
+  if constexpr(export_vectors)
+  {
+    OutputDataBase output_data;
+    output_data.directory = "./";
+    output_data.filename  = "target_vectors";
+    output_data.degree    = element_type == ElementType::Hypercube ? 3 : 1;
+
+    VectorWriter<dim, VectorType::value_type> vector_writer(output_data,
+                                                            0 /* output_counter */,
+                                                            mpi_comm);
+    std::vector<bool>                         component_is_part_of_vector(n_components, true);
+    if(n_components == 1)
+    {
+      component_is_part_of_vector[0] = false;
+    }
+
+    std::string elem_str = element_type == ElementType::Hypercube ? "hypercube" : "simplex";
+    for(unsigned int i = 0; i < vectors_target.size(); ++i)
+    {
+      std::vector<std::string> component_names(n_components,
+                                               "target_" + std::to_string(i) + "_" + elem_str);
+      vector_writer.add_data_vector(vectors_target[i],
+                                    dof_handler_target,
+                                    component_names,
+                                    component_is_part_of_vector);
+    }
+    for(unsigned int i = 0; i < vectors_target_continuous.size(); ++i)
+    {
+      std::vector<std::string> component_names(n_components,
+                                               "target_continuous" + std::to_string(i) + "_" +
+                                                 elem_str);
+      vector_writer.add_data_vector(vectors_target_continuous[i],
+                                    dof_handler_target_continuous,
+                                    component_names,
+                                    component_is_part_of_vector);
+    }
+  }
+
+  // Compare vectors with exact values.
+  std::array<double, 3> constexpr scales = {{1.0, 1.0e2, 1.0e-1}};
+  for(unsigned int i = 0; i < vectors_target.size(); ++i)
+  {
+    ErrorCalculationData<dim> error_data;
+    error_data.time_control_data.is_active  = true;
+    error_data.calculate_relative_errors    = true;
+    error_data.additional_quadrature_points = 1;
+    std::shared_ptr<dealii::Function<dim>> analytical_solution;
+    analytical_solution            = std::make_shared<SampleFunction<dim, n_components>>(scales[i]);
+    error_data.analytical_solution = analytical_solution;
+
+    ErrorCalculator<dim, typename VectorType::value_type> error_calculator(mpi_comm);
+    error_calculator.setup(dof_handler_target, *mapping, error_data);
+    error_calculator.time_control.needs_evaluation(0.0 /* time */, ExaDG::numbers::steady_timestep);
+    error_calculator.evaluate(vectors_target[i], 0.0 /* time */, false /* unsteady */);
+  }
+
+  std::array<double, 3> constexpr scales_continuous = {{1.0, 1.0e3}};
+  for(unsigned int i = 0; i < vectors_target_continuous.size(); ++i)
+  {
+    ErrorCalculationData<dim> error_data;
+    error_data.time_control_data.is_active  = true;
+    error_data.calculate_relative_errors    = true;
+    error_data.additional_quadrature_points = 1;
+    std::shared_ptr<dealii::Function<dim>> analytical_solution;
+    analytical_solution = std::make_shared<SampleFunction<dim, n_components>>(scales_continuous[i]);
+    error_data.analytical_solution = analytical_solution;
+
+    ErrorCalculator<dim, typename VectorType::value_type> error_calculator(mpi_comm);
+    error_calculator.setup(dof_handler_target_continuous, *mapping, error_data);
+    error_calculator.time_control.needs_evaluation(0.0 /* time */, ExaDG::numbers::steady_timestep);
+    error_calculator.evaluate(vectors_target_continuous[i], 0.0 /* time */, false /* unsteady */);
+  }
+}
+
+template<int dim, int n_components>
+void
+GridToGridProjector<dim, n_components>::run()
+{
+  setup();
+  project();
+  check();
+
+  pcout << "\n\n";
+}
+
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+    // Simplex tests.
+    {
+      GridToGridProjector<2, 1> grid_to_grid_projector(false, false, ElementType::Simplex);
+      grid_to_grid_projector.run();
+    }
+    {
+      GridToGridProjector<2, 2> grid_to_grid_projector(false, false, ElementType::Simplex);
+      grid_to_grid_projector.run();
+    }
+
+    // The three-dimensional simplex tests are disabled due to testing time constraints and
+    // `RemotePointEvaluation` requiring more time here to find the integration points.
+    bool constexpr enable_3d_simplex = false;
+    if constexpr(enable_3d_simplex)
+    {
+      GridToGridProjector<3, 1> grid_to_grid_projector(false, false, ElementType::Simplex);
+      grid_to_grid_projector.run();
+    }
+    if constexpr(enable_3d_simplex)
+    {
+      GridToGridProjector<3, 3> grid_to_grid_projector(false, false, ElementType::Simplex);
+      grid_to_grid_projector.run();
+    }
+
+    // Vector-valued tests using hypercube including Raviart-Thomas <-> DGQ.
+    for(unsigned int j = 0; j < 2; ++j)
+    {
+      for(unsigned int k = 0; k < 2; ++k)
+      {
+        bool const vector_target_is_RT_else_DGQ = j == 0;
+        bool const vector_source_is_RT_else_DGQ = k == 0;
+        {
+          GridToGridProjector<2, 2> grid_to_grid_projector(vector_target_is_RT_else_DGQ,
+                                                           vector_source_is_RT_else_DGQ,
+                                                           ElementType::Hypercube);
+          grid_to_grid_projector.run();
+        }
+        {
+          GridToGridProjector<3, 3> grid_to_grid_projector(vector_target_is_RT_else_DGQ,
+                                                           vector_source_is_RT_else_DGQ,
+                                                           ElementType::Hypercube);
+          grid_to_grid_projector.run();
+        }
+      }
+    }
+
+    // Scalar-valued tests using hypercube and DGQ only.
+    {
+      GridToGridProjector<2, 1> grid_to_grid_projector(false, false, ElementType::Hypercube);
+      grid_to_grid_projector.run();
+    }
+    {
+      GridToGridProjector<3, 1> grid_to_grid_projector(false, false, ElementType::Hypercube);
+      grid_to_grid_projector.run();
+    }
+  }
+  catch(std::exception & exc)
+  {
+    std::cerr << std::endl
+              << std::endl
+              << "----------------------------------------------------" << std::endl;
+    std::cerr << "Exception on processing: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------" << std::endl;
+
+    return 1;
+  }
+  catch(...)
+  {
+    std::cerr << std::endl
+              << std::endl
+              << "----------------------------------------------------" << std::endl;
+    std::cerr << "Unknown exception!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/tests/utilities/grid_to_grid_projection.mpirun=4.output
+++ b/tests/utilities/grid_to_grid_projection.mpirun=4.output
@@ -1,0 +1,324 @@
+  element_type == ElementType::Hypercube : 0
+  dim                          = 2
+  n_components                 = 1
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 6144
+            2176 (continuous)
+    SOURCE: 10240
+            4800 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.34535e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.34535e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.34535e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.51442e-06
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.51442e-06
+
+
+  element_type == ElementType::Hypercube : 0
+  dim                          = 2
+  n_components                 = 2
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 12288
+            4352 (continuous)
+    SOURCE: 20480
+            9600 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.98645e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.98645e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.98645e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91480e-06
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91480e-06
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 2
+  n_components                 = 2
+  vector_target_is_RT_else_DGQ = 1
+  vector_source_is_RT_else_DGQ = 1
+  Number of degrees of freedom:
+    TARGET: 1088
+            1152 (continuous)
+    SOURCE: 2400
+            2496 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91093e-04
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91093e-04
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91093e-04
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.73476e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.73476e-03
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 3
+  n_components                 = 3
+  vector_target_is_RT_else_DGQ = 1
+  vector_source_is_RT_else_DGQ = 1
+  Number of degrees of freedom:
+    TARGET: 26112
+            29376 (continuous)
+    SOURCE: 86400
+            93600 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.50903e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.50903e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.50903e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.39129e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.39129e-03
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 2
+  n_components                 = 2
+  vector_target_is_RT_else_DGQ = 1
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 1088
+            1152 (continuous)
+    SOURCE: 4096
+            2496 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91093e-04
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91093e-04
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 1.91093e-04
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.93064e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.93064e-05
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 3
+  n_components                 = 3
+  vector_target_is_RT_else_DGQ = 1
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 26112
+            29376 (continuous)
+    SOURCE: 196608
+            93600 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.50903e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.50903e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 5.50903e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.95529e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.95529e-05
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 2
+  n_components                 = 2
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 1
+  Number of degrees of freedom:
+    TARGET: 2304
+            1152 (continuous)
+    SOURCE: 2400
+            2496 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.90768e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.90768e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.90768e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.73476e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.73476e-03
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 3
+  n_components                 = 3
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 1
+  Number of degrees of freedom:
+    TARGET: 82944
+            29376 (continuous)
+    SOURCE: 86400
+            93600 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.93434e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.93434e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.93434e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.39129e-03
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.39129e-03
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 2
+  n_components                 = 2
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 2304
+            1152 (continuous)
+    SOURCE: 4096
+            2496 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.90768e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.90768e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.90768e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.93064e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.93064e-05
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 3
+  n_components                 = 3
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 82944
+            29376 (continuous)
+    SOURCE: 196608
+            93600 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.93434e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.93434e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.93434e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.95529e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 2.95529e-05
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 2
+  n_components                 = 1
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 1152
+            576 (continuous)
+    SOURCE: 2048
+            1248 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.48717e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.48717e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.48717e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.47141e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.47141e-05
+
+
+  element_type == ElementType::Hypercube : 1
+  dim                          = 3
+  n_components                 = 1
+  vector_target_is_RT_else_DGQ = 0
+  vector_source_is_RT_else_DGQ = 0
+  Number of degrees of freedom:
+    TARGET: 27648
+            9792 (continuous)
+    SOURCE: 65536
+            31200 (continuous)
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.48717e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.48717e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.48717e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.47141e-05
+
+Calculate error for all fields for initial data:
+  Relative error (L2-norm): 3.47141e-05
+
+


### PR DESCRIPTION
This realizes the first part of #729 : grid-to-grid projection in the form of several free functions.
The utility is based on `RemotePointEvaluation`, `FEPointEvaluation` and the `MassOperator`.
The systems are solved in matrix-free fashion, where preconditioners available are: `PointJacobi`, `AdditiveSchwarz`, `AMG`, `InverseMassPreconditioner` and `None`. We can hand over a vector of `DoFHandler`s and source vectors _per_ `DoFHandler`, so that we do not set up multiple `MatrixFree` but only a single one.

The test uses the utility function for `dim=2` or `3`, `ElementType::Simplex` and `ElementType::Hypercube`. The projections (always in both directions _to_ and _from_) between overlapping spaces constructed via `FiniteElement`s considered are:
`FE_Q` <-> `FE_RaviartThomasNodal`
,
`FE_DGQ` <-> `FE_Q`
and
`FE_SimplexP` <-> `FE_SimplexDGP`

The testcase looks like this:
[source grid in white wireframe, target grid in color showing the solution]
![image](https://github.com/user-attachments/assets/71b6d2d2-c8ac-4b18-b14e-cf380f337855)
and we compute the error between:
.) exact function (some `f(x) = 0.5 sin(x)` or similar)
and
.) interpolated function in source grid (`VectorTools::Interpolate`) -> projection to target grid via the proposed `grid_to_grid_projection()`

The 3D Simplex tests are disabled because `RemotePointEvaluation` is taking quite long to find all the points with the current setup. Also, the target grid is a "shrunk" source grid since `RemotePointEvaluation` sometimes did not like the corners (4 individual points on the inner circles). Maybe I am using it wrong or the mapping setup is insufficient idk.