### PR TITLE
enable matrix-based multigrid

### DIFF
--- a/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
+++ b/applications/convection_diffusion/boundary_layer/tests/p_convergence.output
@@ -68,6 +68,7 @@ Solver:
   Multigrid operator type:                   ReactionConvectionDiffusion
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -186,6 +187,7 @@ Solver:
   Multigrid operator type:                   ReactionConvectionDiffusion
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -304,6 +306,7 @@ Solver:
   Multigrid operator type:                   ReactionConvectionDiffusion
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -351,7 +354,7 @@ Solving steady state problem ...
 ... done!
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 1.11728e-04
+  Relative error (L2-norm): 1.11727e-04
 
 
 
@@ -422,6 +425,7 @@ Solver:
   Multigrid operator type:                   ReactionConvectionDiffusion
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -469,7 +473,7 @@ Solving steady state problem ...
 ... done!
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 6.62789e-06
+  Relative error (L2-norm): 6.62871e-06
 
 
 
@@ -540,6 +544,7 @@ Solver:
   Multigrid operator type:                   ReactionConvectionDiffusion
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -587,4 +592,4 @@ Solving steady state problem ...
 ... done!
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.43534e-07
+  Relative error (L2-norm): 4.68837e-07

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int.output
@@ -68,6 +68,7 @@ Solver:
   Block Jacobi matrix-free:                  false
   Multigrid operator type:                   ReactionConvection
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -267,7 +268,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for all fields at time t = 9.0060e-01:
-  Relative error (L2-norm): 2.48091e-02
+  Relative error (L2-norm): 2.48092e-02
 
 ________________________________________________________________________________
 

--- a/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int_amr.output
+++ b/applications/convection_diffusion/rotating_hill/tests/convective_implicit_time_int_amr.output
@@ -75,6 +75,7 @@ Solver:
   Block Jacobi matrix-free:                  false
   Multigrid operator type:                   ReactionConvection
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
+++ b/applications/incompressible_navier_stokes/couette/tests/steady_navier_stokes_coupled.output
@@ -100,6 +100,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid operator type:                   ReactionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -115,6 +116,7 @@ Linear solver:
   Pressure/Schur-complement block:
   Preconditioner:                            PressureConvectionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -161,10 +163,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 7.80921e-13
+  Absolute error (L2-norm): 7.10250e-13
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 2.10768e-11
+  Absolute error (L2-norm): 1.93302e-11
 
 
 
@@ -267,6 +269,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid operator type:                   ReactionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -282,6 +285,7 @@ Linear solver:
   Pressure/Schur-complement block:
   Preconditioner:                            PressureConvectionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -328,10 +332,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 4.17721e-13
+  Absolute error (L2-norm): 1.33547e-12
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 6.95824e-12
+  Absolute error (L2-norm): 3.75586e-11
 
 
 
@@ -434,6 +438,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid operator type:                   ReactionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -449,6 +454,7 @@ Linear solver:
   Pressure/Schur-complement block:
   Preconditioner:                            PressureConvectionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -495,10 +501,10 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 2.96422e-14
+  Absolute error (L2-norm): 3.86312e-14
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 8.08894e-13
+  Absolute error (L2-norm): 1.07113e-12
 
 
 
@@ -601,6 +607,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid operator type:                   ReactionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Jacobi
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -616,6 +623,7 @@ Linear solver:
   Pressure/Schur-complement block:
   Preconditioner:                            PressureConvectionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -662,7 +670,7 @@ Calculate error for pressure for initial data:
 Solve steady state problem:
 
 Calculate error for velocity for solution data:
-  Absolute error (L2-norm): 9.09819e-12
+  Absolute error (L2-norm): 1.13400e-11
 
 Calculate error for pressure for solution data:
-  Absolute error (L2-norm): 2.27289e-10
+  Absolute error (L2-norm): 2.90980e-10

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
@@ -118,6 +118,7 @@ Linear solver:
   Multigrid operator type:                   ReactionDiffusion
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -134,6 +135,7 @@ Linear solver:
   Pressure/Schur-complement block:
   Preconditioner:                            PressureConvectionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
@@ -116,6 +116,7 @@ Linear solver:
   Multigrid operator type:                   ReactionDiffusion
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   BlockJacobi
   Iterations smoother:                       5
@@ -132,6 +133,7 @@ Linear solver:
   Pressure/Schur-complement block:
   Preconditioner:                            PressureConvectionDiffusion
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -113,6 +113,7 @@ High-order dual splitting scheme:
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -113,6 +113,7 @@ High-order dual splitting scheme:
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -113,6 +113,7 @@ High-order dual splitting scheme:
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -113,6 +113,7 @@ High-order dual splitting scheme:
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -194,12 +194,13 @@ public:
       prm.add_parameter("AdaptiveRefinement",
                         adaptive_refinement,
                         "Static adaptive refinement of the mesh.");
-      prm.add_parameter("UseMatrixBasedImplementation",
-                        use_matrix_based_implementation,
-                        "Use matrix-based implementation of the Laplace operator.");
-      prm.add_parameter("Preconditioner",
-                        preconditioner,
-                        "None, PointJacobi, AMG, AdditiveSchwarz or Multigrid");
+      prm.add_parameter("UseMatrixBasedOperator",
+                        use_matrix_based_operator,
+                        "Use matrix-based operators in global Krylov solver and Multigrid.");
+      prm.add_parameter("Preconditioner", preconditioner, "Preconditioner for the linear system.");
+      prm.add_parameter("MinDegreeMatrixFree",
+                        min_degree_matrix_free,
+                        "Minimum polynomial degree for matrix-free operators in multigrid.");
     }
     prm.leave_subsection();
   }
@@ -239,9 +240,10 @@ private:
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
     this->param.multigrid_data.coarse_problem.solver_data.rel_tol = 1.e-6;
+    this->param.multigrid_data.min_degree_matrix_free             = min_degree_matrix_free;
 
-    this->param.use_matrix_based_implementation = use_matrix_based_implementation;
-    this->param.sparse_matrix_type              = SparseMatrixType::Trilinos;
+    this->param.use_matrix_based_operator = use_matrix_based_operator;
+    this->param.sparse_matrix_type        = SparseMatrixType::Trilinos;
   }
 
   void
@@ -398,10 +400,11 @@ private:
 
   MeshType mesh_type = MeshType::Cartesian;
 
-  bool           global_coarsening               = false;
-  bool           adaptive_refinement             = false;
-  bool           use_matrix_based_implementation = false;
-  Preconditioner preconditioner                  = Preconditioner::Multigrid;
+  bool           global_coarsening         = false;
+  bool           adaptive_refinement       = false;
+  bool           use_matrix_based_operator = false;
+  Preconditioner preconditioner            = Preconditioner::Multigrid;
+  unsigned int   min_degree_matrix_free    = 1;
 };
 
 } // namespace Poisson

--- a/applications/poisson/gaussian/input.json
+++ b/applications/poisson/gaussian/input.json
@@ -14,8 +14,9 @@
         "MeshType": "Cartesian",
         "GlobalCoarsening": "false",
         "AdaptiveRefinement": "false",
-        "UseMatrixBasedImplementation": "false",
-        "Preconditioner": "Multigrid"
+        "UseMatrixBasedOperator": "false",
+        "Preconditioner": "Multigrid",
+        "MinDegreeMatrixFree": "1"
     },
     "Output": {
         "OutputDirectory": "output/poisson/gaussian/",

--- a/applications/poisson/gaussian/tests/gaussian.json
+++ b/applications/poisson/gaussian/tests/gaussian.json
@@ -14,8 +14,9 @@
        	"Name": "Gaussian",
         "MeshType": "Cartesian",
         "AdaptiveRefinement": "false",
-        "UseMatrixBasedImplementation": "false",
-        "Preconditioner": "Multigrid"
+        "UseMatrixBasedOperator": "false",
+        "Preconditioner": "Multigrid",
+        "MinDegreeMatrixFree": "1"
     },
     "Output": {
         "OutputDirectory": "output/poisson/gaussian/",

--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -34,7 +34,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         1
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -45,6 +45,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -125,7 +126,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         2
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -136,6 +137,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -216,7 +218,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         3
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -227,6 +229,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -307,7 +310,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         4
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -318,6 +321,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -398,7 +402,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         5
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -409,6 +413,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -489,7 +494,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         6
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -500,6 +505,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -580,7 +586,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         7
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -591,6 +597,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -671,7 +678,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         8
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -682,6 +689,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -762,7 +770,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         9
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -773,6 +781,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -853,7 +862,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         10
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -864,6 +873,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -944,7 +954,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         11
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -955,6 +965,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -1035,7 +1046,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         12
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -1046,6 +1057,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -1089,7 +1101,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.58566e-11
+  Relative error (L2-norm): 4.58597e-11
 
 
 
@@ -1126,7 +1138,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         13
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -1137,6 +1149,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -1180,7 +1193,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 4.24958e-11
+  Relative error (L2-norm): 4.24979e-11
 
 
 
@@ -1217,7 +1230,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         14
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -1228,6 +1241,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -1271,7 +1285,7 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 2.43338e-12
+  Relative error (L2-norm): 2.46814e-12
 
 
 
@@ -1308,7 +1322,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         15
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -1319,6 +1333,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -1362,4 +1377,4 @@ Calculate error for all fields for initial data:
   Relative error (L2-norm): 1.00000e+00
 
 Calculate error for all fields for solution data:
-  Relative error (L2-norm): 2.07757e-12
+  Relative error (L2-norm): 1.48926e-12

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -169,6 +169,7 @@ private:
     this->param.preconditioner              = Preconditioner::Multigrid;
     this->param.multigrid_data.type         = MultigridType::cphMG;
     this->param.multigrid_data.p_sequence   = PSequenceType::Bisect;
+
     // MG smoother
     this->param.multigrid_data.smoother_data.smoother        = MultigridSmoother::Chebyshev;
     this->param.multigrid_data.smoother_data.iterations      = 5;

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -34,7 +34,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         1
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -45,6 +45,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -121,7 +122,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         2
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -132,6 +133,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -208,7 +210,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         3
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -219,6 +221,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -295,7 +298,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         4
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -306,6 +309,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -382,7 +386,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         5
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -393,6 +397,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -469,7 +474,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         6
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -480,6 +485,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -556,7 +562,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         7
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -567,6 +573,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -34,7 +34,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         1
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -45,6 +45,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -121,7 +122,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         2
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -132,6 +133,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -208,7 +210,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         3
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -219,6 +221,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -295,7 +298,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         4
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -306,6 +309,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -382,7 +386,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         5
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -393,6 +397,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -469,7 +474,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         6
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -480,6 +485,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -556,7 +562,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         7
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -567,6 +573,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/poisson/sine/tests/curvilinear_AMG.with_trilinos=true.output
+++ b/applications/poisson/sine/tests/curvilinear_AMG.with_trilinos=true.output
@@ -34,7 +34,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         1
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -45,6 +45,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -125,7 +126,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         2
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -136,6 +137,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -216,7 +218,7 @@ Spatial Discretization:
   FE space:                                  DG
   Polynomial degree:                         3
   IP factor:                                 1.0000e+00
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
   Solver:                                    CG
@@ -227,6 +229,7 @@ Solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -82,8 +82,8 @@ private:
     this->param.spatial_discretization = SpatialDiscretization::DG;
     this->param.IP_factor              = 1.0e0;
 
-    this->param.use_matrix_based_implementation = false;
-    this->param.sparse_matrix_type              = SparseMatrixType::Trilinos;
+    this->param.use_matrix_based_operator = false;
+    this->param.sparse_matrix_type        = SparseMatrixType::Trilinos;
 
     // SOLVER
     this->param.solver         = LinearSolver::CG;

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -268,9 +268,12 @@ public:
       prm.add_parameter("AdaptiveRefinement",
                         adaptive_refinement,
                         "Static adaptive refinement of the mesh.");
-      prm.add_parameter("UseMatrixBasedImplementation",
-                        use_matrix_based_implementation,
-                        "Use matrix-based implementation of the elasticity operator.");
+      prm.add_parameter("UseMatrixBasedOperator",
+                        use_matrix_based_operator,
+                        "Use matrix-based operators in global Krylov solver and Multigrid.");
+      prm.add_parameter("MinDegreeMatrixFree",
+                        min_degree_matrix_free,
+                        "Minimum polynomial degree for matrix-free operators in multigrid.");
     }
     prm.leave_subsection();
   }
@@ -318,8 +321,8 @@ private:
 
     this->param.load_increment = 0.5;
 
-    this->param.use_matrix_based_implementation = use_matrix_based_implementation;
-    this->param.sparse_matrix_type              = SparseMatrixType::Trilinos;
+    this->param.use_matrix_based_operator = use_matrix_based_operator;
+    this->param.sparse_matrix_type        = SparseMatrixType::Trilinos;
 
     this->param.newton_solver_data  = Newton::SolverData(1e2, 1.e-9, 1.e-9);
     this->param.solver              = Solver::FGMRES;
@@ -333,6 +336,7 @@ private:
     this->param.multigrid_data.coarse_problem.solver = MultigridCoarseGridSolver::CG;
     this->param.multigrid_data.coarse_problem.preconditioner =
       MultigridCoarseGridPreconditioner::AMG;
+    this->param.multigrid_data.min_degree_matrix_free = min_degree_matrix_free;
 
     this->param.update_preconditioner                  = true;
     this->param.update_preconditioner_every_time_steps = 1;
@@ -710,12 +714,13 @@ private:
 
   double weak_damping_coefficient = 0.0;
 
-  Preconditioner preconditioner = Preconditioner::Multigrid;
+  Preconditioner preconditioner         = Preconditioner::Multigrid;
+  unsigned int   min_degree_matrix_free = 1;
 
   double displacement = 1.0; // "Dirichlet"
   double area_force   = 1.0; // "Neumann"
 
-  bool use_matrix_based_implementation = false;
+  bool use_matrix_based_operator = false;
 
   // mesh parameters
   bool               adaptive_refinement = false;

--- a/applications/structure/bar/input.json
+++ b/applications/structure/bar/input.json
@@ -28,7 +28,8 @@
         "Displacement": "20.0",
         "Traction":	"0.0",
         "AdaptiveRefinement": "true",
-        "UseMatrixBasedImplementation": "false"
+        "UseMatrixBasedOperator": "false",
+        "MinDegreeMatrixFree": "1"
     },
     "Output": {
         "OutputDirectory": "output/bar/",

--- a/applications/structure/bar/tests/quasistatic_large_strain_multigrid.json
+++ b/applications/structure/bar/tests/quasistatic_large_strain_multigrid.json
@@ -21,12 +21,14 @@
         "ProblemType": "QuasiStatic",
         "LargeDeformation": "true",
         "Preconditioner": "Multigrid",
+        "UseMatrixBasedOperator": "false",
+        "MinDegreeMatrixFree": "1",
         "WeakDamping": "0.0",
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Dirichlet",
         "Displacement": "2.0e-1",
-        "Traction":	"0.0" 
+        "Traction":	"0.0"
     },
     "Output": {
         "OutputDirectory": "output/bar/",

--- a/applications/structure/bar/tests/quasistatic_large_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/quasistatic_large_strain_multigrid.with_trilinos=true.output
@@ -41,7 +41,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -59,6 +59,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/structure/bar/tests/steady_large_strain_multigrid.json
+++ b/applications/structure/bar/tests/steady_large_strain_multigrid.json
@@ -21,12 +21,14 @@
         "ProblemType": "Steady",
         "LargeDeformation": "true",
         "Preconditioner": "Multigrid",
+        "UseMatrixBasedOperator": "false",
+        "MinDegreeMatrixFree": "1",
         "WeakDamping": "0.0",
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Dirichlet",
         "Displacement": "20.0e-3",
-        "Traction":	"0.0" 
+        "Traction":	"0.0"
     },
     "Output": {
         "OutputDirectory": "output/bar/",

--- a/applications/structure/bar/tests/steady_large_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/steady_large_strain_multigrid.with_trilinos=true.output
@@ -40,7 +40,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -58,6 +58,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/structure/bar/tests/steady_small_strain_multigrid.json
+++ b/applications/structure/bar/tests/steady_small_strain_multigrid.json
@@ -21,12 +21,14 @@
         "ProblemType": "Steady",
         "LargeDeformation": "false",
         "Preconditioner": "Multigrid",
+        "UseMatrixBasedOperator": "false",
+        "MinDegreeMatrixFree": "1",
         "WeakDamping": "0.0",
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Dirichlet",
         "Displacement": "20.0e-3",
-        "Traction":	"0.0" 
+        "Traction":	"0.0"
     },
     "Output": {
         "OutputDirectory": "output/bar/",

--- a/applications/structure/bar/tests/steady_small_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/steady_small_strain_multigrid.with_trilinos=true.output
@@ -38,7 +38,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -51,6 +51,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/structure/bar/tests/unsteady_small_strain_multigrid.json
+++ b/applications/structure/bar/tests/unsteady_small_strain_multigrid.json
@@ -21,12 +21,14 @@
         "ProblemType": "Unsteady",
         "LargeDeformation": "false",
         "Preconditioner": "Multigrid",
+        "UseMatrixBasedOperator": "false",
+        "MinDegreeMatrixFree": "1",
         "WeakDamping": "0.0",
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Dirichlet",
         "Displacement": "0.2",
-        "Traction":	"0.0" 
+        "Traction":	"0.0"
     },
     "Output": {
         "OutputDirectory": "output/bar/",

--- a/applications/structure/bar/tests/unsteady_small_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/unsteady_small_strain_multigrid.with_trilinos=true.output
@@ -49,7 +49,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         4
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -62,6 +62,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/structure/bar/tests/weak_damping.json
+++ b/applications/structure/bar/tests/weak_damping.json
@@ -21,12 +21,14 @@
         "ProblemType": "Unsteady",
         "LargeDeformation": "true",
         "Preconditioner": "Multigrid",
+        "UseMatrixBasedOperator": "false",
+        "MinDegreeMatrixFree": "1",
         "WeakDamping": "10000.0",
         "UseVolumeForce": "false",
         "VolumeForce": "1.0",
         "BoundaryType": "Neumann",
         "Displacement": "20.0",
-        "Traction":	"10.0" 
+        "Traction":	"10.0"
     },
     "Output": {
         "OutputDirectory": "output/bar/",

--- a/applications/structure/bar/tests/weak_damping.with_trilinos=true.output
+++ b/applications/structure/bar/tests/weak_damping.with_trilinos=true.output
@@ -52,7 +52,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         1
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -70,6 +70,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -375,8 +375,8 @@ private:
       this->param.newton_solver_data.max_iter;
     this->param.update_preconditioner_once_newton_converged = true;
 
-    this->param.use_matrix_based_implementation = false;                   // true;
-    this->param.sparse_matrix_type              = SparseMatrixType::PETSc; // Trilinos;
+    this->param.use_matrix_based_operator = false;                   // true;
+    this->param.sparse_matrix_type        = SparseMatrixType::PETSc; // Trilinos;
   }
 
   void

--- a/applications/structure/manufactured/tests/2d.output
+++ b/applications/structure/manufactured/tests/2d.output
@@ -51,7 +51,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -69,6 +69,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -169,7 +170,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -187,6 +188,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -287,7 +289,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -305,6 +307,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -405,7 +408,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -423,6 +426,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -523,7 +527,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -541,6 +545,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -641,7 +646,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -659,6 +664,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -759,7 +765,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -777,6 +783,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -877,7 +884,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -895,6 +902,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -995,7 +1003,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -1013,6 +1021,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/applications/structure/manufactured/tests/3d.output
+++ b/applications/structure/manufactured/tests/3d.output
@@ -51,7 +51,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -69,6 +69,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -169,7 +170,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -187,6 +188,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -287,7 +289,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -305,6 +307,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -405,7 +408,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -423,6 +426,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -523,7 +527,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -541,6 +545,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -641,7 +646,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -659,6 +664,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -759,7 +765,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -777,6 +783,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -877,7 +884,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -895,6 +902,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5
@@ -995,7 +1003,7 @@ Spatial Discretization:
   Mapping degree:                            1
   Mapping degree coarse grids:               1
   Polynomial degree:                         3
-  Use matrix-based implementation:           false
+  Use matrix-based operator:                 false
 
 Solver:
 
@@ -1013,6 +1021,7 @@ Linear solver:
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
+  Min degree matrix-free:                    1
   Smoother:                                  Chebyshev
   Preconditioner smoother:                   PointJacobi
   Iterations smoother:                       5

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.cpp
@@ -227,8 +227,14 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 template<int dim, typename Number>
 std::shared_ptr<
   MultigridOperatorBase<dim, typename MultigridPreconditionerBase<dim, Number>::MultigridNumber>>
-MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const level)
+MultigridPreconditioner<dim, Number>::initialize_operator(
+  unsigned int const level,
+  bool const         use_matrix_based_operator_level,
+  bool const         assemble_matrix)
 {
+  AssertThrow(use_matrix_based_operator_level == false,
+              dealii::ExcMessage("Matrix-based implementation not supported."));
+
   // initialize pde_operator in a first step
   std::shared_ptr<PDEOperatorMG> pde_operator_level(new PDEOperatorMG());
 
@@ -241,6 +247,9 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
       this->matrix_free_data_objects[level]->get_dof_index("velocity_dof_handler");
   }
   data.quad_index = this->matrix_free_data_objects[level]->get_quad_index("std_quadrature");
+
+  // the choice matrix-free vs. matrix-based might be different from what we do on the fine level
+  data.use_matrix_based_operator_level = use_matrix_based_operator_level;
 
   pde_operator_level->initialize(*this->matrix_free_objects[level],
                                  *this->constraints[level],

--- a/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/convection_diffusion/preconditioners/multigrid_preconditioner.h
@@ -88,7 +88,9 @@ private:
                         unsigned int const                     dealii_tria_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) final;
+  initialize_operator(unsigned int const level,
+                      bool const         use_matrix_based_operator_level,
+                      bool const         assemble_matrix) final;
 
   void
   initialize_dof_handler_and_constraints(

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.cpp
@@ -219,13 +219,23 @@ MultigridPreconditioner<dim, Number>::fill_matrix_free_data(
 template<int dim, typename Number>
 std::shared_ptr<
   MultigridOperatorBase<dim, typename MultigridPreconditionerBase<dim, Number>::MultigridNumber>>
-MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const level)
+MultigridPreconditioner<dim, Number>::initialize_operator(
+  unsigned int const level,
+  bool const         use_matrix_based_operator_level,
+  bool const         assemble_matrix)
 {
+  (void)assemble_matrix;
+  AssertThrow(use_matrix_based_operator_level == false,
+              dealii::ExcMessage("Matrix-based implementation not supported."));
+
   // initialize pde_operator in a first step
   std::shared_ptr<PDEOperatorMG> pde_operator_level(new PDEOperatorMG());
 
   data.dof_index  = this->matrix_free_data_objects[level]->get_dof_index("std_dof_handler");
   data.quad_index = this->matrix_free_data_objects[level]->get_quad_index("std_quadrature");
+
+  // the choice matrix-free vs. matrix-based might be different from what we do on the fine level
+  data.use_matrix_based_operator_level = use_matrix_based_operator_level;
 
   pde_operator_level->initialize(*this->matrix_free_objects[level],
                                  *this->constraints[level],

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_momentum.h
@@ -82,7 +82,9 @@ private:
                         unsigned int const                     dealii_tria_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) final;
+  initialize_operator(unsigned int const level,
+                      bool const         use_matrix_based_operator_level,
+                      bool const         assemble_matrix) final;
 
   std::shared_ptr<PDEOperatorMG>
   get_operator(unsigned int level);

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.cpp
@@ -159,13 +159,23 @@ MultigridPreconditionerProjection<dim, Number>::fill_matrix_free_data(
 template<int dim, typename Number>
 std::shared_ptr<
   MultigridOperatorBase<dim, typename MultigridPreconditionerBase<dim, Number>::MultigridNumber>>
-MultigridPreconditionerProjection<dim, Number>::initialize_operator(unsigned int const level)
+MultigridPreconditionerProjection<dim, Number>::initialize_operator(
+  unsigned int const level,
+  bool const         use_matrix_based_operator_level,
+  bool const         assemble_matrix)
 {
+  (void)assemble_matrix;
+  AssertThrow(use_matrix_based_operator_level == false,
+              dealii::ExcMessage("Matrix-based implementation not supported."));
+
   // initialize pde_operator in a first step
   std::shared_ptr<PDEOperatorMG> pde_operator_level(new PDEOperatorMG());
 
   data.dof_index  = this->matrix_free_data_objects[level]->get_dof_index("std_dof_handler");
   data.quad_index = this->matrix_free_data_objects[level]->get_quad_index("std_quadrature");
+
+  // the choice matrix-free vs. matrix-based might be different from what we do on the fine level
+  data.use_matrix_based_operator_level = use_matrix_based_operator_level;
 
   // The polynomial degree changes in case of p-multigrid, so we have to adapt the kernel_data
   // objects.

--- a/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
+++ b/include/exadg/incompressible_navier_stokes/preconditioners/multigrid_preconditioner_projection.h
@@ -81,7 +81,9 @@ private:
                         unsigned int const                     dealii_tria_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) final;
+  initialize_operator(unsigned int const level,
+                      bool const         use_matrix_based_operator_level,
+                      bool const         assemble_matrix) final;
 
   std::shared_ptr<PDEOperatorMG>
   get_operator(unsigned int level);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -768,7 +768,8 @@ OperatorCoupled<dim, Number>::setup_iterative_solver_schur_complement()
   laplace_operator = std::make_shared<Poisson::LaplaceOperator<dim, Number, 1>>();
   laplace_operator->initialize(this->get_matrix_free(),
                                this->get_constraint_p(),
-                               laplace_operator_data);
+                               laplace_operator_data,
+                               true /* assemble_matrix */);
 
   solver_pressure_block =
     std::make_shared<Krylov::SolverCG<Poisson::LaplaceOperator<dim, Number, 1>,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -143,7 +143,8 @@ OperatorProjectionMethods<dim, Number>::initialize_laplace_operator()
 
   laplace_operator.initialize(this->get_matrix_free(),
                               this->get_constraint_p(),
-                              laplace_operator_data);
+                              laplace_operator_data,
+                              true /* assemble_matrix */);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1526,7 +1526,10 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
   typedef Poisson::LaplaceOperator<dim, Number, 1> Laplace;
   Laplace                                          laplace_operator;
   dealii::AffineConstraints<Number>                constraint_dummy;
-  laplace_operator.initialize(*matrix_free, constraint_dummy, laplace_operator_data);
+  laplace_operator.initialize(*matrix_free,
+                              constraint_dummy,
+                              laplace_operator_data,
+                              true /* assemble_matrix */);
 
   // setup preconditioner
   std::shared_ptr<PreconditionerBase<Number>> preconditioner;

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -157,20 +157,28 @@ template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::vmult(VectorType & dst, VectorType const & src) const
 {
-  if(this->data.use_matrix_based_vmult)
+  if(this->data.use_matrix_based_operator_level)
+  {
     this->apply_matrix_based(dst, src);
+  }
   else
+  {
     this->apply(dst, src);
+  }
 }
 
 template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::vmult_add(VectorType & dst, VectorType const & src) const
 {
-  if(this->data.use_matrix_based_vmult)
+  if(this->data.use_matrix_based_operator_level)
+  {
     this->apply_matrix_based_add(dst, src);
+  }
   else
+  {
     this->apply_add(dst, src);
+  }
 }
 
 template<int dim, typename Number, int n_components>
@@ -327,7 +335,7 @@ template<int dim, typename Number, int n_components>
 void
 OperatorBase<dim, Number, n_components>::assemble_matrix_if_necessary() const
 {
-  if(this->data.use_matrix_based_vmult)
+  if(this->data.use_matrix_based_operator_level)
   {
     // initialize matrix
     if(not(system_matrix_based_been_initialized))
@@ -417,9 +425,6 @@ void
 OperatorBase<dim, Number, n_components>::apply_matrix_based(VectorType &       dst,
                                                             VectorType const & src) const
 {
-  // Initialize and assemble matrix if necessary
-  assemble_matrix_if_necessary();
-
   if(this->data.sparse_matrix_type == SparseMatrixType::Trilinos)
   {
 #ifdef DEAL_II_WITH_TRILINOS

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -62,7 +62,7 @@ struct OperatorBaseData
     : dof_index(0),
       dof_index_inhomogeneous(dealii::numbers::invalid_unsigned_int),
       quad_index(0),
-      use_matrix_based_vmult(false),
+      use_matrix_based_operator_level(false),
       sparse_matrix_type(SparseMatrixType::Undefined),
       operator_is_singular(false),
       use_cell_based_loops(false),
@@ -83,8 +83,8 @@ struct OperatorBaseData
   unsigned int quad_index;
 
   // this parameter can be used to use sparse matrices for the vmult() operation. The default
-  // case is to use a matrix-free implementation, i.e. use_matrix_based_vmult = false.
-  bool use_matrix_based_vmult;
+  // case is to use a matrix-free implementation, i.e. use_matrix_based_operator_level = false.
+  bool use_matrix_based_operator_level;
 
   SparseMatrixType sparse_matrix_type;
 
@@ -285,8 +285,8 @@ public:
   assemble_matrix_if_necessary() const;
 
   /*
-   * Matrix-based version of the apply function. This function is used if use_matrix_based_vmult =
-   * true.
+   * Matrix-based version of the apply function. This function is used if
+   * use_matrix_based_operator_level = true.
    */
   void
   apply_matrix_based(VectorType & dst, VectorType const & src) const;

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -76,8 +76,11 @@ MultigridPreconditioner<dim, Number, n_components>::update()
 
     this->update_matrix_free_objects();
 
-    this->for_all_levels(
-      [&](unsigned int const level) { get_operator(level)->update_penalty_parameter(); });
+    // update operators
+    this->for_all_levels([&](unsigned int const level) {
+      get_operator(level)->update_penalty_parameter();
+      get_operator(level)->assemble_matrix_if_necessary();
+    });
 
     // Once the operators are updated, the update of smoothers and the coarse grid solver is generic
     // functionality implemented in the base class.
@@ -120,7 +123,10 @@ MultigridPreconditioner<dim, Number, n_components>::fill_matrix_free_data(
 template<int dim, typename Number, int n_components>
 std::shared_ptr<
   MultigridOperatorBase<dim, typename MultigridPreconditionerBase<dim, Number>::MultigridNumber>>
-MultigridPreconditioner<dim, Number, n_components>::initialize_operator(unsigned int const level)
+MultigridPreconditioner<dim, Number, n_components>::initialize_operator(
+  unsigned int const level,
+  bool const         use_matrix_based_operator_level,
+  bool const         assemble_matrix)
 {
   // initialize pde_operator in a first step
   std::shared_ptr<Laplace> pde_operator(new Laplace());
@@ -128,7 +134,13 @@ MultigridPreconditioner<dim, Number, n_components>::initialize_operator(unsigned
   data.dof_index  = this->matrix_free_data_objects[level]->get_dof_index("laplace_dof_handler");
   data.quad_index = this->matrix_free_data_objects[level]->get_quad_index("laplace_quadrature");
 
-  pde_operator->initialize(*this->matrix_free_objects[level], *this->constraints[level], data);
+  // the choice matrix-free vs. matrix-based might be different from what we do on the fine level
+  data.use_matrix_based_operator_level = use_matrix_based_operator_level;
+
+  pde_operator->initialize(*this->matrix_free_objects[level],
+                           *this->constraints[level],
+                           data,
+                           assemble_matrix);
 
   // initialize MGOperator which is a wrapper around the PDEOperator
   std::shared_ptr<MGOperator> mg_operator(new MGOperator(pde_operator));

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.h
@@ -79,7 +79,9 @@ private:
                         unsigned int const                     dealii_triangulation_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) final;
+  initialize_operator(unsigned int const level,
+                      bool const         use_matrix_based_operator_level,
+                      bool const         assemble_matrix) final;
 
   std::shared_ptr<Laplace>
   get_operator(unsigned int level);

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -35,7 +35,8 @@ void
 LaplaceOperator<dim, Number, n_components>::initialize(
   dealii::MatrixFree<dim, Number> const &   matrix_free,
   dealii::AffineConstraints<Number> const & affine_constraints,
-  LaplaceOperatorData<rank, dim> const &    data)
+  LaplaceOperatorData<rank, dim> const &    data,
+  bool const                                assemble_matrix)
 {
   operator_data = data;
 
@@ -44,6 +45,9 @@ LaplaceOperator<dim, Number, n_components>::initialize(
   kernel.reinit(matrix_free, data.kernel_data, data.dof_index);
 
   this->integrator_flags = kernel.get_integrator_flags(this->is_dg);
+
+  if(assemble_matrix)
+    this->assemble_matrix_if_necessary();
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -250,7 +250,8 @@ public:
   void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              dealii::AffineConstraints<Number> const & affine_constraints,
-             LaplaceOperatorData<rank, dim> const &    data);
+             LaplaceOperatorData<rank, dim> const &    data,
+             bool const                                assemble_matrix);
 
   LaplaceOperatorData<rank, dim> const &
   get_data() const

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -237,14 +237,15 @@ Operator<dim, n_components, Number>::setup_operators()
 
     laplace_operator_data.quad_index_gauss_lobatto = get_quad_index_gauss_lobatto();
   }
-  laplace_operator_data.bc                     = boundary_descriptor;
-  laplace_operator_data.use_cell_based_loops   = param.enable_cell_based_face_loops;
-  laplace_operator_data.kernel_data.IP_factor  = param.IP_factor;
-  laplace_operator_data.use_matrix_based_vmult = param.use_matrix_based_implementation;
-  laplace_operator_data.sparse_matrix_type     = param.sparse_matrix_type;
-  laplace_operator.initialize(*matrix_free, affine_constraints, laplace_operator_data);
-
-  laplace_operator.assemble_matrix_if_necessary();
+  laplace_operator_data.bc                              = boundary_descriptor;
+  laplace_operator_data.use_cell_based_loops            = param.enable_cell_based_face_loops;
+  laplace_operator_data.kernel_data.IP_factor           = param.IP_factor;
+  laplace_operator_data.use_matrix_based_operator_level = param.use_matrix_based_operator;
+  laplace_operator_data.sparse_matrix_type              = param.sparse_matrix_type;
+  laplace_operator.initialize(*matrix_free,
+                              affine_constraints,
+                              laplace_operator_data,
+                              true /* assemble_matrix */);
 
   // rhs operator
   if(param.right_hand_side)

--- a/include/exadg/poisson/user_interface/parameters.cpp
+++ b/include/exadg/poisson/user_interface/parameters.cpp
@@ -40,7 +40,7 @@ Parameters::Parameters()
     spatial_discretization(SpatialDiscretization::Undefined),
     degree(1),
     IP_factor(1.0),
-    use_matrix_based_implementation(false),
+    use_matrix_based_operator(false),
     sparse_matrix_type(SparseMatrixType::Undefined),
 
     // SOLVER
@@ -66,7 +66,7 @@ Parameters::check() const
 
   AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
 
-  if(use_matrix_based_implementation)
+  if(use_matrix_based_operator)
   {
     AssertThrow(sparse_matrix_type != SparseMatrixType::Undefined,
                 dealii::ExcMessage("Parameter must be defined."));
@@ -132,9 +132,9 @@ Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream c
   if(spatial_discretization == SpatialDiscretization::DG)
     print_parameter(pcout, "IP factor", IP_factor);
 
-  print_parameter(pcout, "Use matrix-based implementation", use_matrix_based_implementation);
+  print_parameter(pcout, "Use matrix-based operator", use_matrix_based_operator);
 
-  if(use_matrix_based_implementation)
+  if(use_matrix_based_operator)
   {
     print_parameter(pcout, "Sparse matrix type", sparse_matrix_type);
   }

--- a/include/exadg/poisson/user_interface/parameters.h
+++ b/include/exadg/poisson/user_interface/parameters.h
@@ -97,10 +97,12 @@ public:
   // interior penalty parameter scaling factor: default value is 1.0
   double IP_factor;
 
-  // use a matrix-based implementation of linear(ized) operators
-  bool use_matrix_based_implementation;
+  // Use a matrix-based implementation of linear(ized) operators. Note that this parameter only
+  // decides about the implementation of the operator in the Krylov solver. This parameter does not
+  // affect matrix-based vs. matrix-free implementations within multigrid.
+  bool use_matrix_based_operator;
 
-  // this parameter is only relevant if use_matrix_based_implementation == true
+  // this parameter is only relevant if use_matrix_based_operator == true
   SparseMatrixType sparse_matrix_type;
 
 

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_parameters.h
@@ -260,6 +260,7 @@ struct MultigridData
   MultigridData()
     : type(MultigridType::hMG),
       p_sequence(PSequenceType::Bisect),
+      min_degree_matrix_free(1),
       smoother_data(SmootherData()),
       coarse_problem(CoarseGridData())
   {
@@ -274,6 +275,8 @@ struct MultigridData
     {
       print_parameter(pcout, "p-sequence", p_sequence);
     }
+
+    print_parameter(pcout, "Min degree matrix-free", min_degree_matrix_free);
 
     smoother_data.print(pcout);
 
@@ -294,6 +297,13 @@ struct MultigridData
 
   // Sequence of polynomial degrees during p-multigrid
   PSequenceType p_sequence;
+
+  // Use matrix-free implementation for degrees >= min_degree_matrix_free, e.g. if
+  // min_degree_matrix_free = 2, multigrid will use a matrix-based implementation for degree = 1
+  // only. The default case is min_degree_matrix_free = 1, i.e. a matrix-free implementation is used
+  // on all multigrid levels. When AMG is used as coarse-grid solver/preconditioner, a matrix-based
+  // implementation is used for AMG independently of this parameter.
+  unsigned int min_degree_matrix_free;
 
   // Smoother data
   SmootherData smoother_data;

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.cpp
@@ -85,7 +85,7 @@ MultigridPreconditionerBase<dim, Number, MultigridNumber>::initialize(
 
   this->initialize_transfer_operators();
 
-  this->initialize_operators();
+  this->initialize_operators(initialize_preconditioners);
 
   this->initialize_smoothers(initialize_preconditioners);
 
@@ -609,12 +609,17 @@ MultigridPreconditionerBase<dim, Number, MultigridNumber>::update_matrix_free_ob
 
 template<int dim, typename Number, typename MultigridNumber>
 void
-MultigridPreconditionerBase<dim, Number, MultigridNumber>::initialize_operators()
+MultigridPreconditionerBase<dim, Number, MultigridNumber>::initialize_operators(
+  bool const assemble_matrix)
 {
   this->operators.resize(0, this->get_number_of_levels() - 1);
 
-  for_all_levels(
-    [&](unsigned int const level) { operators[level] = this->initialize_operator(level); });
+  for_all_levels([&](unsigned int const level) {
+    bool const use_matrix_based_operator_level =
+      level_info[level].degree() < this->data.min_degree_matrix_free;
+    operators[level] =
+      this->initialize_operator(level, use_matrix_based_operator_level, assemble_matrix);
+  });
 }
 
 template<int dim, typename Number, typename MultigridNumber>
@@ -622,9 +627,13 @@ std::shared_ptr<MultigridOperatorBase<
   dim,
   typename MultigridPreconditionerBase<dim, Number, MultigridNumber>::MultigridNumber>>
 MultigridPreconditionerBase<dim, Number, MultigridNumber>::initialize_operator(
-  unsigned int const level)
+  unsigned int const level,
+  bool const         use_matrix_based_operator_level,
+  bool const         assemble_matrix)
 {
   (void)level;
+  (void)use_matrix_based_operator_level;
+  (void)assemble_matrix;
 
   AssertThrow(false,
               dealii::ExcMessage("This function needs to be implemented by derived classes."));

--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -298,14 +298,21 @@ private:
    * Initializes the multigrid operators for all multigrid levels.
    */
   void
-  initialize_operators();
+  initialize_operators(bool const assemble_matrix);
 
   /*
    * This function initializes an operator for a specified level. It needs to be implemented by
-   * derived classes.
+   * derived classes. The parameter `use_matrix_based_operator_level` describes whether a
+   * matrix-based implementation is used on a given level. The parameter assemble_matrix describes
+   * whether the matrix should be assembled during initialize_operator(). This parameter only has an
+   * effect if `use_matrix_based_operator_level = true`. Note that you have to make sure that the
+   * parameter `use_matrix_based_operator_level` is passed correctly to the underlying PDE operator
+   * when implementing the function initialize_operator() in derived classes.
    */
   virtual std::shared_ptr<Operator>
-  initialize_operator(unsigned int const level);
+  initialize_operator(unsigned int const level,
+                      bool const         use_matrix_based_operator_level,
+                      bool const         assemble_matrix);
 
   /*
    * Smoother.

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -226,11 +226,13 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
     {
       pde_operator->initialize_dof_vector(linearization);
       linearization = 1.0;
+
+      // note that this function assembles the matrix in case of a matrix-based implementation
       pde_operator->set_solution_linearization(linearization);
     }
     else
     {
-      pde_operator->assemble_matrix_if_necessary_for_linear_elasticity_operator();
+      pde_operator->assemble_matrix_if_necessary();
     }
   }
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -125,7 +125,9 @@ MultigridPreconditioner<dim, Number>::update()
   }
   else // linear problems
   {
-    pde_operator->assemble_matrix_if_necessary();
+    this->for_all_levels([&](unsigned int const level) {
+      this->get_operator_linear(level)->assemble_matrix_if_necessary();
+    });
   }
 
   // Update the smoothers and the coarse grid solver. This is generic functionality implemented in
@@ -222,7 +224,10 @@ MultigridPreconditioner<dim, Number>::get_operator_linear(unsigned int level)
 template<int dim, typename Number>
 std::shared_ptr<
   MultigridOperatorBase<dim, typename MultigridPreconditionerBase<dim, Number>::MultigridNumber>>
-MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const level)
+MultigridPreconditioner<dim, Number>::initialize_operator(
+  unsigned int const level,
+  bool const         use_matrix_based_operator_level,
+  bool const         assemble_matrix)
 {
   std::shared_ptr<MGOperatorBase> mg_operator_level;
 
@@ -233,6 +238,9 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
       this->matrix_free_data_objects[level]->get_dof_index("elasticity_dof_index_inhomogeneous");
   }
   data.quad_index = this->matrix_free_data_objects[level]->get_quad_index("elasticity_quadrature");
+
+  // the choice matrix-free vs. matrix-based might be different from what we do on the fine level
+  data.use_matrix_based_operator_level = use_matrix_based_operator_level;
 
   if(nonlinear)
   {
@@ -247,7 +255,8 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
 
     pde_operator_level->initialize(*this->matrix_free_objects[level],
                                    *this->constraints[level],
-                                   data);
+                                   data,
+                                   assemble_matrix);
 
     mg_operator_level = std::make_shared<MGOperatorNonlinear>(pde_operator_level);
   }
@@ -264,7 +273,8 @@ MultigridPreconditioner<dim, Number>::initialize_operator(unsigned int const lev
 
     pde_operator_level->initialize(*this->matrix_free_objects[level],
                                    *this->constraints[level],
-                                   data);
+                                   data,
+                                   assemble_matrix);
 
     mg_operator_level = std::make_shared<MGOperatorLinear>(pde_operator_level);
   }

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.h
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.h
@@ -91,7 +91,9 @@ private:
                         unsigned int const                     dealii_tria_level) final;
 
   std::shared_ptr<MGOperatorBase>
-  initialize_operator(unsigned int const level) final;
+  initialize_operator(unsigned int const level,
+                      bool const         use_matrix_based_operator_level,
+                      bool const         assemble_matrix) final;
 
   /*
    * This function updates the multigrid operators for all levels

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -133,6 +133,7 @@ public:
   void
   set_solution_linearization(VectorType const & solution_linearization) const
   {
+    // note that this function will re-assemble the matrix in case of a matrix-based implementation.
     pde_operator->set_solution_linearization(solution_linearization);
   }
 
@@ -249,7 +250,7 @@ public:
   set_solution_linearization(VectorType const & vector) const;
 
   void
-  assemble_matrix_if_necessary_for_linear_elasticity_operator() const;
+  assemble_matrix_if_necessary() const;
 
   void
   evaluate_elasticity_operator(VectorType &       dst,

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -74,7 +74,8 @@ void
 ElasticityOperatorBase<dim, Number>::initialize(
   dealii::MatrixFree<dim, Number> const &   matrix_free,
   dealii::AffineConstraints<Number> const & affine_constraints,
-  OperatorData<dim> const &                 data)
+  OperatorData<dim> const &                 data,
+  bool const                                assemble_matrix)
 {
   operator_data = data;
 
@@ -84,6 +85,11 @@ ElasticityOperatorBase<dim, Number>::initialize(
 
   material_handler.initialize(
     matrix_free, data.dof_index, data.quad_index, data.material_descriptor, data.large_deformation);
+
+  initialize_derived();
+
+  if(assemble_matrix)
+    this->assemble_matrix_if_necessary();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -92,10 +92,11 @@ public:
   static MappingFlags
   get_mapping_flags();
 
-  virtual void
+  void
   initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
              dealii::AffineConstraints<Number> const & affine_constraints,
-             OperatorData<dim> const &                 data);
+             OperatorData<dim> const &                 data,
+             bool const                                assemble_matrix);
 
   OperatorData<dim> const &
   get_data() const;
@@ -143,6 +144,9 @@ public:
 protected:
   void
   reinit_cell_derived(IntegratorCell & integrator, unsigned int const cell) const override;
+
+  virtual void
+  initialize_derived(){};
 
   OperatorData<dim> operator_data;
 

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -29,13 +29,8 @@ namespace Structure
 {
 template<int dim, typename Number>
 void
-NonLinearOperator<dim, Number>::initialize(
-  dealii::MatrixFree<dim, Number> const &   matrix_free,
-  dealii::AffineConstraints<Number> const & affine_constraints,
-  OperatorData<dim> const &                 data)
+NonLinearOperator<dim, Number>::initialize_derived()
 {
-  Base::initialize(matrix_free, affine_constraints, data);
-
   integrator_lin = std::make_shared<IntegratorCell>(*this->matrix_free,
                                                     this->operator_data.dof_index_inhomogeneous,
                                                     this->operator_data.quad_index);

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -47,15 +47,14 @@ private:
   typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
   typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
 
-public:
+private:
   /**
    * Initialize function.
    */
   void
-  initialize(dealii::MatrixFree<dim, Number> const &   matrix_free,
-             dealii::AffineConstraints<Number> const & affine_constraints,
-             OperatorData<dim> const &                 data) override;
+  initialize_derived() override;
 
+public:
   /**
    * Evaluates the non-linear operator.
    *

--- a/include/exadg/structure/user_interface/parameters.cpp
+++ b/include/exadg/structure/user_interface/parameters.cpp
@@ -65,7 +65,7 @@ Parameters::Parameters()
     mapping_degree(1),
     mapping_degree_coarse_grids(1),
     degree(1),
-    use_matrix_based_implementation(false),
+    use_matrix_based_operator(false),
     sparse_matrix_type(SparseMatrixType::Undefined),
 
     // SOLVER
@@ -114,7 +114,7 @@ Parameters::check() const
 
   AssertThrow(degree > 0, dealii::ExcMessage("Polynomial degree must be larger than zero."));
 
-  if(use_matrix_based_implementation)
+  if(use_matrix_based_operator)
   {
     AssertThrow(sparse_matrix_type != SparseMatrixType::Undefined,
                 dealii::ExcMessage("Parameter must be defined."));
@@ -226,9 +226,9 @@ Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream c
 
   print_parameter(pcout, "Polynomial degree", degree);
 
-  print_parameter(pcout, "Use matrix-based implementation", use_matrix_based_implementation);
+  print_parameter(pcout, "Use matrix-based operator", use_matrix_based_operator);
 
-  if(use_matrix_based_implementation)
+  if(use_matrix_based_operator)
   {
     print_parameter(pcout, "Sparse matrix type", sparse_matrix_type);
   }

--- a/include/exadg/structure/user_interface/parameters.h
+++ b/include/exadg/structure/user_interface/parameters.h
@@ -186,9 +186,12 @@ public:
   unsigned int degree;
 
   // use a matrix-based implementation of linear(ized) operators
-  bool use_matrix_based_implementation;
+  // Note that this parameter only decides about the implementation of the operator in the Krylov
+  // solver. The decision whether a matrix-based or a matrix-free implementation within multigrid is
+  // considered is separate.
+  bool use_matrix_based_operator;
 
-  // this parameter is only relevant if use_matrix_based_implementation == true
+  // this parameter is only relevant if use_matrix_based_operator == true
   SparseMatrixType sparse_matrix_type;
 
   /**************************************************************************************/


### PR DESCRIPTION
closes #709 (replacement)
fixes #706 (I checked, all correct = linear and nonlinear iteration counts identical, might be optimized tough --> #799)

reverts #797 (where I was stupid enough to assemble the matrix in every `op.apply()` because the name `assemble_matrix_if_necessary()` is misleading)

adds a parameter `param.multigrid_data.min_degree_matrix_free`.
if the polynomial degree on a certain MG level is >= `min_degree_matrix_free`, the operator on that level is realized in a matrix-free fashion.

on top of #709, this renames the variable 'use_matrix_based_implementation' with 'use_matrix_based_operator' since it is clearer

(and is compatible with the master)