### PR TITLE
use symmetric tensors in structure module

### DIFF
--- a/include/exadg/structure/material/library/incompressible_neo_hookean.h
+++ b/include/exadg/structure/material/library/incompressible_neo_hookean.h
@@ -64,12 +64,13 @@ template<int dim, typename Number>
 class IncompressibleNeoHookean : public Material<dim, Number>
 {
 public:
-  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
-  typedef std::pair<unsigned int, unsigned int>              Range;
-  typedef CellIntegrator<dim, dim, Number>                   IntegratorCell;
+  typedef typename Material<dim, Number>::VectorType     VectorType;
+  typedef typename Material<dim, Number>::Range          Range;
+  typedef typename Material<dim, Number>::IntegratorCell IntegratorCell;
 
-  typedef dealii::VectorizedArray<Number>                         scalar;
-  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+  typedef typename Material<dim, Number>::scalar           scalar;
+  typedef typename Material<dim, Number>::tensor           tensor;
+  typedef typename Material<dim, Number>::symmetric_tensor symmetric_tensor;
 
   IncompressibleNeoHookean(dealii::MatrixFree<dim, Number> const &   matrix_free,
                            unsigned int const                        dof_index,
@@ -105,13 +106,12 @@ public:
    * S_iso = J^(-2/3) * ( I - 1/3 * I_1 * C^(-1) )
    *
    */
-
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+  symmetric_tensor
   second_piola_kirchhoff_stress(tensor const &     gradient_displacement,
                                 unsigned int const cell,
                                 unsigned int const q) const final;
 
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
+  symmetric_tensor
   second_piola_kirchhoff_stress_displacement_derivative(tensor const &     gradient_increment,
                                                         tensor const &     deformation_gradient,
                                                         unsigned int const cell,

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.h
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.h
@@ -59,9 +59,13 @@ template<int dim, typename Number>
 class StVenantKirchhoff : public Material<dim, Number>
 {
 public:
-  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
-  typedef std::pair<unsigned int, unsigned int>              Range;
-  typedef CellIntegrator<dim, dim, Number>                   IntegratorCell;
+  typedef typename Material<dim, Number>::VectorType     VectorType;
+  typedef typename Material<dim, Number>::Range          Range;
+  typedef typename Material<dim, Number>::IntegratorCell IntegratorCell;
+
+  typedef typename Material<dim, Number>::scalar           scalar;
+  typedef typename Material<dim, Number>::tensor           tensor;
+  typedef typename Material<dim, Number>::symmetric_tensor symmetric_tensor;
 
   StVenantKirchhoff(dealii::MatrixFree<dim, Number> const & matrix_free,
                     unsigned int const                      dof_index,
@@ -69,18 +73,16 @@ public:
                     StVenantKirchhoffData<dim> const &      data,
                     bool const                              large_deformation);
 
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  second_piola_kirchhoff_stress(
-    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & gradient_displacement,
-    unsigned int const                                              cell,
-    unsigned int const                                              q) const final;
+  symmetric_tensor
+  second_piola_kirchhoff_stress(tensor const &     gradient_displacement,
+                                unsigned int const cell,
+                                unsigned int const q) const final;
 
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  second_piola_kirchhoff_stress_displacement_derivative(
-    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & gradient_increment,
-    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & deformation_gradient,
-    unsigned int const                                              cell,
-    unsigned int const                                              q) const final;
+  symmetric_tensor
+  second_piola_kirchhoff_stress_displacement_derivative(tensor const &     gradient_increment,
+                                                        tensor const &     deformation_gradient,
+                                                        unsigned int const cell,
+                                                        unsigned int const q) const final;
 
 private:
   /*
@@ -103,11 +105,10 @@ private:
    * Sij = f2 * (Eij + Eji),    for i, j = 1, ..., dim and i != j.
    * The latter symmetrizes the off-diagonal entries in the strain argument to reduce computations.
    */
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  second_piola_kirchhoff_stress_symmetrize(
-    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & strain,
-    unsigned int const                                              cell,
-    unsigned int const                                              q) const;
+  symmetric_tensor
+  second_piola_kirchhoff_stress_symmetrize(tensor const &     strain,
+                                           unsigned int const cell,
+                                           unsigned int const q) const;
 
   /*
    * Store factors involving (potentially variable) Young's modulus.

--- a/include/exadg/structure/material/material.h
+++ b/include/exadg/structure/material/material.h
@@ -37,6 +37,14 @@ template<int dim, typename Number>
 class Material
 {
 public:
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+  typedef std::pair<unsigned int, unsigned int>              Range;
+  typedef CellIntegrator<dim, dim, Number>                   IntegratorCell;
+
+  typedef dealii::VectorizedArray<Number>                                  scalar;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>          tensor;
+  typedef dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> symmetric_tensor;
+
   virtual ~Material()
   {
   }
@@ -45,24 +53,22 @@ public:
    * Evaluate 2nd Piola-Kirchhoff stress tensor given the gradient of the displacement field
    * with respect to the reference configuration (not to be confused with the deformation gradient).
    */
-  virtual dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  second_piola_kirchhoff_stress(
-    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & gradient_displacement,
-    unsigned int const                                              cell,
-    unsigned int const                                              q) const = 0;
+  virtual symmetric_tensor
+  second_piola_kirchhoff_stress(tensor const &     gradient_displacement,
+                                unsigned int const cell,
+                                unsigned int const q) const = 0;
 
   /*
    * Evaluate the directional derivative with respect to the displacement of the 2nd Piola-Kirchhoff
    * stress tensor given gradient of the displacment increment with respect to the reference
-   * configuration "gradient_increment" and deformation gradient at the current linearization point
-   * "deformation_gradient".
+   * configuration `gradient_increment` and deformation gradient at the current linearization point
+   * `deformation_gradient`.
    */
-  virtual dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  second_piola_kirchhoff_stress_displacement_derivative(
-    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & gradient_increment,
-    dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & deformation_gradient,
-    unsigned int const                                              cell,
-    unsigned int const                                              q) const = 0;
+  virtual symmetric_tensor
+  second_piola_kirchhoff_stress_displacement_derivative(tensor const &     gradient_increment,
+                                                        tensor const &     deformation_gradient,
+                                                        unsigned int const cell,
+                                                        unsigned int const q) const = 0;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/spatial_discretization/operators/continuum_mechanics.h
+++ b/include/exadg/structure/spatial_discretization/operators/continuum_mechanics.h
@@ -30,40 +30,177 @@ namespace ExaDG
 {
 namespace Structure
 {
-template<int dim, typename Number = double>
+template<int dim, typename Number, typename TensorType>
 inline DEAL_II_ALWAYS_INLINE //
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  add_identity(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> gradient)
+  TensorType
+  add_identity(TensorType tensor)
 {
   for(unsigned int i = 0; i < dim; i++)
-    gradient[i][i] = gradient[i][i] + 1.0;
-  return gradient;
+  {
+    tensor[i][i] = tensor[i][i] + 1.0;
+  }
+
+  return tensor;
 }
 
-template<int dim, typename Number = double>
+template<int dim, typename Number, typename TensorType>
 inline DEAL_II_ALWAYS_INLINE //
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  subtract_identity(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> gradient)
+  TensorType
+  subtract_identity(TensorType tensor)
 {
   for(unsigned int i = 0; i < dim; i++)
-    gradient[i][i] = gradient[i][i] - 1.0;
-  return gradient;
+  {
+    tensor[i][i] = tensor[i][i] - 1.0;
+  }
+
+  return tensor;
+}
+
+// Create a symmetric tensor from a tensor H plus H^T.
+// Note that we have (H + H^T)^T = H^T + (H^T)^T = H^T + H = H + H^T.
+template<int dim, typename Number>
+inline DEAL_II_ALWAYS_INLINE //
+  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
+  compute_H_plus_HT(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & H)
+{
+  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> result;
+
+  for(unsigned int i = 0; i < dim; ++i)
+  {
+    for(unsigned int j = i; j < dim; ++j)
+    {
+      result[i][j] = H[i][j] + H[j][i];
+    }
+  }
+
+  // Debug output.
+  if constexpr(false)
+  {
+    if constexpr(std::is_same_v<Number, double>)
+    {
+      dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> check   = H + transpose(H);
+      dealii::VectorizedArray<Number>                         sum_err = 0.0;
+      for(unsigned int i = 0; i < dim; ++i)
+      {
+        for(unsigned int j = 0; j < dim; ++j)
+        {
+          sum_err += std::abs(check[i][j] - result[i][j]);
+        }
+      }
+      std::cout << "compute_H_plus_HT : sum_err = " << sum_err << "\n";
+      AssertThrow(sum_err.sum() < 1e-18,
+                  dealii::ExcMessage("Check in `compute_H_plus_HT()` failed."));
+    }
+  }
+
+  return result;
+}
+
+// Create a symmetric tensor from a tensor H^T times H.
+// Note that we have (H^T * H)^T = H^T * (H^T)^T = H^T * H.
+template<int dim, typename Number>
+inline DEAL_II_ALWAYS_INLINE //
+  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
+  compute_HT_times_H(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & H)
+{
+  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> result;
+
+  for(unsigned int i = 0; i < dim; ++i)
+  {
+    for(unsigned int j = i; j < dim; ++j)
+    {
+      for(unsigned int k = 0; k < dim; ++k)
+      {
+        result[i][j] += /* HT[i][k] */ H[k][i] * H[k][j];
+      }
+    }
+  }
+
+  // Debug output.
+  if constexpr(false)
+  {
+    if constexpr(std::is_same_v<Number, double>)
+    {
+      dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> check   = transpose(H) * H;
+      dealii::VectorizedArray<Number>                         sum_err = 0.0;
+      for(unsigned int i = 0; i < dim; ++i)
+      {
+        for(unsigned int j = 0; j < dim; ++j)
+        {
+          sum_err += std::abs(check[i][j] - result[i][j]);
+        }
+      }
+      std::cout << "compute_HT_times_H : sum_err = " << sum_err << "\n";
+      AssertThrow(sum_err.sum() < 1e-18,
+                  dealii::ExcMessage("Check in `compute_HT_times_H()` failed."));
+    }
+  }
+
+  return result;
+}
+
+// Create a symmetric tensor from a tensor H times H^T.
+// Note that we have (H * H^T)^T = (H^T)^T * H^T = H * H^T.
+template<int dim, typename Number>
+inline DEAL_II_ALWAYS_INLINE //
+  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
+  compute_H_times_HT(dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> const & H)
+{
+  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> result;
+
+  for(unsigned int i = 0; i < dim; ++i)
+  {
+    for(unsigned int j = i; j < dim; ++j)
+    {
+      for(unsigned int k = 0; k < dim; ++k)
+      {
+        result[i][j] += H[i][k] * H[j][k] /* HT[k][j] */;
+      }
+    }
+  }
+
+  // Debug output.
+  if constexpr(false)
+  {
+    if constexpr(std::is_same_v<Number, double>)
+    {
+      dealii::VectorizedArray<Number> sum_err = 0.0;
+
+      dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> check = H * transpose(H);
+      for(unsigned int i = 0; i < dim; ++i)
+      {
+        for(unsigned int j = 0; j < dim; ++j)
+        {
+          sum_err += std::abs(check[i][j] - result[i][j]);
+        }
+      }
+      std::cout << "compute_H_times_HT : sum_err = " << sum_err << "\n";
+      AssertThrow(sum_err.sum() < 1e-18,
+                  dealii::ExcMessage("Check in `compute_H_times_HT()` failed."));
+    }
+  }
+
+  return result;
 }
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
   dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  get_F(const dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> & H)
+  get_F(const dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> & gradient_displacement)
 {
-  return add_identity(H);
+  return add_identity<dim, Number>(gradient_displacement);
 }
 
 template<int dim, typename Number>
 inline DEAL_II_ALWAYS_INLINE //
-  dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>
-  get_E(const dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> & F)
+  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>>
+  get_E(const dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> & gradient_displacement)
 {
-  return 0.5 * subtract_identity(transpose(F) * F);
+  // E = 0.5 (F^T * F) = 0.5 * (H + H^T + H^T * H),
+  // where F is the deformation gradient and H is `gradient_displacement`.
+  // Note that this version has also improved numerical stability.
+  return (0.5 *
+          (compute_H_plus_HT(gradient_displacement) + compute_HT_times_H(gradient_displacement)));
 }
 
 } // namespace Structure


### PR DESCRIPTION
.) forces `material.second_piola_kirchhoff_stress()` and `material.second_piola_kirchhoff_stress_displacement_derivative()` to return a symmetric tensor
.) introduces needed helper functions in `continuum_mechancis.h`