### PR TITLE
Fix deprecation warnings due to deal.II update

### DIFF
--- a/include/exadg/acoustic_conservation_equations/postprocessor/output_generator.h
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/output_generator.h
@@ -76,9 +76,9 @@ private:
 
   OutputData output_data;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
 };
 
 } // namespace Acoustics

--- a/include/exadg/acoustic_conservation_equations/postprocessor/pointwise_output_generator.h
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/pointwise_output_generator.h
@@ -65,8 +65,8 @@ public:
            bool const         unsteady);
 
 private:
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
 
   PointwiseOutputData<dim> pointwise_output_data;
 };

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/operators/operator.h
@@ -506,8 +506,8 @@ private:
 
   mutable Number evaluation_time;
 
-  dealii::SmartPointer<dealii::MatrixFree<dim, Number> const> matrix_free;
-  OperatorData<dim>                                           data;
+  dealii::ObserverPointer<dealii::MatrixFree<dim, Number> const> matrix_free;
+  OperatorData<dim>                                              data;
 
   Number tau;
   Number gamma;

--- a/include/exadg/compressible_navier_stokes/postprocessor/output_generator.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/output_generator.cpp
@@ -99,10 +99,10 @@ OutputGenerator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_
 template<int dim, typename Number>
 void
 OutputGenerator<dim, Number>::evaluate(
-  VectorType const &                                                    solution_conserved,
-  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
-  double const                                                          time,
-  bool const                                                            unsteady)
+  VectorType const &                                                       solution_conserved,
+  std::vector<dealii::ObserverPointer<SolutionField<dim, Number>>> const & additional_fields,
+  double const                                                             time,
+  bool const                                                               unsteady)
 {
   print_write_output_time(time, time_control.get_counter(), unsteady, mpi_comm);
 

--- a/include/exadg/compressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/output_generator.h
@@ -98,19 +98,20 @@ public:
         OutputData const &              output_data_in);
 
   void
-  evaluate(VectorType const &                                                    solution_conserved,
-           std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
-           double const                                                          time,
-           bool const                                                            unsteady);
+  evaluate(
+    VectorType const &                                                       solution_conserved,
+    std::vector<dealii::ObserverPointer<SolutionField<dim, Number>>> const & additional_fields,
+    double const                                                             time,
+    bool const                                                               unsteady);
 
   TimeControl time_control;
 
 private:
   MPI_Comm const mpi_comm;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
-  OutputData                                          output_data;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
+  OutputData                                             output_data;
 };
 
 } // namespace CompNS

--- a/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/pointwise_output_generator.h
@@ -62,8 +62,8 @@ public:
   evaluate(VectorType const & solution, double const time, bool const unsteady);
 
 private:
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
-  PointwiseOutputData<dim>                            pointwise_output_data;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
+  PointwiseOutputData<dim>                               pointwise_output_data;
 };
 
 } // namespace CompNS

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -101,7 +101,7 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     solution,
    */
   if(output_generator.time_control.needs_evaluation(time, time_step_number))
   {
-    std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> additional_fields_vtu;
+    std::vector<dealii::ObserverPointer<SolutionField<dim, Number>>> additional_fields_vtu;
 
     if(pp_data.output_data.write_pressure)
     {

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
@@ -85,7 +85,7 @@ private:
 
   PostProcessorData<dim> pp_data;
 
-  dealii::SmartPointer<Operator<dim, Number> const> navier_stokes_operator;
+  dealii::ObserverPointer<Operator<dim, Number> const> navier_stokes_operator;
 
   OutputGenerator<dim, Number>                 output_generator;
   PointwiseOutputGenerator<dim, Number>        pointwise_output_generator;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/kernels_and_operators.h
@@ -593,7 +593,7 @@ public:
              FaceIntegratorScalar & energy_p,
              unsigned int const     q) const
   {
-    vector normal = momentum_m.get_normal_vector(q);
+    vector normal = momentum_m.normal_vector(q);
 
     // get values
     scalar rho_M   = density_m.get_value(q);
@@ -650,7 +650,7 @@ public:
                       dealii::types::boundary_id const & boundary_id,
                       unsigned int const                 q) const
   {
-    vector normal = momentum.get_normal_vector(q);
+    vector normal = momentum.normal_vector(q);
 
     // element e⁻
     scalar rho_M   = density.get_value(q);
@@ -1082,7 +1082,7 @@ public:
                       scalar const &         tau_IP,
                       unsigned int const     q) const
   {
-    vector normal = momentum_m.get_normal_vector(q);
+    vector normal = momentum_m.normal_vector(q);
 
     // density
     scalar rho_M      = density_m.get_value(q);
@@ -1152,7 +1152,7 @@ public:
                                dealii::types::boundary_id const & boundary_id,
                                unsigned int const                 q) const
   {
-    vector normal = momentum.get_normal_vector(q);
+    vector normal = momentum.normal_vector(q);
 
     // density
     scalar rho_M      = density.get_value(q);
@@ -1264,7 +1264,7 @@ public:
                    FaceIntegratorScalar & energy_p,
                    unsigned int const     q) const
   {
-    vector normal = momentum_m.get_normal_vector(q);
+    vector normal = momentum_m.normal_vector(q);
 
     // density
     scalar rho_M = density_m.get_value(q);
@@ -1344,7 +1344,7 @@ public:
                             dealii::types::boundary_id const & boundary_id,
                             unsigned int const                 q) const
   {
-    vector normal = momentum.get_normal_vector(q);
+    vector normal = momentum.normal_vector(q);
 
     // density
     scalar rho_M = density.get_value(q);

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -42,7 +42,7 @@ Operator<dim, Number>::Operator(
   Parameters const &                             param_in,
   std::string const &                            field_in,
   MPI_Comm const &                               mpi_comm_in)
-  : dealii::Subscriptor(),
+  : dealii::EnableObserverPointer(),
     grid(grid_in),
     mapping(mapping_in),
     boundary_descriptor(boundary_descriptor_in),

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -44,7 +44,7 @@ namespace ExaDG
 namespace CompNS
 {
 template<int dim, typename Number>
-class Operator : public dealii::Subscriptor, public Interface::Operator<Number>
+class Operator : public dealii::EnableObserverPointer, public Interface::Operator<Number>
 {
 private:
   typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -50,7 +50,7 @@ Operator<dim, Number>::Operator(
   Parameters const &                                    param_in,
   std::string const &                                   field_in,
   MPI_Comm const &                                      mpi_comm_in)
-  : dealii::Subscriptor(),
+  : dealii::EnableObserverPointer(),
     grid(grid_in),
     mapping(mapping_in),
     multigrid_mappings(multigrid_mappings_in),

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -45,7 +45,7 @@ namespace ExaDG
 namespace ConvDiff
 {
 template<int dim, typename Number>
-class Operator : public dealii::Subscriptor, public Interface::Operator<Number>
+class Operator : public dealii::EnableObserverPointer, public Interface::Operator<Number>
 {
 private:
   typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/combined_operator.cpp
@@ -271,7 +271,7 @@ CombinedOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
     scalar value_m = integrator_m.get_value(q);
     scalar value_p = integrator_p.get_value(q);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     scalar value_flux_m = dealii::make_vectorized_array<Number>(0.0);
     scalar value_flux_p = dealii::make_vectorized_array<Number>(0.0);
@@ -324,7 +324,7 @@ CombinedOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrator_
     scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
@@ -371,7 +371,7 @@ CombinedOperator<dim, Number>::do_face_int_integral_cell_based(IntegratorFace & 
     scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
@@ -425,7 +425,7 @@ CombinedOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_
     scalar value_p = integrator_p.get_value(q);
 
     // n⁺ = -n⁻
-    vector normal_p = -integrator_p.get_normal_vector(q);
+    vector normal_p = -integrator_p.normal_vector(q);
 
     scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 
@@ -480,7 +480,7 @@ CombinedOperator<dim, Number>::do_boundary_integral(
                                               operator_data.bc,
                                               this->time);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     scalar value_flux = dealii::make_vectorized_array<Number>(0.0);
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operators/convective_operator.cpp
@@ -147,7 +147,7 @@ ConvectiveOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
     scalar value_m = integrator_m.get_value(q);
     scalar value_p = integrator_p.get_value(q);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     std::tuple<scalar, scalar> flux = kernel->calculate_flux_interior_and_neighbor(
       q, integrator_m, value_m, value_p, normal_m, this->time, true);
@@ -170,7 +170,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrato
     scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     scalar flux = kernel->calculate_flux_interior(
       q, integrator_m, value_m, value_p, normal_m, this->time, true);
@@ -195,7 +195,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral_cell_based(
     scalar value_p = dealii::make_vectorized_array<Number>(0.0);
     scalar value_m = integrator_m.get_value(q);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     // TODO
     // The matrix-free implementation in deal.II does currently not allow to access neighboring data
@@ -225,7 +225,7 @@ ConvectiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
     scalar value_p = integrator_p.get_value(q);
 
     // n⁺ = -n⁻
-    vector normal_p = -integrator_p.get_normal_vector(q);
+    vector normal_p = -integrator_p.normal_vector(q);
 
     scalar flux = kernel->calculate_flux_interior(
       q, integrator_p, value_p, value_m, normal_p, this->time, true);
@@ -255,7 +255,7 @@ ConvectiveOperator<dim, Number>::do_boundary_integral(
                                               operator_data.bc,
                                               this->time);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     // In case of numerical velocity field:
     // Simply use velocity_p = velocity_m on boundary faces -> exterior_velocity_available = false.

--- a/include/exadg/fluid_structure_interaction/precice/coupling_base.h
+++ b/include/exadg/fluid_structure_interaction/precice/coupling_base.h
@@ -257,7 +257,7 @@ CouplingBase<dim, data_dim, VectorizedArrayType>::print_info(bool const         
 {
   dealii::ConditionalOStream pcout(std::cout,
                                    dealii::Utilities::MPI::this_mpi_process(
-                                     matrix_free.get_dof_handler().get_communicator()) == 0);
+                                     matrix_free.get_dof_handler().get_mpi_communicator()) == 0);
   auto const                 map = (reader ? read_data_map : write_data_map);
 
   auto        names      = map.begin();
@@ -270,7 +270,8 @@ CouplingBase<dim, data_dim, VectorizedArrayType>::print_info(bool const         
         << "--     . data name(s): " << data_names << "\n"
         << "--     . associated mesh: " << mesh_name << "\n"
         << "--     . Number of coupling nodes: "
-        << dealii::Utilities::MPI::sum(local_size, matrix_free.get_dof_handler().get_communicator())
+        << dealii::Utilities::MPI::sum(local_size,
+                                       matrix_free.get_dof_handler().get_mpi_communicator())
         << "\n"
         << "--     . Node location: " << get_surface_type() << "\n"
         << std::endl;

--- a/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
+++ b/include/exadg/functions_and_boundary_conditions/interface_coupling.cpp
@@ -55,11 +55,11 @@ InterfaceCoupling<rank, dim, Number>::setup(
   for(auto quad_index : interface_data_dst->get_quad_indices())
   {
     // exchange quadrature points with their owners
-    map_evaluator.emplace(quad_index,
-                          std::make_unique<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(
-                            tolerance_, false, 0, [marked_vertices_src_]() {
-                              return marked_vertices_src_;
-                            }));
+    map_evaluator.emplace(
+      quad_index,
+      std::make_unique<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(
+        typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData(
+          tolerance_, false, 0, [marked_vertices_src_]() { return marked_vertices_src_; })));
 
     auto const * points = &interface_data_dst->get_array_q_points(quad_index);
 
@@ -80,7 +80,7 @@ InterfaceCoupling<rank, dim, Number>::setup(
         }
       }
       n_points_not_found =
-        dealii::Utilities::MPI::sum(n_points_not_found, dof_handler_src->get_communicator());
+        dealii::Utilities::MPI::sum(n_points_not_found, dof_handler_src->get_mpi_communicator());
 
       std::string const file_name =
         "interface_coupling_quad_index_" + dealii::Utilities::to_string(quad_index);
@@ -91,10 +91,10 @@ InterfaceCoupling<rank, dim, Number>::setup(
                  "./",
                  file_name,
                  0,
-                 dof_handler_src->get_communicator());
+                 dof_handler_src->get_mpi_communicator());
 
       write_points_in_dummy_triangulation(
-        points_not_found, "./", file_name, 0, dof_handler_src->get_communicator());
+        points_not_found, "./", file_name, 0, dof_handler_src->get_mpi_communicator());
 
       AssertThrow(map_evaluator[quad_index]->all_points_found(),
                   dealii::ExcMessage(std::string("Setup of InterfaceCoupling was not successful: " +

--- a/include/exadg/grid/grid_utilities.h
+++ b/include/exadg/grid/grid_utilities.h
@@ -249,12 +249,13 @@ create_triangulation(
       std::make_shared<dealii::parallel::fullydistributed::Triangulation<dim>>(mpi_comm);
 
     auto const description = dealii::TriangulationDescription::Utilities::
-      create_description_from_triangulation_in_groups<dim, dim>(serial_grid_generator,
-                                                                serial_grid_partitioner,
-                                                                triangulation->get_communicator(),
-                                                                group_size,
-                                                                mesh_smoothing,
-                                                                triangulation_description_setting);
+      create_description_from_triangulation_in_groups<dim, dim>(
+        serial_grid_generator,
+        serial_grid_partitioner,
+        triangulation->get_mpi_communicator(),
+        group_size,
+        mesh_smoothing,
+        triangulation_description_setting);
 
     triangulation->create_triangulation(description);
   }
@@ -313,7 +314,7 @@ create_coarse_triangulations_automatically_from_fine_triangulation(
       dealii::MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
         fine_triangulation,
         BalancedGranularityPartitionPolicy<dim>(
-          dealii::Utilities::MPI::n_mpi_processes(fine_triangulation.get_communicator())));
+          dealii::Utilities::MPI::n_mpi_processes(fine_triangulation.get_mpi_communicator())));
   }
   else
   {
@@ -372,7 +373,7 @@ create_coarse_triangulations_for_fully_distributed_triangulation(
       {
         GridUtilities::create_triangulation<dim>(coarse_triangulations[level],
                                                  coarse_periodic_face_pairs[level],
-                                                 fine_triangulation.get_communicator(),
+                                                 fine_triangulation.get_mpi_communicator(),
                                                  data,
                                                  false /*construct_multigrid_hierarchy */,
                                                  lambda_create_triangulation,
@@ -401,7 +402,7 @@ create_coarse_triangulations_for_fully_distributed_triangulation(
 
         GridUtilities::create_triangulation<dim>(coarse_triangulations[level],
                                                  coarse_periodic_face_pairs[level],
-                                                 fine_triangulation.get_communicator(),
+                                                 fine_triangulation.get_mpi_communicator(),
                                                  data,
                                                  false /*construct_multigrid_hierarchy */,
                                                  lambda_create_triangulation,

--- a/include/exadg/grid/mapping_dof_vector.h
+++ b/include/exadg/grid/mapping_dof_vector.h
@@ -123,11 +123,11 @@ public:
   {
     if(grid_coordinates.size() != dof_handler.n_dofs())
     {
-      dealii::IndexSet relevant_dofs_grid;
-      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs_grid);
+      dealii::IndexSet const relevant_dofs_grid =
+        dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
       grid_coordinates.reinit(dof_handler.locally_owned_dofs(),
                               relevant_dofs_grid,
-                              dof_handler.get_communicator());
+                              dof_handler.get_mpi_communicator());
     }
     else
     {
@@ -221,11 +221,11 @@ public:
     VectorType displacement_vector_ghosted;
     if(dof_handler.n_dofs() > 0 and displacement_vector.size() == dof_handler.n_dofs())
     {
-      dealii::IndexSet locally_relevant_dofs;
-      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+      dealii::IndexSet const locally_relevant_dofs =
+        dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
       displacement_vector_ghosted.reinit(dof_handler.locally_owned_dofs(),
                                          locally_relevant_dofs,
-                                         dof_handler.get_communicator());
+                                         dof_handler.get_mpi_communicator());
       displacement_vector_ghosted.copy_locally_owned_data_from(displacement_vector);
       displacement_vector_ghosted.update_ghost_values();
     }
@@ -378,8 +378,8 @@ initialize_coarse_mappings_from_mapping_dof_vector(
   // ghosting
   for(unsigned int level = 0; level < n_levels; level++)
   {
-    dealii::IndexSet relevant_dofs;
-    dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, relevant_dofs);
+    dealii::IndexSet const relevant_dofs =
+      dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
     grid_coordinates_all_levels_ghosted[level].reinit(
       dof_handler.locally_owned_mg_dofs(level),
@@ -525,12 +525,11 @@ initialize_coarse_mappings_from_mapping_dof_vector(
   // a function that initializes the dof-vector for a given level and dof_handler
   const std::function<void(unsigned int const, VectorType &)> initialize_dof_vector =
     [&](unsigned int const h_level, VectorType & vector) {
-      dealii::IndexSet locally_relevant_dofs;
-      dealii::DoFTools::extract_locally_relevant_dofs(dof_handlers_all_levels[h_level],
-                                                      locally_relevant_dofs);
+      dealii::IndexSet const locally_relevant_dofs =
+        dealii::DoFTools::extract_locally_relevant_dofs(dof_handlers_all_levels[h_level]);
       vector.reinit(dof_handlers_all_levels[h_level].locally_owned_dofs(),
                     locally_relevant_dofs,
-                    dof_handlers_all_levels[h_level].get_communicator());
+                    dof_handlers_all_levels[h_level].get_mpi_communicator());
     };
 
   dealii::MGTransferGlobalCoarsening<dim, VectorType> mg_transfer_global_coarsening(

--- a/include/exadg/incompressible_navier_stokes/postprocessor/divergence_and_mass_error.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/divergence_and_mass_error.cpp
@@ -170,10 +170,10 @@ DivergenceAndMassErrorCalculator<dim, Number>::local_compute_div_face(
     {
       diff_mass_flux_vec +=
         integrator_m.JxW(q) * std::abs((integrator_m.get_value(q) - integrator_p.get_value(q)) *
-                                       integrator_m.get_normal_vector(q));
+                                       integrator_m.normal_vector(q));
       mean_mass_flux_vec += integrator_m.JxW(q) *
                             std::abs(0.5 * (integrator_m.get_value(q) + integrator_p.get_value(q)) *
-                                     integrator_m.get_normal_vector(q));
+                                     integrator_m.normal_vector(q));
     }
 
     // sum over entries of dealii::VectorizedArray, but only over those that are "active"

--- a/include/exadg/incompressible_navier_stokes/postprocessor/flow_rate_calculator.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/flow_rate_calculator.cpp
@@ -138,8 +138,7 @@ FlowRateCalculator<dim, Number>::do_calculate_flow_rates(
 
       for(unsigned int q = 0; q < integrator.n_q_points; ++q)
       {
-        flow_rate_face +=
-          integrator.JxW(q) * integrator.get_value(q) * integrator.get_normal_vector(q);
+        flow_rate_face += integrator.JxW(q) * integrator.get_value(q) * integrator.normal_vector(q);
       }
 
       // sum over all entries of dealii::VectorizedArray

--- a/include/exadg/incompressible_navier_stokes/postprocessor/inflow_data_calculator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/inflow_data_calculator.h
@@ -109,10 +109,10 @@ public:
   calculate(dealii::LinearAlgebra::distributed::Vector<Number> const & velocity);
 
 private:
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
-  InflowData<dim>                                     inflow_data;
-  bool                                                inflow_data_has_been_initialized;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
+  InflowData<dim>                                        inflow_data;
+  bool                                                   inflow_data_has_been_initialized;
 
   MPI_Comm const mpi_comm;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/kinetic_energy_dissipation_detailed.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/kinetic_energy_dissipation_detailed.h
@@ -57,7 +57,7 @@ private:
   void
   calculate_detailed(VectorType const & velocity, double const time);
 
-  dealii::SmartPointer<NavierStokesOperator const> navier_stokes_operator;
+  dealii::ObserverPointer<NavierStokesOperator const> navier_stokes_operator;
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation.h
@@ -66,9 +66,9 @@ private:
 
   mutable bool clear_files;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
 
   LinePlotData<dim> data;
 };

--- a/include/exadg/incompressible_navier_stokes/postprocessor/mean_velocity_calculator.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/mean_velocity_calculator.cpp
@@ -293,8 +293,7 @@ MeanVelocityCalculator<dim, Number>::do_calculate_flow_rate_area(VectorType cons
 
       for(unsigned int q = 0; q < integrator.n_q_points; ++q)
       {
-        flow_rate_face +=
-          integrator.JxW(q) * integrator.get_value(q) * integrator.get_normal_vector(q);
+        flow_rate_face += integrator.JxW(q) * integrator.get_value(q) * integrator.normal_vector(q);
       }
 
       // sum over all entries of dealii::VectorizedArray

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.cpp
@@ -101,11 +101,11 @@ OutputGenerator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_
 template<int dim, typename Number>
 void
 OutputGenerator<dim, Number>::evaluate(
-  VectorType const &                                                    velocity,
-  VectorType const &                                                    pressure,
-  std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
-  double const                                                          time,
-  bool const                                                            unsteady) const
+  VectorType const &                                                       velocity,
+  VectorType const &                                                       pressure,
+  std::vector<dealii::ObserverPointer<SolutionField<dim, Number>>> const & additional_fields,
+  double const                                                             time,
+  bool const                                                               unsteady) const
 {
   print_write_output_time(time, time_control.get_counter(), unsteady, mpi_comm);
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/output_generator.h
@@ -123,11 +123,12 @@ public:
         OutputData const &              output_data_in);
 
   void
-  evaluate(VectorType const &                                                    velocity,
-           VectorType const &                                                    pressure,
-           std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields,
-           double const                                                          time,
-           bool const                                                            unsteady) const;
+  evaluate(
+    VectorType const &                                                       velocity,
+    VectorType const &                                                       pressure,
+    std::vector<dealii::ObserverPointer<SolutionField<dim, Number>>> const & additional_fields,
+    double const                                                             time,
+    bool const                                                               unsteady) const;
 
   TimeControl time_control;
 
@@ -136,9 +137,9 @@ private:
 
   OutputData output_data;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
 };
 
 } // namespace IncNS

--- a/include/exadg/incompressible_navier_stokes/postprocessor/pointwise_output_generator.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/pointwise_output_generator.h
@@ -65,8 +65,8 @@ public:
            bool const         unsteady);
 
 private:
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
 
   PointwiseOutputData<dim> pointwise_output_data;
 };

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -135,7 +135,7 @@ PostProcessor<dim, Number>::do_postprocessing(VectorType const &     velocity,
    */
   if(output_generator.time_control.needs_evaluation(time, time_step_number))
   {
-    std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> additional_fields_vtu;
+    std::vector<dealii::ObserverPointer<SolutionField<dim, Number>>> additional_fields_vtu;
     if(pp_data.output_data.write_vorticity)
     {
       vorticity.evaluate(velocity);

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -95,7 +95,7 @@ private:
 
   PostProcessorData<dim> pp_data;
 
-  dealii::SmartPointer<NavierStokesOperator const> navier_stokes_operator;
+  dealii::ObserverPointer<NavierStokesOperator const> navier_stokes_operator;
 
   // DoF vectors for derived quantities
   SolutionField<dim, Number> vorticity;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -83,7 +83,7 @@ private:
 };
 
 template<int dim, typename Number>
-class LinearOperatorCoupled : public dealii::Subscriptor
+class LinearOperatorCoupled : public dealii::EnableObserverPointer
 {
 private:
   typedef dealii::LinearAlgebra::distributed::BlockVector<Number> BlockVectorType;
@@ -91,7 +91,7 @@ private:
   typedef OperatorCoupled<dim, Number> PDEOperator;
 
 public:
-  LinearOperatorCoupled() : dealii::Subscriptor(), pde_operator(nullptr)
+  LinearOperatorCoupled() : dealii::EnableObserverPointer(), pde_operator(nullptr)
   {
   }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -112,7 +112,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_body_forces_boundary_
                                                    q_points,
                                                    this->evaluation_time);
 
-        scalar flux_times_normal = rhs * integrator.get_normal_vector(q);
+        scalar flux_times_normal = rhs * integrator.normal_vector(q);
         // minus sign is introduced here which allows to call a function of type ...add()
         // and avoids a scaling of the resulting vector by the factor -1.0
         integrator.submit_value(-flux_times_normal, q);
@@ -200,7 +200,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_convective_term_bound
       if(boundary_type == BoundaryTypeU::Dirichlet or
          boundary_type == BoundaryTypeU::DirichletCached)
       {
-        vector normal = pressure.get_normal_vector(q);
+        vector normal = pressure.normal_vector(q);
 
         vector u      = velocity.get_value(q);
         tensor grad_u = velocity.get_gradient(q);
@@ -294,7 +294,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_numerical_time_derivative_
     {
       if(boundary_type == BoundaryTypeP::Neumann)
       {
-        vector normal = integrator_velocity.get_normal_vector(q);
+        vector normal = integrator_velocity.normal_vector(q);
         vector dudt   = integrator_velocity.get_value(q);
         scalar h      = -normal * dudt;
 
@@ -366,7 +366,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_body_force_term_add_bounda
                                                    q_points,
                                                    this->evaluation_time);
 
-        vector normal = integrator.get_normal_vector(q);
+        vector normal = integrator.normal_vector(q);
 
         scalar h = normal * rhs;
 
@@ -439,7 +439,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_convective_add_boundary_fa
     {
       if(boundary_type == BoundaryTypeP::Neumann)
       {
-        vector normal = pressure.get_normal_vector(q);
+        vector normal = pressure.normal_vector(q);
 
         vector u      = velocity.get_value(q);
         tensor grad_u = velocity.get_gradient(q);
@@ -528,13 +528,11 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_viscous_add_boundary_face(
 
       if(boundary_type == BoundaryTypeP::Neumann)
       {
-        scalar h = dealii::make_vectorized_array<Number>(0.0);
+        vector const normal = pressure.normal_vector(q);
 
-        vector normal = pressure.get_normal_vector(q);
+        vector const curl_omega = CurlCompute<dim, FaceIntegratorU>::compute(omega, q);
 
-        vector curl_omega = CurlCompute<dim, FaceIntegratorU>::compute(omega, q);
-
-        h = -normal * (viscosity * curl_omega);
+        scalar const h = -normal * (viscosity * curl_omega);
 
         pressure.submit_value(h, q);
       }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.cpp
@@ -295,7 +295,7 @@ ContinuityPenaltyOperator<dim, Number>::do_face_integral(IntegratorFace & integr
   {
     vector u_m      = integrator_m.get_value(q);
     vector u_p      = integrator_p.get_value(q);
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector flux = kernel->calculate_flux(u_m, u_p, normal_m);
 
@@ -318,7 +318,7 @@ ContinuityPenaltyOperator<dim, Number>::do_boundary_integral(
     vector u_m = calculate_interior_value(q, integrator_m, operator_type);
     vector u_p = calculate_exterior_value(
       u_m, q, integrator_m, operator_type, boundary_type, boundary_id, data.bc, time);
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector flux = kernel->calculate_flux(u_m, u_p, normal_m);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -300,7 +300,7 @@ ConvectiveOperator<dim, Number>::do_face_integral_nonlinear_operator(
   {
     vector u_m      = integrator_m.get_value(q);
     vector u_p      = integrator_p.get_value(q);
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector u_grid;
     if(operator_data.kernel_data.ale == true)
@@ -336,7 +336,7 @@ ConvectiveOperator<dim, Number>::do_boundary_integral_nonlinear_operator(
                                                      operator_data.bc,
                                                      this->time);
 
-    vector normal_m = integrator.get_normal_vector(q);
+    vector normal_m = integrator.normal_vector(q);
 
     vector u_grid;
     if(operator_data.kernel_data.ale == true)
@@ -439,7 +439,7 @@ ConvectiveOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
     vector delta_u_m = integrator_m.get_value(q);
     vector delta_u_p = integrator_p.get_value(q);
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     std::tuple<vector, vector> flux = kernel->calculate_flux_linear_operator_interior_and_neighbor(
       u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
@@ -464,7 +464,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrato
     vector delta_u_m = integrator_m.get_value(q);
     vector delta_u_p; // set exterior value to zero
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector flux =
       kernel->calculate_flux_linear_operator_interior(u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
@@ -494,7 +494,7 @@ ConvectiveOperator<dim, Number>::do_face_int_integral_cell_based(
     vector delta_u_m = integrator_m.get_value(q);
     vector delta_u_p; // set exterior value to zero
 
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector flux =
       kernel->calculate_flux_linear_operator_interior(u_m, u_p, delta_u_m, delta_u_p, normal_m, q);
@@ -518,7 +518,7 @@ ConvectiveOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
     vector delta_u_m; // set exterior value to zero
     vector delta_u_p = integrator_p.get_value(q);
 
-    vector normal_p = -integrator_p.get_normal_vector(q);
+    vector normal_p = -integrator_p.normal_vector(q);
 
     vector flux =
       kernel->calculate_flux_linear_operator_interior(u_p, u_m, delta_u_p, delta_u_m, normal_p, q);
@@ -582,7 +582,7 @@ ConvectiveOperator<dim, Number>::do_boundary_integral(
     }
 
 
-    vector normal_m = integrator.get_normal_vector(q);
+    vector normal_m = integrator.normal_vector(q);
 
     vector flux = kernel->calculate_flux_linear_operator_boundary(
       u_m, u_p, delta_u_m, delta_u_p, normal_m, boundary_type, q);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_operator.cpp
@@ -200,7 +200,7 @@ DivergenceOperator<dim, Number>::do_face_integral(FaceIntegratorU & velocity_m,
     vector flux = kernel.calculate_flux(value_m, value_p);
     if(data.formulation == FormulationVelocityDivergenceTerm::Weak)
     {
-      scalar flux_times_normal = flux * velocity_m.get_normal_vector(q);
+      scalar flux_times_normal = flux * velocity_m.normal_vector(q);
 
       pressure_m.submit_value(flux_times_normal, q);
       // minus sign since n⁺ = - n⁻
@@ -208,7 +208,7 @@ DivergenceOperator<dim, Number>::do_face_integral(FaceIntegratorU & velocity_m,
     }
     else if(data.formulation == FormulationVelocityDivergenceTerm::Strong)
     {
-      vector normal = velocity_m.get_normal_vector(q);
+      vector normal = velocity_m.normal_vector(q);
 
       pressure_m.submit_value((flux - value_m) * normal, q);
       // minus sign since n⁺ = - n⁻
@@ -246,7 +246,7 @@ DivergenceOperator<dim, Number>::do_boundary_integral(
     }
 
     vector flux   = kernel.calculate_flux(value_m, value_p);
-    vector normal = velocity.get_normal_vector(q);
+    vector normal = velocity.normal_vector(q);
     if(data.formulation == FormulationVelocityDivergenceTerm::Weak)
     {
       pressure.submit_value(flux * normal, q);
@@ -288,7 +288,7 @@ DivergenceOperator<dim, Number>::do_boundary_integral_from_dof_vector(
     }
 
     vector flux   = kernel.calculate_flux(value_m, value_p);
-    vector normal = velocity.get_normal_vector(q);
+    vector normal = velocity.normal_vector(q);
     if(data.formulation == FormulationVelocityDivergenceTerm::Weak)
     {
       pressure.submit_value(flux * normal, q);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/gradient_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/gradient_operator.cpp
@@ -226,7 +226,7 @@ GradientOperator<dim, Number>::do_face_integral(FaceIntegratorP & pressure_m,
     scalar flux = kernel.calculate_flux(value_m, value_p);
     if(data.formulation == FormulationPressureGradientTerm::Weak)
     {
-      vector flux_times_normal = flux * pressure_m.get_normal_vector(q);
+      vector flux_times_normal = flux * pressure_m.normal_vector(q);
 
       velocity_m.submit_value(flux_times_normal, q);
       // minus sign since n⁺ = - n⁻
@@ -234,7 +234,7 @@ GradientOperator<dim, Number>::do_face_integral(FaceIntegratorP & pressure_m,
     }
     else if(data.formulation == FormulationPressureGradientTerm::Strong)
     {
-      vector normal = pressure_m.get_normal_vector(q);
+      vector normal = pressure_m.normal_vector(q);
 
       velocity_m.submit_value((flux - value_m) * normal, q);
       // minus sign since n⁺ = - n⁻
@@ -280,7 +280,7 @@ GradientOperator<dim, Number>::do_boundary_integral(
     }
 
     scalar flux   = kernel.calculate_flux(value_m, value_p);
-    vector normal = pressure.get_normal_vector(q);
+    vector normal = pressure.normal_vector(q);
     if(data.formulation == FormulationPressureGradientTerm::Weak)
     {
       velocity.submit_value(flux * normal, q);
@@ -323,7 +323,7 @@ GradientOperator<dim, Number>::do_boundary_integral_from_dof_vector(
     }
 
     scalar flux   = kernel.calculate_flux(value_m, value_p);
-    vector normal = pressure.get_normal_vector(q);
+    vector normal = pressure.normal_vector(q);
     if(data.formulation == FormulationPressureGradientTerm::Weak)
     {
       velocity.submit_value(flux * normal, q);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -434,7 +434,7 @@ MomentumOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
   {
     vector value_m  = integrator_m.get_value(q);
     vector value_p  = integrator_p.get_value(q);
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector value_flux_m, value_flux_p;
     tensor gradient_flux;
@@ -492,7 +492,7 @@ MomentumOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrator_
   {
     vector value_m = integrator_m.get_value(q);
     vector value_p; // set exterior value to zero
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector value_flux_m;
     tensor gradient_flux;
@@ -543,7 +543,7 @@ MomentumOperator<dim, Number>::do_face_int_integral_cell_based(IntegratorFace & 
   {
     vector value_m = integrator_m.get_value(q);
     vector value_p; // set exterior value to zero
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector value_flux_m;
     tensor gradient_flux;
@@ -600,7 +600,7 @@ MomentumOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_
     vector value_m; // set exterior values to zero
     vector value_p = integrator_p.get_value(q);
     // multiply by -1.0 to get the correct normal vector !
-    vector normal_p = -integrator_p.get_normal_vector(q);
+    vector normal_p = -integrator_p.normal_vector(q);
 
     vector value_flux_p;
     tensor gradient_flux;
@@ -658,7 +658,7 @@ MomentumOperator<dim, Number>::do_boundary_integral(
     vector value_m = calculate_interior_value(q, integrator, operator_type);
 
     vector value_p;
-    vector normal_m = integrator.get_normal_vector(q);
+    vector normal_m = integrator.normal_vector(q);
 
     vector value_flux_m;
     tensor gradient_flux;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
@@ -228,7 +228,7 @@ ProjectionOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
   {
     vector u_m      = integrator_m.get_value(q);
     vector u_p      = integrator_p.get_value(q);
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector flux = time_step_size * conti_kernel->calculate_flux(u_m, u_p, normal_m);
 
@@ -248,7 +248,7 @@ ProjectionOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrato
   {
     vector u_m = integrator_m.get_value(q);
     vector u_p; // set u_p to zero
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     vector flux = time_step_size * conti_kernel->calculate_flux(u_m, u_p, normal_m);
 
@@ -267,7 +267,7 @@ ProjectionOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrato
   {
     vector u_m; // set u_m to zero
     vector u_p      = integrator_p.get_value(q);
-    vector normal_p = -integrator_p.get_normal_vector(q);
+    vector normal_p = -integrator_p.normal_vector(q);
 
     vector flux = time_step_size * conti_kernel->calculate_flux(u_p, u_m, normal_p);
 
@@ -297,7 +297,7 @@ ProjectionOperator<dim, Number>::do_boundary_integral(
                                             boundary_id,
                                             operator_data.bc,
                                             this->time);
-      vector normal_m = integrator_m.get_normal_vector(q);
+      vector normal_m = integrator_m.normal_vector(q);
 
       vector flux = time_step_size * conti_kernel->calculate_flux(u_m, u_p, normal_m);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.cpp
@@ -105,7 +105,7 @@ ViscousOperator<dim, Number>::do_face_integral(IntegratorFace & integrator_m,
   {
     vector value_m = integrator_m.get_value(q);
     vector value_p = integrator_p.get_value(q);
-    vector normal  = integrator_m.get_normal_vector(q);
+    vector normal  = integrator_m.normal_vector(q);
 
     scalar average_viscosity =
       kernel->get_viscosity_interior_face(integrator_m.get_current_cell_index(), q);
@@ -137,7 +137,7 @@ ViscousOperator<dim, Number>::do_face_int_integral(IntegratorFace & integrator_m
   {
     vector value_m = integrator_m.get_value(q);
     vector value_p; // set exterior values to zero
-    vector normal_m = integrator_m.get_normal_vector(q);
+    vector normal_m = integrator_m.normal_vector(q);
 
     scalar average_viscosity =
       kernel->get_viscosity_interior_face(integrator_m.get_current_cell_index(), q);
@@ -167,7 +167,7 @@ ViscousOperator<dim, Number>::do_face_ext_integral(IntegratorFace & integrator_m
     vector value_m; // set exterior values to zero
     vector value_p = integrator_p.get_value(q);
     // multiply by -1.0 to get the correct normal vector !
-    vector normal_p = -integrator_p.get_normal_vector(q);
+    vector normal_p = -integrator_p.normal_vector(q);
 
     scalar average_viscosity =
       kernel->get_viscosity_interior_face(integrator_p.get_current_cell_index(), q);
@@ -208,7 +208,7 @@ ViscousOperator<dim, Number>::do_boundary_integral(
                                               operator_data.bc,
                                               this->time);
 
-    vector normal = integrator.get_normal_vector(q);
+    vector normal = integrator.normal_vector(q);
 
     scalar viscosity = kernel->get_viscosity_boundary_face(integrator.get_current_cell_index(), q);
     tensor gradient_flux = kernel->calculate_gradient_flux(value_m, value_p, normal, viscosity);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -474,7 +474,7 @@ public:
                   dealii::ExcMessage("Specified formulation of viscous term is not implemented."));
     }
 
-    vector normal_gradient = gradient * integrator.get_normal_vector(q);
+    vector normal_gradient = gradient * integrator.normal_vector(q);
 
     return normal_gradient;
   }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/weak_boundary_conditions.h
@@ -136,8 +136,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(boundary_type == BoundaryTypeU::Symmetry)
   {
-    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m =
-      integrator.get_normal_vector(q);
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m = integrator.normal_vector(q);
 
     value_p = value_m - 2.0 * (value_m * normal_m) * normal_m;
   }
@@ -228,8 +227,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(boundary_type == BoundaryTypeU::Symmetry)
   {
-    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m =
-      integrator.get_normal_vector(q);
+    dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m = integrator.normal_vector(q);
 
     u_p = u_m - 2. * (u_m * normal_m) * normal_m;
   }
@@ -278,7 +276,7 @@ inline DEAL_II_ALWAYS_INLINE //
   else if(boundary_type == BoundaryTypeU::Symmetry)
   {
     dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal_m =
-      integrator_bc.get_normal_vector(q);
+      integrator_bc.normal_vector(q);
 
     value_p = value_m - 2.0 * (value_m * normal_m) * normal_m;
   }
@@ -489,7 +487,7 @@ inline DEAL_II_ALWAYS_INLINE //
       }
       else
       {
-        auto normals_m = integrator.get_normal_vector(q);
+        auto normals_m = integrator.normal_vector(q);
         h              = FunctionEvaluator<1, dim, Number>::value(
           *(std::dynamic_pointer_cast<FunctionWithNormal<dim>>(bc)), q_points, normals_m, time);
       }
@@ -507,7 +505,7 @@ inline DEAL_II_ALWAYS_INLINE //
   }
   else if(boundary_type == BoundaryTypeU::Symmetry)
   {
-    auto normal_m     = integrator.get_normal_vector(q);
+    auto normal_m     = integrator.normal_vector(q);
     normal_gradient_p = -normal_gradient_m + 2.0 * (normal_gradient_m * normal_m) * normal_m;
   }
   else

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -46,7 +46,7 @@ SpatialOperatorBase<dim, Number>::SpatialOperatorBase(
   Parameters const &                                    parameters_in,
   std::string const &                                   field_in,
   MPI_Comm const &                                      mpi_comm_in)
-  : dealii::Subscriptor(),
+  : dealii::EnableObserverPointer(),
     grid(grid_in),
     mapping(mapping_in),
     multigrid_mappings(multigrid_mappings_in),
@@ -122,9 +122,8 @@ SpatialOperatorBase<dim, Number>::initialize_dof_handler_and_constraints()
     // Periodic boundaries
     // We need to make sure the normal dofs are shared between cells on the periodic boundaries,
     // since these are continuous for HDIV.
-    dealii::IndexSet relevant_dofs;
-    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_u, relevant_dofs);
-    constraint_u.reinit(relevant_dofs);
+    dealii::IndexSet relevant_dofs = dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_u);
+    constraint_u.reinit(dof_handler_u.locally_owned_dofs(), relevant_dofs);
 
     for(auto const & face : grid->periodic_face_pairs)
       dealii::DoFTools::make_periodicity_constraints(
@@ -1860,7 +1859,7 @@ SpatialOperatorBase<dim, Number>::local_interpolate_stress_bc_boundary_face(
 
         // compute traction acting on structure with normal vector in opposite direction
         // as compared to the fluid domain
-        vector normal = integrator_u.get_normal_vector(q);
+        vector normal = integrator_u.normal_vector(q);
         tensor grad_u = integrator_u.get_gradient(q);
         scalar p      = integrator_p.get_value(q);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -64,7 +64,7 @@ template<int dim, typename Number>
 class SpatialOperatorBase;
 
 template<int dim, typename Number>
-class SpatialOperatorBase : public dealii::Subscriptor
+class SpatialOperatorBase : public dealii::EnableObserverPointer
 {
 protected:
   typedef dealii::LinearAlgebra::distributed::Vector<Number>      VectorType;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/viscosity_model_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/viscosity_model_base.cpp
@@ -27,7 +27,7 @@ namespace IncNS
 {
 template<int dim, typename Number>
 ViscosityModelBase<dim, Number>::ViscosityModelBase()
-  : dealii::Subscriptor(), dof_index_velocity(0), matrix_free(nullptr)
+  : dealii::EnableObserverPointer(), dof_index_velocity(0), matrix_free(nullptr)
 {
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/viscosity_model_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/viscosity_model_base.h
@@ -39,7 +39,7 @@ namespace IncNS
  *  Base class for variable viscosity models.
  */
 template<int dim, typename Number>
-class ViscosityModelBase : public dealii::Subscriptor
+class ViscosityModelBase : public dealii::EnableObserverPointer
 {
 private:
   typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;

--- a/include/exadg/operators/adaptive_mesh_refinement.h
+++ b/include/exadg/operators/adaptive_mesh_refinement.h
@@ -140,7 +140,7 @@ any_cells_flagged_for_coarsening_or_refinement(dealii::Triangulation<dim> const 
     }
   }
 
-  any_flag_set = dealii::Utilities::MPI::logical_or(any_flag_set, tria.get_communicator());
+  any_flag_set = dealii::Utilities::MPI::logical_or(any_flag_set, tria.get_mpi_communicator());
 
   return any_flag_set;
 }
@@ -158,7 +158,7 @@ mark_cells_kelly_error_estimator(dealii::Triangulation<dim> &              tria,
   VectorType locally_relevant_solution;
   locally_relevant_solution.reinit(dof_handler.locally_owned_dofs(),
                                    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler),
-                                   dof_handler.get_communicator());
+                                   dof_handler.get_mpi_communicator());
   locally_relevant_solution.copy_locally_owned_data_from(solution);
   constraints.distribute(locally_relevant_solution);
   locally_relevant_solution.update_ghost_values();

--- a/include/exadg/operators/constraints.h
+++ b/include/exadg/operators/constraints.h
@@ -40,9 +40,9 @@ add_hanging_node_and_periodicity_constraints(dealii::AffineConstraints<Number> &
                                              Grid<dim> const &                   grid,
                                              dealii::DoFHandler<dim> const &     dof_handler)
 {
-  dealii::IndexSet locally_relevant_dofs;
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-  affine_constraints.reinit(locally_relevant_dofs);
+  dealii::IndexSet const locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
+  affine_constraints.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
 
   // hanging nodes (needs to be done before imposing periodicity constraints
   if(grid.triangulation->has_hanging_nodes())

--- a/include/exadg/operators/multigrid_operator_base.h
+++ b/include/exadg/operators/multigrid_operator_base.h
@@ -32,7 +32,7 @@
 namespace ExaDG
 {
 template<int dim, typename Number>
-class MultigridOperatorBase : public dealii::Subscriptor
+class MultigridOperatorBase : public dealii::EnableObserverPointer
 {
 public:
   typedef Number                                             value_type;
@@ -40,7 +40,7 @@ public:
 
   static unsigned int const dimension = dim;
 
-  MultigridOperatorBase() : dealii::Subscriptor()
+  MultigridOperatorBase() : dealii::EnableObserverPointer()
   {
   }
 

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -103,7 +103,7 @@ struct OperatorBaseData
 };
 
 template<int dim, typename Number, int n_components = 1>
-class OperatorBase : public dealii::Subscriptor
+class OperatorBase : public dealii::EnableObserverPointer
 {
 public:
   typedef OperatorBase<dim, Number, n_components> This;

--- a/include/exadg/operators/solution_interpolation_between_triangulations.h
+++ b/include/exadg/operators/solution_interpolation_between_triangulations.h
@@ -160,9 +160,9 @@ private:
     }
   }
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_dst;
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_src;
-  dealii::Utilities::MPI::RemotePointEvaluation<dim>  rpe;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_dst;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_src;
+  dealii::Utilities::MPI::RemotePointEvaluation<dim>     rpe;
 };
 
 } // namespace ExaDG

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -227,7 +227,7 @@ project_vectors(
   if(not rpe_source.all_points_found())
   {
     write_points_in_dummy_triangulation(
-      integration_points_target, "./", "all_points", 0, source_dof_handler.get_communicator());
+      integration_points_target, "./", "all_points", 0, source_dof_handler.get_mpi_communicator());
 
     std::vector<dealii::Point<dim>> points_not_found;
     points_not_found.reserve(integration_points_target.size());
@@ -240,7 +240,7 @@ project_vectors(
     }
 
     write_points_in_dummy_triangulation(
-      points_not_found, "./", "points_not_found", 0, source_dof_handler.get_communicator());
+      points_not_found, "./", "points_not_found", 0, source_dof_handler.get_mpi_communicator());
 
     AssertThrow(rpe_source.all_points_found(),
                 dealii::ExcMessage(

--- a/include/exadg/operators/solution_transfer.h
+++ b/include/exadg/operators/solution_transfer.h
@@ -52,8 +52,7 @@ public:
     }
 
     pd_solution_transfer =
-      std::make_shared<dealii::parallel::distributed::SolutionTransfer<dim, VectorType>>(
-        *dof_handler);
+      std::make_shared<dealii::SolutionTransfer<dim, VectorType>>(*dof_handler);
 
     pd_solution_transfer->prepare_for_coarsening_and_refinement(vectors_old_grid_ptr);
   }
@@ -68,10 +67,9 @@ public:
   }
 
 private:
-  std::shared_ptr<dealii::parallel::distributed::SolutionTransfer<dim, VectorType>>
-    pd_solution_transfer;
+  std::shared_ptr<dealii::SolutionTransfer<dim, VectorType>> pd_solution_transfer;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
 };
 
 } // namespace ExaDG

--- a/include/exadg/poisson/overset_grids/user_interface/application_base.h
+++ b/include/exadg/poisson/overset_grids/user_interface/application_base.h
@@ -73,21 +73,13 @@ set_boundary_ids_overlap_region(dealii::Triangulation<dim> const & tria_dst,
   }
 
   // create and reinit RemotePointEvaluation: find points on src-side
-  std::vector<bool> marked_vertices = {};
-  double const      tolerance       = 1.e-10;
+  typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData rpe_data;
+  std::vector<bool>                                                           marked_vertices = {};
+  rpe_data.tolerance       = 1.e-10;
+  rpe_data.marked_vertices = [marked_vertices]() { return marked_vertices; };
 
   dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe =
-    dealii::Utilities::MPI::RemotePointEvaluation<dim>(tolerance,
-                                                       false
-#if DEAL_II_VERSION_GTE(9, 4, 0)
-                                                       ,
-                                                       0,
-                                                       [marked_vertices]() {
-                                                         return marked_vertices;
-                                                       }
-#endif
-    );
-
+    dealii::Utilities::MPI::RemotePointEvaluation<dim>(rpe_data);
   rpe.reinit(points, tria_src, mapping_src);
 
   // check which points have been found and whether a face on dst-side is located inside the src

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -54,7 +54,7 @@ Operator<dim, n_components, Number>::Operator(
   Parameters const &                                    param_in,
   std::string const &                                   field_in,
   MPI_Comm const &                                      mpi_comm_in)
-  : dealii::Subscriptor(),
+  : dealii::EnableObserverPointer(),
     grid(grid_in),
     mapping(mapping_in),
     multigrid_mappings(multigrid_mappings_in),

--- a/include/exadg/poisson/spatial_discretization/operator.h
+++ b/include/exadg/poisson/spatial_discretization/operator.h
@@ -38,7 +38,7 @@ namespace ExaDG
 namespace Poisson
 {
 template<int dim, int n_components, typename Number>
-class Operator : public dealii::Subscriptor
+class Operator : public dealii::EnableObserverPointer
 {
 private:
   static unsigned int const rank =

--- a/include/exadg/postprocessor/error_calculation.h
+++ b/include/exadg/postprocessor/error_calculation.h
@@ -119,8 +119,8 @@ private:
 
   bool clear_files_L2, clear_files_H1_seminorm;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
 
   ErrorCalculationData<dim> error_data;
 };

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.cpp
@@ -372,7 +372,7 @@ apply_taylor_green_symmetry(dealii::DoFHandler<dim> const & dof_handler_symm,
   // determine some useful constants
   auto const & fe = dof_handler.get_fe();
 
-  MPI_Comm const comm = dof_handler.get_communicator();
+  MPI_Comm const comm = dof_handler.get_mpi_communicator();
 
   // determine which process has which index (lex numbering) and wants which
   dealii::IndexSet range_has_lex(dof_handler_symm.n_dofs());  // has in symm system
@@ -557,10 +557,10 @@ void
 initialize_dof_vector(dealii::LinearAlgebra::distributed::Vector<Number> & vec,
                       const MeshType &                                     dof_handler)
 {
-  dealii::IndexSet locally_relevant_dofs;
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  dealii::IndexSet const locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
 
-  MPI_Comm const comm = dof_handler.get_communicator();
+  MPI_Comm const comm = dof_handler.get_mpi_communicator();
 
   vec.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs, comm);
 }

--- a/include/exadg/postprocessor/kinetic_energy_spectrum.h
+++ b/include/exadg/postprocessor/kinetic_energy_spectrum.h
@@ -138,7 +138,7 @@ private:
 
   std::shared_ptr<DealSpectrumWrapper> deal_spectrum_wrapper;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
 
   std::shared_ptr<VectorType>                 velocity_full;
   std::shared_ptr<dealii::Triangulation<dim>> tria_full;

--- a/include/exadg/postprocessor/lift_and_drag_calculation.cpp
+++ b/include/exadg/postprocessor/lift_and_drag_calculation.cpp
@@ -77,7 +77,7 @@ calculate_lift_and_drag_force(dealii::Tensor<1, dim, Number> &             Force
         dealii::VectorizedArray<Number> pressure = integrator_pressure.get_value(q);
 
         dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> normal =
-          integrator_velocity.get_normal_vector(q);
+          integrator_velocity.normal_vector(q);
         dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> velocity_gradient =
           integrator_velocity.get_gradient(q);
 

--- a/include/exadg/postprocessor/lift_and_drag_calculation.h
+++ b/include/exadg/postprocessor/lift_and_drag_calculation.h
@@ -100,8 +100,8 @@ private:
 
   mutable bool clear_files;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
-  dealii::MatrixFree<dim, Number> const *             matrix_free;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_velocity;
+  dealii::MatrixFree<dim, Number> const *                matrix_free;
   unsigned int dof_index_velocity, dof_index_pressure, quad_index;
 
   mutable double c_L_min, c_L_max, c_D_min, c_D_max;

--- a/include/exadg/postprocessor/normal_flux_calculation.cpp
+++ b/include/exadg/postprocessor/normal_flux_calculation.cpp
@@ -85,8 +85,7 @@ NormalFluxCalculator<dim, Number>::evaluate(VectorType const & solution,
 
       for(unsigned int q = 0; q < integrator.n_q_points; ++q)
       {
-        flux_face +=
-          integrator.JxW(q) * integrator.get_gradient(q) * integrator.get_normal_vector(q);
+        flux_face += integrator.JxW(q) * integrator.get_gradient(q) * integrator.normal_vector(q);
       }
 
       // sum over all entries of dealii::VectorizedArray

--- a/include/exadg/postprocessor/output_generator_scalar.h
+++ b/include/exadg/postprocessor/output_generator_scalar.h
@@ -54,9 +54,9 @@ public:
 private:
   MPI_Comm const mpi_comm;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
-  OutputDataBase                                      output_data;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
+  OutputDataBase                                         output_data;
 };
 
 } // namespace ExaDG

--- a/include/exadg/postprocessor/pointwise_output_generator_base.cpp
+++ b/include/exadg/postprocessor/pointwise_output_generator_base.cpp
@@ -176,8 +176,8 @@ template<int dim, typename Number>
 void
 PointwiseOutputGeneratorBase<dim, Number>::setup_remote_evaluator()
 {
-  remote_evaluator =
-    std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(1e-6, false, 0);
+  remote_evaluator = std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(
+    typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData(1e-6, false, 0));
   reinit_remote_evaluator();
 }
 

--- a/include/exadg/postprocessor/pointwise_output_generator_base.h
+++ b/include/exadg/postprocessor/pointwise_output_generator_base.h
@@ -165,8 +165,8 @@ private:
 
   MPI_Comm const mpi_comm;
 
-  dealii::SmartPointer<dealii::Triangulation<dim> const>              triangulation;
-  dealii::SmartPointer<dealii::Mapping<dim> const>                    mapping;
+  dealii::ObserverPointer<dealii::Triangulation<dim> const>           triangulation;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>                 mapping;
   PointwiseOutputDataBase<dim>                                        pointwise_output_data;
   dealii::Vector<Number>                                              componentwise_result;
   unsigned int                                                        n_out_samples;

--- a/include/exadg/postprocessor/pressure_difference_calculation.h
+++ b/include/exadg/postprocessor/pressure_difference_calculation.h
@@ -87,8 +87,8 @@ private:
 
   mutable bool clear_files;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler_pressure;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
 
   PressureDifferenceData<dim> data;
 };

--- a/include/exadg/postprocessor/solution_field.h
+++ b/include/exadg/postprocessor/solution_field.h
@@ -36,7 +36,7 @@ enum class SolutionFieldType
 };
 
 template<int dim, typename Number>
-class SolutionField : public dealii::Subscriptor
+class SolutionField : public dealii::EnableObserverPointer
 {
 public:
   using VectorType = dealii::LinearAlgebra::distributed::Vector<Number>;

--- a/include/exadg/postprocessor/statistics_manager.cpp
+++ b/include/exadg/postprocessor/statistics_manager.cpp
@@ -43,7 +43,7 @@ StatisticsManager<dim, Number>::StatisticsManager(
   : n_points_y_per_cell(0),
     dof_handler(dof_handler_velocity),
     mapping(mapping_in),
-    mpi_comm(dof_handler_velocity.get_communicator()),
+    mpi_comm(dof_handler_velocity.get_mpi_communicator()),
     number_of_samples(0),
     data(TurbulentChannelData())
 {

--- a/include/exadg/postprocessor/time_control.cpp
+++ b/include/exadg/postprocessor/time_control.cpp
@@ -165,7 +165,7 @@ TimeControl::reached_end_time() const
   return end_time_reached;
 }
 
-bool
+double
 TimeControl::get_epsilon() const
 {
   return EPSILON;

--- a/include/exadg/postprocessor/time_control.h
+++ b/include/exadg/postprocessor/time_control.h
@@ -77,7 +77,7 @@ public:
   bool
   reached_end_time() const;
 
-  bool
+  double
   get_epsilon() const;
 
 private:

--- a/include/exadg/postprocessor/write_output.h
+++ b/include/exadg/postprocessor/write_output.h
@@ -210,7 +210,7 @@ public:
 
   void
   add_fields(
-    std::vector<dealii::SmartPointer<SolutionField<dim, Number>>> const & additional_fields)
+    std::vector<dealii::ObserverPointer<SolutionField<dim, Number>>> const & additional_fields)
   {
     for(auto & additional_field : additional_fields)
     {
@@ -282,10 +282,10 @@ public:
   }
 
 private:
-  OutputDataBase const                             output_data;
-  unsigned int                                     output_counter;
-  dealii::SmartPointer<dealii::Mapping<dim> const> mapping;
-  MPI_Comm const                                   mpi_comm;
+  OutputDataBase const                                output_data;
+  unsigned int                                        output_counter;
+  dealii::ObserverPointer<dealii::Mapping<dim> const> mapping;
+  MPI_Comm const                                      mpi_comm;
 
   dealii::Vector<double> aspect_ratios;
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
@@ -127,12 +127,11 @@ add_constraints(bool                                is_dg,
   affine_constraints_own.clear();
 
   // ... and set local dofs
-  dealii::IndexSet relevant_dofs;
-  if(level != dealii::numbers::invalid_unsigned_int)
-    dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, relevant_dofs);
-  else
-    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
-  affine_constraints_own.reinit(relevant_dofs);
+  dealii::IndexSet const relevant_dofs =
+    (level != dealii::numbers::invalid_unsigned_int) ?
+      dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level) :
+      dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
+  affine_constraints_own.reinit(dof_handler.locally_owned_dofs(), relevant_dofs);
 
   // 1) add periodic BCs
   add_periodicity_constraints<dim, Number>(dof_handler,

--- a/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/constraints.h
@@ -127,11 +127,18 @@ add_constraints(bool                                is_dg,
   affine_constraints_own.clear();
 
   // ... and set local dofs
-  dealii::IndexSet const relevant_dofs =
-    (level != dealii::numbers::invalid_unsigned_int) ?
-      dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level) :
+  if(level == dealii::numbers::invalid_unsigned_int)
+  {
+    dealii::IndexSet const relevant_dofs =
       dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
-  affine_constraints_own.reinit(dof_handler.locally_owned_dofs(), relevant_dofs);
+    affine_constraints_own.reinit(dof_handler.locally_owned_dofs(), relevant_dofs);
+  }
+  else
+  {
+    dealii::IndexSet const relevant_dofs =
+      dealii::DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
+    affine_constraints_own.reinit(dof_handler.locally_owned_mg_dofs(level), relevant_dofs);
+  }
 
   // 1) add periodic BCs
   add_periodicity_constraints<dim, Number>(dof_handler,

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_algorithm.h
@@ -268,12 +268,12 @@ private:
   /**
    * The matrix for each level.
    */
-  dealii::SmartPointer<dealii::MGLevelObject<std::shared_ptr<MatrixType>> const> matrix;
+  dealii::ObserverPointer<dealii::MGLevelObject<std::shared_ptr<MatrixType>> const> matrix;
 
   /**
    * The matrix for each level.
    */
-  dealii::SmartPointer<dealii::MGCoarseGridBase<VectorType> const> coarse;
+  dealii::ObserverPointer<dealii::MGCoarseGridBase<VectorType> const> coarse;
 
   /**
    * Object for grid transfer.
@@ -283,7 +283,7 @@ private:
   /**
    * The smoothing object.
    */
-  dealii::SmartPointer<dealii::MGLevelObject<std::shared_ptr<SmootherType>> const> smoother;
+  dealii::ObserverPointer<dealii::MGLevelObject<std::shared_ptr<SmootherType>> const> smoother;
 
   MPI_Comm const mpi_comm;
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -430,8 +430,8 @@ MultigridPreconditionerBase<dim, Number, MultigridNumber>::
 
       AssertThrow(is_singular == false, dealii::ExcNotImplemented());
 
-      dealii::IndexSet locally_relevant_dofs;
-      dealii::DoFTools::extract_locally_relevant_dofs(*dof_handler, locally_relevant_dofs);
+      dealii::IndexSet const locally_relevant_dofs =
+        dealii::DoFTools::extract_locally_relevant_dofs(*dof_handler);
       affine_constraints_own->reinit(locally_relevant_dofs);
 
       // hanging nodes (needs to be done before imposing periodicity constraints and boundary

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -432,7 +432,7 @@ MultigridPreconditionerBase<dim, Number, MultigridNumber>::
 
       dealii::IndexSet const locally_relevant_dofs =
         dealii::DoFTools::extract_locally_relevant_dofs(*dof_handler);
-      affine_constraints_own->reinit(locally_relevant_dofs);
+      affine_constraints_own->reinit(dof_handler->locally_owned_dofs(), locally_relevant_dofs);
 
       // hanging nodes (needs to be done before imposing periodicity constraints and boundary
       // conditions)

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -53,7 +53,7 @@ create_subcommunicator(dealii::DoFHandler<dim, spacedim> const & dof_handler)
     if(cell->is_locally_owned())
       ++n_locally_owned_cells;
 
-  MPI_Comm const mpi_comm = dof_handler.get_communicator();
+  MPI_Comm const mpi_comm = dof_handler.get_mpi_communicator();
 
   // In case some of the MPI ranks do not have cells, we create a
   // sub-communicator to exclude all those processes from the MPI
@@ -172,7 +172,7 @@ public:
   {
     // initialize system matrix
     pde_operator.init_system_matrix(system_matrix,
-                                    op.get_matrix_free().get_dof_handler().get_communicator());
+                                    op.get_matrix_free().get_dof_handler().get_mpi_communicator());
 
     if(initialize)
     {

--- a/include/exadg/structure/postprocessor/output_generator.h
+++ b/include/exadg/structure/postprocessor/output_generator.h
@@ -54,9 +54,9 @@ public:
 private:
   MPI_Comm const mpi_comm;
 
-  dealii::SmartPointer<dealii::DoFHandler<dim> const> dof_handler;
-  dealii::SmartPointer<dealii::Mapping<dim> const>    mapping;
-  OutputDataBase                                      output_data;
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
+  OutputDataBase                                         output_data;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -48,7 +48,7 @@ Operator<dim, Number>::Operator(
   Parameters const &                                    param_in,
   std::string const &                                   field_in,
   MPI_Comm const &                                      mpi_comm_in)
-  : dealii::Subscriptor(),
+  : dealii::EnableObserverPointer(),
     grid(grid_in),
     mapping(mapping_in),
     multigrid_mappings(multigrid_mappings_in),

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -107,7 +107,7 @@ private:
  * operators that implement the physics.
  */
 template<int dim, typename Number>
-class LinearizedOperator : public dealii::Subscriptor
+class LinearizedOperator : public dealii::EnableObserverPointer
 {
 private:
   typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
@@ -116,7 +116,7 @@ private:
 
 public:
   LinearizedOperator()
-    : dealii::Subscriptor(), pde_operator(nullptr), scaling_factor_mass(0.0), time(0.0)
+    : dealii::EnableObserverPointer(), pde_operator(nullptr), scaling_factor_mass(0.0), time(0.0)
   {
   }
 
@@ -163,7 +163,7 @@ private:
 };
 
 template<int dim, typename Number>
-class Operator : public dealii::Subscriptor, public Interface::Operator<Number>
+class Operator : public dealii::EnableObserverPointer, public Interface::Operator<Number>
 {
 private:
   typedef float MultigridNumber;

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -73,7 +73,7 @@ NonLinearOperator<dim, Number>::valid_deformation(VectorType const & displacemen
   // sum over all MPI processes
   Number valid = 0.0;
   valid        = dealii::Utilities::MPI::sum(
-    dst, this->matrix_free->get_dof_handler(this->operator_data.dof_index).get_communicator());
+    dst, this->matrix_free->get_dof_handler(this->operator_data.dof_index).get_mpi_communicator());
 
   return (valid == 0.0);
 }
@@ -289,7 +289,7 @@ NonLinearOperator<dim, Number>::do_boundary_integral_continuous(
     if(this->operator_data.pull_back_traction)
     {
       tensor F = get_F<dim, Number>(integrator.get_gradient(q));
-      vector N = integrator.get_normal_vector(q);
+      vector N = integrator.normal_vector(q);
       // da/dA * n = det F F^{-T} * N := n_star
       // -> da/dA = n_star.norm()
       vector n_star = determinant(F) * transpose(invert(F)) * N;


### PR DESCRIPTION
Address the following four warnings due to interfaces that were deprecated in deal.II (with the switch to the 9.8 pre-release):
- Switch `SmartPointer/Subscriptor` to `ObserverPointer/EnableObserverPointer`
- Switch `FEFaceEvaluation::get_normal_vector()` to `FEFaceEvaluation::normal_vector()`
- Use the version of `extract_locally_relevant_dofs` that returns the index set, rather than passing it as a last argument to the function.
- `Trianglation/DoFHandler::get_communicator()` -> `Triangulation/DoFHandler::get_mpi_communicator()`

The second and third functions were around for quite some time in deal.II, the other two happened last year. This requires the minimal deal.II version to be 9.7, which makes sense anyway because each old version to be supported adds maintenance work. I will add that as a separate PR soon.