### PR TITLE
fix vector init for consistent splitting

### DIFF
--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -189,6 +189,16 @@ TimeIntBDF<dim, Number>::advance_one_timestep_partitioned_solve(bool const use_e
                 dealii::ExcMessage("TemporalDiscretization::BDFCoupledSolution cannot "
                                    "recover velocity and pressure independently."));
   }
+  else if(this->param.temporal_discretization ==
+          TemporalDiscretization::BDFConsistentSplittingScheme)
+  {
+    AssertThrow(not(this->param.temporal_discretization ==
+                      TemporalDiscretization::BDFConsistentSplittingScheme and
+                    this->store_solution),
+                dealii::ExcMessage(
+                  "Storing the previous solution in a partitioned scheme is not"
+                  "supported for TemporalDiscretization::BDFConsistentSplittingScheme."));
+  }
 
   AssertThrow(this->update_velocity or this->update_pressure,
               dealii::ExcMessage("No update from fluid time stepper requested."));

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting.cpp
@@ -617,14 +617,14 @@ TimeIntBDFConsistentSplitting<dim, Number>::penalty_step()
 
     // compute right-hand-side vector
     VectorType rhs;
-    rhs.reinit(velocity_np, true);
+    rhs.reinit(velocity_np, true /* omit_zeroing_entries */);
     pde_operator->apply_mass_operator(rhs, velocity_np);
 
     // extrapolate velocity to time t_n+1 and use this velocity field to
     // calculate the penalty parameter for the divergence and continuity penalty term
     VectorType velocity_extrapolated;
-    velocity_extrapolated.reinit(velocity_np, true);
-    velocity_extrapolated.add(this->extra.get_beta(0), velocity[0]);
+    velocity_extrapolated.reinit(velocity_np, true /* omit_zeroing_entries */);
+    velocity_extrapolated.equ(this->extra.get_beta(0), velocity[0]);
     for(unsigned int i = 1; i < velocity.size(); ++i)
       velocity_extrapolated.add(this->extra.get_beta(i), velocity[i]);
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -1017,14 +1017,16 @@ TimeIntBDFDualSplitting<dim, Number>::penalty_step()
     timer.restart();
 
     // compute right-hand-side vector
-    VectorType rhs(velocity_np);
+    VectorType rhs;
+    rhs.reinit(velocity_np, true /* omit_zeroing_entries */);
     pde_operator->apply_mass_operator(rhs, velocity_np);
 
     // extrapolate velocity to time t_n+1 and use this velocity field to
     // calculate the penalty parameter for the divergence and continuity penalty term
-    VectorType velocity_extrapolated(velocity_np);
-    velocity_extrapolated = 0.0;
-    for(unsigned int i = 0; i < velocity.size(); ++i)
+    VectorType velocity_extrapolated;
+    velocity_extrapolated.reinit(velocity_np, true /* omit_zeroing_entries */);
+    velocity_extrapolated.equ(this->extra.get_beta(0), velocity[0]);
+    for(unsigned int i = 1; i < velocity.size(); ++i)
       velocity_extrapolated.add(this->extra.get_beta(i), velocity[i]);
 
     pde_operator->update_projection_operator(velocity_extrapolated, this->get_time_step_size());

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -494,6 +494,7 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
     AssertThrow(order_extrapolation_pressure_nbc <= order_time_integrator,
                 dealii::ExcMessage("Invalid parameter order_extrapolation_pressure_nbc!"));
 
+    // ALE and consequently FSI (including storing of last iterates therein) are disabled.
     AssertThrow(!ale_formulation, dealii::ExcMessage("Not implemented."));
 
     AssertThrow(!viscosity_is_variable(), dealii::ExcMessage("Not implemented."));


### PR DESCRIPTION
... and refactor in all projection schemes

note that only for the consistent splitting scheme the actual behavior is different.
For `BDFPressureCorrection` and `BDFCoupledSolution`, only the sequence of steps leading to the final result is different (saving a few copy operations here and there afaik).

Tests fail in `debug` mode, which are not included in the github actions CI.

Also added some asserts regarding the combination `BDFConsistentSplitting` and ALE.