### PR TITLE
restart: put RestartData in interface, introduce serialization time window

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -227,9 +227,7 @@ private:
         // Save the *coarse* triangulation for later deserialization.
         if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
         {
-          save_coarse_triangulation<dim>(this->param.restart_data.directory,
-                                         this->param.restart_data.filename,
-                                         tria);
+          save_coarse_triangulation<dim>(this->param.restart_data, tria);
         }
 
         tria.refine_global(global_refinements);

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -481,9 +481,7 @@ private:
       // Save the *coarse* triangulation for later deserialization.
       if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
       {
-        save_coarse_triangulation<dim>(this->param.restart_data.directory,
-                                       this->param.restart_data.filename,
-                                       tria);
+        save_coarse_triangulation<dim>(this->param.restart_data, tria);
       }
 
       tria.refine_global(global_refinements);

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -240,9 +240,7 @@ private:
         // Save the *coarse* triangulation for later deserialization.
         if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
         {
-          save_coarse_triangulation<dim>(this->param.restart_data.directory,
-                                         this->param.restart_data.filename,
-                                         tria);
+          save_coarse_triangulation<dim>(this->param.restart_data, tria);
         }
 
         tria.refine_global(global_refinements);

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -179,9 +179,7 @@ private:
         // Save the *coarse* triangulation for later deserialization.
         if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
         {
-          save_coarse_triangulation<dim>(this->param.restart_data.directory,
-                                         this->param.restart_data.filename,
-                                         tria);
+          save_coarse_triangulation<dim>(this->param.restart_data, tria);
         }
 
         tria.refine_global(global_refinements);

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -533,9 +533,14 @@ private:
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
-    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
-    this->param.restart_data.directory     = this->output_parameters.directory;
-    this->param.restart_data.filename      = this->output_parameters.filename + "_restart";
+    this->param.restart_data.n_snapshots_keep = 10;
+    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.01;
+    this->param.restart_data.interval_time_start =
+      (this->param.end_time - this->param.start_time) * 0.8;
+    this->param.restart_data.interval_time_end =
+      (this->param.end_time - this->param.start_time) * 0.9;
+    this->param.restart_data.directory           = this->output_parameters.directory;
+    this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;
 
@@ -652,9 +657,7 @@ private:
         // Save the *coarse* triangulation for later deserialization.
         if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
         {
-          save_coarse_triangulation<dim>(this->param.restart_data.directory,
-                                         this->param.restart_data.filename,
-                                         tria);
+          save_coarse_triangulation<dim>(this->param.restart_data, tria);
         }
 
         if(vector_local_refinements.size() > 0)

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -362,9 +362,7 @@ private:
       // Save the *coarse* triangulation for later deserialization.
       if(write_restart and this->param.grid.triangulation_type == TriangulationType::Serial)
       {
-        save_coarse_triangulation<dim>(this->param.restart_data.directory,
-                                       this->param.restart_data.filename,
-                                       tria);
+        save_coarse_triangulation<dim>(this->param.restart_data, tria);
       }
 
       tria.refine_global(global_refinements);

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -255,10 +255,7 @@ SpatialOperator<dim, Number>::serialize_vectors(
   deserialization_parameters.mapping_degree         = param.mapping_degree;
   deserialization_parameters.consider_mapping_write = param.restart_data.consider_mapping_write;
   deserialization_parameters.triangulation_type     = param.grid.triangulation_type;
-  write_deserialization_parameters(mpi_comm,
-                                   param.restart_data.directory,
-                                   param.restart_data.filename,
-                                   deserialization_parameters);
+  write_deserialization_parameters(mpi_comm, param.restart_data, deserialization_parameters);
 
   // Attach vectors to triangulation and serialize.
   std::vector<dealii::DoFHandler<dim> const *> dof_handlers(2);
@@ -270,8 +267,7 @@ SpatialOperator<dim, Number>::serialize_vectors(
 
   if(param.restart_data.consider_mapping_write)
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler,
                                                  *this->get_mapping(),
@@ -280,8 +276,7 @@ SpatialOperator<dim, Number>::serialize_vectors(
   }
   else
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler);
   }
@@ -297,14 +292,11 @@ SpatialOperator<dim, Number>::deserialize_vectors(
 
   // Load the deserialization parameters.
   DeserializationParameters const deserialization_parameters =
-    read_deserialization_parameters(mpi_comm,
-                                    param.restart_data.directory,
-                                    param.restart_data.filename);
+    read_deserialization_parameters(mpi_comm, param.restart_data);
 
   // Load potentially unfitting checkpoint triangulation of TriangulationType.
   std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
-    deserialize_triangulation<dim>(param.restart_data.directory,
-                                   param.restart_data.filename,
+    deserialize_triangulation<dim>(param.restart_data,
                                    deserialization_parameters.triangulation_type,
                                    mpi_comm);
 

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -349,18 +349,14 @@ Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const &
   deserialization_parameters.mapping_degree         = param.mapping_degree;
   deserialization_parameters.consider_mapping_write = param.restart_data.consider_mapping_write;
   deserialization_parameters.triangulation_type     = param.grid.triangulation_type;
-  write_deserialization_parameters(mpi_comm,
-                                   param.restart_data.directory,
-                                   param.restart_data.filename,
-                                   deserialization_parameters);
+  write_deserialization_parameters(mpi_comm, param.restart_data, deserialization_parameters);
 
   // Attach vectors to triangulation and serialize.
   std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
   std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
   if(param.restart_data.consider_mapping_write)
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler,
                                                  this->get_mapping(),
@@ -369,8 +365,7 @@ Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const &
   }
   else
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler);
   }
@@ -385,14 +380,11 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
 
   // Load the deserialization parameters.
   DeserializationParameters const deserialization_parameters =
-    read_deserialization_parameters(mpi_comm,
-                                    param.restart_data.directory,
-                                    param.restart_data.filename);
+    read_deserialization_parameters(mpi_comm, param.restart_data);
 
   // Load potentially unfitting checkpoint triangulation of TriangulationType.
   std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
-    deserialize_triangulation<dim>(param.restart_data.directory,
-                                   param.restart_data.filename,
+    deserialize_triangulation<dim>(param.restart_data,
                                    deserialization_parameters.triangulation_type,
                                    mpi_comm);
 

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -596,18 +596,14 @@ Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const &
   deserialization_parameters.mapping_degree         = param.mapping_degree;
   deserialization_parameters.consider_mapping_write = param.restart_data.consider_mapping_write;
   deserialization_parameters.triangulation_type     = param.grid.triangulation_type;
-  write_deserialization_parameters(mpi_comm,
-                                   param.restart_data.directory,
-                                   param.restart_data.filename,
-                                   deserialization_parameters);
+  write_deserialization_parameters(mpi_comm, param.restart_data, deserialization_parameters);
 
   // Attach vectors to triangulation and serialize.
   std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler};
   std::vector<std::vector<VectorType const *>> vectors_per_dof_handler{vectors};
   if(param.restart_data.consider_mapping_write)
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler,
                                                  *this->get_mapping(),
@@ -616,8 +612,7 @@ Operator<dim, Number>::serialize_vectors(std::vector<VectorType const *> const &
   }
   else
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler);
   }
@@ -632,14 +627,11 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
 
   // Load the deserialization parameters.
   DeserializationParameters const deserialization_parameters =
-    read_deserialization_parameters(mpi_comm,
-                                    param.restart_data.directory,
-                                    param.restart_data.filename);
+    read_deserialization_parameters(mpi_comm, param.restart_data);
 
   // Load potentially unfitting checkpoint triangulation of TriangulationType.
   std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
-    deserialize_triangulation<dim>(param.restart_data.directory,
-                                   param.restart_data.filename,
+    deserialize_triangulation<dim>(param.restart_data,
                                    deserialization_parameters.triangulation_type,
                                    mpi_comm);
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1002,10 +1002,7 @@ SpatialOperatorBase<dim, Number>::serialize_vectors(
   deserialization_parameters.mapping_degree         = param.mapping_degree;
   deserialization_parameters.consider_mapping_write = param.restart_data.consider_mapping_write;
   deserialization_parameters.triangulation_type     = param.grid.triangulation_type;
-  write_deserialization_parameters(mpi_comm,
-                                   param.restart_data.directory,
-                                   param.restart_data.filename,
-                                   deserialization_parameters);
+  write_deserialization_parameters(mpi_comm, param.restart_data, deserialization_parameters);
 
   // Attach vectors to triangulation and serialize.
   std::vector<dealii::DoFHandler<dim> const *> dof_handlers{&dof_handler_u, &dof_handler_p};
@@ -1013,8 +1010,7 @@ SpatialOperatorBase<dim, Number>::serialize_vectors(
                                                                        vectors_pressure};
   if(param.restart_data.consider_mapping_write)
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler,
                                                  *this->get_mapping(),
@@ -1023,8 +1019,7 @@ SpatialOperatorBase<dim, Number>::serialize_vectors(
   }
   else
   {
-    store_vectors_in_triangulation_and_serialize(param.restart_data.directory,
-                                                 param.restart_data.filename,
+    store_vectors_in_triangulation_and_serialize(param.restart_data,
                                                  dof_handlers,
                                                  vectors_per_dof_handler);
   }
@@ -1041,14 +1036,11 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
 
   // Load the deserialization parameters.
   DeserializationParameters const deserialization_parameters =
-    read_deserialization_parameters(mpi_comm,
-                                    param.restart_data.directory,
-                                    param.restart_data.filename);
+    read_deserialization_parameters(mpi_comm, param.restart_data);
 
   // Load potentially unfitting checkpoint triangulation of TriangulationType.
   std::shared_ptr<dealii::Triangulation<dim>> checkpoint_triangulation =
-    deserialize_triangulation<dim>(param.restart_data.directory,
-                                   param.restart_data.filename,
+    deserialize_triangulation<dim>(param.restart_data,
                                    deserialization_parameters.triangulation_type,
                                    mpi_comm);
 

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -84,7 +84,10 @@ struct RestartData
 {
   RestartData()
     : write_restart(false),
+      n_snapshots_keep(2),
       interval_time(std::numeric_limits<double>::max()),
+      interval_time_start(std::numeric_limits<double>::lowest()),
+      interval_time_end(std::numeric_limits<double>::max()),
       interval_wall_time(std::numeric_limits<double>::max()),
       interval_time_steps(std::numeric_limits<unsigned int>::max()),
       directory("./output/"),
@@ -109,6 +112,8 @@ struct RestartData
     if(write_restart == true)
     {
       print_parameter(pcout, "Interval physical time", interval_time);
+      print_parameter(pcout, "Interval physical time window start", interval_time_start);
+      print_parameter(pcout, "Interval physical time window end", interval_time_end);
       print_parameter(pcout, "Interval wall time", interval_wall_time);
       print_parameter(pcout, "Interval time steps", interval_time_steps);
       print_parameter(pcout, "Directory", directory);
@@ -129,19 +134,31 @@ struct RestartData
     if(reset_counter)
       counter += int((time + 1.e-10) / interval_time);
 
-    bool do_restart = wall_time > interval_wall_time * counter or time > interval_time * counter or
-                      time_step_number > interval_time_steps * counter;
+    bool const trigger_restart_base = wall_time > interval_wall_time * counter or
+                                      time > interval_time * counter or
+                                      time_step_number > interval_time_steps * counter;
 
-    if(do_restart)
+    // Additionally use the physical time window.
+    bool const trigger_restart =
+      trigger_restart_base and time >= interval_time_start and time <= interval_time_end;
+
+    if(trigger_restart)
       ++counter;
 
-    return do_restart;
+    return trigger_restart;
   }
 
   bool write_restart;
 
-  // physical time
+  // Number of snapshots to keep
+  unsigned int n_snapshots_keep;
+
+  // physical time interval between serializations
   double interval_time;
+
+  // physical time interval in which serialization is enabled
+  double interval_time_start;
+  double interval_time_end;
 
   // wall time in seconds (= hours * 3600)
   double interval_wall_time;

--- a/include/exadg/time_integration/time_int_base.cpp
+++ b/include/exadg/time_integration/time_int_base.cpp
@@ -213,7 +213,7 @@ TimeIntBase::write_restart() const
       restart_data.directory + generate_restart_filename(restart_data.filename);
 
     if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
-      rename_restart_files(filename);
+      rename_old_restart_files(filename, restart_data.n_snapshots_keep);
 
     do_write_restart(filename);
 


### PR DESCRIPTION
.) put `RestartData` in the argument list instead of a list of its parameters for the reading/writing/renaming functions
.) enable a time window in which serialization is enabled (default are upper and lower numerical limits in `double`).
.) enable keeping `n` snapshots alive, defaults to `n_snapshots_keep=2`, restoring previous behavior of keeping one old copy in case anything goes wrong while saving.

All of this is useful for:
.) if you run a sim and you want to change numerical parameters or the mesh, you can choose a time frame where you would maybe want to restart, run, look at the output and start from any of the stored snapshots.
.) if you want to generate data for model order reduction, you can select a time window and export as many snapshots as you like for a given interval.