### PR TITLE
unify `is_pressure_level_undefined` settings in `OperatorProjectionMethods::initialize_laplace_operator`

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -95,7 +95,7 @@ OperatorProjectionMethods<dim, Number>::initialize_laplace_operator()
   laplace_operator_data.quad_index = this->get_quad_index_pressure();
 
   /*
-   * In case no Dirichlet boundary conditions as prescribed for the pressure, the pressure Poisson
+   * In case no Dirichlet boundary conditions are prescribed for the pressure, the pressure Poisson
    * equation is singular (i.e. vectors describing a constant pressure state form the nullspace
    * of the discrete pressure Poisson operator). To solve the pressure Poisson equation in that
    * case, a Krylov subspace projection is applied during the solution of the linear system of
@@ -113,33 +113,31 @@ OperatorProjectionMethods<dim, Number>::initialize_laplace_operator()
    *
    *  p0^T * A * p = (A^T * p0)^T * p = 0 != p0 * rhs (since A is symmetric).
    */
-  if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme or
+     this->param.temporal_discretization == TemporalDiscretization::BDFConsistentSplittingScheme or
+     this->param.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
   {
-    // the Krylov subspace projection is needed for the dual splitting scheme since the linear
-    // system of equations is not consistent for this splitting method (due to the boundary
-    // conditions).
+    /*
+     * For the dual splitting and the consistent splitting scheme, a Krylov subspace projection is
+     * needed since the linear system of equations is not consistent for these methods due to the
+     * boundary conditions.
+     *
+     * One can show that the linear system of equations of the pressure Poisson equation is
+     * consistent in case of the pressure-correction scheme if the velocity Dirichlet BC is
+     * consistent. So there should be no need to solve a transformed linear system of equations. In
+     * theory, the Krylov subspace projection should not be necessary as the linear system of
+     * equations is consistent. However, we observed convergence issues for some test cases using
+     * specific parameters. Hence, to increase robustness, we also solve a transformed linear system
+     * of equations in case of the pressure-correction scheme.
+     */
     laplace_operator_data.operator_is_singular = this->is_pressure_level_undefined();
   }
-  else if(this->param.temporal_discretization ==
-          TemporalDiscretization::BDFConsistentSplittingScheme)
+  else
   {
-    // the Krylov subspace projection is needed for the consistent splitting scheme since the linear
-    // system of equations is not consistent for this splitting method (due to the boundary
-    // conditions).
-    laplace_operator_data.operator_is_singular = this->is_pressure_level_undefined();
-  }
-  else if(this->param.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
-  {
-    // One can show that the linear system of equations of the pressure Poisson equation is
-    // consistent in case of the pressure-correction scheme if the velocity Dirichlet BC is
-    // consistent. So there should be no need to solve a transformed linear system of equations.
-    //    laplace_operator_data.operator_is_singular = false;
-
-    // In principle, it works (since the linear system of equations is consistent)
-    // but we detected no convergence for some test cases and specific parameters.
-    // Hence, for reasons of robustness we also solve a transformed linear system of equations
-    // in case of the pressure-correction scheme.
-    laplace_operator_data.operator_is_singular = this->is_pressure_level_undefined();
+    AssertThrow(false,
+                dealii::ExcMessage(
+                  "Unknown time integration scheme. "
+                  "Consider Krylov subspace projection for the Laplace operator."));
   }
 
   laplace_operator_data.bc                   = this->boundary_descriptor_laplace;


### PR DESCRIPTION
... in `OperatorProjectionMethods::initialize_laplace_operator`

since the treatment for the time integration schemes is the same in all cases, I unified the `if` clause.
I think we should keep the `if()` there though, such that one is forced to think about what to do for a new time integration scheme added.

I think the original concern in https://github.com/exadg/exadg/pull/789#discussion_r2513373554 by @kronbichler was more readability than performance, so I think keeping the `if()` is ok.

fixes #804 