### PR TITLE
Fix issue #802: rename `push_back()` to `swap_back_one_step()`

### DIFF
--- a/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
+++ b/include/exadg/convection_diffusion/time_integration/time_int_bdf.cpp
@@ -23,9 +23,9 @@
 #include <exadg/convection_diffusion/spatial_discretization/operator.h>
 #include <exadg/convection_diffusion/time_integration/time_int_bdf.h>
 #include <exadg/convection_diffusion/user_interface/parameters.h>
-#include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/restart.h>
 #include <exadg/time_integration/time_step_calculation.h>
+#include <exadg/time_integration/vector_handling.h>
 #include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
@@ -380,7 +380,7 @@ template<int dim, typename Number>
 void
 TimeIntBDF<dim, Number>::prepare_vectors_for_next_timestep()
 {
-  push_back(solution);
+  swap_back_one_step(solution);
 
   solution[0].swap(solution_np);
 
@@ -389,14 +389,14 @@ TimeIntBDF<dim, Number>::prepare_vectors_for_next_timestep()
   {
     if(param.ale_formulation == false)
     {
-      push_back(vec_convective_term);
+      swap_back_one_step(vec_convective_term);
       vec_convective_term[0].swap(convective_term_np);
     }
   }
 
   if(param.ale_formulation)
   {
-    push_back(vec_grid_coordinates);
+    swap_back_one_step(vec_grid_coordinates);
     vec_grid_coordinates[0].swap(grid_coordinates_np);
   }
 }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -23,9 +23,9 @@
 #include <exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
-#include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/restart.h>
 #include <exadg/time_integration/time_step_calculation.h>
+#include <exadg/time_integration/vector_handling.h>
 
 namespace ExaDG
 {
@@ -141,14 +141,14 @@ TimeIntBDF<dim, Number>::prepare_vectors_for_next_timestep()
   {
     if(this->param.ale_formulation == false)
     {
-      push_back(this->vec_convective_term);
+      swap_back_one_step(this->vec_convective_term);
       vec_convective_term[0].swap(convective_term_np);
     }
   }
 
   if(param.ale_formulation)
   {
-    push_back(vec_grid_coordinates);
+    swap_back_one_step(vec_grid_coordinates);
     vec_grid_coordinates[0].swap(grid_coordinates_np);
   }
 }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting.cpp
@@ -24,9 +24,9 @@
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_consistent_splitting.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
-#include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/restart.h>
 #include <exadg/time_integration/time_step_calculation.h>
+#include <exadg/time_integration/vector_handling.h>
 #include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
@@ -668,21 +668,21 @@ TimeIntBDFConsistentSplitting<dim, Number>::prepare_vectors_for_next_timestep()
 {
   Base::prepare_vectors_for_next_timestep();
 
-  push_back(velocity);
+  swap_back_one_step(velocity);
   velocity[0].swap(velocity_np);
 
-  push_back(pressure);
+  swap_back_one_step(pressure);
   pressure[0].swap(pressure_np);
 
   // Compute the divergence of the velocity for the next timestep
   if(this->param.apply_leray_projection)
   {
-    push_back(velocity_divergence);
+    swap_back_one_step(velocity_divergence);
     pde_operator->apply_velocity_divergence_term(velocity_divergence[0], velocity[0]);
   }
 
   // Compute divergence of convective term
-  push_back(vec_convective_term_div);
+  swap_back_one_step(vec_convective_term_div);
   pde_operator->apply_convective_divergence_term(vec_convective_term_div[0], velocity[0]);
 }
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -22,8 +22,8 @@
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
-#include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/time_step_calculation.h>
+#include <exadg/time_integration/vector_handling.h>
 #include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
@@ -647,7 +647,7 @@ TimeIntBDFCoupled<dim, Number>::prepare_vectors_for_next_timestep()
 {
   Base::prepare_vectors_for_next_timestep();
 
-  push_back(solution);
+  swap_back_one_step(solution);
   solution[0].swap(solution_np);
 }
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -24,9 +24,9 @@
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
-#include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/restart.h>
 #include <exadg/time_integration/time_step_calculation.h>
+#include <exadg/time_integration/vector_handling.h>
 #include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
@@ -1070,15 +1070,15 @@ TimeIntBDFDualSplitting<dim, Number>::prepare_vectors_for_next_timestep()
 {
   Base::prepare_vectors_for_next_timestep();
 
-  push_back(velocity);
+  swap_back_one_step(velocity);
   velocity[0].swap(velocity_np);
 
-  push_back(pressure);
+  swap_back_one_step(pressure);
   pressure[0].swap(pressure_np);
 
   // We also have to care about the history of velocity Dirichlet boundary conditions.
   // Note that velocity_dbc_np has already been updated.
-  push_back(velocity_dbc);
+  swap_back_one_step(velocity_dbc);
   velocity_dbc[0].swap(velocity_dbc_np);
 }
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -24,9 +24,9 @@
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operator_pressure_correction.h>
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h>
 #include <exadg/incompressible_navier_stokes/user_interface/parameters.h>
-#include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/restart.h>
 #include <exadg/time_integration/time_step_calculation.h>
+#include <exadg/time_integration/vector_handling.h>
 #include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
@@ -905,16 +905,16 @@ TimeIntBDFPressureCorrection<dim, Number>::prepare_vectors_for_next_timestep()
 {
   Base::prepare_vectors_for_next_timestep();
 
-  push_back(velocity);
+  swap_back_one_step(velocity);
   velocity[0].swap(velocity_np);
 
-  push_back(pressure);
+  swap_back_one_step(pressure);
   pressure[0].swap(pressure_np);
 
   // We also have to care about the history of pressure Dirichlet boundary conditions.
   if(extra_pressure_gradient.get_order() > 0)
   {
-    push_back(pressure_dbc);
+    swap_back_one_step(pressure_dbc);
 
     // no need to move the mesh here since we still have the mesh Omega_{n+1} at this point!
     pde_operator->interpolate_pressure_dirichlet_bc(pressure_dbc[0], this->get_next_time());

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_interpolate_analytical_solution.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_interpolate_analytical_solution.h
@@ -24,7 +24,7 @@
 
 // ExaDG
 #include <exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h>
-#include <exadg/time_integration/push_back_vectors.h>
+#include <exadg/time_integration/vector_handling.h>
 #include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
@@ -135,10 +135,10 @@ private:
   {
     Base::prepare_vectors_for_next_timestep();
 
-    push_back(velocity);
+    swap_back_one_step(velocity);
     velocity[0].swap(velocity_np);
 
-    push_back(pressure);
+    swap_back_one_step(pressure);
     pressure[0].swap(pressure_np);
   }
 

--- a/include/exadg/time_integration/time_int_abm_base.h
+++ b/include/exadg/time_integration/time_int_abm_base.h
@@ -25,9 +25,9 @@
 // ExaDG
 #include <exadg/time_integration/ab_constants.h>
 #include <exadg/time_integration/am_constants.h>
-#include <exadg/time_integration/push_back_vectors.h>
 #include <exadg/time_integration/restart.h>
 #include <exadg/time_integration/time_int_multistep_base.h>
+#include <exadg/time_integration/vector_handling.h>
 #include <exadg/utilities/print_solver_results.h>
 
 namespace ExaDG
@@ -215,7 +215,7 @@ private:
   {
     if(vec_evaluated_operators.size() > 0)
     {
-      push_back(vec_evaluated_operators);
+      swap_back_one_step(vec_evaluated_operators);
       std::swap(vec_evaluated_operators[0], evaluated_operator_np);
     }
   }

--- a/include/exadg/time_integration/vector_handling.h
+++ b/include/exadg/time_integration/vector_handling.h
@@ -19,8 +19,8 @@
  *  ______________________________________________________________________
  */
 
-#ifndef EXADG_TIME_INTEGRATION_PUSH_BACK_VECTORS_H_
-#define EXADG_TIME_INTEGRATION_PUSH_BACK_VECTORS_H_
+#ifndef EXADG_TIME_INTEGRATION_VECTOR_HANDLING_H_
+#define EXADG_TIME_INTEGRATION_VECTOR_HANDLING_H_
 
 // C/C++
 #include <vector>
@@ -30,12 +30,12 @@ namespace ExaDG
 /*
  * This function implements a push-back operation that is needed in multistep time integration
  * schemes like BDF schemes in order to update the solution vectors from one time step to the
- * next. The prerequisite to call this function is that the type VectorType implements a
- * swap-function!
+ * next. The prerequisite to call this function is that the type `VectorType` implements a
+ * swap-function.
  */
 template<typename VectorType>
 void
-push_back(std::vector<VectorType> & vector)
+swap_back_one_step(std::vector<VectorType> & vector)
 {
   /*
    *   time t
@@ -59,4 +59,4 @@ push_back(std::vector<VectorType> & vector)
 
 } // namespace ExaDG
 
-#endif /* EXADG_TIME_INTEGRATION_PUSH_BACK_VECTORS_H_ */
+#endif /* EXADG_TIME_INTEGRATION_VECTOR_HANDLING_H_ */


### PR DESCRIPTION
such that we replace
`push_back(std::vector<VectorType> & vec)`
with
`swap_back_one_step(std::vector<VectorType> & vec)`.

This naming makes clear that we **swap** contents,
hints at the prerequisite that the `VectorType` needs to have the `swap()` functionality, 
and avoids confusion with `std::vector<typename T>::push_back(T element)`.

fixes #802 