### PR TITLE
Unify inverse mass operators

### DIFF
--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
@@ -239,8 +239,8 @@ private:
     this->param.preconditioner_pressure_block = SchurComplementPreconditioner::CahouetChabard;
 
     // Inversion of mass operator in case of H(div)-conforming method
-    this->param.inverse_mass_operator_hdiv.solver_data    = SolverData(1000, ABS_TOL, REL_TOL);
-    this->param.inverse_mass_operator_hdiv.preconditioner = PreconditionerMass::PointJacobi;
+    this->param.inverse_mass_operator.solver_data    = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.inverse_mass_operator.preconditioner = PreconditionerMass::PointJacobi;
   }
 
   void

--- a/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/project_velocity.h
@@ -58,7 +58,7 @@ public:
     VectorType src;
     matrix_free.cell_loop(&VelocityProjection<dim, Number>::cell_loop, this, vector, src);
 
-    // apply M^{-1}
+    // construct and apply M^{-1}
     InverseMassOperator<dim, dim, Number> inverse_mass;
     inverse_mass.initialize(matrix_free, inverse_mass_operator_data);
     inverse_mass.apply(vector, vector);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -409,22 +409,17 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   mass_operator_data.quad_index = get_quad_index_velocity_standard();
   mass_operator.initialize(*matrix_free, constraint_u, mass_operator_data);
 
-  InverseMassOperatorDataHdiv inverse_mass_data_hdiv;
-  inverse_mass_data_hdiv.dof_index  = get_dof_index_velocity();
-  inverse_mass_data_hdiv.quad_index = get_quad_index_velocity_standard();
-  inverse_mass_data_hdiv.parameters = this->param.inverse_mass_operator_hdiv;
+  // inverse mass operator velocity
+  InverseMassOperatorData inverse_mass_operator_data_velocity;
+  inverse_mass_operator_data_velocity.dof_index  = get_dof_index_velocity();
+  inverse_mass_operator_data_velocity.quad_index = get_quad_index_velocity_standard();
+  inverse_mass_operator_data_velocity.parameters = param.inverse_mass_operator;
+  inverse_mass_velocity.initialize(*matrix_free,
+                                   inverse_mass_operator_data_velocity,
+                                   param.spatial_discretization == SpatialDiscretization::L2 ?
+                                     nullptr :
+                                     &constraint_u);
 
-  inverse_mass_hdiv.initialize(*matrix_free, constraint_u, inverse_mass_data_hdiv);
-
-  // inverse mass operator
-  if(param.spatial_discretization == SpatialDiscretization::L2)
-  {
-    InverseMassOperatorData inverse_mass_operator_data_velocity;
-    inverse_mass_operator_data_velocity.dof_index  = get_dof_index_velocity();
-    inverse_mass_operator_data_velocity.quad_index = get_quad_index_velocity_standard();
-    inverse_mass_operator_data_velocity.parameters = param.inverse_mass_operator;
-    inverse_mass_velocity.initialize(*matrix_free, inverse_mass_operator_data_velocity);
-  }
   // inverse mass operator velocity scalar
   InverseMassOperatorData inverse_mass_operator_data_velocity_scalar;
   inverse_mass_operator_data_velocity_scalar.dof_index  = get_dof_index_velocity_scalar();
@@ -1374,18 +1369,7 @@ unsigned int
 SpatialOperatorBase<dim, Number>::apply_inverse_mass_operator(VectorType &       dst,
                                                               VectorType const & src) const
 {
-  if(param.spatial_discretization == SpatialDiscretization::L2)
-  {
-    inverse_mass_velocity.apply(dst, src);
-  }
-  else if(param.spatial_discretization == SpatialDiscretization::HDIV)
-  {
-    inverse_mass_hdiv.apply(dst, src);
-  }
-  else
-  {
-    AssertThrow(false, dealii::ExcMessage("Not implemented."));
-  }
+  inverse_mass_velocity.apply(dst, src);
   return 0;
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -578,15 +578,10 @@ protected:
   mutable MomentumOperator<dim, Number> momentum_operator;
 
   /*
-   * Inverse mass operator (for L2 spaces)
+   * Inverse mass operator.
    */
   InverseMassOperator<dim, dim, Number> inverse_mass_velocity;
   InverseMassOperator<dim, 1, Number>   inverse_mass_velocity_scalar;
-
-  /*
-   * Inverse mass operator used in case of H(div)-conforming space
-   */
-  InverseMassOperatorHdiv<dim, dim, Number> inverse_mass_hdiv;
 
   /*
    * Projection operator.

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -472,14 +472,10 @@ public:
   /*                 Solver parameters for mass matrix problem                          */
   /*                                                                                    */
   /**************************************************************************************/
-  // These parameters are relevant if the inverse mass can not be realized as a
-  // matrix-free operator evaluation. The typical use case is a DG formulation with non
-  // hypercube elements (e.g. simplex).
-
+  // These parameters are relevant if the inverse mass can not be realized as a cell-wise
+  // matrix-free operator evaluation. The typical use case is a DG formulation with non hypercube
+  // elements (e.g. simplex) or a continuous finite element space.
   InverseMassParameters inverse_mass_operator;
-
-  // This parameter is only relevant if an H(div)-conforming formulation is chosen.
-  InverseMassParametersHdiv inverse_mass_operator_hdiv;
 
   /**************************************************************************************/
   /*                                                                                    */

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -70,8 +70,9 @@ public:
   }
 
   void
-  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
-             InverseMassOperatorData const           inverse_mass_operator_data)
+  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free_in,
+             InverseMassOperatorData const             inverse_mass_operator_data,
+             dealii::AffineConstraints<Number> const * constraints = nullptr)
   {
     this->matrix_free = &matrix_free_in;
     dof_index         = inverse_mass_operator_data.dof_index;
@@ -81,39 +82,34 @@ public:
 
     dealii::FiniteElement<dim> const & fe = matrix_free->get_dof_handler(dof_index).get_fe();
 
-    // The inverse mass operator is only available for discontinuous Galerkin discretizations
-    AssertThrow(fe.conforms(dealii::FiniteElementData<dim>::L2),
-                dealii::ExcMessage("InverseMassOperator only implemented for DG!"));
-
+    // Some implementation variants of the inverse mass operator are based on assumptions on the
+    // discretization and more efficient choices are available for tensor-product elements or
+    // L2-conforming spaces.
     if(data.implementation_type == InverseMassType::MatrixfreeOperator)
     {
-      // Currently, the inverse mass realized as matrix-free operator evaluation is only available
-      // in deal.II for tensor-product elements.
       AssertThrow(
         fe.base_element(0).dofs_per_cell == dealii::Utilities::pow(fe.degree + 1, dim),
         dealii::ExcMessage(
-          "The matrix-free inverse mass operator is currently only available for tensor-product elements."));
+          "The matrix-free cell-wise inverse mass operator is currently only available for isotropic tensor-product elements."));
 
-      // Currently, the inverse mass realized as matrix-free operator evaluation is only available
-      // in deal.II if n_q_points_1d = n_nodes_1d.
       AssertThrow(
         this->matrix_free->get_shape_info(0, quad_index).data[0].n_q_points_1d == fe.degree + 1,
         dealii::ExcMessage(
-          "The matrix-free inverse mass operator is currently only available if n_q_points_1d = n_nodes_1d."));
-    }
-    // We create a block-Jacobi preconditioner with MassOperator as underlying operator in case the
-    // inverse mass can not be realized as a matrix-free operator.
-    else if(data.implementation_type == InverseMassType::ElementwiseKrylovSolver or
-            data.implementation_type == InverseMassType::BlockMatrices)
-    {
-      // initialize mass operator
-      dealii::AffineConstraints<Number> constraint;
-      constraint.clear();
-      constraint.close();
+          "The matrix-free cell-wise inverse mass operator is currently only available if n_q_points_1d = n_nodes_1d."));
 
+      AssertThrow(
+        fe.conforms(dealii::FiniteElementData<dim>::L2),
+        dealii::ExcMessage(
+          "The matrix-free cell-wise inverse mass operator is only available for L2-conforming elements."));
+    }
+    else
+    {
+      // Setup MassOperator as underlying operator for cell-wise direct/iterative inverse or global
+      // solve.
       MassOperatorData<dim, Number> mass_operator_data;
       mass_operator_data.dof_index  = dof_index;
       mass_operator_data.quad_index = quad_index;
+
       if(data.implementation_type == InverseMassType::ElementwiseKrylovSolver)
       {
         mass_operator_data.implement_block_diagonal_preconditioner_matrix_free = true;
@@ -132,20 +128,82 @@ public:
           inverse_mass_operator_data.parameters.solver_data;
       }
 
-      mass_operator.initialize(*matrix_free, constraint, mass_operator_data);
+      // Use constraints if provided.
+      if(constraints == nullptr)
+      {
+        dealii::AffineConstraints<Number> dummy_constraints;
+        dummy_constraints.close();
+        mass_operator.initialize(*matrix_free, dummy_constraints, mass_operator_data);
+      }
+      else
+      {
+        mass_operator.initialize(*matrix_free, *constraints, mass_operator_data);
+      }
 
-      block_jacobi_preconditioner =
-        std::make_shared<BlockJacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
-          mass_operator, true /* initialize_preconditioner */);
-    }
-    else
-    {
-      AssertThrow(false, dealii::ExcMessage("The specified InverseMassType is not implemented."));
+      if(data.implementation_type == InverseMassType::ElementwiseKrylovSolver or
+         data.implementation_type == InverseMassType::BlockMatrices)
+      {
+        // Non-L2-conforming elements are asserted here because the cell-wise inverse neglecting
+        // cell-coupling terms is only an approximation of the inverse mass matrix.
+        AssertThrow(
+          fe.conforms(dealii::FiniteElementData<dim>::L2),
+          dealii::ExcMessage(
+            "The cell-wise inverse mass operator is only available for L2-conforming elements."));
+
+        block_jacobi_preconditioner =
+          std::make_shared<BlockJacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
+            mass_operator, true /* initialize_preconditioner */);
+      }
+      else if(data.implementation_type == InverseMassType::GlobalKrylovSolver)
+      {
+        Krylov::SolverDataCG solver_data;
+        solver_data.max_iter = inverse_mass_operator_data.parameters.solver_data.max_iter;
+        solver_data.solver_tolerance_abs =
+          inverse_mass_operator_data.parameters.solver_data.abs_tol;
+        solver_data.solver_tolerance_rel =
+          inverse_mass_operator_data.parameters.solver_data.rel_tol;
+
+        solver_data.use_preconditioner =
+          inverse_mass_operator_data.parameters.preconditioner != PreconditionerMass::None;
+        if(inverse_mass_operator_data.parameters.preconditioner == PreconditionerMass::None)
+        {
+          // no setup required.
+        }
+        else if(inverse_mass_operator_data.parameters.preconditioner ==
+                PreconditionerMass::PointJacobi)
+        {
+          global_preconditioner =
+            std::make_shared<JacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
+              mass_operator, true /* initialize_preconditioner */);
+        }
+        else if(inverse_mass_operator_data.parameters.preconditioner ==
+                PreconditionerMass::BlockJacobi)
+        {
+          global_preconditioner =
+            std::make_shared<BlockJacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
+              mass_operator, true /* initialize_preconditioner */);
+        }
+        else
+        {
+          AssertThrow(false, dealii::ExcMessage("This `PreconditionerMass` is not implemented."));
+        }
+
+        global_solver = std::make_shared<Krylov::SolverCG<MassOperator<dim, n_components, Number>,
+                                                          PreconditionerBase<Number>,
+                                                          VectorType>>(mass_operator,
+                                                                       *global_preconditioner,
+                                                                       solver_data);
+      }
+      else
+      {
+        AssertThrow(false,
+                    dealii::ExcMessage("The specified `InverseMassType` is not implemented."));
+      }
     }
   }
 
   /**
-   * Updates the inverse mass operator. This function recomputes the diagonal/block-diagonal in case
+   * Updates the inverse mass operator. This function recomputes the preconditioners in case
    * the geometry has changed (e.g. the mesh has been deformed).
    */
   void
@@ -165,6 +223,10 @@ public:
       // update the matrix-based components of the block-Jacobi preconditioner
       block_jacobi_preconditioner->update();
     }
+    else if(data.implementation_type == InverseMassType::GlobalKrylovSolver)
+    {
+      global_preconditioner->update();
+    }
     else
     {
       AssertThrow(false, dealii::ExcMessage("The specified InverseMassType is not implemented."));
@@ -175,15 +237,39 @@ public:
   void
   apply(VectorType & dst, VectorType const & src) const
   {
-    dst.zero_out_ghost_values();
+    if(data.implementation_type == InverseMassType::GlobalKrylovSolver)
+    {
+      AssertThrow(global_solver.get() != 0,
+                  dealii::ExcMessage("Global mass solver has not been initialized."));
 
-    if(data.implementation_type == InverseMassType::MatrixfreeOperator)
-    {
-      matrix_free->cell_loop(&This::cell_loop_matrix_free_operator, this, dst, src);
+      // Note that the inverse mass operator might be called like inverse_mass.apply(dst, dst),
+      // i.e. with identical destination and source vectors. In this case, we need to make sure
+      // that the result is still correct.
+      if(&dst == &src)
+      {
+        VectorType tmp = src;
+        global_solver->solve(dst, tmp);
+      }
+      else
+      {
+        global_solver->solve(dst, src);
+      }
     }
-    else // ElementwiseKrylovSolver or BlockMatrices
+    else
     {
-      block_jacobi_preconditioner->vmult(dst, src);
+      dst.zero_out_ghost_values();
+
+      if(data.implementation_type == InverseMassType::MatrixfreeOperator)
+      {
+        matrix_free->cell_loop(&This::cell_loop_matrix_free_operator, this, dst, src);
+      }
+      else // ElementwiseKrylovSolver or BlockMatrices
+      {
+        AssertThrow(block_jacobi_preconditioner.get() != 0,
+                    dealii::ExcMessage(
+                      "Cell-wise iterative/direct block-Jacobi solver has not been initialized."));
+        block_jacobi_preconditioner->vmult(dst, src);
+      }
     }
   }
 
@@ -246,122 +332,21 @@ private:
 
   InverseMassParameters data;
 
-  // This variable is only relevant if the inverse mass can not be realized as a matrix-free
-  // operator. Since this class allows only L2-conforming spaces (discontinuous Galerkin method),
+  // Solver and preconditioner for solving a global linear system of equations for all degrees of
+  // freedom.
+  std::shared_ptr<PreconditionerBase<Number>>     global_preconditioner;
+  std::shared_ptr<Krylov::SolverBase<VectorType>> global_solver;
+
+  // Block-Jacobi preconditioner used as cell-wise inverse for L2-conforming spaces. In this case,
   // the mass matrix is block-diagonal and a block-Jacobi preconditioner inverts the mass operator
   // exactly (up to solver tolerances). The implementation of the block-Jacobi preconditioner can be
   // matrix-based or matrix-free, depending on the parameters specified.
   std::shared_ptr<BlockJacobiPreconditioner<MassOperator<dim, n_components, Number>>>
     block_jacobi_preconditioner;
 
-  // In case we realize the inverse mass as block-Jacobi preconditioner, we need a MassOperator as
-  // underlying operator for the block-Jacobi preconditioner.
+  // MassOperator as underlying operator for the cell-wise or global iterative solves.
   MassOperator<dim, n_components, Number> mass_operator;
 };
-
-struct InverseMassOperatorDataHdiv
-{
-  InverseMassOperatorDataHdiv() : dof_index(0), quad_index(0)
-  {
-  }
-
-  // Parameters referring to dealii::MatrixFree
-  unsigned int dof_index;
-  unsigned int quad_index;
-
-  InverseMassParametersHdiv parameters;
-};
-
-/*
- * Inverse mass operator for H(div)-conforming space:
- *
- * This class applies the inverse mass operator by solving the mass system as a global linear system
- * of equations for all degrees of freedom. It is used in case the mass operator is not
- * block-diagonal and can not be inverted element-wise (e.g. H(div)-conforming space).
- */
-template<int dim, int n_components, typename Number>
-class InverseMassOperatorHdiv
-{
-private:
-  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
-
-public:
-  void
-  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
-             dealii::AffineConstraints<Number> const & constraints,
-             InverseMassOperatorDataHdiv const         inverse_mass_operator_data)
-  {
-    // mass operator
-    MassOperatorData<dim, Number> mass_operator_data;
-    mass_operator_data.dof_index  = inverse_mass_operator_data.dof_index;
-    mass_operator_data.quad_index = inverse_mass_operator_data.quad_index;
-    mass_operator.initialize(matrix_free, constraints, mass_operator_data);
-
-    Krylov::SolverDataCG solver_data;
-    solver_data.max_iter             = inverse_mass_operator_data.parameters.solver_data.max_iter;
-    solver_data.solver_tolerance_abs = inverse_mass_operator_data.parameters.solver_data.abs_tol;
-    solver_data.solver_tolerance_rel = inverse_mass_operator_data.parameters.solver_data.rel_tol;
-
-    if(inverse_mass_operator_data.parameters.preconditioner == PreconditionerMass::None)
-    {
-      solver_data.use_preconditioner = false;
-    }
-    else if(inverse_mass_operator_data.parameters.preconditioner == PreconditionerMass::PointJacobi)
-    {
-      preconditioner =
-        std::make_shared<JacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
-          mass_operator, true /* initialize_preconditioner */);
-
-      solver_data.use_preconditioner = true;
-    }
-    else
-    {
-      AssertThrow(false, dealii::ExcMessage("Not implemented."));
-    }
-
-    solver =
-      std::make_shared<Krylov::SolverCG<MassOperator<dim, n_components, Number>,
-                                        PreconditionerBase<Number>,
-                                        VectorType>>(mass_operator, *preconditioner, solver_data);
-  }
-
-  /**
-   * This function applies the inverse mass operator. Note that this function allows identical dst,
-   * src vector, i.e. the function can be called like apply(dst, dst).
-   */
-  unsigned int
-  apply(VectorType & dst, VectorType const & src) const
-  {
-    Assert(solver.get() != 0, dealii::ExcMessage("Mass solver has not been initialized."));
-
-    VectorType temp;
-
-    // Note that the inverse mass operator might be called like inverse_mass.apply(dst, dst),
-    // i.e. with identical destination and source vectors. In this case, we need to make sure
-    // that the result is still correct.
-    if(&dst == &src)
-    {
-      temp = src;
-      return solver->solve(dst, temp);
-    }
-    else
-    {
-      return solver->solve(dst, src);
-    }
-  }
-
-private:
-  // Solver/preconditioner for mass system solving a global linear system of equations for all
-  // degrees of freedom.
-  std::shared_ptr<PreconditionerBase<Number>>     preconditioner;
-  std::shared_ptr<Krylov::SolverBase<VectorType>> solver;
-
-  // We need a MassOperator as underlying operator.
-  MassOperator<dim, n_components, Number> mass_operator;
-
-  InverseMassParametersHdiv data;
-};
-
 } // namespace ExaDG
 
 

--- a/include/exadg/operators/inverse_mass_parameters.h
+++ b/include/exadg/operators/inverse_mass_parameters.h
@@ -32,18 +32,23 @@ enum class InverseMassType
   MatrixfreeOperator, // currently only available via deal.II for Hypercube elements with n_nodes_1d
                       // = n_q_points_1d
   ElementwiseKrylovSolver,
-  BlockMatrices
+  BlockMatrices,
+  GlobalKrylovSolver
 };
 
 enum class PreconditionerMass
 {
   None,
-  PointJacobi
+  PointJacobi,
+  BlockJacobi
 };
 
 /**
- * Data struct for mass operator inversion in case of discontinuous Galerkin methods with a
- * block-diagonal mass matrix.
+ * Data struct for mass operator inversion covering L2-conforming or Hdiv-conforming discontinuous
+ * Galerkin methods and continuous Glarking methods. Depending on the underlying discretization,
+ * various implementations exploiting the structure of the matrix related to the discretized mass
+ * operator are available. Choices not approximating the inverse operator up to linear solver
+ * tolerance are asserted.
  */
 struct InverseMassParameters
 {
@@ -58,30 +63,12 @@ struct InverseMassParameters
   InverseMassType implementation_type;
 
   // This parameter is only relevant if the mass operator is inverted by an iterative solver with
-  // matrix-free implementation, InverseMassType::ElementwiseKrylovSolver.
+  // matrix-free implementation, InverseMassType::ElementwiseKrylovSolver or
+  // InverseMassType::GlobalKrylovSolver.
   PreconditionerMass preconditioner;
 
   // solver data for iterative solver in case of implementation type
-  // InverseMassType::ElementwiseKrylovSolver.
-  SolverData solver_data;
-};
-
-/**
- * Data struct for mass operator inversion by iterative solution techniques in case of
- * H(div)-conforming discretization where the mass matrix is a globally coupled problem as opposed
- * to DG methods (where the mass matrix is block-diagonal).
- */
-struct InverseMassParametersHdiv
-{
-  InverseMassParametersHdiv()
-    : preconditioner(PreconditionerMass::PointJacobi), solver_data(SolverData(1000, 1e-12, 1e-12))
-  {
-  }
-
-  // The preconditioner used to iteratively solve the global mass problem
-  PreconditionerMass preconditioner;
-
-  // solver data for iterative solver
+  // InverseMassType::ElementwiseKrylovSolver or InverseMassType::GlobalKrylovSolver.
   SolverData solver_data;
 };
 } // namespace ExaDG


### PR DESCRIPTION
fixes #746 
where "fixes" is a strong word ...

I still prefer this variant to not have `InverseMassOperator` and `InverseMassOperatorHdiv`, where the latter might be seen as the general case (solving the global mass operator problem iteratively) covering the actual algorithms included in the former (but is probably slower). 
The present variant checks if the requested `InverseMassType` can be used for the discretization and asserts the rest.

One can optionally provide constraints, which are not needed for a mass operator in general, but can be provided to enforce harde constraints, e.g., for adaptive-CG or Raviart-Thomas discretizations.

additionally:
.) the `InverseMassOperatorHdiv` is now only set up when actually needed
.) the new `InverseMassOperator` also has the option to use a block-jacobi preconditioner: `PreconditionerMass::BlockJacobi` (before we had `None` or `PointJacobi`)