### PR TITLE
fix InverseMass, -test, and ElemwiseKrylov for &src=&dst

### DIFF
--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -266,26 +266,11 @@ public:
   void
   apply(VectorType & dst, VectorType const & src) const
   {
-    // Note that the inverse mass operator might be called like inverse_mass.apply(dst, dst),
-    // i.e. with identical destination and source vectors. In this case, we need to make sure
-    // that the result is still correct.
-    VectorType const * src_ptr;
-    VectorType         src_copy;
-    if(&dst == &src)
-    {
-      src_copy = src;
-      src_ptr  = &src_copy;
-    }
-    else
-    {
-      src_ptr = &src;
-    }
-
     if(data.implementation_type == InverseMassType::GlobalKrylovSolver)
     {
       AssertThrow(global_solver.get() != 0,
                   dealii::ExcMessage("Global mass solver has not been initialized."));
-      global_solver->solve(dst, *src_ptr);
+      global_solver->solve(dst, src);
     }
     else
     {
@@ -293,14 +278,14 @@ public:
 
       if(data.implementation_type == InverseMassType::MatrixfreeOperator)
       {
-        matrix_free->cell_loop(&This::cell_loop_matrix_free_operator, this, dst, *src_ptr);
+        matrix_free->cell_loop(&This::cell_loop_matrix_free_operator, this, dst, src);
       }
       else // ElementwiseKrylovSolver or BlockMatrices
       {
         AssertThrow(block_jacobi_preconditioner.get() != 0,
                     dealii::ExcMessage(
                       "Cell-wise iterative/direct block-Jacobi solver has not been initialized."));
-        block_jacobi_preconditioner->vmult(dst, *src_ptr);
+        block_jacobi_preconditioner->vmult(dst, src);
       }
     }
   }
@@ -355,7 +340,7 @@ private:
         integrator.read_dof_values(src, 0);
 
         dealii::AlignedVector<dealii::VectorizedArray<Number>> inverse_JxW_times_coefficient(
-          this->matrix_free->get_dofs_per_cell(dof_index));
+          integrator.n_q_points);
         inverse_mass.fill_inverse_JxW_values(inverse_JxW_times_coefficient);
 
         if(consider_inverse_coefficient)

--- a/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/wrapper_elementwise_solvers.h
@@ -90,8 +90,6 @@ public:
   unsigned int
   solve(VectorType & dst, VectorType const & src) const override
   {
-    dst = 0;
-
     op.get_matrix_free().cell_loop(&THIS::solve_elementwise, this, dst, src);
 
     return 0;
@@ -110,7 +108,8 @@ private:
 
     unsigned int const dofs_per_cell = integrator.dofs_per_cell;
 
-    dealii::AlignedVector<dealii::VectorizedArray<Number>> solution(dofs_per_cell);
+    dealii::AlignedVector<dealii::VectorizedArray<Number>> solution(
+      dofs_per_cell, dealii::make_vectorized_array<Number>(0.0));
 
     // setup elementwise solver
     if(iterative_solver_data.solver_type == Solver::CG)

--- a/tests/operators/inverse_mass_variable_coefficient.cc
+++ b/tests/operators/inverse_mass_variable_coefficient.cc
@@ -121,7 +121,7 @@ private:
 
   InverseMassType inverse_mass_implementation_type;
 
-  static unsigned int constexpr fe_degree = 2;
+  static unsigned int constexpr fe_degree = 1;
 
   dealii::parallel::fullydistributed::Triangulation<dim> tria;
 
@@ -317,7 +317,7 @@ Projector<dim, n_components>::compute(bool const consider_inverse_coefficient)
   MassOperator<dim, n_components, Number> mass_operator;
   mass_operator.initialize(matrix_free, empty_constraints, mass_operator_data);
 
-  // Setup a `InverseMassOperator` with a variable coefficient.
+  // Setup an `InverseMassOperator` with a variable coefficient.
   InverseMassOperatorData<Number> inverse_mass_operator_data;
   inverse_mass_operator_data.dof_index                    = 0;
   inverse_mass_operator_data.quad_index                   = 0;
@@ -442,35 +442,43 @@ main(int argc, char * argv[])
       bool RT_on_Hypercube = false;
 
       // Simplex tests FE_SimplexP or FE_SimplexDGP.
-      InverseMassType inverse_mass_type_simplex =
-        is_dg ? InverseMassType::ElementwiseKrylovSolver : InverseMassType::GlobalKrylovSolver;
+      for(unsigned int j = 0; j < 2; ++j)
       {
-        Projector<2 /* dim */, 1 /* n_components */> projector(is_dg,
-                                                               RT_on_Hypercube,
-                                                               ElementType::Simplex,
-                                                               inverse_mass_type_simplex);
-        projector.run();
-      }
-      {
-        Projector<2 /* dim */, 2 /* n_components */> projector(is_dg,
-                                                               RT_on_Hypercube,
-                                                               ElementType::Simplex,
-                                                               inverse_mass_type_simplex);
-        projector.run();
-      }
-      {
-        Projector<3 /* dim */, 1 /* n_components */> projector(is_dg,
-                                                               RT_on_Hypercube,
-                                                               ElementType::Simplex,
-                                                               inverse_mass_type_simplex);
-        projector.run();
-      }
-      {
-        Projector<3 /* dim */, 3 /* n_components */> projector(is_dg,
-                                                               RT_on_Hypercube,
-                                                               ElementType::Simplex,
-                                                               inverse_mass_type_simplex);
-        projector.run();
+        if(j == 0 or is_dg)
+        {
+          InverseMassType inverse_mass_type_dg =
+            j == 0 ? InverseMassType::ElementwiseKrylovSolver : InverseMassType::BlockMatrices;
+          InverseMassType inverse_mass_type_simplex =
+            is_dg ? inverse_mass_type_dg : InverseMassType::GlobalKrylovSolver;
+          {
+            Projector<2 /* dim */, 1 /* n_components */> projector(is_dg,
+                                                                   RT_on_Hypercube,
+                                                                   ElementType::Simplex,
+                                                                   inverse_mass_type_simplex);
+            projector.run();
+          }
+          {
+            Projector<2 /* dim */, 2 /* n_components */> projector(is_dg,
+                                                                   RT_on_Hypercube,
+                                                                   ElementType::Simplex,
+                                                                   inverse_mass_type_simplex);
+            projector.run();
+          }
+          {
+            Projector<3 /* dim */, 1 /* n_components */> projector(is_dg,
+                                                                   RT_on_Hypercube,
+                                                                   ElementType::Simplex,
+                                                                   inverse_mass_type_simplex);
+            projector.run();
+          }
+          {
+            Projector<3 /* dim */, 3 /* n_components */> projector(is_dg,
+                                                                   RT_on_Hypercube,
+                                                                   ElementType::Simplex,
+                                                                   inverse_mass_type_simplex);
+            projector.run();
+          }
+        }
       }
 
       // Hypercube tests FE_Q or FE_DGQ.

--- a/tests/operators/inverse_mass_variable_coefficient.output
+++ b/tests/operators/inverse_mass_variable_coefficient.output
@@ -4,49 +4,49 @@
   is_dg            = 1
   RT_on_hypercube  = 0
   InverseMassType  = ElementwiseKrylovSolver
-  Number of degrees of freedom: 384
+  Number of degrees of freedom: 192
 
   ||ref||_infty = 0.999994
   &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 3.21965e-15
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 2.44249e-15
+
+  ||ref||_infty = 0.986467
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 1.95677e-15
+
+
+  element_type     = Simplex
+  dim              = 2
+  n_components     = 2
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = ElementwiseKrylovSolver
+  Number of degrees of freedom: 384
 
   ||ref||_infty = 0.99797
   &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 3.44169e-15
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 1.9984e-15
+
+  ||ref||_infty = 0.996042
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 2.10942e-15
 
 
   element_type     = Simplex
-  dim              = 2
-  n_components     = 2
+  dim              = 3
+  n_components     = 1
   is_dg            = 1
   RT_on_hypercube  = 0
   InverseMassType  = ElementwiseKrylovSolver
-  Number of degrees of freedom: 768
+  Number of degrees of freedom: 1536
 
   ||ref||_infty = 0.999241
   &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 3.77476e-15
-
-  ||ref||_infty = 0.998142
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 3.9968e-15
-
-
-  element_type     = Simplex
-  dim              = 3
-  n_components     = 1
-  is_dg            = 1
-  RT_on_hypercube  = 0
-  InverseMassType  = ElementwiseKrylovSolver
-  Number of degrees of freedom: 3840
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 1.43219e-14
 
   ||ref||_infty = 0.99966
   &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 3.60822e-15
-
-  ||ref||_infty = 0.999696
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 3.55271e-15
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 1.25455e-14
 
 
   element_type     = Simplex
@@ -55,15 +55,83 @@
   is_dg            = 1
   RT_on_hypercube  = 0
   InverseMassType  = ElementwiseKrylovSolver
-  Number of degrees of freedom: 11520
+  Number of degrees of freedom: 4608
+
+  ||ref||_infty = 0.999696
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 2.29816e-14
 
   ||ref||_infty = 0.999992
   &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 4.73233e-15
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 2.52021e-14
+
+
+  element_type     = Simplex
+  dim              = 2
+  n_components     = 1
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = BlockMatrices
+  Number of degrees of freedom: 192
+
+  ||ref||_infty = 0.995733
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 6.66134e-16
+
+  ||ref||_infty = 0.999373
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 5.55112e-16
+
+
+  element_type     = Simplex
+  dim              = 2
+  n_components     = 2
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = BlockMatrices
+  Number of degrees of freedom: 384
+
+  ||ref||_infty = 0.996732
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 7.77156e-16
+
+  ||ref||_infty = 0.993933
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 7.77156e-16
+
+
+  element_type     = Simplex
+  dim              = 3
+  n_components     = 1
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = BlockMatrices
+  Number of degrees of freedom: 1536
+
+  ||ref||_infty = 0.999402
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 1.11022e-15
+
+  ||ref||_infty = 0.998749
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 1.33227e-15
+
+
+  element_type     = Simplex
+  dim              = 3
+  n_components     = 3
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = BlockMatrices
+  Number of degrees of freedom: 4608
 
   ||ref||_infty = 0.999968
   &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 4.85723e-15
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 1.33227e-15
+
+  ||ref||_infty = 0.999779
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 1.33227e-15
 
 
   element_type     = Hypercube
@@ -72,171 +140,103 @@
   is_dg            = 1
   RT_on_hypercube  = 0
   InverseMassType  = MatrixfreeOperator
+  Number of degrees of freedom: 32
+
+  ||ref||_infty = 0.938772
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 9.99201e-16
+
+  ||ref||_infty = 0.98091
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 1.66533e-15
+
+
+  element_type     = Hypercube
+  dim              = 2
+  n_components     = 2
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = MatrixfreeOperator
+  Number of degrees of freedom: 64
+
+  ||ref||_infty = 0.998551
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 1.77636e-15
+
+  ||ref||_infty = 0.997072
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 1.66533e-15
+
+
+  element_type     = Hypercube
+  dim              = 3
+  n_components     = 1
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = MatrixfreeOperator
+  Number of degrees of freedom: 128
+
+  ||ref||_infty = 0.968867
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 3.77476e-15
+
+  ||ref||_infty = 0.999406
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 2.10942e-15
+
+
+  element_type     = Hypercube
+  dim              = 3
+  n_components     = 3
+  is_dg            = 1
+  RT_on_hypercube  = 0
+  InverseMassType  = MatrixfreeOperator
+  Number of degrees of freedom: 384
+
+  ||ref||_infty = 0.997656
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 2.9976e-15
+
+  ||ref||_infty = 0.998806
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 2.55351e-15
+
+
+  element_type     = Hypercube
+  dim              = 2
+  n_components     = 2
+  is_dg            = 1
+  RT_on_hypercube  = 1
+  InverseMassType  = GlobalKrylovSolver
+  Number of degrees of freedom: 24
+
+  ||ref||_infty = 0.994656
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.39073e-12
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
+
+  ||ref||_infty = 0.998113
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.90539e-12
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
+
+
+  element_type     = Hypercube
+  dim              = 3
+  n_components     = 3
+  is_dg            = 1
+  RT_on_hypercube  = 1
+  InverseMassType  = GlobalKrylovSolver
   Number of degrees of freedom: 72
 
-  ||ref||_infty = 0.998761
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 1.02002e-15
-
-  ||ref||_infty = 0.968522
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 1.44329e-15
-
-
-  element_type     = Hypercube
-  dim              = 2
-  n_components     = 2
-  is_dg            = 1
-  RT_on_hypercube  = 0
-  InverseMassType  = MatrixfreeOperator
-  Number of degrees of freedom: 144
-
-  ||ref||_infty = 0.989935
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0.990984
-
-  ||ref||_infty = 0.995006
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0.486198
-
-
-  element_type     = Hypercube
-  dim              = 3
-  n_components     = 1
-  is_dg            = 1
-  RT_on_hypercube  = 0
-  InverseMassType  = MatrixfreeOperator
-  Number of degrees of freedom: 432
-
-  ||ref||_infty = 0.999011
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 2.10942e-15
-
-  ||ref||_infty = 0.996247
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 2.22045e-15
-
-
-  element_type     = Hypercube
-  dim              = 3
-  n_components     = 3
-  is_dg            = 1
-  RT_on_hypercube  = 0
-  InverseMassType  = MatrixfreeOperator
-  Number of degrees of freedom: 1296
-
-  ||ref||_infty = 0.998531
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 1.02751
-
-  ||ref||_infty = 0.998839
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 0
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0.504598
-
-
-  element_type     = Hypercube
-  dim              = 2
-  n_components     = 2
-  is_dg            = 1
-  RT_on_hypercube  = 1
-  InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 80
-
-  ||ref||_infty = 0.996777
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.28915e-12
+  ||ref||_infty = 0.986796
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.61066e-11
   consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
 
-  ||ref||_infty = 0.999371
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 6.51161e-12
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
-
-
-  element_type     = Hypercube
-  dim              = 3
-  n_components     = 3
-  is_dg            = 1
-  RT_on_hypercube  = 1
-  InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 480
-
-  ||ref||_infty = 0.999053
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.72312e-11
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
-
-  ||ref||_infty = 0.993165
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.52985e-11
+  ||ref||_infty = 0.988108
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.17257e-12
   consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
 
 
   element_type     = Simplex
-  dim              = 2
-  n_components     = 1
-  is_dg            = 0
-  RT_on_hypercube  = 0
-  InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 160
-
-  ||ref||_infty = 0.999882
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 4.30968e-12
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
-
-  ||ref||_infty = 0.988576
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.94629e-12
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
-
-
-  element_type     = Simplex
-  dim              = 2
-  n_components     = 2
-  is_dg            = 0
-  RT_on_hypercube  = 0
-  InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 320
-
-  ||ref||_infty = 0.988951
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 4.1677e-12
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
-
-  ||ref||_infty = 0.998532
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 5.51026e-12
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
-
-
-  element_type     = Simplex
-  dim              = 3
-  n_components     = 1
-  is_dg            = 0
-  RT_on_hypercube  = 0
-  InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 720
-
-  ||ref||_infty = 0.999438
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 5.24847e-12
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
-
-  ||ref||_infty = 0.998963
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 6.01852e-12
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
-
-
-  element_type     = Simplex
-  dim              = 3
-  n_components     = 3
-  is_dg            = 0
-  RT_on_hypercube  = 0
-  InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 2160
-
-  ||ref||_infty = 0.999717
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.06033e-11
-  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
-
-  ||ref||_infty = 0.999556
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 9.37594e-12
-  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
-
-
-  element_type     = Hypercube
   dim              = 2
   n_components     = 1
   is_dg            = 0
@@ -244,12 +244,80 @@
   InverseMassType  = GlobalKrylovSolver
   Number of degrees of freedom: 48
 
-  ||ref||_infty = 0.99947
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.69412e-12
+  ||ref||_infty = 0.935288
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.89893e-12
   consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
 
-  ||ref||_infty = 0.979917
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 4.84934e-12
+  ||ref||_infty = 0.999922
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.89468e-12
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
+
+
+  element_type     = Simplex
+  dim              = 2
+  n_components     = 2
+  is_dg            = 0
+  RT_on_hypercube  = 0
+  InverseMassType  = GlobalKrylovSolver
+  Number of degrees of freedom: 96
+
+  ||ref||_infty = 0.993914
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.59648e-12
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
+
+  ||ref||_infty = 0.996245
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 4.30311e-12
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
+
+
+  element_type     = Simplex
+  dim              = 3
+  n_components     = 1
+  is_dg            = 0
+  RT_on_hypercube  = 0
+  InverseMassType  = GlobalKrylovSolver
+  Number of degrees of freedom: 120
+
+  ||ref||_infty = 0.990025
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 4.59227e-12
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
+
+  ||ref||_infty = 0.996509
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 4.19054e-12
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
+
+
+  element_type     = Simplex
+  dim              = 3
+  n_components     = 3
+  is_dg            = 0
+  RT_on_hypercube  = 0
+  InverseMassType  = GlobalKrylovSolver
+  Number of degrees of freedom: 360
+
+  ||ref||_infty = 0.999524
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.9893e-12
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
+
+  ||ref||_infty = 0.998155
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.92144e-12
+  consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
+
+
+  element_type     = Hypercube
+  dim              = 2
+  n_components     = 1
+  is_dg            = 0
+  RT_on_hypercube  = 0
+  InverseMassType  = GlobalKrylovSolver
+  Number of degrees of freedom: 16
+
+  ||ref||_infty = 0.930171
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.43139e-14
+  consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
+
+  ||ref||_infty = 0.931347
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.26565e-14
   consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
 
 
@@ -259,14 +327,14 @@
   is_dg            = 0
   RT_on_hypercube  = 0
   InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 96
+  Number of degrees of freedom: 32
 
-  ||ref||_infty = 0.965227
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.41349e-12
+  ||ref||_infty = 0.956524
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.87548e-14
   consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
 
-  ||ref||_infty = 0.98873
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 6.08158e-12
+  ||ref||_infty = 0.977503
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.385e-14
   consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
 
 
@@ -276,14 +344,14 @@
   is_dg            = 0
   RT_on_hypercube  = 0
   InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 240
+  Number of degrees of freedom: 48
 
-  ||ref||_infty = 0.988659
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.44935e-11
+  ||ref||_infty = 0.911832
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 6.98441e-13
   consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
 
-  ||ref||_infty = 0.994493
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.65695e-11
+  ||ref||_infty = 0.964755
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 3.75733e-12
   consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
 
 
@@ -293,14 +361,14 @@
   is_dg            = 0
   RT_on_hypercube  = 0
   InverseMassType  = GlobalKrylovSolver
-  Number of degrees of freedom: 720
+  Number of degrees of freedom: 144
 
-  ||ref||_infty = 0.99992
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 1.67409e-11
+  ||ref||_infty = 0.994434
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 5.91913e-12
   consider_inverse_coefficient = 0   : || vec  - ref ||_infty = 0
 
-  ||ref||_infty = 0.997987
-  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 2.02277e-11
+  ||ref||_infty = 0.992968
+  &src == &dst in InverseMassOperator: || vec1 - vec2||_infty = 4.241e-12
   consider_inverse_coefficient = 1   : || vec  - ref ||_infty = 0
 
 


### PR DESCRIPTION
fixes #754 
by actually setting all the coefficients, not only the ones for the first component :face_exhaling: 

.) adds the `InverseMassType::BlockMatrices` to the inverse mass test

then i tested again the case `&src == &dst`:

.) removes the copying of the vector for the case `&src=&dst` in `InverseMassOperator::apply()`

-> this needed a fix in `Elementwise::IterativeSolver`, which set also `dst = 0;` for the case when `&dst==&src`. Now, we set the initial condition on the element-local vector, since then we set `integrator.set_dof_values(dst, 0);` anyways ... so I think we did not even set the initial guess with that line before (`AlignedVector` calls default initializer on `VectorizedArray`, so the elements are uninitialized).