### PR TITLE
update output for 2D simplices, lower error -> no other changes

### DIFF
--- a/tests/utilities/grid_to_grid_projection.mpirun=4.output
+++ b/tests/utilities/grid_to_grid_projection.mpirun=4.output
@@ -10,13 +10,13 @@
             4800 (continuous)
 
 Calculate error for all fields for initial data:
-  Relative error (L2-norm): 5.34535e-03
+  Relative error (L2-norm): 1.40436e-06
 
 Calculate error for all fields for initial data:
-  Relative error (L2-norm): 5.34535e-03
+  Relative error (L2-norm): 1.40436e-06
 
 Calculate error for all fields for initial data:
-  Relative error (L2-norm): 5.34535e-03
+  Relative error (L2-norm): 1.40436e-06
 
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.51442e-06
@@ -37,13 +37,13 @@ Calculate error for all fields for initial data:
             9600 (continuous)
 
 Calculate error for all fields for initial data:
-  Relative error (L2-norm): 5.98645e-03
+  Relative error (L2-norm): 1.59669e-06
 
 Calculate error for all fields for initial data:
-  Relative error (L2-norm): 5.98645e-03
+  Relative error (L2-norm): 1.59669e-06
 
 Calculate error for all fields for initial data:
-  Relative error (L2-norm): 5.98645e-03
+  Relative error (L2-norm): 1.59669e-06
 
 Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.91480e-06


### PR DESCRIPTION
I think this is from
https://github.com/dealii/dealii/pull/18832
note how the errors went down tremendously from
5e-3 ----> 1.6e-6
Maybe be coincidence only, I did not look into that.
Since the error between the interpolation to the exact solution reduces, no other changes in ExaDG are needed. 