### PR TITLE
refactor restart data 

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -198,12 +198,11 @@ private:
     this->param.restart_data.directory           = this->output_parameters.directory;
     this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
 
-    this->param.restart_data.degree_u                   = 5;
-    this->param.restart_data.degree_p                   = 5;
-    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
-    this->param.restart_data.discretization_identical   = false;
-    this->param.restart_data.consider_mapping           = true;
-    this->param.restart_data.mapping_degree             = 2;
+    this->param.restart_data.discretization_identical     = false;
+    this->param.restart_data.consider_mapping_write       = true;
+    this->param.restart_data.consider_mapping_read_source = true;
+
+    this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;
     this->param.restart_data.rpe_enforce_unique_mapping = false;
   }

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -413,12 +413,11 @@ private:
     this->param.restart_data.directory           = this->output_parameters.directory;
     this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
 
-    this->param.restart_data.degree_u                   = 6;
-    this->param.restart_data.degree_p                   = 6;
-    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
-    this->param.restart_data.discretization_identical   = false;
-    this->param.restart_data.consider_mapping           = true;
-    this->param.restart_data.mapping_degree             = 6;
+    this->param.restart_data.discretization_identical     = false;
+    this->param.restart_data.consider_mapping_write       = true;
+    this->param.restart_data.consider_mapping_read_source = true;
+
+    this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;
     this->param.restart_data.rpe_enforce_unique_mapping = false;
 

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -148,12 +148,11 @@ private:
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;
 
-    this->param.restart_data.degree_u                   = 5;
-    this->param.restart_data.degree_p                   = 5;
-    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
-    this->param.restart_data.discretization_identical   = false;
-    this->param.restart_data.consider_mapping           = true;
-    this->param.restart_data.mapping_degree             = this->param.mapping_degree;
+    this->param.restart_data.discretization_identical     = false;
+    this->param.restart_data.consider_mapping_write       = true;
+    this->param.restart_data.consider_mapping_read_source = true;
+
+    this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-2;
     this->param.restart_data.rpe_enforce_unique_mapping = false;
 

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -137,12 +137,11 @@ private:
     this->param.restart_data.directory           = this->output_parameters.directory;
     this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
 
-    this->param.restart_data.degree_u                   = 7;
-    this->param.restart_data.degree_p                   = 7;
-    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
-    this->param.restart_data.discretization_identical   = false;
-    this->param.restart_data.consider_mapping           = false;
-    this->param.restart_data.mapping_degree             = this->param.mapping_degree;
+    this->param.restart_data.discretization_identical     = false;
+    this->param.restart_data.consider_mapping_write       = true;
+    this->param.restart_data.consider_mapping_read_source = true;
+
+    this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;
     this->param.restart_data.rpe_enforce_unique_mapping = false;
   }

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -459,7 +459,7 @@ private:
     this->param.solver_type                   = SolverType::Unsteady;
     this->param.temporal_discretization       = temporal_discretization;
     this->param.calculation_of_time_step_size = TimeStepCalculation::UserSpecified;
-    this->param.time_step_size                = std::abs(end_time - start_time);
+    this->param.time_step_size                = std::abs(end_time - start_time) / 100;
     this->param.order_time_integrator         = 2;     // 1; // 2; // 3;
     this->param.start_with_low_order          = false; // true;
 
@@ -539,13 +539,11 @@ private:
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;
 
-    this->param.restart_data.degree_u                   = 5;
-    this->param.restart_data.degree_p                   = 4;
-    this->param.restart_data.triangulation_type         = TriangulationType::Distributed;
-    this->param.restart_data.spatial_discretization     = SpatialDiscretization::L2;
-    this->param.restart_data.discretization_identical   = false;
-    this->param.restart_data.consider_mapping           = false;
-    this->param.restart_data.mapping_degree             = 5;
+    this->param.restart_data.discretization_identical     = false;
+    this->param.restart_data.consider_mapping_write       = false;
+    this->param.restart_data.consider_mapping_read_source = false;
+
+    this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-2;
     this->param.restart_data.rpe_enforce_unique_mapping = false;
 
@@ -769,7 +767,7 @@ private:
     // write output for visualization of results
     pp_data.output_data.time_control_data.is_active        = this->output_parameters.write;
     pp_data.output_data.time_control_data.start_time       = start_time;
-    pp_data.output_data.time_control_data.trigger_interval = (end_time - start_time);
+    pp_data.output_data.time_control_data.trigger_interval = (end_time - start_time) / 100.0;
     pp_data.output_data.directory          = this->output_parameters.directory + "vtu/";
     pp_data.output_data.filename           = this->output_parameters.filename;
     pp_data.output_data.write_divergence   = true;

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -247,6 +247,20 @@ void
 SpatialOperator<dim, Number>::serialize_vectors(
   std::vector<BlockVectorType const *> const & block_vectors) const
 {
+  // Write deserialization parameters. These do not change during the simulation, but the data are
+  // small and we want to make sure to overwrite them.
+  DeserializationParameters deserialization_parameters;
+  deserialization_parameters.degree_u               = param.degree_u;
+  deserialization_parameters.degree_p               = param.degree_p;
+  deserialization_parameters.mapping_degree         = param.mapping_degree;
+  deserialization_parameters.consider_mapping_write = param.restart_data.consider_mapping_write;
+  deserialization_parameters.triangulation_type     = param.grid.triangulation_type;
+  write_deserialization_parameters(mpi_comm,
+                                   param.restart_data.directory,
+                                   param.restart_data.filename,
+                                   deserialization_parameters);
+
+  // Attach vectors to triangulation and serialize.
   std::vector<dealii::DoFHandler<dim> const *> dof_handlers(2);
   dof_handlers.at(block_index_velocity) = &this->get_dof_handler_u();
   dof_handlers.at(block_index_pressure) = &this->get_dof_handler_p();
@@ -254,7 +268,7 @@ SpatialOperator<dim, Number>::serialize_vectors(
   std::vector<std::vector<VectorType const *>> vectors_per_dof_handler =
     get_vectors_per_block<VectorType const, BlockVectorType const>(block_vectors);
 
-  if(param.restart_data.consider_mapping)
+  if(param.restart_data.consider_mapping_write)
   {
     store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
                                                  param.restart_data.filename,
@@ -281,11 +295,17 @@ SpatialOperator<dim, Number>::deserialize_vectors(
   // Store ghost state to recover after deserialization.
   std::vector<bool> const has_ghost_elements = get_ghost_state(block_vectors);
 
+  // Load the deserialization parameters.
+  DeserializationParameters const deserialization_parameters =
+    read_deserialization_parameters(mpi_comm,
+                                    param.restart_data.directory,
+                                    param.restart_data.filename);
+
   // Load potentially unfitting checkpoint triangulation of TriangulationType.
   std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
     deserialize_triangulation<dim>(param.restart_data.directory,
                                    param.restart_data.filename,
-                                   param.restart_data.triangulation_type,
+                                   deserialization_parameters.triangulation_type,
                                    mpi_comm);
 
   // Set up DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
@@ -294,10 +314,10 @@ SpatialOperator<dim, Number>::deserialize_vectors(
 
   ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
 
-  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_u =
-    create_finite_element<dim>(checkpoint_element_type, true, dim, param.restart_data.degree_u);
-  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_p =
-    create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_u = create_finite_element<dim>(
+    checkpoint_element_type, true, dim, deserialization_parameters.degree_u);
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_p = create_finite_element<dim>(
+    checkpoint_element_type, true, 1, deserialization_parameters.degree_p);
 
   checkpoint_dof_handler_u.distribute_dofs(*checkpoint_fe_u);
   checkpoint_dof_handler_p.distribute_dofs(*checkpoint_fe_p);
@@ -341,23 +361,25 @@ SpatialOperator<dim, Number>::deserialize_vectors(
       get_vectors_per_block<VectorType, BlockVectorType>(block_vectors);
 
     // Deserialize mapping from vector or project on reference triangulations.
+    check_mapping_deserialization(param.restart_data.consider_mapping_read_source,
+                                  deserialization_parameters.consider_mapping_write);
     std::shared_ptr<dealii::Mapping<dim> const> checkpoint_mapping;
     std::shared_ptr<MappingDoFVector<dim, typename VectorType::value_type>>
       checkpoint_mapping_dof_vector;
-    if(param.restart_data.consider_mapping)
+    if(param.restart_data.consider_mapping_read_source)
     {
       dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
       std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping =
         create_finite_element<dim>(checkpoint_element_type,
                                    true,
                                    dim,
-                                   param.restart_data.mapping_degree);
+                                   deserialization_parameters.mapping_degree);
       checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
 
       checkpoint_mapping_dof_vector = load_vectors(checkpoint_vectors,
                                                    checkpoint_dof_handlers,
                                                    &checkpoint_dof_handler_mapping,
-                                                   param.restart_data.mapping_degree);
+                                                   deserialization_parameters.mapping_degree);
 
       checkpoint_mapping = checkpoint_mapping_dof_vector->get_mapping();
     }
@@ -374,6 +396,7 @@ SpatialOperator<dim, Number>::deserialize_vectors(
     }
 
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
+    data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
     data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;
 
@@ -538,8 +561,8 @@ SpatialOperator<dim, Number>::initialize_dof_handler_and_constraints()
   dof_handler_u.distribute_dofs(*fe_u);
 
   // de-/serialization of mapping requires DoFHandler
-  if(param.restart_data.consider_mapping and
-     (param.restarted_simulation or param.restart_data.write_restart))
+  if((param.restart_data.consider_mapping_write and param.restart_data.write_restart) or
+     (param.restart_data.consider_mapping_read_source and param.restarted_simulation))
   {
     fe_mapping =
       create_finite_element<dim>(param.grid.element_type, true, dim, param.mapping_degree);

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -78,8 +78,8 @@ Operator<dim, Number>::initialize_dof_handler_and_constraints()
   dof_handler_vector.distribute_dofs(*fe_vector);
   dof_handler_scalar.distribute_dofs(*fe_scalar);
 
-  if(param.restart_data.consider_mapping and
-     (param.restarted_simulation or param.restart_data.write_restart))
+  if((param.restart_data.consider_mapping_write and param.restart_data.write_restart) or
+     (param.restart_data.consider_mapping_read_source and param.restarted_simulation))
   {
     fe_mapping =
       create_finite_element<dim>(ElementType::Hypercube, true, dim, param.mapping_degree);
@@ -342,9 +342,22 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const & vectors) const
 {
+  // Write deserialization parameters. These do not change during the simulation, but the data are
+  // small and we want to make sure to overwrite them.
+  DeserializationParameters deserialization_parameters;
+  deserialization_parameters.degree                 = param.degree;
+  deserialization_parameters.mapping_degree         = param.mapping_degree;
+  deserialization_parameters.consider_mapping_write = param.restart_data.consider_mapping_write;
+  deserialization_parameters.triangulation_type     = param.grid.triangulation_type;
+  write_deserialization_parameters(mpi_comm,
+                                   param.restart_data.directory,
+                                   param.restart_data.filename,
+                                   deserialization_parameters);
+
+  // Attach vectors to triangulation and serialize.
   std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
   std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
-  if(param.restart_data.consider_mapping)
+  if(param.restart_data.consider_mapping_write)
   {
     store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
                                                  param.restart_data.filename,
@@ -370,11 +383,17 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
   // Store ghost state to recover after deserialization.
   std::vector<bool> const has_ghost_elements = get_ghost_state(vectors);
 
+  // Load the deserialization parameters.
+  DeserializationParameters const deserialization_parameters =
+    read_deserialization_parameters(mpi_comm,
+                                    param.restart_data.directory,
+                                    param.restart_data.filename);
+
   // Load potentially unfitting checkpoint triangulation of TriangulationType.
   std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
     deserialize_triangulation<dim>(param.restart_data.directory,
                                    param.restart_data.filename,
-                                   param.restart_data.triangulation_type,
+                                   deserialization_parameters.triangulation_type,
                                    mpi_comm);
 
   // Set up DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
@@ -382,8 +401,8 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
 
   ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
 
-  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe =
-    create_finite_element<dim>(checkpoint_element_type, true, dim + 2, param.restart_data.degree_u);
+  std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe = create_finite_element<dim>(
+    checkpoint_element_type, true, dim + 2, deserialization_parameters.degree);
 
   checkpoint_dof_handler.distribute_dofs(*checkpoint_fe);
 
@@ -415,23 +434,25 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     std::vector<std::vector<VectorType *>>       vectors_per_dof_handler{vectors};
 
     // Deserialize mapping from vector or project on reference triangulations.
+    check_mapping_deserialization(param.restart_data.consider_mapping_read_source,
+                                  deserialization_parameters.consider_mapping_write);
     std::shared_ptr<dealii::Mapping<dim> const> checkpoint_mapping;
     std::shared_ptr<MappingDoFVector<dim, typename VectorType::value_type>>
       checkpoint_mapping_dof_vector;
-    if(param.restart_data.consider_mapping)
+    if(param.restart_data.consider_mapping_read_source)
     {
       dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
       std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping =
         create_finite_element<dim>(checkpoint_element_type,
                                    true,
                                    dim,
-                                   param.restart_data.mapping_degree);
+                                   deserialization_parameters.mapping_degree);
       checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
 
       checkpoint_mapping_dof_vector = load_vectors(checkpoint_vectors_ptr,
                                                    checkpoint_dof_handlers,
                                                    &checkpoint_dof_handler_mapping,
-                                                   param.restart_data.mapping_degree);
+                                                   deserialization_parameters.mapping_degree);
 
       checkpoint_mapping = checkpoint_mapping_dof_vector->get_mapping();
     }
@@ -448,6 +469,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     }
 
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
+    data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
     data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -589,9 +589,22 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const & vectors) const
 {
+  // Write deserialization parameters. These do not change during the simulation, but the data are
+  // small and we want to make sure to overwrite them.
+  DeserializationParameters deserialization_parameters;
+  deserialization_parameters.degree                 = param.degree;
+  deserialization_parameters.mapping_degree         = param.mapping_degree;
+  deserialization_parameters.consider_mapping_write = param.restart_data.consider_mapping_write;
+  deserialization_parameters.triangulation_type     = param.grid.triangulation_type;
+  write_deserialization_parameters(mpi_comm,
+                                   param.restart_data.directory,
+                                   param.restart_data.filename,
+                                   deserialization_parameters);
+
+  // Attach vectors to triangulation and serialize.
   std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
   std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
-  if(param.restart_data.consider_mapping)
+  if(param.restart_data.consider_mapping_write)
   {
     store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
                                                  param.restart_data.filename,
@@ -617,11 +630,17 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
   // Store ghost state to recover after deserialization.
   std::vector<bool> const has_ghost_elements = get_ghost_state(vectors);
 
+  // Load the deserialization parameters.
+  DeserializationParameters const deserialization_parameters =
+    read_deserialization_parameters(mpi_comm,
+                                    param.restart_data.directory,
+                                    param.restart_data.filename);
+
   // Load potentially unfitting checkpoint triangulation of TriangulationType.
   std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
     deserialize_triangulation<dim>(param.restart_data.directory,
                                    param.restart_data.filename,
-                                   param.restart_data.triangulation_type,
+                                   deserialization_parameters.triangulation_type,
                                    mpi_comm);
 
   // Set up DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
@@ -630,7 +649,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
   ElementType const checkpoint_element_type = get_element_type(*checkpoint_triangulation);
 
   std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe =
-    create_finite_element<dim>(checkpoint_element_type, true, 1, param.restart_data.degree_p);
+    create_finite_element<dim>(checkpoint_element_type, true, 1, deserialization_parameters.degree);
 
   checkpoint_dof_handler.distribute_dofs(*checkpoint_fe);
 
@@ -664,23 +683,25 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     std::vector<std::vector<VectorType *>>       vectors_per_dof_handler{vectors};
 
     // Deserialize mapping from vector or project on reference triangulations.
+    check_mapping_deserialization(param.restart_data.consider_mapping_read_source,
+                                  deserialization_parameters.consider_mapping_write);
     std::shared_ptr<dealii::Mapping<dim> const> checkpoint_mapping;
     std::shared_ptr<MappingDoFVector<dim, typename VectorType::value_type>>
       checkpoint_mapping_dof_vector;
-    if(param.restart_data.consider_mapping)
+    if(param.restart_data.consider_mapping_read_source)
     {
       dealii::DoFHandler<dim> checkpoint_dof_handler_mapping(*checkpoint_triangulation);
       std::shared_ptr<dealii::FiniteElement<dim>> checkpoint_fe_mapping =
         create_finite_element<dim>(checkpoint_element_type,
                                    true,
                                    dim,
-                                   param.restart_data.mapping_degree);
+                                   deserialization_parameters.mapping_degree);
       checkpoint_dof_handler_mapping.distribute_dofs(*checkpoint_fe_mapping);
 
       checkpoint_mapping_dof_vector = load_vectors(checkpoint_vectors_ptr,
                                                    checkpoint_dof_handlers,
                                                    &checkpoint_dof_handler_mapping,
-                                                   param.restart_data.mapping_degree);
+                                                   deserialization_parameters.mapping_degree);
 
       checkpoint_mapping = checkpoint_mapping_dof_vector->get_mapping();
     }
@@ -697,6 +718,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     }
 
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
+    data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
     data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;
 
@@ -1125,8 +1147,8 @@ template<int dim, typename Number>
 bool
 Operator<dim, Number>::needs_dof_handler_mapping() const
 {
-  return param.restart_data.consider_mapping and
-         (param.restart_data.write_restart or param.restarted_simulation);
+  return ((param.restart_data.consider_mapping_write and param.restart_data.write_restart) or
+          (param.restart_data.consider_mapping_read_source and param.restarted_simulation));
 }
 
 template<int dim, typename Number>

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -40,17 +40,16 @@
 // ExaDG
 #include <exadg/grid/grid_utilities.h>
 #include <exadg/grid/mapping_dof_vector.h>
+#include <exadg/time_integration/restart_data.h>
 #include <exadg/utilities/create_directories.h>
 
 namespace ExaDG
 {
 inline std::string
-restart_filename(std::string const & name, MPI_Comm const & mpi_comm)
+generate_restart_filename(std::string const & name)
 {
-  std::string const rank =
-    dealii::Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process(mpi_comm));
-
-  std::string const filename = name + "." + rank + ".restart";
+  // Filename does not incorporate rank information, files in-/output with single rank only.
+  std::string const filename = name + ".restart";
 
   return filename;
 }
@@ -179,6 +178,120 @@ set_ghost_state(std::vector<VectorType *> const & vectors,
     else
     {
       vectors[i]->zero_out_ghost_values();
+    }
+  }
+}
+
+/**
+ * Utility function to write the parameters a discretization is serialized with. This is to recover
+ * the parameters when deserializing.
+ */
+inline void
+write_deserialization_parameters(MPI_Comm const &                  mpi_comm,
+                                 std::string const &               directory,
+                                 std::string const &               filename_base,
+                                 DeserializationParameters const & parameters)
+{
+  // Create folder if not existent.
+  create_directories(directory, mpi_comm);
+
+  // Filename for deserialization parameters has to match `read_deserialization_parameters()`.
+  std::string const filename = directory + filename_base + ".deserialization_parameters";
+
+  // Write the parameters with a single processor.
+  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  {
+    // Serialization only creates a single file, move with one process only.
+    rename_restart_files(filename);
+
+    // Write deserialization parameters.
+    std::ofstream stream(filename);
+    AssertThrow(stream, dealii::ExcMessage("Could not write deserialization parameters to file."));
+
+    // Text archive type for debugging purposes.
+    // boost::archive::text_oarchive output_archive(stream);
+    boost::archive::binary_oarchive output_archive(stream);
+
+    // Sequence has to match `read_deserialization_parameters()`.
+    output_archive & parameters.degree;
+    output_archive & parameters.degree_u;
+    output_archive & parameters.degree_p;
+    output_archive & parameters.mapping_degree;
+    output_archive & parameters.consider_mapping_write;
+    output_archive & parameters.triangulation_type;
+    output_archive & parameters.spatial_discretization;
+  }
+}
+
+/**
+ * Utility function to read the parameters a discretization is serialized with. This is to recover
+ * the parameters when deserializing.
+ */
+inline DeserializationParameters
+read_deserialization_parameters(MPI_Comm const &    mpi_comm,
+                                std::string const & directory,
+                                std::string const & filename_base)
+{
+  DeserializationParameters parameters;
+
+  // Filename for deserialization parameters has to match `write_deserialization_parameters()`.
+  std::string const filename = directory + filename_base + ".deserialization_parameters";
+
+  // Read the parameters with a single processor.
+  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  {
+    // Read deserialization parameters.
+    std::ifstream stream(filename);
+    AssertThrow(stream, dealii::ExcMessage("Could not read deserialization parameters from file."));
+
+    // Text archive type for debugging purposes.
+    // boost::archive::text_iarchive input_archive(stream);
+    boost::archive::binary_iarchive input_archive(stream);
+
+    // Sequence has to match `write_deserialization_parameters()`.
+    input_archive & parameters.degree;
+    input_archive & parameters.degree_u;
+    input_archive & parameters.degree_p;
+    input_archive & parameters.mapping_degree;
+    input_archive & parameters.consider_mapping_write;
+    input_archive & parameters.triangulation_type;
+    input_archive & parameters.spatial_discretization;
+  }
+
+  // Broadcast parameters to all processes.
+  parameters = dealii::Utilities::MPI::broadcast(mpi_comm, parameters, 0);
+
+  return parameters;
+}
+
+/*
+ * Utility function to check if mapping is correctly treated in de-/serialization. This is to
+ * provide easier to interpret error messages on ExaDG level in case the number of DoF vectors
+ * mismatches. This might be due to the mapping being described as a displacement vector, which
+ * might also be de-/serialized, while we have to deserialize exactly what we serialized.
+ */
+inline void
+check_mapping_deserialization(bool const consider_mapping_read_source,
+                              bool const consider_mapping_write_as_serialized)
+{
+  if(consider_mapping_read_source)
+  {
+    if(consider_mapping_write_as_serialized == false)
+    {
+      AssertThrow(false,
+                  dealii::ExcMessage(
+                    "Mapping was not considered when writing the restart data, but shall "
+                    "be considered when reading the restart data. This is not supported."));
+    }
+  }
+  else
+  {
+    if(consider_mapping_write_as_serialized == true)
+    {
+      AssertThrow(false,
+                  dealii::ExcMessage(
+                    "Mapping was considered when writing the restart data, but shall "
+                    "not be considered when reading the restart data. This is not supported."));
     }
   }
 }

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -36,6 +36,50 @@
 
 namespace ExaDG
 {
+struct DeserializationParameters
+{
+  DeserializationParameters()
+    : degree(dealii::numbers::invalid_unsigned_int),
+      degree_u(dealii::numbers::invalid_unsigned_int),
+      degree_p(dealii::numbers::invalid_unsigned_int),
+      mapping_degree(dealii::numbers::invalid_unsigned_int),
+      consider_mapping_write(false),
+      triangulation_type(TriangulationType::Serial),
+      spatial_discretization(IncNS::SpatialDiscretization::L2)
+  {
+  }
+
+  void
+  print(dealii::ConditionalOStream const & pcout) const
+  {
+    pcout << "  Deserialization parameters:" << std::endl;
+    print_parameter(pcout, "Polynomial degree `degree`", degree);
+    print_parameter(pcout, "Polynomial degree `degree_u`", degree_u);
+    print_parameter(pcout, "Polynomial degree `degree_p`", degree_p);
+    print_parameter(pcout, "Mapping degree", mapping_degree);
+    print_parameter(pcout, "Consider mapping", consider_mapping_write);
+    print_parameter(pcout, "Triangulation type", triangulation_type);
+    print_parameter(pcout, "Spatial discretization", spatial_discretization);
+  }
+
+  // Polynomial degrees of the finite elements used at serialization.
+  unsigned int degree;
+  unsigned int degree_u;
+  unsigned int degree_p;
+
+  // Polynomial degree of the mapping used at serialization.
+  unsigned int mapping_degree;
+
+  // The mapping is stored during serialization as a displacement vector.
+  bool consider_mapping_write;
+
+  // Triangulation type used at serialization.
+  TriangulationType triangulation_type;
+
+  // Spatial discretization used at serialization. Relevant for incompressible Navier-Stokes only.
+  IncNS::SpatialDiscretization spatial_discretization;
+};
+
 struct RestartData
 {
   RestartData()
@@ -46,13 +90,10 @@ struct RestartData
       directory("./output/"),
       filename("restart"),
       counter(1),
-      degree_u(dealii::numbers::invalid_unsigned_int),
-      degree_p(dealii::numbers::invalid_unsigned_int),
-      triangulation_type(TriangulationType::Serial),
-      spatial_discretization(IncNS::SpatialDiscretization::L2),
       discretization_identical(false),
-      consider_mapping(false),
-      mapping_degree(dealii::numbers::invalid_unsigned_int),
+      consider_mapping_write(false),
+      consider_mapping_read_source(false),
+      rpe_rtree_level(0),
       rpe_tolerance_unit_cell(1e-12),
       rpe_enforce_unique_mapping(false)
   {
@@ -116,16 +157,6 @@ struct RestartData
   // counter needed do decide when to write restart
   mutable unsigned int counter;
 
-  // Finite element degree used when restart data was written (relevant for restart run only).
-  unsigned int degree_u;
-  unsigned int degree_p;
-
-  // TriangulationType used when restart data was written (relevant for restart run only).
-  TriangulationType triangulation_type;
-
-  // Finite element space used when the restart data was written.
-  IncNS::SpatialDiscretization spatial_discretization;
-
   // The discretization used when writing the restart data was identical to the current one.
   // Note that this includes the finite element, uniform and adaptive refinement, and the
   // `TriangulationType`, *but* one might consider a different number of MPI ranks for
@@ -133,18 +164,25 @@ struct RestartData
   // necessary global projection.
   bool discretization_identical;
 
-  // The mapping of the triangulation should be de-/serialized as well to consider for a mapped
-  // geometry at serialization and during deserialization. This is option toggles storing the
-  // mapping via a displacement vector *and* reading it back in. Hence, this parameter needs to
-  // match in serialization/deserialization runs.
-  bool consider_mapping;
+  /**
+   * The following options are only effective for the grid-to-grid projection, when
+   * `discretization_identical == false`
+   * These options toggle storing and reading the mapping via a displacement vector.
+   * Mismatching parameters might lead to undesired configurations, use with care.
+   */
 
-  // The `mapping_degree` considered when storing or reading the grid.
-  unsigned int mapping_degree;
+  // Attache the mapping as a displacement vector when *writing* the restart data.
+  bool consider_mapping_write;
 
-  // Parameters for `dealii::RemotePointEvaluation` used for grid-to-grid projection.
-  double rpe_tolerance_unit_cell;
-  bool   rpe_enforce_unique_mapping;
+  // Reconstruct the mapping for the serialized grid (`source`) in the grid-to-grid projection at
+  // restart. Note that the grid use at restart is always considered as defined in the applciation.
+  bool consider_mapping_read_source;
+
+  // Parameters for `dealii::Utilities::MPI::RemotePointEvaluation<dim>::RemotePointEvaluation`
+  // used for grid-to-grid projection.
+  unsigned int rpe_rtree_level;
+  double       rpe_tolerance_unit_cell;
+  bool         rpe_enforce_unique_mapping;
 };
 
 } // namespace ExaDG

--- a/include/exadg/time_integration/time_int_base.cpp
+++ b/include/exadg/time_integration/time_int_base.cpp
@@ -210,9 +210,10 @@ TimeIntBase::write_restart() const
           << " Writing restart file at time t = " << this->get_time() << ":" << std::endl;
 
     std::string const filename =
-      restart_data.directory + restart_filename(restart_data.filename, mpi_comm);
+      restart_data.directory + generate_restart_filename(restart_data.filename);
 
-    rename_restart_files(filename);
+    if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+      rename_restart_files(filename);
 
     do_write_restart(filename);
 
@@ -228,7 +229,8 @@ TimeIntBase::read_restart()
         << std::endl
         << " Reading restart file:" << std::endl;
 
-  std::string filename = restart_data.directory + restart_filename(restart_data.filename, mpi_comm);
+  std::string filename = restart_data.directory + generate_restart_filename(restart_data.filename);
+
   std::ifstream in(filename);
   AssertThrow(in, dealii::ExcMessage("File " + filename + " does not exist."));
 

--- a/include/exadg/time_integration/time_int_multistep_base.h
+++ b/include/exadg/time_integration/time_int_multistep_base.h
@@ -215,9 +215,6 @@ private:
   void
   do_read_restart(std::ifstream & in) final;
 
-  void
-  read_restart_preamble(BoostInputArchiveType & ia);
-
   virtual void
   read_restart_vectors() = 0;
 
@@ -227,9 +224,6 @@ private:
    */
   void
   do_write_restart(std::string const & filename) const final;
-
-  void
-  write_restart_preamble(BoostOutputArchiveType & oa) const;
 
   virtual void
   write_restart_vectors() const = 0;


### PR DESCRIPTION
fixes #770
replaces #778

.) serialize deserialization data to not "guess" them in the application (polynomial degrees used, triangulation type, mapping considered or not ...)
.) write deserialization header with 1 thread only 
.) make all implementations of `do_read_restart()` and `do_write_restart()` uniform

Note that #733 persists, if I test in `incompressible_navier_stokes/navier_stokes_manufactured`, not only the output is weird but considering for the mapping the points outside the mapped domain cannot be found. Currently, in that application we can get away with not storing the mapping, since then at restart the grid is not yet mapped. I will tackle that in #733.