### PR TITLE
Variable viscosity preconditioners

### DIFF
--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -363,7 +363,7 @@ PostProcessor<dim, Number>::initialize_derived_fields()
       navier_stokes_operator->initialize_vector_velocity_scalar(dst);
     };
     viscosity.recompute_solution_field = [&](VectorType & dst, VectorType const & src) {
-      navier_stokes_operator->get_viscosity(dst, src);
+      navier_stokes_operator->access_viscosity(dst, src);
     };
 
     viscosity.reinit();

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -138,6 +138,9 @@ template<int dim, typename Number>
 dealii::LinearAlgebra::distributed::Vector<Number> const &
 MomentumOperator<dim, Number>::get_velocity() const
 {
+  AssertThrow(operator_data.convective_problem,
+              dealii::ExcMessage("Cannot access velocity stored in `convective_kernel`"));
+
   return convective_kernel->get_velocity();
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -113,6 +113,12 @@ public:
     return this->data;
   }
 
+  VariableCoefficients<dealii::VectorizedArray<Number>> const *
+  get_viscosity_coefficients() const
+  {
+    return &viscosity_coefficients;
+  }
+
   unsigned int
   get_quad_index() const
   {

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -980,6 +980,12 @@ SpatialOperatorBase<dim, Number>::prescribe_initial_conditions(VectorType & velo
                         pressure,
                         field_functions->initial_solution_pressure,
                         time);
+
+  // Compute initial variable viscosity using the initial velocity field.
+  if(this->param.viscous_problem() and this->param.viscosity_is_variable())
+  {
+    this->update_viscosity(velocity);
+  }
 }
 
 template<int dim, typename Number>
@@ -1226,11 +1232,11 @@ SpatialOperatorBase<dim, Number>::compute_shear_rate(VectorType & dst, VectorTyp
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::get_viscosity(VectorType & dst, VectorType const & src) const
+SpatialOperatorBase<dim, Number>::access_viscosity(VectorType & dst, VectorType const & src) const
 {
   if(param.viscosity_is_variable())
   {
-    viscosity_calculator.get_viscosity(dst, src);
+    viscosity_calculator.access_viscosity(dst, src);
     inverse_mass_velocity_scalar.apply(dst, dst);
   }
   else

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -350,7 +350,7 @@ public:
 
   // get the current visosity field as vector
   void
-  get_viscosity(VectorType & dst, VectorType const & src) const;
+  access_viscosity(VectorType & dst, VectorType const & src) const;
 
   /*
    * Operators.

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -62,8 +62,7 @@ struct InverseMassOperatorData
   // (2) : (u_h , v_h / c)_Omega
   bool consider_inverse_coefficient;
 
-  std::shared_ptr<VariableCoefficients<dealii::VectorizedArray<Number>> const>
-    variable_coefficients;
+  VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients;
 };
 
 template<int dim, int n_components, typename Number>
@@ -413,8 +412,7 @@ private:
   bool coefficient_is_variable;
   bool consider_inverse_coefficient;
 
-  std::shared_ptr<VariableCoefficients<dealii::VectorizedArray<Number>> const>
-    variable_coefficients;
+  VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients;
 
   // Solver and preconditioner for solving a global linear system of equations for all degrees of
   // freedom.

--- a/include/exadg/operators/mass_kernel.h
+++ b/include/exadg/operators/mass_kernel.h
@@ -77,21 +77,19 @@ public:
    */
   void
   set_variable_coefficients_ptr(
-    std::shared_ptr<VariableCoefficients<dealii::VectorizedArray<Number>> const>
-      variable_coefficients_in)
+    VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients_in)
   {
     variable_coefficients = variable_coefficients_in;
   }
 
-  std::shared_ptr<VariableCoefficients<dealii::VectorizedArray<Number>> const>
+  VariableCoefficients<dealii::VectorizedArray<Number>> const *
   get_variable_coefficients_ptr() const
   {
     return variable_coefficients;
   }
 
 private:
-  std::shared_ptr<VariableCoefficients<dealii::VectorizedArray<Number>> const>
-    variable_coefficients;
+  VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients;
 };
 
 } // namespace ExaDG

--- a/include/exadg/operators/mass_operator.h
+++ b/include/exadg/operators/mass_operator.h
@@ -42,9 +42,8 @@ struct MassOperatorData : public OperatorBaseData
   }
 
   // variable coefficients
-  bool coefficient_is_variable;
-  std::shared_ptr<VariableCoefficients<dealii::VectorizedArray<Number>> const>
-    variable_coefficients;
+  bool                                                          coefficient_is_variable;
+  VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients;
   // use the inverse of the coefficients stored in `variable_coefficients`
   bool consider_inverse_coefficient;
 };

--- a/include/exadg/operators/navier_stokes_calculators.cpp
+++ b/include/exadg/operators/navier_stokes_calculators.cpp
@@ -166,7 +166,7 @@ ViscosityCalculator<dim, Number>::initialize(
 
 template<int dim, typename Number>
 void
-ViscosityCalculator<dim, Number>::get_viscosity(VectorType & dst, VectorType const & src) const
+ViscosityCalculator<dim, Number>::access_viscosity(VectorType & dst, VectorType const & src) const
 {
   dst = 0.0;
 

--- a/include/exadg/operators/navier_stokes_calculators.h
+++ b/include/exadg/operators/navier_stokes_calculators.h
@@ -170,7 +170,7 @@ public:
              IncNS::Operators::ViscousKernel<dim, Number> const & viscous_kernel_in);
 
   void
-  get_viscosity(VectorType & dst, VectorType const & src) const;
+  access_viscosity(VectorType & dst, VectorType const & src) const;
 
 private:
   void

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
@@ -212,7 +212,7 @@ struct SmootherData
   // Chebyshev smoother: sets the smoothing range (range of eigenvalues to be smoothed)
   double smoothing_range;
 
-  // Chebyshev smmother: number of CG iterations for estimation of eigenvalues
+  // Chebyshev smoother: number of CG iterations for estimation of eigenvalues
   unsigned int iterations_eigenvalue_estimation;
 };
 


### PR DESCRIPTION
fixes #743  

Additionally, I changed the `std::shared_ptr` in the `MassOperator` and `InverseMassOperator` to a `VariableCoefficients<dealii::VectorizedArray<Number>> const * variable_coefficients`
to make clear that the two operators do not own the coefficients. One might think of introducing the variable coefficients to these operators such that they could manage their own coefficients.
But ... we have currently no use-case for this (only use-case is the pressure mass matrix with inverse variable viscosity coefficient) and I would rather not have the problem to always keep these coefficients scattered over multiple operators in sync. 