### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/applications/aero_acoustic/co_rotating_vortex_pair/application.h
+++ b/applications/aero_acoustic/co_rotating_vortex_pair/application.h
@@ -640,12 +640,12 @@ public:
   double const REL_TOL_LINEAR = 1.e-2;
 
   // parameters specified via input.json
-  double n_rotations                          = 2.0;
-  double additional_refinements_around_source = 0;
-  double domain_radius                        = 40.0;
-  double intensity                            = 7.54;
-  double r_0                                  = 1.0;
-  double r_c                                  = 0.1 * r_0;
+  double       n_rotations                          = 2.0;
+  unsigned int additional_refinements_around_source = 0;
+  double       domain_radius                        = 40.0;
+  double       intensity                            = 7.54;
+  double       r_0                                  = 1.0;
+  double       r_c                                  = 0.1 * r_0;
 };
 } // namespace FluidAeroAcoustic
 

--- a/include/exadg/acoustic_conservation_equations/driver.h
+++ b/include/exadg/acoustic_conservation_equations/driver.h
@@ -49,13 +49,13 @@ get_dofs_per_element(unsigned int const       dim,
                      unsigned int const       degree,
                      ExaDG::ElementType const element_type)
 {
-  unsigned int const pressure_dofs_per_element =
+  double const pressure_dofs_per_element =
     ExaDG::get_dofs_per_element(element_type, true /* is_dg */, 1 /* n_components */, degree, dim);
 
-  unsigned int const velocity_dofs_per_element = ExaDG::get_dofs_per_element(
+  double const velocity_dofs_per_element = ExaDG::get_dofs_per_element(
     element_type, true /* is_dg */, dim /* n_components */, degree, dim);
 
-  return velocity_dofs_per_element + pressure_dofs_per_element;
+  return static_cast<unsigned int>(velocity_dofs_per_element + pressure_dofs_per_element);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/driver.h
+++ b/include/exadg/incompressible_navier_stokes/driver.h
@@ -83,17 +83,17 @@ get_dofs_per_element(OperatorType const &     operator_type,
   else
     AssertThrow(false, dealii::ExcMessage("Not implemented."));
 
-  unsigned int const velocity_dofs_per_element = ExaDG::get_dofs_per_element(
+  double const velocity_dofs_per_element = ExaDG::get_dofs_per_element(
     element_type, true /* is_dg */, dim /* n_components */, degree, dim);
 
-  unsigned int const pressure_dofs_per_element = ExaDG::get_dofs_per_element(
+  double const pressure_dofs_per_element = ExaDG::get_dofs_per_element(
     element_type, true /* is_dg */, 1 /* n_components */, degree_p, dim);
 
   // coupled/monolithic problem
   if(operator_type == OperatorType::CoupledNonlinearResidual or
      operator_type == OperatorType::CoupledLinearized)
   {
-    return velocity_dofs_per_element + pressure_dofs_per_element;
+    return static_cast<unsigned int>(velocity_dofs_per_element + pressure_dofs_per_element);
   }
   // velocity only
   else if(operator_type == OperatorType::ConvectiveOperator or
@@ -102,12 +102,12 @@ get_dofs_per_element(OperatorType const &     operator_type,
           operator_type == OperatorType::ProjectionOperator or
           operator_type == OperatorType::InverseMassOperator)
   {
-    return velocity_dofs_per_element;
+    return static_cast<unsigned int>(velocity_dofs_per_element);
   }
   // pressure only
   else if(operator_type == OperatorType::PressurePoissonOperator)
   {
-    return pressure_dofs_per_element;
+    return static_cast<unsigned int>(pressure_dofs_per_element);
   }
   else
   {

--- a/include/exadg/operators/hypercube_resolution_parameters.h
+++ b/include/exadg/operators/hypercube_resolution_parameters.h
@@ -82,8 +82,9 @@ fill_resolutions_vector(
   }
 
   dealii::types::global_dof_index const n_cells_min =
-    (n_dofs_min + dofs_per_cube - 1) / dofs_per_cube;
-  dealii::types::global_dof_index const n_cells_max = n_dofs_max / dofs_per_cube;
+    static_cast<dealii::types::global_dof_index>((n_dofs_min + dofs_per_cube - 1) / dofs_per_cube);
+  dealii::types::global_dof_index const n_cells_max =
+    static_cast<dealii::types::global_dof_index>(n_dofs_max / dofs_per_cube);
 
   // From the maximum number of cells, we derive a maximum refinement level for a uniformly refined
   // mesh with one coarse-grid cells

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -67,11 +67,10 @@ struct GridToGridProjectionData
     print_parameter(pcout, "RPE rtree level", rpe_data.rtree_level);
   }
 
-  typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData::AdditionalData
-                     rpe_data;
-  SolverData         solver_data;
-  PreconditionerMass preconditioner;
-  InverseMassType    inverse_mass_type;
+  typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData rpe_data;
+  SolverData                                                                  solver_data;
+  PreconditionerMass                                                          preconditioner;
+  InverseMassType                                                             inverse_mass_type;
 
   // Number of additional integration points used for sampling the source grid.
   // The default `additional_quadrature_points = 1` considers `fe_degree + 1` quadrature points in


### PR DESCRIPTION
My compiler warned about
- a few implicit conversions between integer and floating point numbers -> adapted some types, made casts explicit in some places
- the erroneous use of `typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData::AdditionalData` (should not have the second `AdditionalData` name, because that calls the constructor rather than identifying the type.