### PR TITLE
rename `OperatorBase::assemble_matrix_if_necessary()`

### DIFF
--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -333,7 +333,7 @@ OperatorBase<dim, Number, n_components>::apply_add(VectorType & dst, VectorType 
 
 template<int dim, typename Number, int n_components>
 void
-OperatorBase<dim, Number, n_components>::assemble_matrix_if_necessary() const
+OperatorBase<dim, Number, n_components>::assemble_matrix_if_matrix_based() const
 {
   if(this->data.use_matrix_based_operator_level)
   {

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -282,7 +282,7 @@ public:
   apply_add(VectorType & dst, VectorType const & src) const;
 
   void
-  assemble_matrix_if_necessary() const;
+  assemble_matrix_if_matrix_based() const;
 
   /*
    * Matrix-based version of the apply function. This function is used if

--- a/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/poisson/preconditioners/multigrid_preconditioner.cpp
@@ -79,7 +79,7 @@ MultigridPreconditioner<dim, Number, n_components>::update()
     // update operators
     this->for_all_levels([&](unsigned int const level) {
       get_operator(level)->update_penalty_parameter();
-      get_operator(level)->assemble_matrix_if_necessary();
+      get_operator(level)->assemble_matrix_if_matrix_based();
     });
 
     // Once the operators are updated, the update of smoothers and the coarse grid solver is generic

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.cpp
@@ -47,7 +47,7 @@ LaplaceOperator<dim, Number, n_components>::initialize(
   this->integrator_flags = kernel.get_integrator_flags(this->is_dg);
 
   if(assemble_matrix)
-    this->assemble_matrix_if_necessary();
+    this->assemble_matrix_if_matrix_based();
 }
 
 template<int dim, typename Number, int n_components>

--- a/include/exadg/structure/driver.cpp
+++ b/include/exadg/structure/driver.cpp
@@ -232,7 +232,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
     }
     else
     {
-      pde_operator->assemble_matrix_if_necessary();
+      pde_operator->assemble_matrix_if_matrix_based();
     }
   }
 

--- a/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
+++ b/include/exadg/structure/preconditioners/multigrid_preconditioner.cpp
@@ -126,7 +126,7 @@ MultigridPreconditioner<dim, Number>::update()
   else // linear problems
   {
     this->for_all_levels([&](unsigned int const level) {
-      this->get_operator_linear(level)->assemble_matrix_if_necessary();
+      this->get_operator_linear(level)->assemble_matrix_if_matrix_based();
     });
   }
 

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -845,15 +845,15 @@ Operator<dim, Number>::set_solution_linearization(VectorType const & vector) con
 
 template<int dim, typename Number>
 void
-Operator<dim, Number>::assemble_matrix_if_necessary() const
+Operator<dim, Number>::assemble_matrix_if_matrix_based() const
 {
   if(param.large_deformation)
   {
-    elasticity_operator_nonlinear.assemble_matrix_if_necessary();
+    elasticity_operator_nonlinear.assemble_matrix_if_matrix_based();
   }
   else
   {
-    elasticity_operator_linear.assemble_matrix_if_necessary();
+    elasticity_operator_linear.assemble_matrix_if_matrix_based();
   }
 }
 
@@ -978,7 +978,7 @@ Operator<dim, Number>::solve_linear(VectorType &       sol,
   update_elasticity_operator(scaling_factor_mass, time);
 
   // In case of a matrix-based implementation, we assemble the matrix once at initialization, since
-  // it remains constant, and avoid calling `assemble_matrix_if_necessary()` here.
+  // it remains constant, and avoid calling `assemble_matrix_if_matrix_based()` here.
 
   linear_solver->update_preconditioner(update_preconditioner);
 

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -250,7 +250,7 @@ public:
   set_solution_linearization(VectorType const & vector) const;
 
   void
-  assemble_matrix_if_necessary() const;
+  assemble_matrix_if_matrix_based() const;
 
   void
   evaluate_elasticity_operator(VectorType &       dst,

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -89,7 +89,7 @@ ElasticityOperatorBase<dim, Number>::initialize(
   initialize_derived();
 
   if(assemble_matrix)
-    this->assemble_matrix_if_necessary();
+    this->assemble_matrix_if_matrix_based();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -85,7 +85,7 @@ NonLinearOperator<dim, Number>::set_solution_linearization(VectorType const & ve
     displacement_lin = vector;
     displacement_lin.update_ghost_values();
 
-    this->assemble_matrix_if_necessary();
+    this->assemble_matrix_if_matrix_based();
   }
 }
 


### PR DESCRIPTION
should have been #800, forgot to push somehow.

I chose `assemble_matrix_if_matrix_based()` over `assemble_matrix_if_necessary()` since the latter indicates that the would be some logic involved that checks if the underlying operator has actually changed, but all it does is check, if a matrix-based operator is used on that level and then assembles the matrix.
The new name describes that condition better I think.