### PR TITLE
refactor STVK material

### DIFF
--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -29,9 +29,9 @@ double const U_X_MAX         = 1.0;
 double const FLUID_VISCOSITY = 0.01;
 double const FLUID_DENSITY   = 0.01;
 
-double const DENSITY_STRUCTURE       = 1.0;
-double const POISSON_RATIO_STRUCTURE = 0.3;
-double const E_STRUCTURE             = 80.0; // 20.0; // TODO
+double const DENSITY_STRUCTURE        = 1.0;
+double const POISSONS_RATIO_STRUCTURE = 0.3;
+double const YOUNGS_MODULUS_STRUCTURE = 80.0; // 20.0; // TODO
 
 double const L_F = 3.0;
 double const B_F = 1.0;
@@ -729,12 +729,14 @@ private:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;
 
-    double const                           E       = 1.0;
-    double const                           poisson = 0.3;
-    std::shared_ptr<dealii::Function<dim>> E_function;
-    E_function.reset(new SpatiallyVaryingE<dim>());
+    double const                           youngs_modulus = 1.0;
+    double const                           poissons_ratio = 0.3;
+    std::shared_ptr<dealii::Function<dim>> youngs_modulus_function;
+    youngs_modulus_function.reset(new SpatiallyVaryingE<dim>());
     material_descriptor->insert(
-      Pair(0, new StVenantKirchhoffData<dim>(type, E, poisson, two_dim_type, E_function)));
+      Pair(0,
+           new StVenantKirchhoffData<dim>(
+             type, youngs_modulus, poissons_ratio, two_dim_type, youngs_modulus_function)));
   }
 
   void
@@ -910,8 +912,11 @@ private:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;
 
-    material_descriptor->insert(Pair(
-      0, new StVenantKirchhoffData<dim>(type, E_STRUCTURE, POISSON_RATIO_STRUCTURE, two_dim_type)));
+    material_descriptor->insert(Pair(0,
+                                     new StVenantKirchhoffData<dim>(type,
+                                                                    YOUNGS_MODULUS_STRUCTURE,
+                                                                    POISSONS_RATIO_STRUCTURE,
+                                                                    two_dim_type)));
   }
 
   void

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -35,27 +35,27 @@ double const U_MEAN          = 0.2;
 double const FLUID_VISCOSITY = 1.0e-3;
 double const FLUID_DENSITY   = 1.0e3;
 
-double const DENSITY_STRUCTURE       = 1.0e3;
-double const POISSON_RATIO_STRUCTURE = 0.4;
-double const E_STRUCTURE             = 0.5e6 * 2.0 * (1.0 + POISSON_RATIO_STRUCTURE);
+double const DENSITY_STRUCTURE        = 1.0e3;
+double const POISSONS_RATIO_STRUCTURE = 0.4;
+double const YOUNGS_MODULUS_STRUCTURE = 0.5e6 * 2.0 * (1.0 + POISSONS_RATIO_STRUCTURE);
 #elif TESTCASE == 2
 // FSI 2
 double const U_MEAN          = 1.0;
 double const FLUID_VISCOSITY = 1.0e-3;
 double const FLUID_DENSITY   = 1.0e3;
 
-double const DENSITY_STRUCTURE       = 1.0e4;
-double const POISSON_RATIO_STRUCTURE = 0.4;
-double const E_STRUCTURE             = 0.5e6 * 2.0 * (1.0 + POISSON_RATIO_STRUCTURE);
+double const DENSITY_STRUCTURE        = 1.0e4;
+double const POISSONS_RATIO_STRUCTURE = 0.4;
+double const YOUNGS_MODULUS_STRUCTURE = 0.5e6 * 2.0 * (1.0 + POISSONS_RATIO_STRUCTURE);
 #elif TESTCASE == 3
 // FSI 3
 double const U_MEAN          = 2.0;
 double const FLUID_VISCOSITY = 1.0e-3;
 double const FLUID_DENSITY   = 1.0e3;
 
-double const DENSITY_STRUCTURE       = 1.0e3;
-double const POISSON_RATIO_STRUCTURE = 0.4;
-double const E_STRUCTURE             = 2.0e6 * 2.0 * (1.0 + POISSON_RATIO_STRUCTURE);
+double const DENSITY_STRUCTURE        = 1.0e3;
+double const POISSONS_RATIO_STRUCTURE = 0.4;
+double const YOUNGS_MODULUS_STRUCTURE = 2.0e6 * 2.0 * (1.0 + POISSONS_RATIO_STRUCTURE);
 #endif
 
 // physical dimensions (diameter D and center coordinate Y_C can be varied)
@@ -747,12 +747,14 @@ private:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
-    double const                           E       = 1.0;
-    double const                           poisson = 0.3;
-    std::shared_ptr<dealii::Function<dim>> E_function;
-    E_function.reset(new SpatiallyVaryingE<dim>());
+    double const                           youngs_modulus = 1.0;
+    double const                           poissons_ratio = 0.3;
+    std::shared_ptr<dealii::Function<dim>> youngs_modulus_function;
+    youngs_modulus_function.reset(new SpatiallyVaryingE<dim>());
     material_descriptor->insert(
-      Pair(0, new StVenantKirchhoffData<dim>(type, E, poisson, two_dim_type, E_function)));
+      Pair(0,
+           new StVenantKirchhoffData<dim>(
+             type, youngs_modulus, poissons_ratio, two_dim_type, youngs_modulus_function)));
   }
 
   void
@@ -1134,8 +1136,11 @@ private:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
-    material_descriptor->insert(Pair(
-      0, new StVenantKirchhoffData<dim>(type, E_STRUCTURE, POISSON_RATIO_STRUCTURE, two_dim_type)));
+    material_descriptor->insert(Pair(0,
+                                     new StVenantKirchhoffData<dim>(type,
+                                                                    YOUNGS_MODULUS_STRUCTURE,
+                                                                    POISSONS_RATIO_STRUCTURE,
+                                                                    two_dim_type)));
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -29,10 +29,10 @@ double const U_MEAN          = 10;
 double const FLUID_VISCOSITY = 1;
 double const FLUID_DENSITY   = 1;
 
-double const DENSITY_STRUCTURE       = 3.0e3;
-double const POISSON_RATIO_STRUCTURE = 0.3;
+double const DENSITY_STRUCTURE        = 3.0e3;
+double const POISSONS_RATIO_STRUCTURE = 0.3;
 // 1538462 being the shear modulus
-double const E_STRUCTURE = 1538462 * 2.0 * (1.0 + POISSON_RATIO_STRUCTURE);
+double const YOUNGS_MODULUS_STRUCTURE = 1538462 * 2.0 * (1.0 + POISSONS_RATIO_STRUCTURE);
 
 // physical dimensions (diameter D and center coordinate Y_C can be varied)
 double const X_0         = -3.0; // origin (x-coordinate)
@@ -607,12 +607,14 @@ private:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
-    double const                           E       = 1.0;
-    double const                           poisson = 0.3;
-    std::shared_ptr<dealii::Function<dim>> E_function;
-    E_function.reset(new SpatiallyVaryingE<dim>());
+    double const                           youngs_modulus = 1.0;
+    double const                           poissons_ratio = 0.3;
+    std::shared_ptr<dealii::Function<dim>> youngs_modulus_function;
+    youngs_modulus_function.reset(new SpatiallyVaryingE<dim>());
     material_descriptor->insert(
-      Pair(0, new StVenantKirchhoffData<dim>(type, E, poisson, two_dim_type, E_function)));
+      Pair(0,
+           new StVenantKirchhoffData<dim>(
+             type, youngs_modulus, poissons_ratio, two_dim_type, youngs_modulus_function)));
   }
 
   void
@@ -810,8 +812,11 @@ public:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
-    material_descriptor->insert(Pair(
-      0, new StVenantKirchhoffData<dim>(type, E_STRUCTURE, POISSON_RATIO_STRUCTURE, two_dim_type)));
+    material_descriptor->insert(Pair(0,
+                                     new StVenantKirchhoffData<dim>(type,
+                                                                    YOUNGS_MODULUS_STRUCTURE,
+                                                                    POISSONS_RATIO_STRUCTURE,
+                                                                    two_dim_type)));
   }
 
   std::shared_ptr<Structure::PostProcessor<dim, Number>>

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -30,9 +30,9 @@ namespace ExaDG
 double const FLUID_VISCOSITY = 3.0e-6;
 double const FLUID_DENSITY   = 1.0e3;
 
-double const DENSITY_STRUCTURE       = 1.2e3;
-double const POISSON_RATIO_STRUCTURE = 0.3;
-double const E_STRUCTURE             = 3.0e5;
+double const DENSITY_STRUCTURE        = 1.2e3;
+double const POISSONS_RATIO_STRUCTURE = 0.3;
+double const YOUNGS_MODULUS_STRUCTURE = 3.0e5;
 
 double const R_INNER = 0.5e-2;
 double const R_OUTER = 0.6e-2;
@@ -621,10 +621,10 @@ private:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;
 
-    double const E       = 1.0;
-    double const poisson = 0.3;
+    double const youngs_modulus = 1.0;
+    double const poissons_ratio = 0.3;
     material_descriptor->insert(
-      Pair(0, new StVenantKirchhoffData<dim>(type, E, poisson, two_dim_type)));
+      Pair(0, new StVenantKirchhoffData<dim>(type, youngs_modulus, poissons_ratio, two_dim_type)));
   }
 
   void
@@ -839,8 +839,11 @@ private:
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;
 
-    material_descriptor->insert(Pair(
-      0, new StVenantKirchhoffData<dim>(type, E_STRUCTURE, POISSON_RATIO_STRUCTURE, two_dim_type)));
+    material_descriptor->insert(Pair(0,
+                                     new StVenantKirchhoffData<dim>(type,
+                                                                    YOUNGS_MODULUS_STRUCTURE,
+                                                                    POISSONS_RATIO_STRUCTURE,
+                                                                    two_dim_type)));
   }
 
   void

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -178,10 +178,10 @@ template<int dim>
 class SolutionNBC : public dealii::Function<dim>
 {
 public:
-  SolutionNBC(double length, double area_force, double volume_force, double E_youngs_modulus)
+  SolutionNBC(double length, double area_force, double volume_force, double youngs_modulus)
     : dealii::Function<dim>(dim),
-      A(-volume_force / (2.0 * E_youngs_modulus)),
-      B(area_force / E_youngs_modulus - length * 2.0 * A)
+      A(-volume_force / (2.0 * youngs_modulus)),
+      B(area_force / youngs_modulus - length * 2.0 * A)
   {
   }
 
@@ -204,9 +204,9 @@ template<int dim>
 class SolutionDBC : public dealii::Function<dim>
 {
 public:
-  SolutionDBC(double length, double displacement, double volume_force, double E_youngs_modulus)
+  SolutionDBC(double length, double displacement, double volume_force, double youngs_modulus)
     : dealii::Function<dim>(dim),
-      A(-volume_force / (2.0 * E_youngs_modulus)),
+      A(-volume_force / (2.0 * youngs_modulus)),
       B(displacement / length - A * length)
   {
   }
@@ -659,12 +659,12 @@ private:
 
     if(this->param.material_type == MaterialType::StVenantKirchhoff)
     {
-      Type2D const two_dim_type = Type2D::PlaneStress;
-      double const nu           = 0.3;
+      Type2D const two_dim_type   = Type2D::PlaneStress;
+      double const poissons_ratio = 0.3;
       this->material_descriptor->insert(
         Pair(0,
              new StVenantKirchhoffData<dim>(
-               this->param.material_type, E_youngs_modulus, nu, two_dim_type)));
+               this->param.material_type, youngs_modulus, poissons_ratio, two_dim_type)));
     }
     else if(this->param.material_type == MaterialType::IncompressibleNeoHookean)
     {
@@ -719,12 +719,12 @@ private:
     if(boundary_type == BoundaryType::Dirichlet)
     {
       pp_data.error_data.analytical_solution.reset(
-        new SolutionDBC<dim>(this->length, this->displacement, vol_force, this->E_youngs_modulus));
+        new SolutionDBC<dim>(this->length, this->displacement, vol_force, this->youngs_modulus));
     }
     else if(boundary_type == BoundaryType::Neumann)
     {
       pp_data.error_data.analytical_solution.reset(
-        new SolutionNBC<dim>(this->length, this->area_force, vol_force, this->E_youngs_modulus));
+        new SolutionNBC<dim>(this->length, this->area_force, vol_force, this->youngs_modulus));
     }
     else
     {
@@ -769,8 +769,8 @@ private:
   bool               adaptive_refinement = false;
   unsigned int const repetitions0 = 4, repetitions1 = 1, repetitions2 = 1;
 
-  MaterialType material_type    = MaterialType::Undefined;
-  double const E_youngs_modulus = 200.0;
+  MaterialType material_type  = MaterialType::Undefined;
+  double const youngs_modulus = 200.0;
 
   double const start_time = 0.0;
   double const end_time   = 100.0;

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -314,11 +314,12 @@ private:
 
     MaterialType const type = MaterialType::StVenantKirchhoff;
     // E-Modulus of Steel in unit = [N/mm^2]
-    double const E = 200e3, nu = 0.3;
-    Type2D const two_dim_type = Type2D::PlaneStress;
+    double const youngs_modulus = 200.0e3;
+    double const poissons_ratio = 0.3;
+    Type2D const two_dim_type   = Type2D::PlaneStress;
 
     this->material_descriptor->insert(
-      Pair(0, new StVenantKirchhoffData<dim>(type, E, nu, two_dim_type)));
+      Pair(0, new StVenantKirchhoffData<dim>(type, youngs_modulus, poissons_ratio, two_dim_type)));
   }
 
   void

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -298,12 +298,13 @@ private:
   {
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
-    MaterialType const type = MaterialType::StVenantKirchhoff;
-    double const       E = 200.0e9, nu = 0.3;
-    Type2D const       two_dim_type = Type2D::PlaneStress;
+    MaterialType const type           = MaterialType::StVenantKirchhoff;
+    double const       youngs_modulus = 200.0e9;
+    double const       poissons_ratio = 0.3;
+    Type2D const       two_dim_type   = Type2D::PlaneStress;
 
     this->material_descriptor->insert(
-      Pair(0, new StVenantKirchhoffData<dim>(type, E, nu, two_dim_type)));
+      Pair(0, new StVenantKirchhoffData<dim>(type, youngs_modulus, poissons_ratio, two_dim_type)));
   }
 
   void

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -457,7 +457,7 @@ private:
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
     this->material_descriptor->insert(
-      Pair(0, new StVenantKirchhoffData<dim>(type, E, nu, two_dim_type)));
+      Pair(0, new StVenantKirchhoffData<dim>(type, youngs_modulus, poissons_ratio, two_dim_type)));
   }
 
   void
@@ -504,9 +504,10 @@ private:
 
   double length = 1.0, height = 1.0, width = 1.0;
 
-  double const E  = 1.0;
-  double const nu = 0.3;
-  double const f0 = E * (1.0 - nu) / (1 + nu) / (1.0 - 2.0 * nu); // plane strain
+  double const youngs_modulus = 1.0;
+  double const poissons_ratio = 0.3;
+  double const f0             = youngs_modulus * (1.0 - poissons_ratio) / (1 + poissons_ratio) /
+                    (1.0 - 2.0 * poissons_ratio); // plane strain
 
   double const density = 1.0;
 

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.cpp
@@ -38,25 +38,23 @@ StVenantKirchhoff<dim, Number>::StVenantKirchhoff(
     quad_index(quad_index),
     data(data),
     large_deformation(large_deformation),
-    E_is_variable(data.E_function != nullptr)
+    f0_factor(get_f0_factor(data.poissons_ratio, data.type_two_dim)),
+    f1_factor(get_f1_factor(data.poissons_ratio, data.type_two_dim)),
+    f2_factor(get_f2_factor(data.poissons_ratio, data.type_two_dim)),
+    youngs_modulus_is_variable(data.youngs_modulus_function != nullptr)
 {
-  // initialize (potentially variable) factors
-  Number const E = data.E;
-  f0             = dealii::make_vectorized_array<Number>(get_f0_factor() * E);
-  f1             = dealii::make_vectorized_array<Number>(get_f1_factor() * E);
-  f2             = dealii::make_vectorized_array<Number>(get_f2_factor() * E);
+  // initialize factors, overwritten using stored coefficients in variable coefficients case, i.e.,
+  // when `youngs_modulus_is_variable == true`.
+  f0 = dealii::make_vectorized_array<Number>(f0_factor * data.youngs_modulus);
+  f1 = dealii::make_vectorized_array<Number>(f1_factor * data.youngs_modulus);
+  f2 = dealii::make_vectorized_array<Number>(f2_factor * data.youngs_modulus);
 
-  if(E_is_variable)
+  if(youngs_modulus_is_variable)
   {
-    // allocate vectors for variable coefficients and initialize with constant values
+    // allocate vectors for variable coefficients
     f0_coefficients.initialize(matrix_free, quad_index, false, false);
-    f0_coefficients.set_coefficients(get_f0_factor() * E);
-
     f1_coefficients.initialize(matrix_free, quad_index, false, false);
-    f1_coefficients.set_coefficients(get_f1_factor() * E);
-
     f2_coefficients.initialize(matrix_free, quad_index, false, false);
-    f2_coefficients.set_coefficients(get_f2_factor() * E);
 
     VectorType dummy;
     matrix_free.cell_loop(&StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients,
@@ -68,40 +66,70 @@ StVenantKirchhoff<dim, Number>::StVenantKirchhoff(
 
 template<int dim, typename Number>
 Number
-StVenantKirchhoff<dim, Number>::get_f0_factor() const
+StVenantKirchhoff<dim, Number>::get_f0_factor(Number const & poissons_ratio,
+                                              Type2D const   type_two_dim) const
 {
-  Number const nu           = data.nu;
-  Type2D const type_two_dim = data.type_two_dim;
-
-  return (dim == 3) ?
-           (1. - nu) / ((1. + nu) * (1. - 2. * nu)) :
-           (type_two_dim == Type2D::PlaneStress ? (1. / (1. - nu * nu)) :
-                                                  ((1. - nu) / ((1. + nu) * (1. - 2. * nu))));
+  if constexpr(dim == 3)
+  {
+    return (1. - poissons_ratio) / ((1. + poissons_ratio) * (1. - 2. * poissons_ratio));
+  }
+  else
+  {
+    if(type_two_dim == Type2D::PlaneStress)
+    {
+      return (1. / (1. - poissons_ratio * poissons_ratio));
+    }
+    else
+    {
+      return ((1. - poissons_ratio) / ((1. + poissons_ratio) * (1. - 2. * poissons_ratio)));
+    }
+  }
 }
 
 template<int dim, typename Number>
 Number
-StVenantKirchhoff<dim, Number>::get_f1_factor() const
+StVenantKirchhoff<dim, Number>::get_f1_factor(Number const & poissons_ratio,
+                                              Type2D const   type_two_dim) const
 {
-  Number const nu           = data.nu;
-  Type2D const type_two_dim = data.type_two_dim;
-
-  return (dim == 3) ? (nu) / ((1. + nu) * (1. - 2. * nu)) :
-                      (type_two_dim == Type2D::PlaneStress ? (nu / (1. - nu * nu)) :
-                                                             (nu / ((1. + nu) * (1. - 2. * nu))));
+  if constexpr(dim == 3)
+  {
+    return (poissons_ratio / ((1. + poissons_ratio) * (1. - 2. * poissons_ratio)));
+  }
+  else
+  {
+    if(type_two_dim == Type2D::PlaneStress)
+    {
+      return (poissons_ratio / (1. - poissons_ratio * poissons_ratio));
+    }
+    else
+    {
+      return (poissons_ratio / ((1. + poissons_ratio) * (1. - 2. * poissons_ratio)));
+    }
+  }
 }
 
 template<int dim, typename Number>
 Number
-StVenantKirchhoff<dim, Number>::get_f2_factor() const
+StVenantKirchhoff<dim, Number>::get_f2_factor(Number const & poissons_ratio,
+                                              Type2D const   type_two_dim) const
 {
-  Number const nu           = data.nu;
-  Type2D const type_two_dim = data.type_two_dim;
-
-  return (dim == 3) ? (1. - 2. * nu) / (2.0 * (1. + nu) * (1. - 2. * nu)) :
-                      (type_two_dim == Type2D::PlaneStress ?
-                         ((1. - nu) / (2.0 * (1. - nu * nu))) :
-                         ((1. - 2. * nu) / (2.0 * (1. + nu) * (1. - 2. * nu))));
+  if constexpr(dim == 3)
+  {
+    return ((1. - 2. * poissons_ratio) /
+            (2.0 * (1. + poissons_ratio) * (1. - 2. * poissons_ratio)));
+  }
+  else
+  {
+    if(type_two_dim == Type2D::PlaneStress)
+    {
+      return ((1. - poissons_ratio) / (2.0 * (1. - poissons_ratio * poissons_ratio)));
+    }
+    else
+    {
+      return ((1. - 2. * poissons_ratio) /
+              (2.0 * (1. + poissons_ratio) * (1. - 2. * poissons_ratio)));
+    }
+  }
 }
 
 template<int dim, typename Number>
@@ -114,10 +142,6 @@ StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients(
 {
   IntegratorCell integrator(matrix_free, dof_index, quad_index);
 
-  auto const f0_factor = get_f0_factor();
-  auto const f1_factor = get_f1_factor();
-  auto const f2_factor = get_f2_factor();
-
   // loop over all cells
   for(unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
   {
@@ -126,15 +150,15 @@ StVenantKirchhoff<dim, Number>::cell_loop_set_coefficients(
     // loop over all quadrature points
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
-      dealii::VectorizedArray<Number> E_vec =
-        FunctionEvaluator<0, dim, Number>::value(*(data.E_function),
+      dealii::VectorizedArray<Number> youngs_modulus_vec =
+        FunctionEvaluator<0, dim, Number>::value(*(data.youngs_modulus_function),
                                                  integrator.quadrature_point(q),
                                                  0.0 /*time*/);
 
       // set the coefficients
-      f0_coefficients.set_coefficient_cell(cell, q, f0_factor * E_vec);
-      f1_coefficients.set_coefficient_cell(cell, q, f1_factor * E_vec);
-      f2_coefficients.set_coefficient_cell(cell, q, f2_factor * E_vec);
+      f0_coefficients.set_coefficient_cell(cell, q, f0_factor * youngs_modulus_vec);
+      f1_coefficients.set_coefficient_cell(cell, q, f1_factor * youngs_modulus_vec);
+      f2_coefficients.set_coefficient_cell(cell, q, f2_factor * youngs_modulus_vec);
     }
   }
 }
@@ -147,7 +171,7 @@ StVenantKirchhoff<dim, Number>::second_piola_kirchhoff_stress_symmetrize(tensor 
 {
   symmetric_tensor S;
 
-  if(E_is_variable)
+  if(youngs_modulus_is_variable)
   {
     f0 = f0_coefficients.get_coefficient_cell(cell, q);
     f1 = f1_coefficients.get_coefficient_cell(cell, q);

--- a/include/exadg/structure/material/library/st_venant_kirchhoff.h
+++ b/include/exadg/structure/material/library/st_venant_kirchhoff.h
@@ -39,19 +39,24 @@ namespace Structure
 template<int dim>
 struct StVenantKirchhoffData : public MaterialData
 {
-  StVenantKirchhoffData(MaterialType const &                         type,
-                        double const &                               E,
-                        double const &                               nu,
-                        Type2D const &                               type_two_dim,
-                        std::shared_ptr<dealii::Function<dim>> const E_function = nullptr)
-    : MaterialData(type), E(E), E_function(E_function), nu(nu), type_two_dim(type_two_dim)
+  StVenantKirchhoffData(
+    MaterialType const &                         type,
+    double const &                               youngs_modulus,
+    double const &                               poissons_ratio,
+    Type2D const &                               type_two_dim,
+    std::shared_ptr<dealii::Function<dim>> const youngs_modulus_function = nullptr)
+    : MaterialData(type),
+      youngs_modulus(youngs_modulus),
+      youngs_modulus_function(youngs_modulus_function),
+      poissons_ratio(poissons_ratio),
+      type_two_dim(type_two_dim)
   {
   }
 
-  double                                 E;
-  std::shared_ptr<dealii::Function<dim>> E_function;
+  double                                 youngs_modulus;
+  std::shared_ptr<dealii::Function<dim>> youngs_modulus_function;
 
-  double nu;
+  double poissons_ratio;
   Type2D type_two_dim;
 };
 
@@ -90,13 +95,13 @@ private:
    * (potentially variable) Young's modulus.
    */
   Number
-  get_f0_factor() const;
+  get_f0_factor(Number const & poissons_ratio, Type2D const type_two_dim) const;
 
   Number
-  get_f1_factor() const;
+  get_f1_factor(Number const & poissons_ratio, Type2D const type_two_dim) const;
 
   Number
-  get_f2_factor() const;
+  get_f2_factor(Number const & poissons_ratio, Type2D const type_two_dim) const;
 
   /*
    * The second Piola-Kirchhoff stress tensor S is given as S = lambda * I * tr(E) + 2 mu E, with E
@@ -126,12 +131,16 @@ private:
 
   bool large_deformation;
 
+  Number const f0_factor;
+  Number const f1_factor;
+  Number const f2_factor;
+
   mutable dealii::VectorizedArray<Number> f0;
   mutable dealii::VectorizedArray<Number> f1;
   mutable dealii::VectorizedArray<Number> f2;
 
   // cache coefficients for spatially varying material parameters
-  bool                                                          E_is_variable;
+  bool                                                          youngs_modulus_is_variable;
   mutable VariableCoefficients<dealii::VectorizedArray<Number>> f0_coefficients;
   mutable VariableCoefficients<dealii::VectorizedArray<Number>> f1_coefficients;
   mutable VariableCoefficients<dealii::VectorizedArray<Number>> f2_coefficients;


### PR DESCRIPTION
1) rename `E` and `nu` --> change to `youngs_modulus` and `poissons_ratio`
just in case someone is not too familiar with the variables usually used and to not confuse the often used Green--Lagrange strain tensor **E** with E. We also use **E** in the comments.
2) remove nested ternary operator for readability and put in some `constexpr` (more for the reader than the compiler)
3) do not set variable coefficients twice in a row at setup, we had:
```
E = E_constant;
E = E(x);
```

I also checked if storing a single variable coefficient for Young's modulus would be better than 3 for `f0`, `f1` and `f2`.
My tests were inconclusive, not showing really a benefit, so I figured the person implementing it in the first place had a reason to take 3 coefficients.