### PR TITLE
add `restart_data.directory_coarse_triangulation`

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -193,10 +193,11 @@ private:
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
-    this->param.restart_data.interval_wall_time  = 1.e6;
-    this->param.restart_data.interval_time_steps = 1e8;
-    this->param.restart_data.directory           = this->output_parameters.directory;
-    this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
+    this->param.restart_data.interval_wall_time             = 1.e6;
+    this->param.restart_data.interval_time_steps            = 1e8;
+    this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
+    this->param.restart_data.directory                      = this->output_parameters.directory;
+    this->param.restart_data.filename = this->output_parameters.filename + "_restart";
 
     this->param.restart_data.discretization_identical     = false;
     this->param.restart_data.consider_mapping_write       = true;

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -408,10 +408,11 @@ private:
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
-    this->param.restart_data.interval_wall_time  = 1.e6;
-    this->param.restart_data.interval_time_steps = 1e8;
-    this->param.restart_data.directory           = this->output_parameters.directory;
-    this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
+    this->param.restart_data.interval_wall_time             = 1.e6;
+    this->param.restart_data.interval_time_steps            = 1e8;
+    this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
+    this->param.restart_data.directory                      = this->output_parameters.directory;
+    this->param.restart_data.filename = this->output_parameters.filename + "_restart";
 
     this->param.restart_data.discretization_identical     = false;
     this->param.restart_data.consider_mapping_write       = true;

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -143,8 +143,9 @@ private:
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
-    this->param.restart_data.directory     = this->output_parameters.directory;
-    this->param.restart_data.filename      = this->output_parameters.filename + "_restart";
+    this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
+    this->param.restart_data.directory                      = this->output_parameters.directory;
+    this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;
 

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -132,10 +132,11 @@ private:
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
-    this->param.restart_data.interval_wall_time  = 1.e6;
-    this->param.restart_data.interval_time_steps = 1e8;
-    this->param.restart_data.directory           = this->output_parameters.directory;
-    this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
+    this->param.restart_data.interval_wall_time             = 1.e6;
+    this->param.restart_data.interval_time_steps            = 1e8;
+    this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
+    this->param.restart_data.directory                      = this->output_parameters.directory;
+    this->param.restart_data.filename = this->output_parameters.filename + "_restart";
 
     this->param.restart_data.discretization_identical     = false;
     this->param.restart_data.consider_mapping_write       = true;

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -539,7 +539,8 @@ private:
       (this->param.end_time - this->param.start_time) * 0.8;
     this->param.restart_data.interval_time_end =
       (this->param.end_time - this->param.start_time) * 0.9;
-    this->param.restart_data.directory           = this->output_parameters.directory;
+    this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
+    this->param.restart_data.directory                      = this->output_parameters.directory;
     this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -228,8 +228,9 @@ private:
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
     this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
-    this->param.restart_data.directory     = this->output_parameters.directory;
-    this->param.restart_data.filename      = this->output_parameters.filename + "_restart";
+    this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
+    this->param.restart_data.directory                      = this->output_parameters.directory;
+    this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;
 

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -322,10 +322,10 @@ save_coarse_triangulation(RestartData const & restart_data, TriangulationType co
   MPI_Comm const & mpi_comm = triangulation.get_mpi_communicator();
 
   // Create folder if not existent.
-  create_directories(restart_data.directory, mpi_comm);
+  create_directories(restart_data.directory_coarse_triangulation, mpi_comm);
 
   std::string const filename =
-    restart_data.directory + restart_data.filename + ".coarse_triangulation";
+    restart_data.directory_coarse_triangulation + restart_data.filename + ".coarse_triangulation";
   if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
   {
     // Serialization only creates a single file, move with one process only.
@@ -511,15 +511,18 @@ deserialize_triangulation(RestartData const &     restart_data,
     // Deserialize the coarse triangulation to be stored by the user
     // during `create_grid` in the respective application.
     dealii::Triangulation<dim, dim> coarse_triangulation;
+    std::string const               filename_coarse_triangulation =
+      restart_data.directory_coarse_triangulation + restart_data.filename;
     try
     {
-      coarse_triangulation.load(filename + ".coarse_triangulation");
+      coarse_triangulation.load(filename_coarse_triangulation + ".coarse_triangulation");
     }
     catch(...)
     {
       AssertThrow(false,
                   dealii::ExcMessage(
-                    "Deserializing coarse triangulation expected in\n" + filename +
+                    "Deserializing coarse triangulation expected in\n" +
+                    filename_coarse_triangulation +
                     ".coarse_triangulation\n"
                     "make sure to store the coarse grid during `create_grid`\n"
                     "in the respective application.h using TriangulationType::Serial."));

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -90,6 +90,7 @@ struct RestartData
       interval_time_end(std::numeric_limits<double>::max()),
       interval_wall_time(std::numeric_limits<double>::max()),
       interval_time_steps(std::numeric_limits<unsigned int>::max()),
+      directory_coarse_triangulation("./output/"),
       directory("./output/"),
       filename("restart"),
       counter(1),
@@ -116,6 +117,7 @@ struct RestartData
       print_parameter(pcout, "Interval physical time window end", interval_time_end);
       print_parameter(pcout, "Interval wall time", interval_wall_time);
       print_parameter(pcout, "Interval time steps", interval_time_steps);
+      print_parameter(pcout, "Directory coarse triangulation", directory_coarse_triangulation);
       print_parameter(pcout, "Directory", directory);
       print_parameter(pcout, "Filename", filename);
     }
@@ -166,7 +168,8 @@ struct RestartData
   // number of time steps after which to write restart
   unsigned int interval_time_steps;
 
-  // directory for restart files
+  // directory for restart files: coarse triangulation and snapshot data can be stored separately.
+  std::string directory_coarse_triangulation;
   std::string directory;
 
   // filename for restart files


### PR DESCRIPTION
... to enable reading from single coarse triangulation instance potentially outside the 'restart_data.directory'.
This is useful for deserialization of multiple snapshots as occuring in model order reduction and the like.