### PR TITLE
variable coefficients for InverseMassOperator

### DIFF
--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -416,7 +416,7 @@ SpatialOperator<dim, Number>::initialize_operators()
 {
   // inverse mass operator pressure
   {
-    InverseMassOperatorData data;
+    InverseMassOperatorData<Number> data;
     data.dof_index  = get_dof_index_pressure();
     data.quad_index = get_quad_index_pressure();
     inverse_mass_pressure.initialize(*matrix_free, data);
@@ -424,7 +424,7 @@ SpatialOperator<dim, Number>::initialize_operators()
 
   // inverse mass operator velocity
   {
-    InverseMassOperatorData data;
+    InverseMassOperatorData<Number> data;
     data.dof_index  = get_dof_index_velocity();
     data.quad_index = get_quad_index_velocity();
     inverse_mass_velocity.initialize(*matrix_free, data);

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -164,19 +164,19 @@ Operator<dim, Number>::setup_operators()
   mass_operator.initialize(*matrix_free, mass_operator_data);
 
   // inverse mass operator
-  InverseMassOperatorData inverse_mass_operator_data_all;
+  InverseMassOperatorData<Number> inverse_mass_operator_data_all;
   inverse_mass_operator_data_all.dof_index  = get_dof_index_all();
   inverse_mass_operator_data_all.quad_index = get_quad_index_standard();
   inverse_mass_operator_data_all.parameters = param.inverse_mass_operator;
   inverse_mass_all.initialize(*matrix_free, inverse_mass_operator_data_all);
 
-  InverseMassOperatorData inverse_mass_operator_data_vector;
+  InverseMassOperatorData<Number> inverse_mass_operator_data_vector;
   inverse_mass_operator_data_vector.dof_index  = get_dof_index_vector();
   inverse_mass_operator_data_vector.quad_index = get_quad_index_standard();
   inverse_mass_operator_data_vector.parameters = param.inverse_mass_operator;
   inverse_mass_vector.initialize(*matrix_free, inverse_mass_operator_data_vector);
 
-  InverseMassOperatorData inverse_mass_operator_data_scalar;
+  InverseMassOperatorData<Number> inverse_mass_operator_data_scalar;
   inverse_mass_operator_data_scalar.dof_index  = get_dof_index_scalar();
   inverse_mass_operator_data_scalar.quad_index = get_quad_index_standard();
   inverse_mass_operator_data_scalar.parameters = param.inverse_mass_operator;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -170,7 +170,7 @@ Operator<dim, Number>::setup_operators()
   mass_operator.initialize(*matrix_free, affine_constraints, mass_operator_data);
 
   // inverse mass operator
-  InverseMassOperatorData inverse_mass_operator_data;
+  InverseMassOperatorData<Number> inverse_mass_operator_data;
   inverse_mass_operator_data.dof_index  = get_dof_index();
   inverse_mass_operator_data.quad_index = get_quad_index();
   inverse_mass_operator_data.parameters = param.inverse_mass_operator;
@@ -390,7 +390,7 @@ Operator<dim, Number>::setup_preconditioner()
 {
   if(param.preconditioner == Preconditioner::InverseMassMatrix)
   {
-    InverseMassOperatorData inverse_mass_operator_data;
+    InverseMassOperatorData<Number> inverse_mass_operator_data;
     inverse_mass_operator_data.dof_index  = get_dof_index();
     inverse_mass_operator_data.quad_index = get_quad_index();
     inverse_mass_operator_data.parameters = param.inverse_mass_preconditioner;
@@ -560,7 +560,7 @@ Operator<dim, Number>::project_velocity(VectorType & velocity, double const time
 {
   VelocityProjection<dim, Number> l2_projection;
 
-  InverseMassOperatorData inverse_mass_operator_data_l2_projection;
+  InverseMassOperatorData<Number> inverse_mass_operator_data_l2_projection;
   inverse_mass_operator_data_l2_projection.dof_index  = get_dof_index_velocity();
   inverse_mass_operator_data_l2_projection.quad_index = get_quad_index();
 

--- a/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
@@ -44,7 +44,7 @@ public:
    */
   void
   apply(dealii::MatrixFree<dim, Number> const &      matrix_free,
-        InverseMassOperatorData const                inverse_mass_operator_data,
+        InverseMassOperatorData<Number> const        inverse_mass_operator_data,
         std::shared_ptr<dealii::Function<dim>> const function,
         double const &                               time,
         VectorType &                                 vector)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -456,7 +456,7 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_velocity_block()
   }
   else if(type == MomentumPreconditioner::InverseMassMatrix)
   {
-    InverseMassOperatorData inverse_mass_operator_data;
+    InverseMassOperatorData<Number> inverse_mass_operator_data;
     inverse_mass_operator_data.dof_index  = this->get_dof_index_velocity();
     inverse_mass_operator_data.quad_index = this->get_quad_index_velocity_standard();
     inverse_mass_operator_data.parameters = this->param.inverse_mass_preconditioner;
@@ -546,7 +546,7 @@ OperatorCoupled<dim, Number>::initialize_preconditioner_pressure_block()
 {
   auto type = this->param.preconditioner_pressure_block;
 
-  InverseMassOperatorData inverse_mass_operator_data;
+  InverseMassOperatorData<Number> inverse_mass_operator_data;
   inverse_mass_operator_data.dof_index  = this->get_dof_index_pressure();
   inverse_mass_operator_data.quad_index = this->get_quad_index_pressure();
   inverse_mass_operator_data.parameters = this->param.inverse_mass_preconditioner;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.cpp
@@ -77,7 +77,7 @@ OperatorPressureCorrection<dim, Number>::setup_inverse_mass_operator_pressure()
 {
   // inverse mass operator pressure (needed for pressure update in case of rotational
   // formulation)
-  InverseMassOperatorData inverse_mass_operator_data_pressure;
+  InverseMassOperatorData<Number> inverse_mass_operator_data_pressure;
   inverse_mass_operator_data_pressure.dof_index  = this->get_dof_index_pressure();
   inverse_mass_operator_data_pressure.quad_index = this->get_quad_index_pressure();
   inverse_mass_operator_data_pressure.parameters = this->param.inverse_mass_operator;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -264,7 +264,7 @@ OperatorProjectionMethods<dim, Number>::setup_momentum_preconditioner()
 {
   if(this->param.preconditioner_momentum == MomentumPreconditioner::InverseMassMatrix)
   {
-    InverseMassOperatorData inverse_mass_operator_data;
+    InverseMassOperatorData<Number> inverse_mass_operator_data;
     inverse_mass_operator_data.dof_index  = this->get_dof_index_velocity();
     inverse_mass_operator_data.quad_index = this->get_quad_index_velocity_standard();
     inverse_mass_operator_data.parameters = this->param.inverse_mass_preconditioner;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -410,7 +410,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   mass_operator.initialize(*matrix_free, constraint_u, mass_operator_data);
 
   // inverse mass operator velocity
-  InverseMassOperatorData inverse_mass_operator_data_velocity;
+  InverseMassOperatorData<Number> inverse_mass_operator_data_velocity;
   inverse_mass_operator_data_velocity.dof_index  = get_dof_index_velocity();
   inverse_mass_operator_data_velocity.quad_index = get_quad_index_velocity_standard();
   inverse_mass_operator_data_velocity.parameters = param.inverse_mass_operator;
@@ -421,7 +421,7 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
                                      &constraint_u);
 
   // inverse mass operator velocity scalar
-  InverseMassOperatorData inverse_mass_operator_data_velocity_scalar;
+  InverseMassOperatorData<Number> inverse_mass_operator_data_velocity_scalar;
   inverse_mass_operator_data_velocity_scalar.dof_index  = get_dof_index_velocity_scalar();
   inverse_mass_operator_data_velocity_scalar.quad_index = get_quad_index_velocity_standard();
   inverse_mass_operator_data_velocity_scalar.parameters = param.inverse_mass_operator;
@@ -1626,7 +1626,7 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
     }
     else if(param.preconditioner_projection == PreconditionerProjection::InverseMassMatrix)
     {
-      InverseMassOperatorData inverse_mass_operator_data;
+      InverseMassOperatorData<Number> inverse_mass_operator_data;
       inverse_mass_operator_data.dof_index  = get_dof_index_velocity();
       inverse_mass_operator_data.quad_index = get_quad_index_velocity_standard();
       inverse_mass_operator_data.parameters = param.inverse_mass_preconditioner;

--- a/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
@@ -44,7 +44,7 @@ public:
   typedef typename PreconditionerBase<Number>::VectorType VectorType;
 
   InverseMassPreconditioner(dealii::MatrixFree<dim, Number> const & matrix_free,
-                            InverseMassOperatorData const           inverse_mass_operator_data)
+                            InverseMassOperatorData<Number> const   inverse_mass_operator_data)
   {
     inverse_mass_operator.initialize(matrix_free, inverse_mass_operator_data);
 


### PR DESCRIPTION
**note** only really considers the `InverseMassType::MatrixfreeOperator` since the `MassOperator` only features variable coefficients after #741 .
I wanted to make the smallest changes possible.
we can address then enabling variable coefficients also for the other `InverMassType`s in follow-up PRs.