### PR TITLE
avoid `tmp` vector in pressure scaling

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1152,16 +1152,12 @@ SpatialOperatorBase<dim, Number>::adjust_pressure_level_if_undefined(VectorType 
       field_functions->analytical_solution_pressure->set_time(time);
       double const exact = field_functions->analytical_solution_pressure->value(first_point);
 
-      double current = 0.;
+      double current = -std::numeric_limits<double>::max();
       if(pressure.locally_owned_elements().is_element(dof_index_first_point))
         current = pressure(dof_index_first_point);
-      current = dealii::Utilities::MPI::sum(current, mpi_comm);
+      current = dealii::Utilities::MPI::max(current, mpi_comm);
 
-      VectorType vec_temp(pressure);
-      for(unsigned int i = 0; i < vec_temp.locally_owned_size(); ++i)
-        vec_temp.local_element(i) = 1.;
-
-      pressure.add(exact - current, vec_temp);
+      pressure.add(exact - current);
     }
     else if(this->param.adjust_pressure_level == AdjustPressureLevel::ApplyZeroMeanValue)
     {
@@ -1189,11 +1185,7 @@ SpatialOperatorBase<dim, Number>::adjust_pressure_level_if_undefined(VectorType 
       double const exact   = vec_double.mean_value();
       double const current = pressure.mean_value();
 
-      VectorType vec_temp(pressure);
-      for(unsigned int i = 0; i < vec_temp.locally_owned_size(); ++i)
-        vec_temp.local_element(i) = 1.;
-
-      pressure.add(exact - current, vec_temp);
+      pressure.add(exact - current);
     }
     else
     {


### PR DESCRIPTION
also i changed the `dealii::Utilities::sum()` to `dealii::Utilities::max()` to make it clearer that we only ever use one value even though the `dof_index_first_point` is unique and only one rank evaluates the `if` to true. 