### PR TITLE
Rename consistent and dual splitting

### DIFF
--- a/applications/aero_acoustic/co_rotating_vortex_pair/application.h
+++ b/applications/aero_acoustic/co_rotating_vortex_pair/application.h
@@ -458,7 +458,7 @@ public:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -154,7 +154,7 @@ private:
     // TEMPORAL DISCRETIZATION
     param.solver_type = SolverType::Unsteady;
     param.temporal_discretization =
-      TemporalDiscretization::BDFPressureCorrection; // BDFDualSplittingScheme;
+      TemporalDiscretization::BDFPressureCorrection; // BDFDualSplitting;
     param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Implicit; // Explicit;
     param.order_time_integrator           = 2;
     param.start_with_low_order            = true;
@@ -234,7 +234,7 @@ private:
       param.order_time_integrator <= 2 ? param.order_time_integrator : 2;
     param.formulation_convective_term_bc = FormulationConvectiveTerm::ConvectiveFormulation;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -184,7 +184,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     param.solver_type                     = SolverType::Unsteady;
-    param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     param.order_time_integrator           = 2;
     param.start_with_low_order            = true;
@@ -263,7 +263,7 @@ private:
       param.order_time_integrator <= 2 ? param.order_time_integrator : 2;
     param.formulation_convective_term_bc = FormulationConvectiveTerm::ConvectiveFormulation;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -147,7 +147,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     param.solver_type                     = SolverType::Unsteady;
-    param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     param.order_time_integrator           = 1;
     param.start_with_low_order            = true;
@@ -226,7 +226,7 @@ private:
       param.order_time_integrator <= 2 ? param.order_time_integrator : 2;
     param.formulation_convective_term_bc = FormulationConvectiveTerm::ConvectiveFormulation;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -226,7 +226,7 @@ private:
       param.order_time_integrator <= 2 ? param.order_time_integrator : 2;
     param.formulation_convective_term_bc = FormulationConvectiveTerm::ConvectiveFormulation;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
@@ -639,7 +639,7 @@ private:
   }
 
   IncNS::TemporalDiscretization temporal_discretization =
-    IncNS::TemporalDiscretization::BDFDualSplittingScheme;
+    IncNS::TemporalDiscretization::BDFDualSplitting;
 };
 } // namespace FluidFSI
 

--- a/applications/fluid_structure_interaction/pressure_wave/input.json
+++ b/applications/fluid_structure_interaction/pressure_wave/input.json
@@ -13,7 +13,7 @@
         "RefineSpace": "0"
     },
     "Fluid" : {
-        "TemporalDiscretization": "BDFDualSplittingScheme"
+        "TemporalDiscretization": "BDFDualSplitting"
     },
     "FSI" : {
         "AccelerationMethod": "IQN_ILS",

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -181,7 +181,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -213,7 +213,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                  = SolverMomentum::CG;
       this->param.solver_data_momentum             = SolverData(1000, 1.e-30, reltol);

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -124,7 +124,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                     = SolverType::Unsteady;
-    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     this->param.adaptive_time_stepping          = adaptive_time_stepping;
     this->param.order_time_integrator           = 2;
@@ -192,7 +192,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6);

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -126,7 +126,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                     = SolverType::Unsteady;
-    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     this->param.order_time_integrator           = 2;
     this->param.start_with_low_order            = true;
@@ -194,7 +194,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -91,7 +91,7 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
 
   // TEMPORAL DISCRETIZATION
   param.solver_type                     = SolverType::Unsteady;
-  param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+  param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
   param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
   param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
   param.order_time_integrator           = 2;
@@ -182,7 +182,7 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
   param.order_extrapolation_pressure_nbc =
     param.order_time_integrator <= 2 ? param.order_time_integrator : 2;
 
-  if(param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  if(param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
     param.solver_momentum         = SolverMomentum::CG;
     param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -165,7 +165,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                  = SolverMomentum::CG;
       this->param.solver_data_momentum             = SolverData(1000, 1.e-12, 1.e-8);

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -130,7 +130,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-8);

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -79,7 +79,7 @@ private:
     // TEMPORAL DISCRETIZATION
     this->param.solver_type = SolverType::Steady; // Unsteady;
     this->param.temporal_discretization =
-      TemporalDiscretization::BDFCoupledSolution; // BDFDualSplittingScheme;
+      TemporalDiscretization::BDFCoupledSolution; // BDFDualSplitting;
     this->param.treatment_of_convective_term  = TreatmentOfConvectiveTerm::Implicit; // Explicit;
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
     this->param.max_velocity                  = max_velocity;
@@ -125,7 +125,7 @@ private:
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
     // viscous step
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                  = SolverMomentum::CG;
       this->param.solver_data_momentum             = SolverData(1000, 1.e-20, 1.e-6);

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -125,7 +125,7 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
   // TEMPORAL DISCRETIZATION
   param.solver_type = SolverType::Unsteady;
 
-  //  param.temporal_discretization = TemporalDiscretization::BDFDualSplittingScheme;
+  //  param.temporal_discretization = TemporalDiscretization::BDFDualSplitting;
   //  param.treatment_of_convective_term = TreatmentOfConvectiveTerm::Explicit;
   //  param.calculation_of_time_step_size = TimeStepCalculation::CFL;
   //  param.adaptive_time_stepping = true;
@@ -200,7 +200,7 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
   param.order_extrapolation_pressure_nbc =
     param.order_time_integrator <= 2 ? param.order_time_integrator : 2;
 
-  if(param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  if(param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
     param.solver_momentum         = SolverMomentum::CG;
     param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-3);

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -173,7 +173,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                     = SolverType::Unsteady;
-    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     this->param.order_time_integrator           = 3;
     this->param.start_with_low_order            = true;
@@ -251,7 +251,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                = SolverMomentum::CG;
       this->param.solver_data_momentum           = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/incompressible_navier_stokes/flow_past_sphere/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/application.h
@@ -113,7 +113,7 @@ public:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                     = SolverType::Unsteady;
-    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     this->param.order_time_integrator           = 2;
     this->param.start_with_low_order            = true;
@@ -191,7 +191,7 @@ public:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                = SolverMomentum::CG;
       this->param.solver_data_momentum           = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -174,7 +174,7 @@ private:
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
     this->param.formulation_convective_term_bc = FormulationConvectiveTerm::ConvectiveFormulation;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                  = SolverMomentum::CG;
       this->param.solver_data_momentum             = SolverData(1000, 1.e-14, 1.e-14);

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -95,7 +95,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                     = SolverType::Unsteady;
-    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     this->param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
     this->param.max_velocity                    = max_velocity;
@@ -141,7 +141,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                  = SolverMomentum::CG;
       this->param.solver_data_momentum             = SolverData(1000, 1.e-12, 1.e-6);

--- a/applications/incompressible_navier_stokes/kovasznay/application.h
+++ b/applications/incompressible_navier_stokes/kovasznay/application.h
@@ -153,7 +153,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                   = SolverType::Unsteady;
-    this->param.temporal_discretization       = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization       = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term  = TreatmentOfConvectiveTerm::Explicit;
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
     this->param.max_velocity                  = 3.6;
@@ -195,7 +195,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum                  = SolverMomentum::CG;
       this->param.solver_data_momentum             = SolverData(1000, 1.e-20, 1.e-6);

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -504,7 +504,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum =
         treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit ?

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/input.json
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/input.json
@@ -29,7 +29,7 @@
         "KinematicViscosity": "1e-6",
         "UseGeneralizedNewtonianModel": "true",
         "FormulationViscousTerm" : "DivergenceFormulation",
-        "TemporalDiscretization" : "BDFDualSplittingScheme",
+        "TemporalDiscretization" : "BDFDualSplitting",
         "TreatmentOfConvectiveTerm" : "LinearlyImplicit",
         "TreatmentOfVariableViscosity" : "Explicit",
         "GeneralizedNewtonianViscosityMargin": "49e-6",

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -247,7 +247,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, 1.e-14, 1.e-14);

--- a/applications/incompressible_navier_stokes/periodic_hill/input.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input.json
@@ -17,7 +17,7 @@
     "Application": {
         "ReadRestart": "false",
         "WriteRestart": "false",
-        "TemporalDiscretization": "BDFDualSplittingScheme",
+        "TemporalDiscretization": "BDFDualSplitting",
         "SpatialDiscretization": "L2",
         "Inviscid": "false",
         "ReynoldsNumber": "5600.0",

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -208,7 +208,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                     = SolverType::Unsteady;
-    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     this->param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
     this->param.adaptive_time_stepping          = true;
@@ -260,7 +260,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, 1.e-20, 1.e-6);

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -39,7 +39,7 @@ Physical quantities:
   Density:                                   1.0000e+00
 
 Temporal discretization:
-  Temporal discretization method:            BDFDualSplittingScheme
+  Temporal discretization method:            BDFDualSplitting
   Calculation of time step size:             CFL
   Adaptive time stepping:                    true
   Adaptive time stepping limiting factor:    1.2000e+00

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -39,7 +39,7 @@ Physical quantities:
   Density:                                   1.0000e+00
 
 Temporal discretization:
-  Temporal discretization method:            BDFDualSplittingScheme
+  Temporal discretization method:            BDFDualSplitting
   Calculation of time step size:             CFL
   Adaptive time stepping:                    true
   Adaptive time stepping limiting factor:    1.2000e+00

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -39,7 +39,7 @@ Physical quantities:
   Density:                                   1.0000e+00
 
 Temporal discretization:
-  Temporal discretization method:            BDFDualSplittingScheme
+  Temporal discretization method:            BDFDualSplitting
   Calculation of time step size:             CFL
   Adaptive time stepping:                    true
   Adaptive time stepping limiting factor:    1.2000e+00

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -39,7 +39,7 @@ Physical quantities:
   Density:                                   1.0000e+00
 
 Temporal discretization:
-  Temporal discretization method:            BDFDualSplittingScheme
+  Temporal discretization method:            BDFDualSplitting
   Calculation of time step size:             CFL
   Adaptive time stepping:                    true
   Adaptive time stepping limiting factor:    1.2000e+00

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -87,11 +87,11 @@ private:
 
 
     // TEMPORAL DISCRETIZATION
-    this->param.solver_type                   = SolverType::Unsteady;
-    this->param.temporal_discretization       = TemporalDiscretization::BDFDualSplittingScheme;
-    this->param.treatment_of_convective_term  = TreatmentOfConvectiveTerm::Explicit;
-    this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
-    this->param.adaptive_time_stepping        = true;
+    this->param.solver_type                            = SolverType::Unsteady;
+    this->param.temporal_discretization                = TemporalDiscretization::BDFDualSplitting;
+    this->param.treatment_of_convective_term           = TreatmentOfConvectiveTerm::Explicit;
+    this->param.calculation_of_time_step_size          = TimeStepCalculation::CFL;
+    this->param.adaptive_time_stepping                 = true;
     this->param.adaptive_time_stepping_limiting_factor = 3.0;
     this->param.max_velocity                           = 1.5;
     this->param.cfl                                    = 0.25;

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -132,7 +132,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                   = SolverType::Unsteady;
-    this->param.temporal_discretization       = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization       = TemporalDiscretization::BDFDualSplitting;
     this->param.calculation_of_time_step_size = TimeStepCalculation::UserSpecified;
     this->param.time_step_size                = this->param.end_time;
     this->param.order_time_integrator         = 1; // 1; // 2; // 3;
@@ -194,7 +194,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-8);

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -157,13 +157,13 @@ private:
 
 
     // TEMPORAL DISCRETIZATION
-    this->param.solver_type                   = SolverType::Unsteady;
-    this->param.temporal_discretization       = TemporalDiscretization::BDFDualSplittingScheme;
-    this->param.treatment_of_convective_term  = TreatmentOfConvectiveTerm::Explicit;
-    this->param.order_time_integrator         = 2;
-    this->param.start_with_low_order          = not read_restart;
-    this->param.adaptive_time_stepping        = true;
-    this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
+    this->param.solver_type                            = SolverType::Unsteady;
+    this->param.temporal_discretization                = TemporalDiscretization::BDFDualSplitting;
+    this->param.treatment_of_convective_term           = TreatmentOfConvectiveTerm::Explicit;
+    this->param.order_time_integrator                  = 2;
+    this->param.start_with_low_order                   = not read_restart;
+    this->param.adaptive_time_stepping                 = true;
+    this->param.calculation_of_time_step_size          = TimeStepCalculation::CFL;
     this->param.adaptive_time_stepping_limiting_factor = 3.0;
     this->param.max_velocity                           = max_velocity;
     this->param.cfl                                    = 0.4;
@@ -249,7 +249,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -75,8 +75,8 @@ private:
     // TEMPORAL DISCRETIZATION
     this->param.solver_type = SolverType::Unsteady;
     this->param.temporal_discretization =
-      TemporalDiscretization::BDFDualSplittingScheme; // BDFPressureCorrection;
-                                                      // //BDFCoupledSolution;
+      TemporalDiscretization::BDFDualSplitting; // BDFPressureCorrection;
+                                                // //BDFCoupledSolution;
     this->param.treatment_of_convective_term  = TreatmentOfConvectiveTerm::Explicit;
     this->param.calculation_of_time_step_size = TimeStepCalculation::CFL;
     this->param.cfl                           = 1.0;
@@ -129,7 +129,7 @@ private:
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.preconditioner_momentum = MomentumPreconditioner::None;

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -197,7 +197,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                     = SolverType::Unsteady;
-    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplittingScheme;
+    this->param.temporal_discretization         = TemporalDiscretization::BDFDualSplitting;
     this->param.treatment_of_convective_term    = TreatmentOfConvectiveTerm::Explicit;
     this->param.calculation_of_time_step_size   = TimeStepCalculation::CFL;
     this->param.order_time_integrator           = 2;
@@ -268,7 +268,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -258,7 +258,7 @@ private:
 
     // TEMPORAL DISCRETIZATION
     this->param.solver_type                  = SolverType::Unsteady;
-    this->param.temporal_discretization      = TemporalDiscretization::BDFConsistentSplittingScheme;
+    this->param.temporal_discretization      = TemporalDiscretization::BDFConsistentSplitting;
     this->param.treatment_of_convective_term = TreatmentOfConvectiveTerm::LinearlyImplicit;
     this->param.order_time_integrator        = 2;
     this->param.start_with_low_order         = false;
@@ -348,7 +348,7 @@ private:
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
     this->param.formulation_convective_term_bc = FormulationConvectiveTerm::ConvectiveFormulation;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
       {

--- a/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting.output
+++ b/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting.output
@@ -39,7 +39,7 @@ Physical quantities:
   Density:                                   1.0000e+00
 
 Temporal discretization:
-  Temporal discretization method:            BDFConsistentSplittingScheme
+  Temporal discretization method:            BDFConsistentSplitting
   Calculation of time step size:             UserSpecified
   Adaptive time stepping:                    false
   Maximum number of time steps:              4294967295

--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
@@ -186,7 +186,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       this->param.solver_momentum         = SolverMomentum::CG;
       this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -382,7 +382,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
                 dealii::ExcMessage("Invalid operator specified for coupled solution approach."));
   }
   else if(application->get_parameters().temporal_discretization ==
-          TemporalDiscretization::BDFDualSplittingScheme)
+          TemporalDiscretization::BDFDualSplitting)
   {
     AssertThrow(operator_type == OperatorType::ConvectiveOperator or
                   operator_type == OperatorType::PressurePoissonOperator or
@@ -392,7 +392,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
                 dealii::ExcMessage("Invalid operator specified for dual splitting scheme."));
   }
   else if(application->get_parameters().temporal_discretization ==
-          TemporalDiscretization::BDFConsistentSplittingScheme)
+          TemporalDiscretization::BDFConsistentSplitting)
   {
     AssertThrow(operator_type == OperatorType::ConvectiveOperator or
                   operator_type == OperatorType::PressurePoissonOperator or
@@ -444,7 +444,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
     }
   }
   else if(application->get_parameters().temporal_discretization ==
-          TemporalDiscretization::BDFDualSplittingScheme)
+          TemporalDiscretization::BDFDualSplitting)
   {
     if(operator_type == OperatorType::ConvectiveOperator or
        operator_type == OperatorType::HelmholtzOperator or
@@ -467,7 +467,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
     src2 = 1.0;
   }
   else if(application->get_parameters().temporal_discretization ==
-          TemporalDiscretization::BDFConsistentSplittingScheme)
+          TemporalDiscretization::BDFConsistentSplitting)
   {
     if(operator_type == OperatorType::ConvectiveOperator or
        operator_type == OperatorType::HelmholtzOperator or
@@ -534,7 +534,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
       else
         AssertThrow(false,dealii::ExcMessage("Not implemented."));
     }
-    else if(application->get_parameters().temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+    else if(application->get_parameters().temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
       std::shared_ptr<OperatorDualSplitting<dim, Number>>      operator_dual_splitting =
           std::dynamic_pointer_cast<OperatorDualSplitting<dim, Number>>(pde_operator);
@@ -552,7 +552,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
       else
         AssertThrow(false,dealii::ExcMessage("Not implemented."));
     }
-    else if(application->get_parameters().temporal_discretization == TemporalDiscretization::BDFConsistentSplittingScheme)
+    else if(application->get_parameters().temporal_discretization == TemporalDiscretization::BDFConsistentSplitting)
     {
       std::shared_ptr<OperatorConsistentSplitting<dim, Number>>      operator_consistent_splitting =
           std::dynamic_pointer_cast<OperatorConsistentSplitting<dim, Number>>(pde_operator);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/create_operator.h
@@ -61,7 +61,7 @@ create_operator(std::shared_ptr<Grid<dim> const>                      grid,
                                                                   field,
                                                                   mpi_comm);
   }
-  else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
     pde_operator = std::make_shared<OperatorDualSplitting<dim, Number>>(grid,
                                                                         mapping,
@@ -72,8 +72,7 @@ create_operator(std::shared_ptr<Grid<dim> const>                      grid,
                                                                         field,
                                                                         mpi_comm);
   }
-  else if(parameters.temporal_discretization ==
-          TemporalDiscretization::BDFConsistentSplittingScheme)
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFConsistentSplitting)
   {
     pde_operator = std::make_shared<OperatorConsistentSplitting<dim, Number>>(grid,
                                                                               mapping,

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -113,8 +113,8 @@ OperatorProjectionMethods<dim, Number>::initialize_laplace_operator()
    *
    *  p0^T * A * p = (A^T * p0)^T * p = 0 != p0 * rhs (since A is symmetric).
    */
-  if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme or
-     this->param.temporal_discretization == TemporalDiscretization::BDFConsistentSplittingScheme or
+  if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting or
+     this->param.temporal_discretization == TemporalDiscretization::BDFConsistentSplitting or
      this->param.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
   {
     /*

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -620,8 +620,8 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
 
   if(param.use_divergence_penalty or param.use_continuity_penalty)
   {
-    if(param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme or
-       param.temporal_discretization == TemporalDiscretization::BDFConsistentSplittingScheme or
+    if(param.temporal_discretization == TemporalDiscretization::BDFDualSplitting or
+       param.temporal_discretization == TemporalDiscretization::BDFConsistentSplitting or
        param.temporal_discretization == TemporalDiscretization::BDFPressureCorrection or
        (param.temporal_discretization == TemporalDiscretization::BDFCoupledSolution and
         param.apply_penalty_terms_in_postprocessing_step == true))

--- a/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/create_time_integrator.h
@@ -56,7 +56,7 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
     time_integrator = std::make_shared<IncNS::TimeIntBDFCoupled<dim, Number>>(
       operator_coupled, helpers_ale, postprocessor, parameters, mpi_comm, is_test);
   }
-  else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
     std::shared_ptr<OperatorDualSplitting<dim, Number>> operator_dual_splitting =
       std::dynamic_pointer_cast<OperatorDualSplitting<dim, Number>>(pde_operator);
@@ -64,8 +64,7 @@ create_time_integrator(std::shared_ptr<SpatialOperatorBase<dim, Number>> pde_ope
     time_integrator = std::make_shared<IncNS::TimeIntBDFDualSplitting<dim, Number>>(
       operator_dual_splitting, helpers_ale, postprocessor, parameters, mpi_comm, is_test);
   }
-  else if(parameters.temporal_discretization ==
-          TemporalDiscretization::BDFConsistentSplittingScheme)
+  else if(parameters.temporal_discretization == TemporalDiscretization::BDFConsistentSplitting)
   {
     std::shared_ptr<OperatorConsistentSplitting<dim, Number>> operator_consistent_splitting =
       std::dynamic_pointer_cast<OperatorConsistentSplitting<dim, Number>>(pde_operator);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -64,7 +64,7 @@ TimeIntBDF<dim, Number>::TimeIntBDF(
   needs_vector_convective_term =
     this->param.convective_problem() and
     (this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit or
-     this->param.temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme);
+     this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting);
 }
 
 template<int dim, typename Number>
@@ -189,15 +189,13 @@ TimeIntBDF<dim, Number>::advance_one_timestep_partitioned_solve(bool const use_e
                 dealii::ExcMessage("TemporalDiscretization::BDFCoupledSolution cannot "
                                    "recover velocity and pressure independently."));
   }
-  else if(this->param.temporal_discretization ==
-          TemporalDiscretization::BDFConsistentSplittingScheme)
+  else if(this->param.temporal_discretization == TemporalDiscretization::BDFConsistentSplitting)
   {
-    AssertThrow(not(this->param.temporal_discretization ==
-                      TemporalDiscretization::BDFConsistentSplittingScheme and
-                    this->store_solution),
-                dealii::ExcMessage(
-                  "Storing the previous solution in a partitioned scheme is not"
-                  "supported for TemporalDiscretization::BDFConsistentSplittingScheme."));
+    AssertThrow(
+      not(this->param.temporal_discretization == TemporalDiscretization::BDFConsistentSplitting and
+          this->store_solution),
+      dealii::ExcMessage("Storing the previous solution in a partitioned scheme is not"
+                         "supported for TemporalDiscretization::BDFConsistentSplitting."));
   }
 
   AssertThrow(this->update_velocity or this->update_pressure,

--- a/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
@@ -124,8 +124,8 @@ enum class SolverType
 enum class TemporalDiscretization
 {
   Undefined,
-  BDFDualSplittingScheme,
-  BDFConsistentSplittingScheme,
+  BDFDualSplitting,
+  BDFConsistentSplitting,
   BDFPressureCorrection,
   BDFCoupledSolution,
   InterpolateAnalyticalSolution

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -378,7 +378,7 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
 
     if(continuity_penalty_use_boundary_data == true)
     {
-      if(temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+      if(temporal_discretization == TemporalDiscretization::BDFDualSplitting)
       {
         AssertThrow(
           apply_penalty_terms_in_postprocessing_step == true,
@@ -445,7 +445,7 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
   }
 
   // HIGH-ORDER DUAL SPLITTING SCHEME
-  if(temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  if(temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
     if(spatial_discretization == SpatialDiscretization::HDIV)
     {
@@ -483,7 +483,7 @@ Parameters::check(dealii::ConditionalOStream const & pcout) const
   }
 
   // CONSISTENT SPLITTING SCHEME
-  if(temporal_discretization == TemporalDiscretization::BDFConsistentSplittingScheme)
+  if(temporal_discretization == TemporalDiscretization::BDFConsistentSplitting)
   {
     AssertThrow(spatial_discretization != SpatialDiscretization::HDIV,
                 dealii::ExcMessage("Not implemented."));
@@ -673,8 +673,8 @@ Parameters::involves_h_multigrid() const
   // scheme in case of InterpolateAnalyticalSolution. This is only a temporary solution and we need
   // to write a separate class SpatialOperatorInterpolateAnalyticalSolution that does not create
   // preconditioners (including multigrid)
-  else if(temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme or
-          temporal_discretization == TemporalDiscretization::BDFConsistentSplittingScheme or
+  else if(temporal_discretization == TemporalDiscretization::BDFDualSplitting or
+          temporal_discretization == TemporalDiscretization::BDFConsistentSplitting or
           temporal_discretization == TemporalDiscretization::BDFPressureCorrection or
           temporal_discretization == TemporalDiscretization::InterpolateAnalyticalSolution)
   {
@@ -764,11 +764,11 @@ Parameters::print(dealii::ConditionalOStream const & pcout, std::string const & 
   print_parameters_numerical_parameters(pcout);
 
   // HIGH-ORDER DUAL SPLITTING SCHEME
-  if(temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+  if(temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     print_parameters_dual_splitting(pcout);
 
   // CONSISTENT SPLITTING SCHEME
-  if(temporal_discretization == TemporalDiscretization::BDFConsistentSplittingScheme)
+  if(temporal_discretization == TemporalDiscretization::BDFConsistentSplitting)
     print_parameters_consistent_splitting(pcout);
 
   // PRESSURE-CORRECTION  SCHEME
@@ -998,7 +998,7 @@ Parameters::print_parameters_spatial_discretization(dealii::ConditionalOStream c
   print_parameter(pcout, "Use continuity penalty term", use_continuity_penalty);
 
   if(temporal_discretization == TemporalDiscretization::BDFCoupledSolution or
-     temporal_discretization == TemporalDiscretization::BDFDualSplittingScheme)
+     temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
     if(use_divergence_penalty == true or use_continuity_penalty == true)
     {


### PR DESCRIPTION
based on #812 since the same lines are affected, hence `draft`.

`BDFDualSplittingScheme` --> `BDFDualSplitting`
`BDFConsistentSplittingScheme` --> `BDFConsistentSplitting`
because for the others, namely
`BDFCoupledSolution`
and
`BDFPressureCorrection`,
one could also add the `Scheme`.
Let's keep the names short.