### PR TITLE
introduce `VectorWriter` and use

### DIFF
--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -498,6 +498,7 @@ private:
     pp_data.output_data.write_velocity_magnitude  = true;
     pp_data.output_data.write_vorticity_magnitude = true;
     pp_data.output_data.write_processor_id        = true;
+    pp_data.output_data.write_aspect_ratio        = true;
     pp_data.output_data.write_q_criterion         = true;
     pp_data.output_data.degree                    = this->param.degree_u;
     pp_data.output_data.write_higher_order        = true;

--- a/include/exadg/acoustic_conservation_equations/postprocessor/output_generator.cpp
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/output_generator.cpp
@@ -19,16 +19,8 @@
  *  ______________________________________________________________________
  */
 
-// C/C++
-#include <fstream>
-
-// deal.II
-#include <deal.II/grid/grid_tools.h>
-#include <deal.II/numerics/data_out.h>
-
 // ExaDG
 #include <exadg/acoustic_conservation_equations/postprocessor/output_generator.h>
-#include <exadg/grid/grid_data.h>
 #include <exadg/postprocessor/write_output.h>
 #include <exadg/utilities/create_directories.h>
 
@@ -36,46 +28,6 @@ namespace ExaDG
 {
 namespace Acoustics
 {
-template<int dim, typename Number>
-void
-write_output(OutputData const &                                         output_data,
-             dealii::DoFHandler<dim> const &                            dof_handler_pressure,
-             dealii::DoFHandler<dim> const &                            dof_handler_velocity,
-             dealii::Mapping<dim> const &                               mapping,
-             dealii::LinearAlgebra::distributed::Vector<Number> const & pressure,
-             dealii::LinearAlgebra::distributed::Vector<Number> const & velocity,
-             unsigned int const                                         output_counter,
-             MPI_Comm const &                                           mpi_comm)
-{
-  std::string folder = output_data.directory, file = output_data.filename;
-
-  dealii::DataOutBase::VtkFlags flags;
-  flags.write_higher_order_cells = output_data.write_higher_order;
-
-  dealii::DataOut<dim> data_out;
-  data_out.set_flags(flags);
-
-  if(output_data.write_pressure)
-    data_out.add_data_vector(dof_handler_pressure, pressure, "p");
-
-  if(output_data.write_velocity)
-  {
-    std::vector<std::string> velocity_names(dim, "velocity_times_density");
-    std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
-      velocity_component_interpretation(
-        dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
-
-    data_out.add_data_vector(dof_handler_velocity,
-                             velocity,
-                             velocity_names,
-                             velocity_component_interpretation);
-  }
-
-  data_out.build_patches(mapping, output_data.degree, dealii::DataOut<dim>::curved_inner_cells);
-
-  data_out.write_vtu_with_pvtu_record(folder, file, output_counter, mpi_comm, 4);
-}
-
 template<int dim, typename Number>
 OutputGenerator<dim, Number>::OutputGenerator(MPI_Comm const & comm) : mpi_comm(comm)
 {
@@ -155,14 +107,26 @@ OutputGenerator<dim, Number>::evaluate(VectorType const & pressure,
 {
   print_write_output_time(time, time_control.get_counter(), unsteady, mpi_comm);
 
-  write_output<dim>(output_data,
-                    *dof_handler_pressure,
-                    *dof_handler_velocity,
-                    *mapping,
-                    pressure,
-                    velocity,
-                    time_control.get_counter(),
-                    mpi_comm);
+  VectorWriter<dim, Number> vector_writer(output_data, time_control.get_counter(), mpi_comm);
+
+  if(output_data.write_pressure)
+  {
+    vector_writer.add_data_vector(pressure, *dof_handler_pressure, {"pressure"});
+  }
+
+  if(output_data.write_velocity)
+  {
+    std::vector<std::string> component_names(dim, "velocity");
+    std::vector<bool>        component_is_part_of_vector(dim, true);
+    vector_writer.add_data_vector(velocity,
+                                  *dof_handler_velocity,
+                                  component_names,
+                                  component_is_part_of_vector);
+  }
+
+  vector_writer.write_aspect_ratio(*dof_handler_velocity, *mapping);
+
+  vector_writer.write_pvtu(&(*mapping));
 }
 
 template class OutputGenerator<2, float>;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
@@ -19,17 +19,8 @@
  *  ______________________________________________________________________
  */
 
-// C/C++
-#include <fstream>
-
-// deal.II
-#include <deal.II/grid/grid_tools.h>
-#include <deal.II/numerics/data_out.h>
-
 // ExaDG
-#include <exadg/grid/grid_data.h>
 #include <exadg/incompressible_navier_stokes/postprocessor/output_generator.h>
-#include <exadg/operators/quadrature.h>
 #include <exadg/postprocessor/write_output.h>
 #include <exadg/utilities/create_directories.h>
 
@@ -37,88 +28,6 @@ namespace ExaDG
 {
 namespace IncNS
 {
-template<int dim, typename Number>
-void
-write_output(
-  OutputData const &                                                    output_data,
-  dealii::DoFHandler<dim> const &                                       dof_handler_velocity,
-  dealii::DoFHandler<dim> const &                                       dof_handler_pressure,
-  dealii::Mapping<dim> const &                                          mapping,
-  dealii::LinearAlgebra::distributed::Vector<Number> const &            velocity,
-  dealii::LinearAlgebra::distributed::Vector<Number> const &            pressure,
-  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
-  unsigned int const                                                    output_counter,
-  MPI_Comm const &                                                      mpi_comm)
-{
-  std::string folder = output_data.directory, file = output_data.filename;
-
-  dealii::DataOutBase::VtkFlags flags;
-  flags.write_higher_order_cells = output_data.write_higher_order;
-
-  dealii::DataOut<dim> data_out;
-  data_out.set_flags(flags);
-
-  std::vector<std::string> velocity_names(dim, "velocity");
-  std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
-    velocity_component_interpretation(
-      dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
-
-  data_out.add_data_vector(dof_handler_velocity,
-                           velocity,
-                           velocity_names,
-                           velocity_component_interpretation);
-
-  data_out.add_data_vector(dof_handler_pressure, pressure, "p");
-
-  // vector needs to survive until build_patches
-  dealii::Vector<double> aspect_ratios;
-  if(output_data.write_aspect_ratio)
-  {
-    dealii::Triangulation<dim> const & tria = dof_handler_velocity.get_triangulation();
-
-    ElementType const element_type = get_element_type(tria);
-
-    std::shared_ptr<dealii::Quadrature<dim>> quadrature = create_quadrature<dim>(element_type, 4);
-
-    aspect_ratios = dealii::GridTools::compute_aspect_ratio_of_cells(mapping, tria, *quadrature);
-    data_out.add_data_vector(aspect_ratios, "aspect_ratio");
-  }
-
-  for(auto & additional_field : additional_fields)
-  {
-    if(additional_field->get_type() == SolutionFieldType::scalar)
-    {
-      data_out.add_data_vector(additional_field->get_dof_handler(),
-                               additional_field->get(),
-                               additional_field->get_name());
-    }
-    else if(additional_field->get_type() == SolutionFieldType::cellwise)
-    {
-      data_out.add_data_vector(additional_field->get(), additional_field->get_name());
-    }
-    else if(additional_field->get_type() == SolutionFieldType::vector)
-    {
-      std::vector<std::string> names(dim, additional_field->get_name());
-      std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
-        component_interpretation(dim,
-                                 dealii::DataComponentInterpretation::component_is_part_of_vector);
-
-      data_out.add_data_vector(additional_field->get_dof_handler(),
-                               additional_field->get(),
-                               names,
-                               component_interpretation);
-    }
-    else
-    {
-      AssertThrow(false, dealii::ExcMessage("Not implemented."));
-    }
-  }
-
-  data_out.build_patches(mapping, output_data.degree, dealii::DataOut<dim>::curved_inner_cells);
-
-  data_out.write_vtu_with_pvtu_record(folder, file, output_counter, mpi_comm, 4);
-}
-
 template<int dim, typename Number>
 OutputGenerator<dim, Number>::OutputGenerator(MPI_Comm const & comm) : mpi_comm(comm)
 {
@@ -200,15 +109,22 @@ OutputGenerator<dim, Number>::evaluate(
 {
   print_write_output_time(time, time_control.get_counter(), unsteady, mpi_comm);
 
-  write_output<dim>(output_data,
-                    *dof_handler_velocity,
-                    *dof_handler_pressure,
-                    *mapping,
-                    velocity,
-                    pressure,
-                    additional_fields,
-                    time_control.get_counter(),
-                    mpi_comm);
+  VectorWriter<dim, Number> vector_writer(output_data, time_control.get_counter(), mpi_comm);
+
+  std::vector<std::string> component_names(dim, "velocity");
+  std::vector<bool>        component_is_part_of_vector(dim, true);
+  vector_writer.add_data_vector(velocity,
+                                *dof_handler_velocity,
+                                component_names,
+                                component_is_part_of_vector);
+
+  vector_writer.add_data_vector(pressure, *dof_handler_pressure, {"pressure"});
+
+  vector_writer.write_aspect_ratio(*dof_handler_velocity, *mapping);
+
+  vector_writer.add_fields(additional_fields);
+
+  vector_writer.write_pvtu(&(*mapping));
 }
 
 template class OutputGenerator<2, float>;

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
@@ -43,8 +43,7 @@ struct OutputData : public OutputDataBase
       write_streamfunction(false),
       write_q_criterion(false),
       mean_velocity(TimeControlData()),
-      write_cfl(false),
-      write_aspect_ratio(false)
+      write_cfl(false)
   {
   }
 
@@ -104,9 +103,6 @@ struct OutputData : public OutputDataBase
 
   // write cfl
   bool write_cfl;
-
-  // write aspect ratio
-  bool write_aspect_ratio;
 };
 
 template<int dim, typename Number>

--- a/include/exadg/postprocessor/output_data_base.h
+++ b/include/exadg/postprocessor/output_data_base.h
@@ -36,6 +36,7 @@ struct OutputDataBase
       write_surface_mesh(false),
       write_boundary_IDs(false),
       write_grid(false),
+      write_aspect_ratio(false),
       write_processor_id(false),
       write_higher_order(true),
       degree(1)
@@ -55,6 +56,7 @@ struct OutputDataBase
       print_parameter(pcout, "Write surface mesh", write_surface_mesh);
       print_parameter(pcout, "Write boundary IDs", write_boundary_IDs);
 
+      print_parameter(pcout, "Write aspect ratio", write_aspect_ratio);
       print_parameter(pcout, "Write processor ID", write_processor_id);
 
       print_parameter(pcout, "Write higher order", write_higher_order);
@@ -81,6 +83,9 @@ struct OutputDataBase
 
   // write grid output for debug meshing
   bool write_grid;
+
+  // write the aspect ratio to check the mesh quality
+  bool write_aspect_ratio;
 
   // write processor ID to scalar field in order to visualize the
   // distribution of cells to processors

--- a/include/exadg/postprocessor/output_generator_scalar.cpp
+++ b/include/exadg/postprocessor/output_generator_scalar.cpp
@@ -19,12 +19,6 @@
  *  ______________________________________________________________________
  */
 
-// C/C++
-#include <fstream>
-
-// deal.II
-#include <deal.II/numerics/data_out.h>
-
 // ExaDG
 #include <exadg/postprocessor/output_generator_scalar.h>
 #include <exadg/postprocessor/write_output.h>
@@ -32,31 +26,6 @@
 
 namespace ExaDG
 {
-template<int dim, typename VectorType>
-void
-write_output(OutputDataBase const &          output_data,
-             dealii::DoFHandler<dim> const & dof_handler,
-             dealii::Mapping<dim> const &    mapping,
-             VectorType const &              solution_vector,
-             unsigned int const              output_counter,
-             MPI_Comm const &                mpi_comm)
-{
-  std::string folder = output_data.directory, file = output_data.filename;
-
-  dealii::DataOutBase::VtkFlags flags;
-  flags.write_higher_order_cells = output_data.write_higher_order;
-
-  dealii::DataOut<dim> data_out;
-  data_out.set_flags(flags);
-
-  data_out.attach_dof_handler(dof_handler);
-
-  data_out.add_data_vector(solution_vector, "solution");
-  data_out.build_patches(mapping, output_data.degree, dealii::DataOut<dim>::curved_inner_cells);
-
-  data_out.write_vtu_with_pvtu_record(folder, file, output_counter, mpi_comm, 4);
-}
-
 template<int dim, typename Number>
 OutputGenerator<dim, Number>::OutputGenerator(MPI_Comm const & comm) : mpi_comm(comm)
 {
@@ -121,8 +90,13 @@ OutputGenerator<dim, Number>::evaluate(VectorType const & solution,
 {
   print_write_output_time(time, time_control.get_counter(), unsteady, mpi_comm);
 
-  write_output<dim>(
-    output_data, *dof_handler, *mapping, solution, time_control.get_counter(), mpi_comm);
+  VectorWriter<dim, Number> vector_writer(output_data, time_control.get_counter(), mpi_comm);
+
+  vector_writer.add_data_vector(solution, *dof_handler, {"solution"});
+
+  vector_writer.write_aspect_ratio(*dof_handler, *mapping);
+
+  vector_writer.write_pvtu(&(*mapping));
 }
 
 template class OutputGenerator<2, float>;

--- a/include/exadg/postprocessor/write_output.h
+++ b/include/exadg/postprocessor/write_output.h
@@ -27,13 +27,21 @@
 
 // deal.II
 #include <deal.II/base/bounding_box.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/data_out_faces.h>
 #include <deal.II/particles/data_out.h>
 #include <deal.II/particles/particle_handler.h>
+
+// ExaDG
+#include <exadg/grid/grid_data.h>
+#include <exadg/operators/quadrature.h>
+#include <exadg/postprocessor/output_data_base.h>
+#include <exadg/postprocessor/solution_field.h>
 
 namespace ExaDG
 {
@@ -148,86 +156,141 @@ write_points_in_dummy_triangulation(std::vector<dealii::Point<dim>> const & poin
     particle_dummy_tria, particle_dummy_mapping, points, folder, file, counter, mpi_comm);
 }
 
-template<int dim, typename VectorType>
-void
-write_vector(dealii::DoFHandler<dim> const & dof_handler,
-             dealii::Mapping<dim> const &    mapping,
-             VectorType const &              vector,
-             std::string const &             folder,
-             std::string const &             file,
-             unsigned int const              n_subdivisions,
-             unsigned int const              n_components = 1)
+template<int dim, typename Number>
+class VectorWriter
 {
-  // Write higher order output.
-  dealii::DataOut<dim>          data_out;
-  dealii::DataOutBase::VtkFlags flags;
-  flags.write_higher_order_cells = n_subdivisions > 1;
-  data_out.set_flags(flags);
-  data_out.attach_dof_handler(dof_handler);
-
-  // Get vector with locally relevant entries.
-  VectorType       rel_vector;
-  dealii::IndexSet rel_dofs;
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, rel_dofs);
-  MPI_Comm const & mpi_comm = dof_handler.get_communicator();
-  rel_vector.reinit(dof_handler.locally_owned_dofs(), rel_dofs, mpi_comm);
-  rel_vector = vector;
-
-  // Vector entries are to be interpreted as components of a vector.
-  if(n_components > 1)
+public:
+  VectorWriter(OutputDataBase const & output_data,
+               unsigned int const &   output_counter,
+               MPI_Comm const &       mpi_comm)
+    : output_data(output_data), output_counter(output_counter), mpi_comm(mpi_comm)
   {
-    std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
-      data_component_interpretation(
-        dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
-    std::vector<std::string> solution_names(n_components, "vector");
-    data_out.add_data_vector(rel_vector,
-                             "vector",
-                             dealii::DataOut<dim>::type_dof_data,
-                             data_component_interpretation);
-  }
-  else
-  {
-    data_out.add_data_vector(rel_vector, "vector");
+    // Write higher order output.
+    dealii::DataOutBase::VtkFlags flags;
+    flags.write_higher_order_cells = output_data.write_higher_order;
+    data_out.set_flags(flags);
   }
 
-  auto const & triangulation = dof_handler.get_triangulation();
-
-  // Add vector indicating subdomain.
-  dealii::Vector<float> subdomain;
-  if constexpr(true)
+  // Note that the vectors must remain valid until we call `write_pvtu()`, which is not the
+  // responsibility of this class.
+  template<typename VectorType>
+  void
+  add_data_vector(VectorType const &               vector,
+                  dealii::DoFHandler<dim> const &  dof_handler,
+                  std::vector<std::string> const & component_names,
+                  std::vector<bool> const &        component_is_part_of_vector = {false})
   {
-    subdomain.reinit(triangulation.n_active_cells());
-    for(unsigned int i = 0; i < subdomain.size(); ++i)
+    unsigned int n_components = component_names.size();
+    AssertThrow(n_components > 0, dealii::ExcMessage("Provide names for each component."));
+
+    AssertThrow(n_components == component_is_part_of_vector.size(),
+                dealii::ExcMessage("Provide names and vector info for each component."));
+
+    // Vector entries are to be interpreted as components of a vector.
+    if(n_components > 1)
     {
-      subdomain(i) = triangulation.locally_owned_subdomain();
+      std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+        data_component_interpretation(n_components,
+                                      dealii::DataComponentInterpretation::component_is_scalar);
+      for(unsigned int i = 0; i < n_components; ++i)
+      {
+        if(component_is_part_of_vector[i])
+        {
+          data_component_interpretation[i] =
+            dealii::DataComponentInterpretation::component_is_part_of_vector;
+        }
+      }
+      data_out.add_data_vector(dof_handler, vector, component_names, data_component_interpretation);
     }
-    data_out.add_data_vector(subdomain, "subdomain");
-  }
-
-  // Build patches, vectors to export must stay in scope until after this call.
-  data_out.build_patches(mapping, n_subdivisions, dealii::DataOut<dim>::curved_inner_cells);
-
-  // Create vtu files + pvtu record.
-  std::string filename =
-    folder + file + "_p" +
-    dealii::Utilities::int_to_string(triangulation.locally_owned_subdomain(), 4);
-  std::ofstream output((filename + ".vtu").c_str());
-  data_out.write_vtu(output);
-
-  // Combine outputs using rank 0.
-  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
-  {
-    std::vector<std::string> filenames;
-    for(unsigned int i = 0; i < dealii::Utilities::MPI::n_mpi_processes(mpi_comm); ++i)
+    else
     {
-      filenames.push_back(folder + file + "_p" + dealii::Utilities::int_to_string(i, 4) + ".vtu");
+      data_out.add_data_vector(dof_handler, vector, component_names[0]);
+    }
+  }
+
+  void
+  add_fields(
+    std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields)
+  {
+    for(auto & additional_field : additional_fields)
+    {
+      if(additional_field->get_type() == SolutionFieldType::scalar)
+      {
+        data_out.add_data_vector(additional_field->get_dof_handler(),
+                                 additional_field->get(),
+                                 additional_field->get_name());
+      }
+      else if(additional_field->get_type() == SolutionFieldType::cellwise)
+      {
+        data_out.add_data_vector(additional_field->get(), additional_field->get_name());
+      }
+      else if(additional_field->get_type() == SolutionFieldType::vector)
+      {
+        std::vector<std::string> names(dim, additional_field->get_name());
+        std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+          component_interpretation(
+            dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
+
+        data_out.add_data_vector(additional_field->get_dof_handler(),
+                                 additional_field->get(),
+                                 names,
+                                 component_interpretation);
+      }
+      else
+      {
+        AssertThrow(false, dealii::ExcMessage("This `SolutionFieldType` is not implemented."));
+      }
+    }
+  }
+
+  void
+  write_aspect_ratio(dealii::DoFHandler<dim> const & dof_handler,
+                     dealii::Mapping<dim> const &    mapping)
+  {
+    // Add aspect ratio. Vector needs to survive until build_patches.
+    if(output_data.write_aspect_ratio)
+    {
+      dealii::Triangulation<dim> const & tria = dof_handler.get_triangulation();
+
+      ElementType const element_type = get_element_type(tria);
+
+      std::shared_ptr<dealii::Quadrature<dim>> quadrature = create_quadrature<dim>(element_type, 4);
+
+      aspect_ratios = dealii::GridTools::compute_aspect_ratio_of_cells(mapping, tria, *quadrature);
+      data_out.add_data_vector(aspect_ratios, "aspect_ratio");
+    }
+  }
+
+  void
+  write_pvtu(dealii::Mapping<dim> const * mapping = nullptr)
+  {
+    // Build patches, vectors to export must stay in scope until after this call.
+    if(mapping == nullptr)
+    {
+      data_out.build_patches(output_data.degree);
+    }
+    else
+    {
+      data_out.build_patches(*mapping,
+                             output_data.degree,
+                             dealii::DataOut<dim>::curved_inner_cells);
     }
 
-    // Combine outputs of individual threads.
-    std::ofstream master_output((folder + file + ".pvtu").c_str());
-    data_out.write_pvtu_record(master_output, filenames);
+    unsigned int constexpr n_groups = 4;
+    data_out.write_vtu_with_pvtu_record(
+      output_data.directory, output_data.filename, output_counter, mpi_comm, n_groups);
   }
-}
+
+private:
+  OutputDataBase const                             output_data;
+  unsigned int                                     output_counter;
+  dealii::SmartPointer<dealii::Mapping<dim> const> mapping;
+  MPI_Comm const                                   mpi_comm;
+
+  dealii::Vector<double> aspect_ratios;
+
+  dealii::DataOut<dim> data_out;
+};
 
 } // namespace ExaDG
 


### PR DESCRIPTION
this new lightweight class removes the free function introduced in #759 
reason for making a class instead of a free function is that I could not fix at compile time for all physics how many vectors are added to `data_out` and I could do a `std::vector<VectorType const>` since that violates the preconditions for `std::vector`. I liked the idea of a  free function as used before, but could not find a way to make it general enough.

I also moved the `write_aspect_ratio` to `OutputDataBase` since it is a basic parameter that can be computed for all physics.  Now we can output the `aspect_ratio` in the grid for all physics.

I checked all the output of all affected modules as well and everything seemed fine.
