### PR TITLE
add iNS ViscosityCalculator

### DIFF
--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -718,6 +718,7 @@ private:
     pp_data.output_data.filename           = this->output_parameters.filename;
     pp_data.output_data.write_divergence   = true;
     pp_data.output_data.write_shear_rate   = true;
+    pp_data.output_data.write_viscosity    = true;
     pp_data.output_data.degree             = this->param.degree_u;
     pp_data.output_data.write_higher_order = true;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
@@ -36,6 +36,7 @@ struct OutputData : public OutputDataBase
     : write_vorticity(false),
       write_divergence(false),
       write_shear_rate(false),
+      write_viscosity(false),
       write_velocity_magnitude(false),
       write_vorticity_magnitude(false),
       write_streamfunction(false),
@@ -54,6 +55,7 @@ struct OutputData : public OutputDataBase
     print_parameter(pcout, "Write vorticity", write_vorticity);
     print_parameter(pcout, "Write divergence", write_divergence);
     print_parameter(pcout, "Write shear rate", write_shear_rate);
+    print_parameter(pcout, "Write viscosity", write_viscosity);
     print_parameter(pcout, "Write velocity magnitude", write_velocity_magnitude);
     print_parameter(pcout, "Write vorticity magnitude", write_vorticity_magnitude);
     print_parameter(pcout, "Write streamfunction", write_streamfunction);
@@ -68,8 +70,11 @@ struct OutputData : public OutputDataBase
   // write divergence of velocity field
   bool write_divergence;
 
-  // write shear rate in velocity field
+  // write shear rate of velocity field
   bool write_shear_rate;
+
+  // write viscosity depending on viscosity field
+  bool write_viscosity;
 
   // write velocity magnitude
   bool write_velocity_magnitude;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -161,6 +161,11 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     velocity,
       shear_rate.evaluate(velocity);
       additional_fields_vtu.push_back(&shear_rate);
     }
+    if(pp_data.output_data.write_viscosity)
+    {
+      viscosity.evaluate(velocity);
+      additional_fields_vtu.push_back(&viscosity);
+    }
     if(pp_data.output_data.write_velocity_magnitude)
     {
       velocity_magnitude.evaluate(velocity);
@@ -348,6 +353,22 @@ PostProcessor<dim, Number>::initialize_derived_fields()
     shear_rate.reinit();
   }
 
+  // viscosity
+  if(pp_data.output_data.write_viscosity)
+  {
+    viscosity.type              = SolutionFieldType::scalar;
+    viscosity.name              = "viscosity";
+    viscosity.dof_handler       = &navier_stokes_operator->get_dof_handler_u_scalar();
+    viscosity.initialize_vector = [&](VectorType & dst) {
+      navier_stokes_operator->initialize_vector_velocity_scalar(dst);
+    };
+    viscosity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
+      navier_stokes_operator->get_viscosity(dst, src);
+    };
+
+    viscosity.reinit();
+  }
+
   // velocity magnitude
   if(pp_data.output_data.write_velocity_magnitude)
   {
@@ -423,6 +444,7 @@ PostProcessor<dim, Number>::invalidate_derived_fields()
   vorticity.invalidate();
   divergence.invalidate();
   shear_rate.invalidate();
+  viscosity.invalidate();
   velocity_magnitude.invalidate();
   vorticity_magnitude.invalidate();
   streamfunction.invalidate();

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -100,6 +100,7 @@ private:
   SolutionField<dim, Number> vorticity;
   SolutionField<dim, Number> divergence;
   SolutionField<dim, Number> shear_rate;
+  SolutionField<dim, Number> viscosity;
   SolutionField<dim, Number> velocity_magnitude;
   SolutionField<dim, Number> vorticity_magnitude;
   SolutionField<dim, Number> streamfunction;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -665,6 +665,10 @@ SpatialOperatorBase<dim, Number>::initialize_calculators_for_derived_quantities(
                                    get_dof_index_velocity(),
                                    get_dof_index_velocity_scalar(),
                                    get_quad_index_velocity_standard());
+  viscosity_calculator.initialize(*matrix_free,
+                                  get_dof_index_velocity_scalar(),
+                                  get_quad_index_velocity_standard(),
+                                  *viscous_kernel);
   magnitude_calculator.initialize(*matrix_free,
                                   get_dof_index_velocity(),
                                   get_dof_index_velocity_scalar(),
@@ -1223,6 +1227,21 @@ SpatialOperatorBase<dim, Number>::compute_shear_rate(VectorType & dst, VectorTyp
   shear_rate_calculator.compute_shear_rate(dst, src);
 
   inverse_mass_velocity_scalar.apply(dst, dst);
+}
+
+template<int dim, typename Number>
+void
+SpatialOperatorBase<dim, Number>::get_viscosity(VectorType & dst, VectorType const & src) const
+{
+  if(param.viscosity_is_variable())
+  {
+    viscosity_calculator.get_viscosity(dst, src);
+    inverse_mass_velocity_scalar.apply(dst, dst);
+  }
+  else
+  {
+    dst = param.viscosity;
+  }
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -348,6 +348,10 @@ public:
   void
   compute_q_criterion(VectorType & dst, VectorType const & src) const;
 
+  // get the current visosity field as vector
+  void
+  get_viscosity(VectorType & dst, VectorType const & src) const;
+
   /*
    * Operators.
    */
@@ -613,6 +617,7 @@ protected:
   VorticityCalculator<dim, Number>  vorticity_calculator;
   DivergenceCalculator<dim, Number> divergence_calculator;
   ShearRateCalculator<dim, Number>  shear_rate_calculator;
+  ViscosityCalculator<dim, Number>  viscosity_calculator;
   MagnitudeCalculator<dim, Number>  magnitude_calculator;
   QCriterionCalculator<dim, Number> q_criterion_calculator;
 

--- a/include/exadg/operators/navier_stokes_calculators.cpp
+++ b/include/exadg/operators/navier_stokes_calculators.cpp
@@ -145,6 +145,61 @@ ShearRateCalculator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> cons
 }
 
 template<int dim, typename Number>
+ViscosityCalculator<dim, Number>::ViscosityCalculator()
+  : matrix_free(nullptr), dof_index_u_scalar(0), quad_index(0), viscous_kernel(nullptr)
+{
+}
+
+template<int dim, typename Number>
+void
+ViscosityCalculator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const &              matrix_free_in,
+  unsigned int const                                   dof_index_u_scalar_in,
+  unsigned int const                                   quad_index_in,
+  IncNS::Operators::ViscousKernel<dim, Number> const & viscous_kernel_in)
+{
+  matrix_free        = &matrix_free_in;
+  dof_index_u_scalar = dof_index_u_scalar_in;
+  quad_index         = quad_index_in;
+  viscous_kernel     = &viscous_kernel_in;
+}
+
+template<int dim, typename Number>
+void
+ViscosityCalculator<dim, Number>::get_viscosity(VectorType & dst, VectorType const & src) const
+{
+  dst = 0.0;
+
+  matrix_free->cell_loop(&This::cell_loop, this, dst, src);
+}
+
+template<int dim, typename Number>
+void
+ViscosityCalculator<dim, Number>::cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+                                            VectorType &                            dst,
+                                            VectorType const &                      src,
+                                            Range const & cell_range) const
+{
+  (void)src;
+
+  CellIntegratorScalar integrator_scalar(matrix_free, dof_index_u_scalar, quad_index);
+
+  for(unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+  {
+    integrator_scalar.reinit(cell);
+
+    for(unsigned int q = 0; q < integrator_scalar.n_q_points; q++)
+    {
+      scalar viscosity = this->viscous_kernel->get_viscosity_cell(cell, q);
+
+      integrator_scalar.submit_value(viscosity, q);
+    }
+
+    integrator_scalar.integrate_scatter(dealii::EvaluationFlags::values, dst);
+  }
+}
+
+template<int dim, typename Number>
 VorticityCalculator<dim, Number>::VorticityCalculator()
   : matrix_free(nullptr), dof_index(0), quad_index(0)
 {
@@ -353,6 +408,12 @@ template class ShearRateCalculator<2, double>;
 
 template class ShearRateCalculator<3, float>;
 template class ShearRateCalculator<3, double>;
+
+template class ViscosityCalculator<2, float>;
+template class ViscosityCalculator<2, double>;
+
+template class ViscosityCalculator<3, float>;
+template class ViscosityCalculator<3, double>;
 
 template class VorticityCalculator<2, float>;
 template class VorticityCalculator<2, double>;

--- a/include/exadg/operators/navier_stokes_calculators.h
+++ b/include/exadg/operators/navier_stokes_calculators.h
@@ -26,6 +26,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 // ExaDG
+#include <exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h>
 #include <exadg/matrix_free/integrators.h>
 
 namespace ExaDG
@@ -143,6 +144,47 @@ private:
   dealii::MatrixFree<dim, Number> const * matrix_free;
   unsigned int                            dof_index;
   unsigned int                            quad_index;
+};
+
+template<int dim, typename Number>
+class ViscosityCalculator
+{
+private:
+  typedef ViscosityCalculator<dim, Number> This;
+
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+
+  typedef dealii::VectorizedArray<Number> scalar;
+
+  typedef std::pair<unsigned int, unsigned int> Range;
+
+  typedef CellIntegrator<dim, 1, Number> CellIntegratorScalar;
+
+public:
+  ViscosityCalculator();
+
+  void
+  initialize(dealii::MatrixFree<dim, Number> const &              matrix_free_in,
+             unsigned int const                                   dof_index_u_scalar_in,
+             unsigned int const                                   quad_index_in,
+             IncNS::Operators::ViscousKernel<dim, Number> const & viscous_kernel_in);
+
+  void
+  get_viscosity(VectorType & dst, VectorType const & src) const;
+
+private:
+  void
+  cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
+            VectorType &                            dst,
+            VectorType const &                      src,
+            Range const &                           cell_range) const;
+
+  dealii::MatrixFree<dim, Number> const * matrix_free;
+
+  unsigned int dof_index_u_scalar;
+  unsigned int quad_index;
+
+  IncNS::Operators::ViscousKernel<dim, Number> const * viscous_kernel;
 };
 
 template<int dim, typename Number>

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
@@ -209,7 +209,7 @@ struct SmootherData
   // damping/relaxation factor for Jacobi smoother
   double relaxation_factor;
 
-  // Chebyshev smmother: sets the smoothing range (range of eigenvalues to be smoothed)
+  // Chebyshev smoother: sets the smoothing range (range of eigenvalues to be smoothed)
   double smoothing_range;
 
   // Chebyshev smmother: number of CG iterations for estimation of eigenvalues


### PR DESCRIPTION
this is a first step to bring the corrections for the variable viscosity Navier--Stokes solvers into the main branch.

Based on this, I will tackle:
1) variable viscosity in multigrid operators (this is currently ignored)
2) variable parameter in `InverseMassOperator`
3) variable viscosity in the iNS preconditioners for monolithic formulations

Instead of recomputing the viscosity, we simply access the precomputed quantity.
similar functionality is needed to then evaluate the viscosity gradient in some boundary terms for the `TimeIntBDFDualSplittingScheme`.