### PR TITLE
consider mesh movement function at restart

### DIFF
--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -539,9 +539,10 @@ private:
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;
 
-    this->param.restart_data.discretization_identical     = false;
-    this->param.restart_data.consider_mapping_write       = false;
-    this->param.restart_data.consider_mapping_read_source = false;
+    this->param.restart_data.discretization_identical                        = false;
+    this->param.restart_data.consider_mapping_write                          = true;
+    this->param.restart_data.consider_mapping_read_source                    = true;
+    this->param.restart_data.consider_restart_time_in_mesh_movement_function = true;
 
     this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-2;

--- a/include/exadg/convection_diffusion/driver.cpp
+++ b/include/exadg/convection_diffusion/driver.cpp
@@ -63,6 +63,35 @@ Driver<dim, Number>::setup()
 
   if(ale) // moving mesh
   {
+    // determine correct starting time for restarted run.
+    double start_time_mesh_movement_function = application->get_parameters().start_time;
+    {
+      RestartData const & restart_data = application->get_parameters().restart_data;
+      if(application->get_parameters().restarted_simulation and
+         restart_data.consider_restart_time_in_mesh_movement_function)
+      {
+        if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+        {
+          std::string const filename =
+            restart_data.directory + generate_restart_filename(restart_data.filename);
+
+          std::ifstream in(filename);
+          AssertThrow(in, dealii::ExcMessage("File " + filename + " does not exist."));
+
+          TimeIntBase::BoostInputArchiveType ia(in);
+
+          // Note that the operations done here must be in sync with `do_write_restart()`.
+
+          // 1. time
+          ia & start_time_mesh_movement_function;
+        }
+
+        // Synchronize read data.
+        start_time_mesh_movement_function =
+          dealii::Utilities::MPI::broadcast(mpi_comm, start_time_mesh_movement_function, 0);
+      }
+    }
+
     std::shared_ptr<dealii::Function<dim>> mesh_motion =
       application->create_mesh_movement_function();
     ale_mapping = std::make_shared<DeformedMappingFunction<dim, Number>>(

--- a/include/exadg/incompressible_flow_with_transport/driver.cpp
+++ b/include/exadg/incompressible_flow_with_transport/driver.cpp
@@ -72,7 +72,36 @@ Driver<dim, Number>::setup()
   {
     AssertThrow(application->fluid->get_parameters().mesh_movement_type ==
                   IncNS::MeshMovementType::Function,
-                dealii::ExcMessage("not implemented."));
+                dealii::ExcMessage("Only `IncNS::MeshMovementType::Function` supported."));
+
+    // determine correct starting time for restarted run.
+    double start_time_mesh_movement_function = application->fluid->get_parameters().start_time;
+    {
+      RestartData const & restart_data = application->fluid->get_parameters().restart_data;
+      if(application->fluid->get_parameters().restarted_simulation and
+         restart_data.consider_restart_time_in_mesh_movement_function)
+      {
+        if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+        {
+          std::string const filename =
+            restart_data.directory + generate_restart_filename(restart_data.filename);
+
+          std::ifstream in(filename);
+          AssertThrow(in, dealii::ExcMessage("File " + filename + " does not exist."));
+
+          TimeIntBase::BoostInputArchiveType ia(in);
+
+          // Note that the operations done here must be in sync with `do_write_restart()`.
+
+          // 1. time
+          ia & start_time_mesh_movement_function;
+        }
+
+        // Synchronize read data.
+        start_time_mesh_movement_function =
+          dealii::Utilities::MPI::broadcast(mpi_comm, start_time_mesh_movement_function, 0);
+      }
+    }
 
     std::shared_ptr<dealii::Function<dim>> mesh_motion;
     mesh_motion = application->fluid->create_mesh_movement_function();

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -93,6 +93,7 @@ struct RestartData
       discretization_identical(false),
       consider_mapping_write(false),
       consider_mapping_read_source(false),
+      consider_restart_time_in_mesh_movement_function(true),
       rpe_rtree_level(0),
       rpe_tolerance_unit_cell(1e-12),
       rpe_enforce_unique_mapping(false)
@@ -177,6 +178,10 @@ struct RestartData
   // Reconstruct the mapping for the serialized grid (`source`) in the grid-to-grid projection at
   // restart. Note that the grid use at restart is always considered as defined in the applciation.
   bool consider_mapping_read_source;
+
+  // When creating a mapping function via `create_mesh_movement_function()`, use the `start_time` or
+  // the `time` serialized to evaluate the mapping at restart.
+  bool consider_restart_time_in_mesh_movement_function;
 
   // Parameters for `dealii::Utilities::MPI::RemotePointEvaluation<dim>::RemotePointEvaluation`
   // used for grid-to-grid projection.


### PR DESCRIPTION
fixes #733 
the time given to the mesh movement function was always 'parameters->start_time'.
with this PR, one can use either
'parameters->start_time'
or the time used when serializing the solution (first parameter written to boost archive).
Tested with incompressible Navier Stokes in `navier_stokes_manufactured/application.h`
If we have a ALE mapping via `MeshMovementFunction`, we can now choose between
1.) consider both grids undeformed
2.) consider both mapped

The option 1.) will be obsolete once we can consider for unmapped grids at serialization in general.