### PR TITLE
add variable coefficient to mass operator

### DIFF
--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -160,7 +160,7 @@ void
 Operator<dim, Number>::setup_operators()
 {
   // mass operator
-  MassOperatorData<dim> mass_operator_data;
+  MassOperatorData<dim, Number> mass_operator_data;
   mass_operator_data.dof_index            = get_dof_index();
   mass_operator_data.quad_index           = get_quad_index();
   mass_operator_data.use_cell_based_loops = param.use_cell_based_face_loops;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -404,7 +404,7 @@ void
 SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_index_temperature)
 {
   // mass operator
-  MassOperatorData<dim> mass_operator_data;
+  MassOperatorData<dim, Number> mass_operator_data;
   mass_operator_data.dof_index  = get_dof_index_velocity();
   mass_operator_data.quad_index = get_quad_index_velocity_standard();
   mass_operator.initialize(*matrix_free, constraint_u, mass_operator_data);

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -111,7 +111,7 @@ public:
       constraint.clear();
       constraint.close();
 
-      MassOperatorData<dim> mass_operator_data;
+      MassOperatorData<dim, Number> mass_operator_data;
       mass_operator_data.dof_index  = dof_index;
       mass_operator_data.quad_index = quad_index;
       if(data.implementation_type == InverseMassType::ElementwiseKrylovSolver)
@@ -292,7 +292,7 @@ public:
              InverseMassOperatorDataHdiv const         inverse_mass_operator_data)
   {
     // mass operator
-    MassOperatorData<dim> mass_operator_data;
+    MassOperatorData<dim, Number> mass_operator_data;
     mass_operator_data.dof_index  = inverse_mass_operator_data.dof_index;
     mass_operator_data.quad_index = inverse_mass_operator_data.quad_index;
     mass_operator.initialize(matrix_free, constraints, mass_operator_data);

--- a/include/exadg/operators/mass_operator.cpp
+++ b/include/exadg/operators/mass_operator.cpp
@@ -33,11 +33,18 @@ void
 MassOperator<dim, n_components, Number>::initialize(
   dealii::MatrixFree<dim, Number> const &   matrix_free,
   dealii::AffineConstraints<Number> const & affine_constraints,
-  MassOperatorData<dim> const &             data)
+  MassOperatorData<dim, Number> const &     data)
 {
   Base::reinit(matrix_free, affine_constraints, data);
 
   this->integrator_flags = kernel.get_integrator_flags();
+
+  coefficient_is_variable = data.coefficient_is_variable;
+  variable_coefficients   = data.variable_coefficients;
+
+  // Variable coefficients only implemented for the the matrix-free operator.
+  AssertThrow(not coefficient_is_variable or variable_coefficients != nullptr,
+              dealii::ExcMessage("Pointer to variable coefficients not set properly."));
 }
 
 template<int dim, int n_components, typename Number>
@@ -77,9 +84,24 @@ template<int dim, int n_components, typename Number>
 void
 MassOperator<dim, n_components, Number>::do_cell_integral(IntegratorCell & integrator) const
 {
-  for(unsigned int q = 0; q < integrator.n_q_points; ++q)
+  if(coefficient_is_variable)
   {
-    integrator.submit_value(kernel.get_volume_flux(scaling_factor, integrator.get_value(q)), q);
+    for(unsigned int q = 0; q < integrator.n_q_points; ++q)
+    {
+      dealii::VectorizedArray<Number> const coefficient =
+        this->variable_coefficients->get_coefficient_cell(integrator.get_current_cell_index(), q);
+
+      integrator.submit_value(coefficient *
+                                kernel.get_volume_flux(scaling_factor, integrator.get_value(q)),
+                              q);
+    }
+  }
+  else
+  {
+    for(unsigned int q = 0; q < integrator.n_q_points; ++q)
+    {
+      integrator.submit_value(kernel.get_volume_flux(scaling_factor, integrator.get_value(q)), q);
+    }
   }
 }
 

--- a/include/exadg/operators/mass_operator.h
+++ b/include/exadg/operators/mass_operator.h
@@ -22,18 +22,25 @@
 #ifndef INCLUDE_OPERATORS_MASS_OPERATOR_H_
 #define INCLUDE_OPERATORS_MASS_OPERATOR_H_
 
+// ExaDG
 #include <exadg/matrix_free/integrators.h>
 #include <exadg/operators/mass_kernel.h>
 #include <exadg/operators/operator_base.h>
+#include <exadg/operators/variable_coefficients.h>
 
 namespace ExaDG
 {
-template<int dim>
+template<int dim, typename Number>
 struct MassOperatorData : public OperatorBaseData
 {
-  MassOperatorData() : OperatorBaseData()
+  MassOperatorData()
+    : OperatorBaseData(), coefficient_is_variable(false), variable_coefficients(nullptr)
   {
   }
+
+  // variable coefficients
+  bool                                                          coefficient_is_variable;
+  VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients;
 };
 
 template<int dim, int n_components, typename Number>
@@ -52,7 +59,7 @@ public:
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              dealii::AffineConstraints<Number> const & affine_constraints,
-             MassOperatorData<dim> const &             data);
+             MassOperatorData<dim, Number> const &     data);
 
   void
   set_scaling_factor(Number const & number);
@@ -70,6 +77,10 @@ private:
   MassKernel<dim, Number> kernel;
 
   mutable double scaling_factor;
+
+  // Variable coefficients not managed by this class.
+  bool                                                          coefficient_is_variable;
+  VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients;
 };
 
 } // namespace ExaDG

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -249,7 +249,7 @@ Operator<dim, Number>::setup_operators()
   // mass operator
   if(param.problem_type == ProblemType::Unsteady)
   {
-    Structure::MassOperatorData<dim> mass_data;
+    Structure::MassOperatorData<dim, Number> mass_data;
     mass_data.dof_index               = get_dof_index();
     mass_data.dof_index_inhomogeneous = get_dof_index_periodicity_and_hanging_node_constraints();
     mass_data.quad_index              = get_quad_index();

--- a/include/exadg/structure/spatial_discretization/operators/mass_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/mass_operator.h
@@ -32,8 +32,8 @@ namespace ExaDG
 {
 namespace Structure
 {
-template<int dim>
-struct MassOperatorData : public ExaDG::MassOperatorData<dim>
+template<int dim, typename Number>
+struct MassOperatorData : public ExaDG::MassOperatorData<dim, Number>
 {
   std::shared_ptr<BoundaryDescriptor<dim> const> bc;
 };
@@ -49,7 +49,7 @@ public:
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              dealii::AffineConstraints<Number> const & affine_constraints,
-             MassOperatorData<dim> const &             data)
+             MassOperatorData<dim, Number> const &     data)
   {
     operator_data = data;
 
@@ -84,7 +84,7 @@ public:
   }
 
 private:
-  MassOperatorData<dim> operator_data;
+  MassOperatorData<dim, Number> operator_data;
 };
 
 } // namespace Structure


### PR DESCRIPTION
... and manage the coefficients, `VariableCoefficients<dealii::VectorizedArray<Number>>`, outside.
We have to add the `Number` template parameter to `MassOperatorData` to store the pointer.