### PR TITLE
add AMG preconditioner to InverseMassOperator`s global solver

### DIFF
--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -35,6 +35,7 @@
 #include <exadg/operators/variable_coefficients.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
+#include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h>
 
 namespace ExaDG
 {
@@ -110,6 +111,12 @@ private:
 public:
   InverseMassOperator() : matrix_free(nullptr), dof_index(0), quad_index(0)
   {
+  }
+
+  unsigned int
+  get_n_iter_global_last() const
+  {
+    return this->n_iter_global_last;
   }
 
   void
@@ -237,6 +244,14 @@ public:
             std::make_shared<BlockJacobiPreconditioner<MassOperator<dim, n_components, Number>>>(
               mass_operator, true /* initialize_preconditioner */);
         }
+        else if(inverse_mass_operator_data.parameters.preconditioner == PreconditionerMass::AMG)
+        {
+          global_preconditioner =
+            std::make_shared<PreconditionerAMG<MassOperator<dim, n_components, Number>, Number>>(
+              mass_operator,
+              true /* initialize_preconditioner */,
+              inverse_mass_operator_data.parameters.amg_data);
+        }
         else
         {
           AssertThrow(false, dealii::ExcMessage("This `PreconditionerMass` is not implemented."));
@@ -295,7 +310,7 @@ public:
     {
       AssertThrow(global_solver.get() != 0,
                   dealii::ExcMessage("Global mass solver has not been initialized."));
-      global_solver->solve(dst, src);
+      this->n_iter_global_last = global_solver->solve(dst, src);
     }
     else
     {
@@ -429,6 +444,9 @@ private:
   // freedom.
   std::shared_ptr<PreconditionerBase<Number>>     global_preconditioner;
   std::shared_ptr<Krylov::SolverBase<VectorType>> global_solver;
+
+  // Iterations needed in global Krylov solver at last inverse application.
+  mutable unsigned int n_iter_global_last = dealii::numbers::invalid_unsigned_int;
 
   // Block-Jacobi preconditioner used as cell-wise inverse for L2-conforming spaces. In this case,
   // the mass matrix is block-diagonal and a block-Jacobi preconditioner inverts the mass operator

--- a/include/exadg/operators/inverse_mass_parameters.h
+++ b/include/exadg/operators/inverse_mass_parameters.h
@@ -23,6 +23,7 @@
 #define EXADG_OPERATORS_INVERSE_MASS_PARAMETERS_H_
 
 // ExaDG
+#include <exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h>
 #include <exadg/solvers_and_preconditioners/solvers/solver_data.h>
 
 namespace ExaDG
@@ -40,7 +41,8 @@ enum class PreconditionerMass
 {
   None,
   PointJacobi,
-  BlockJacobi
+  BlockJacobi,
+  AMG
 };
 
 /**
@@ -55,7 +57,8 @@ struct InverseMassParameters
   InverseMassParameters()
     : implementation_type(InverseMassType::MatrixfreeOperator),
       preconditioner(PreconditionerMass::PointJacobi),
-      solver_data(SolverData(1000, 1e-12, 1e-12))
+      solver_data(SolverData(1000, 1e-12, 1e-12)),
+      amg_data(AMGData())
   {
   }
 
@@ -63,13 +66,16 @@ struct InverseMassParameters
   InverseMassType implementation_type;
 
   // This parameter is only relevant if the mass operator is inverted by an iterative solver with
-  // matrix-free implementation, InverseMassType::ElementwiseKrylovSolver or
-  // InverseMassType::GlobalKrylovSolver.
+  // matrix-free implementation, `InverseMassType::ElementwiseKrylovSolver` or
+  // `InverseMassType::GlobalKrylovSolver`.
   PreconditionerMass preconditioner;
 
   // solver data for iterative solver in case of implementation type
-  // InverseMassType::ElementwiseKrylovSolver or InverseMassType::GlobalKrylovSolver.
+  // `InverseMassType::ElementwiseKrylovSolver` or `InverseMassType::GlobalKrylovSolver`.
   SolverData solver_data;
+
+  // Configuration of AMG settings for `PreconditionerMass::AMG`.
+  AMGData amg_data;
 };
 
 } // namespace ExaDG

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -55,6 +55,7 @@ struct GridToGridProjectionData
     : rpe_data(),
       solver_data(),
       preconditioner(PreconditionerMass::PointJacobi),
+      amg_data(AMGData()),
       additional_quadrature_points(1)
   {
   }
@@ -70,11 +71,13 @@ struct GridToGridProjectionData
     // That is for `InverseMassType != InverseMassType::MatrixfreeOperator` determined at runtime.
     solver_data.print(pcout);
     print_parameter(pcout, "Preconditioner", preconditioner);
+    amg_data.print(pcout);
   }
 
   typename dealii::Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData rpe_data;
   SolverData                                                                  solver_data;
   PreconditionerMass                                                          preconditioner;
+  AMGData                                                                     amg_data;
 
   // Number of additional integration points used for sampling the source grid.
   // The default `additional_quadrature_points = 1` considers `fe_degree + 1` quadrature points in
@@ -207,6 +210,7 @@ project_vectors(
   inverse_mass_operator_data.quad_index                = quad_index;
   inverse_mass_operator_data.parameters.preconditioner = data.preconditioner;
   inverse_mass_operator_data.parameters.solver_data    = data.solver_data;
+  inverse_mass_operator_data.parameters.amg_data       = data.amg_data;
   inverse_mass_operator_data.parameters.implementation_type =
     InverseMassOperatorData<Number>::template get_optimal_inverse_mass_type<dim>(
       target_matrix_free.get_dof_handler(dof_index).get_fe(),


### PR DESCRIPTION
its more robust than `PreconditionerMass::PointJacobi` w.r.t badly shaped elements and easy to set up.
For CG we cannot use the block-Jacobi (solver) as preconditioner.
(This is I think also something we should think about changing, as we want to use it as preconditioner in some scenarios ...)