### PR TITLE
Fix issue 769

### DIFF
--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -428,10 +428,8 @@ TimeIntBDF<dim, Number>::print_solver_info() const
 
 template<int dim, typename Number>
 void
-TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
+TimeIntBDF<dim, Number>::read_restart_vectors()
 {
-  (void)ia;
-
   std::vector<VectorType *> vectors;
 
   for(unsigned int i = 0; i < this->order; i++)
@@ -464,10 +462,8 @@ TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
 
 template<int dim, typename Number>
 void
-TimeIntBDF<dim, Number>::write_restart_vectors(BoostOutputArchiveType & oa) const
+TimeIntBDF<dim, Number>::write_restart_vectors() const
 {
-  (void)oa;
-
   std::vector<VectorType const *> vectors;
 
   for(unsigned int i = 0; i < this->order; i++)

--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.h
@@ -117,10 +117,10 @@ private:
   print_solver_info() const final;
 
   void
-  read_restart_vectors(BoostInputArchiveType & ia) final;
+  read_restart_vectors() final;
 
   void
-  write_restart_vectors(BoostOutputArchiveType & oa) const final;
+  write_restart_vectors() const final;
 
   void
   postprocessing() const final;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -254,10 +254,8 @@ TimeIntBDF<dim, Number>::initialize_vec_convective_term()
 
 template<int dim, typename Number>
 void
-TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
+TimeIntBDF<dim, Number>::read_restart_vectors()
 {
-  (void)ia;
-
   // Setup vectors locally to read into.
   std::vector<VectorType> vectors_velocity;
   std::vector<VectorType> vectors_pressure;
@@ -334,10 +332,8 @@ TimeIntBDF<dim, Number>::read_restart_vectors(BoostInputArchiveType & ia)
 
 template<int dim, typename Number>
 void
-TimeIntBDF<dim, Number>::write_restart_vectors(BoostOutputArchiveType & oa) const
+TimeIntBDF<dim, Number>::write_restart_vectors() const
 {
-  (void)oa;
-
   std::vector<VectorType const *> vectors_velocity;
   std::vector<VectorType const *> vectors_pressure;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -110,10 +110,10 @@ protected:
   setup_derived() override;
 
   void
-  read_restart_vectors(BoostInputArchiveType & ia) final;
+  read_restart_vectors() final;
 
   void
-  write_restart_vectors(BoostOutputArchiveType & oa) const final;
+  write_restart_vectors() const final;
 
   virtual void
   get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -92,59 +92,6 @@ print_vector_l2_norm(VectorType const & vector)
   }
 }
 
-/**
- * Utility function to read or write the local entries of a
- * dealii::LinearAlgebra::distributed::(Block)Vector
- * from/to a boost archive per block and entry.
- * Using the `&` operator, loading from or writing to the
- * archive is determined from the type.
- */
-template<typename VectorType, typename BoostArchiveType>
-inline void
-read_write_distributed_vector(VectorType & vector, BoostArchiveType & archive)
-{
-  // Print vector norm here only *before* writing.
-  if(std::is_same<BoostArchiveType, boost::archive::text_oarchive>::value or
-     std::is_same<BoostArchiveType, boost::archive::binary_oarchive>::value)
-  {
-    print_vector_l2_norm(vector);
-  }
-
-  // Depending on VectorType, we have to loop over the blocks to
-  // access the local entries via vector.local_element(i).
-  using Number = typename VectorType::value_type;
-  if constexpr(std::is_same<std::remove_cv_t<VectorType>,
-                            dealii::LinearAlgebra::distributed::Vector<Number>>::value)
-  {
-    for(unsigned int i = 0; i < vector.locally_owned_size(); ++i)
-    {
-      archive & vector.local_element(i);
-    }
-  }
-  else if constexpr(std::is_same<std::remove_cv_t<VectorType>,
-                                 dealii::LinearAlgebra::distributed::BlockVector<Number>>::value)
-  {
-    for(unsigned int i = 0; i < vector.n_blocks(); ++i)
-    {
-      for(unsigned int j = 0; j < vector.block(i).locally_owned_size(); ++j)
-      {
-        archive & vector.block(i).local_element(j);
-      }
-    }
-  }
-  else
-  {
-    AssertThrow(false, dealii::ExcMessage("Reading into this VectorType not supported."));
-  }
-
-  // Print vector norm here only *after* reading.
-  if(std::is_same<BoostArchiveType, boost::archive::text_iarchive>::value or
-     std::is_same<BoostArchiveType, boost::archive::binary_iarchive>::value)
-  {
-    print_vector_l2_norm(vector);
-  }
-}
-
 /** Utility function to convert a vector of block vector pointers into a
  * vector of vectors of `VectorType` pointers, where all vectors from each
  * individual block are summarized in a std::vector.

--- a/include/exadg/time_integration/time_int_abm_base.h
+++ b/include/exadg/time_integration/time_int_abm_base.h
@@ -221,10 +221,8 @@ private:
   }
 
   void
-  read_restart_vectors(BoostInputArchiveType & ia) final
+  read_restart_vectors() final
   {
-    (void)ia;
-
     std::vector<VectorType *> vectors{&solution, &prediction};
     for(unsigned int i = 0; i < vec_evaluated_operators.size(); ++i)
     {
@@ -235,10 +233,8 @@ private:
   }
 
   void
-  write_restart_vectors(BoostOutputArchiveType & oa) const final
+  write_restart_vectors() const final
   {
-    (void)oa;
-
     std::vector<VectorType const *> vectors{&solution, &prediction};
     for(unsigned int i = 0; i < vec_evaluated_operators.size(); ++i)
     {

--- a/include/exadg/time_integration/time_int_base.h
+++ b/include/exadg/time_integration/time_int_base.h
@@ -47,9 +47,10 @@ namespace ExaDG
 class TimeIntBase
 {
 public:
-  // Archive type used for serialization, alternatively choose text archive type.
+  // Archive type used for serialization. Binary type for reduced file size.
   typedef boost::archive::binary_iarchive BoostInputArchiveType;
   typedef boost::archive::binary_oarchive BoostOutputArchiveType;
+  // Alternative human-readable type for debugging.
   // typedef boost::archive::text_iarchive BoostInputArchiveType;
   // typedef boost::archive::text_oarchive BoostOutputArchiveType;
 

--- a/include/exadg/time_integration/time_int_explicit_runge_kutta_base.cpp
+++ b/include/exadg/time_integration/time_int_explicit_runge_kutta_base.cpp
@@ -136,18 +136,13 @@ TimeIntExplRKBase<Number>::do_write_restart(std::string const & filename) const
 
   BoostOutputArchiveType oa(oss);
 
-  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(this->mpi_comm);
-
-  // 1. ranks
-  oa & n_ranks;
-
-  // 2. time
+  // 1. time
   oa & time;
 
-  // 3. time step size
+  // 2. time step size
   oa & time_step;
 
-  // 4. solution vectors
+  // 3. solution vectors
   std::vector<VectorType const *> vectors{&solution_n};
   this->write_restart_vectors(vectors);
 
@@ -162,28 +157,17 @@ TimeIntExplRKBase<Number>::do_read_restart(std::ifstream & in)
 
   // Note that the operations done here must be in sync with the output.
 
-  // 1. ranks
-  unsigned int n_old_ranks = 1;
-  ia &         n_old_ranks;
-
-  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(this->mpi_comm);
-  AssertThrow(n_old_ranks == n_ranks,
-              dealii::ExcMessage("Tried to restart with " + dealii::Utilities::to_string(n_ranks) +
-                                 " processes, "
-                                 "but restart was written on " +
-                                 dealii::Utilities::to_string(n_old_ranks) + " processes."));
-
-  // 2. time
+  // 1. time
   ia & time;
 
   // Note that start_time has to be set to the new start_time (since param.start_time might still be
   // the original start time).
   this->start_time = time;
 
-  // 3. time step size
+  // 2. time step size
   ia & time_step;
 
-  // 4. solution vectors
+  // 3. solution vectors
   std::vector<VectorType *> vectors{&solution_n};
   this->read_restart_vectors(vectors);
 }

--- a/include/exadg/time_integration/time_int_multistep_base.cpp
+++ b/include/exadg/time_integration/time_int_multistep_base.cpp
@@ -244,7 +244,7 @@ TimeIntMultistepBase::do_read_restart(std::ifstream & in)
 {
   BoostInputArchiveType ia(in);
   read_restart_preamble(ia);
-  read_restart_vectors(ia);
+  read_restart_vectors();
 
   // In order to change the CFL number (or the time step calculation criterion in general),
   // start_with_low_order = true has to be used. Otherwise, the old solutions would not fit the
@@ -258,31 +258,20 @@ TimeIntMultistepBase::read_restart_preamble(BoostInputArchiveType & ia)
 {
   // Note that the operations done here must be in sync with the output.
 
-  // 1. ranks
-  unsigned int n_old_ranks = 1;
-  ia &         n_old_ranks;
-
-  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
-  AssertThrow(n_old_ranks == n_ranks,
-              dealii::ExcMessage("Tried to restart with " + dealii::Utilities::to_string(n_ranks) +
-                                 " processes, "
-                                 "but restart was written on " +
-                                 dealii::Utilities::to_string(n_old_ranks) + " processes."));
-
-  // 2. time
+  // 1. time
   ia & time;
 
   // Note that start_time has to be set to the new start_time (since param.start_time might still be
   // the original start time).
   this->start_time = time;
 
-  // 3. order
+  // 2. order
   unsigned int old_order = 1;
   ia &         old_order;
 
   AssertThrow(old_order == order, dealii::ExcMessage("Order of time integrator may not change."));
 
-  // 4. time step sizes
+  // 3. time step sizes
   for(unsigned int i = 0; i < order; i++)
     ia & time_steps[i];
 }
@@ -295,25 +284,20 @@ TimeIntMultistepBase::do_write_restart(std::string const & filename) const
   BoostOutputArchiveType oa(oss);
 
   write_restart_preamble(oa);
-  write_restart_vectors(oa);
+  write_restart_vectors();
   write_restart_file(oss, filename);
 }
 
 void
 TimeIntMultistepBase::write_restart_preamble(BoostOutputArchiveType & oa) const
 {
-  unsigned int n_ranks = dealii::Utilities::MPI::n_mpi_processes(mpi_comm);
-
-  // 1. ranks
-  oa & n_ranks;
-
-  // 2. time
+  // 1. time
   oa & time;
 
-  // 3. order
+  // 2. order
   oa & order;
 
-  // 4. time step sizes
+  // 3. time step sizes
   for(unsigned int i = 0; i < order; i++)
     oa & time_steps[i];
 }

--- a/include/exadg/time_integration/time_int_multistep_base.h
+++ b/include/exadg/time_integration/time_int_multistep_base.h
@@ -219,7 +219,7 @@ private:
   read_restart_preamble(BoostInputArchiveType & ia);
 
   virtual void
-  read_restart_vectors(BoostInputArchiveType & ia) = 0;
+  read_restart_vectors() = 0;
 
   /*
    * Write solution vectors to files so that the simulation can be restart from an intermediate
@@ -232,7 +232,7 @@ private:
   write_restart_preamble(BoostOutputArchiveType & oa) const;
 
   virtual void
-  write_restart_vectors(BoostOutputArchiveType & oa) const = 0;
+  write_restart_vectors() const = 0;
 
   /*
    * Recalculate the time step size after each time step in case of adaptive time stepping.

--- a/tests/utilities/boost_archive.mpirun=2.output
+++ b/tests/utilities/boost_archive.mpirun=2.output
@@ -1,11 +1,4 @@
-Setting up vector.
-Filling vector with ordered global indices [0, 35937).
-Storing the vector in the archive.
-    vector global l2 norm:       3.93317290e+06
-Reading the vector from the archive.
-    vector global l2 norm:       3.93317290e+06
-vector_out.linfty_norm() = 3.59360000e+04
-vector_out.l2_norm()     = 3.93317290e+06
-
-error in linfty_norm = 0.00000000e+00
-error in l2_norm     = 0.00000000e+00
+Storing the number in the archive.
+Reading the number from the archive.
+Maximum relative difference in numbers written and read over all processors:
+0

--- a/tests/utilities/boost_archive.output
+++ b/tests/utilities/boost_archive.output
@@ -1,11 +1,4 @@
-Setting up vector.
-Filling vector with ordered global indices [0, 35937).
-Storing the vector in the archive.
-    vector global l2 norm:       3.93317290e+06
-Reading the vector from the archive.
-    vector global l2 norm:       3.93317290e+06
-vector_out.linfty_norm() = 3.59360000e+04
-vector_out.l2_norm()     = 3.93317290e+06
-
-error in linfty_norm = 0.00000000e+00
-error in l2_norm     = 0.00000000e+00
+Storing the number in the archive.
+Reading the number from the archive.
+Maximum relative difference in numbers written and read over all processors:
+0


### PR DESCRIPTION
fixes #769 
i.e., removes the old serialization and adapts the tests to reading/writing a scalar to a `boost::archive::text_iarchive` to check if that part is working as it is still needed for de-/serialization.