### PR TITLE
change some parameter names in iNS block solver

### DIFF
--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -197,7 +197,7 @@ private:
     this->param.multigrid_data_velocity_block.coarse_problem.solver =
       MultigridCoarseGridSolver::GMRES;
 
-    this->param.exact_inversion_of_velocity_block = false; // true;
+    this->param.iterative_solve_of_velocity_block = false; // true;
     this->param.solver_data_velocity_block        = SolverData(1e4, 1.e-12, 1.e-6, 100);
 
     // preconditioner Schur-complement block
@@ -205,8 +205,8 @@ private:
       SchurComplementPreconditioner::PressureConvectionDiffusion;
     this->param.multigrid_data_pressure_block.coarse_problem.solver =
       MultigridCoarseGridSolver::Chebyshev;
-    this->param.exact_inversion_of_laplace_operator = false;
-    this->param.solver_data_pressure_block          = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.iterative_solve_of_pressure_block = false;
+    this->param.solver_data_pressure_block        = SolverData(1e4, 1.e-12, 1.e-6, 100);
   }
 
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -469,7 +469,7 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_velocity_block()
   {
     setup_multigrid_preconditioner_momentum();
 
-    if(this->param.exact_inversion_of_velocity_block == true)
+    if(this->param.iterative_solve_of_velocity_block == true)
     {
       setup_iterative_solver_momentum();
     }
@@ -561,7 +561,7 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_pressure_block()
   {
     setup_multigrid_preconditioner_schur_complement();
 
-    if(this->param.exact_inversion_of_laplace_operator == true)
+    if(this->param.iterative_solve_of_pressure_block == true)
     {
       setup_iterative_solver_schur_complement();
     }
@@ -574,7 +574,7 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_pressure_block()
 
     setup_multigrid_preconditioner_schur_complement();
 
-    if(this->param.exact_inversion_of_laplace_operator == true)
+    if(this->param.iterative_solve_of_pressure_block == true)
     {
       setup_iterative_solver_schur_complement();
     }
@@ -595,7 +595,7 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_pressure_block()
     // I. multigrid for negative Laplace operator (classical or compatible discretization)
     setup_multigrid_preconditioner_schur_complement();
 
-    if(this->param.exact_inversion_of_laplace_operator == true)
+    if(this->param.iterative_solve_of_pressure_block == true)
     {
       setup_iterative_solver_schur_complement();
     }
@@ -889,7 +889,7 @@ OperatorCoupled<dim, Number>::update_block_preconditioner()
        type == SchurComplementPreconditioner::CahouetChabard or
        type == SchurComplementPreconditioner::PressureConvectionDiffusion)
     {
-      if(this->param.exact_inversion_of_laplace_operator == true)
+      if(this->param.iterative_solve_of_pressure_block == true)
       {
         laplace_operator->update_penalty_parameter();
       }
@@ -1068,12 +1068,12 @@ OperatorCoupled<dim, Number>::apply_preconditioner_velocity_block(VectorType &  
   }
   else if(type == MomentumPreconditioner::Multigrid)
   {
-    if(this->param.exact_inversion_of_velocity_block == false)
+    if(this->param.iterative_solve_of_velocity_block == false)
     {
       // perform one multigrid V-cylce
       preconditioner_momentum->vmult(dst, src);
     }
-    else // exact_inversion_of_velocity_block == true
+    else // iterative_solve_of_velocity_block == true
     {
       // check correctness of multigrid V-cycle
 
@@ -1198,13 +1198,13 @@ void
 OperatorCoupled<dim, Number>::apply_inverse_negative_laplace_operator(VectorType &       dst,
                                                                       VectorType const & src) const
 {
-  if(this->param.exact_inversion_of_laplace_operator == false)
+  if(this->param.iterative_solve_of_pressure_block == false)
   {
     // perform one multigrid V-cycle in order to approximately invert the negative Laplace
     // operator (classical or compatible)
     multigrid_preconditioner_schur_complement->vmult(dst, src);
   }
-  else // exact_inversion_of_laplace_operator == true
+  else // iterative_solve_of_pressure_block == true
   {
     // solve a linear system of equations related to the negative Laplace operator to given
     // (relative) tolerance using an iterative method

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -210,13 +210,13 @@ Parameters::Parameters()
     preconditioner_velocity_block(MomentumPreconditioner::InverseMassMatrix),
     multigrid_operator_type_velocity_block(MultigridOperatorType::Undefined),
     multigrid_data_velocity_block(MultigridData()),
-    exact_inversion_of_velocity_block(false),
+    iterative_solve_of_velocity_block(false),
     solver_data_velocity_block(SolverData(1e4, 1.e-12, 1.e-6, 100)),
 
     // preconditioner pressure/Schur-complement block
     preconditioner_pressure_block(SchurComplementPreconditioner::PressureConvectionDiffusion),
     multigrid_data_pressure_block(MultigridData()),
-    exact_inversion_of_laplace_operator(false),
+    iterative_solve_of_pressure_block(false),
     solver_data_pressure_block(SolverData(1e4, 1.e-12, 1.e-6, 100))
 {
 }
@@ -1284,9 +1284,9 @@ Parameters::print_parameters_coupled_solver(dealii::ConditionalOStream const & p
 
     multigrid_data_velocity_block.print(pcout);
 
-    print_parameter(pcout, "Exact inversion of velocity block", exact_inversion_of_velocity_block);
+    print_parameter(pcout, "Exact inversion of velocity block", iterative_solve_of_velocity_block);
 
-    if(exact_inversion_of_velocity_block == true)
+    if(iterative_solve_of_velocity_block == true)
     {
       solver_data_velocity_block.print(pcout);
     }
@@ -1304,9 +1304,9 @@ Parameters::print_parameters_coupled_solver(dealii::ConditionalOStream const & p
 
     print_parameter(pcout,
                     "Exact inversion of Laplace operator",
-                    exact_inversion_of_laplace_operator);
+                    iterative_solve_of_pressure_block);
 
-    if(exact_inversion_of_laplace_operator)
+    if(iterative_solve_of_pressure_block)
     {
       solver_data_pressure_block.print(pcout);
     }

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -681,7 +681,7 @@ public:
   // The momentum block is inverted "exactly" in block preconditioner
   // by solving the velocity convection-diffusion problem to a given
   // relative tolerance
-  bool exact_inversion_of_velocity_block;
+  bool iterative_solve_of_velocity_block;
 
   // solver data for velocity block (only relevant if velocity block
   // is inverted exactly)
@@ -695,10 +695,10 @@ public:
 
   // The Laplace operator is inverted "exactly" in block preconditioner
   // by solving the Laplace problem to a given relative tolerance
-  bool exact_inversion_of_laplace_operator;
+  bool iterative_solve_of_pressure_block;
 
   // solver data for Schur complement
-  // (only relevant if exact_inversion_of_laplace_operator == true)
+  // (only relevant if iterative_solve_of_pressure_block == true)
   SolverData solver_data_pressure_block;
 };
 


### PR DESCRIPTION
I find `exact_inversion` misleading when we use iterative solvers at most.
Additionally, the pressure operator is only in a subset of cases a Laplace operator. 

I think these parameter names relate to an earlier version of the implementation and are now a bit outdated.