### PR TITLE
Structure postprocessor jacobian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ SET(TARGET_SRC
      include/exadg/operators/inverse_mass_operator.cpp
      include/exadg/operators/rhs_operator.cpp
      include/exadg/operators/navier_stokes_calculators.cpp
+     include/exadg/operators/structure_calculators.cpp
      # Poisson equation
      include/exadg/poisson/user_interface/parameters.cpp
      include/exadg/poisson/spatial_discretization/operator.cpp

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -708,6 +708,7 @@ private:
     pp_data.output_data.directory                    = this->output_parameters.directory + "vtu/";
     pp_data.output_data.filename                     = this->output_parameters.filename;
     pp_data.output_data.write_displacement_magnitude = true;
+    pp_data.output_data.write_displacement_jacobian  = true;
     pp_data.output_data.write_higher_order           = true;
     pp_data.output_data.degree                       = this->param.degree;
 

--- a/include/exadg/operators/structure_calculators.cpp
+++ b/include/exadg/operators/structure_calculators.cpp
@@ -1,0 +1,101 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// ExaDG
+#include <exadg/operators/structure_calculators.h>
+#include <exadg/structure/spatial_discretization/operators/continuum_mechanics.h>
+
+namespace ExaDG
+{
+template<int dim, typename Number>
+DisplacementJacobianCalculator<dim, Number>::DisplacementJacobianCalculator()
+  : matrix_free(nullptr), dof_index_vector(0), dof_index_scalar(0), quad_index(0)
+{
+}
+
+template<int dim, typename Number>
+void
+DisplacementJacobianCalculator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      dof_index_vector_in,
+  unsigned int const                      dof_index_scalar_in,
+  unsigned int const                      quad_index_in)
+{
+  matrix_free      = &matrix_free_in;
+  dof_index_vector = dof_index_vector_in;
+  dof_index_scalar = dof_index_scalar_in;
+  quad_index       = quad_index_in;
+}
+
+template<int dim, typename Number>
+void
+DisplacementJacobianCalculator<dim, Number>::compute_projection_rhs(
+  VectorType &       dst_scalar_valued,
+  VectorType const & src_vector_valued) const
+{
+  dst_scalar_valued = 0;
+
+  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued);
+}
+
+template<int dim, typename Number>
+void
+DisplacementJacobianCalculator<dim, Number>::cell_loop(
+  dealii::MatrixFree<dim, Number> const &       matrix_free,
+  VectorType &                                  dst_scalar_valued,
+  VectorType const &                            src_vector_valued,
+  std::pair<unsigned int, unsigned int> const & cell_range) const
+{
+  CellIntegratorVector integrator_vector(matrix_free, dof_index_vector, quad_index, 0);
+  CellIntegratorScalar integrator_scalar(matrix_free, dof_index_scalar, quad_index, 0);
+
+  for(unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+  {
+    integrator_vector.reinit(cell);
+    // Do not enforce constraints on the `src` vector, as constraints are already applied and
+    // `dealii::MatrixFree` object stores constraints relevant in linear systemes, not necessarily
+    // constraints suitable for a DoF vector corresponding to the solution (e.g., in Newton's
+    // method).
+    integrator_vector.read_dof_values_plain(src_vector_valued);
+    integrator_vector.evaluate(dealii::EvaluationFlags::gradients);
+
+    integrator_scalar.reinit(cell);
+
+    for(unsigned int q = 0; q < integrator_vector.n_q_points; q++)
+    {
+      tensor const gradient_displacement = integrator_vector.get_gradient(q);
+      tensor const F                     = Structure::get_F(gradient_displacement);
+      scalar const Jacobian              = determinant(F);
+
+      integrator_scalar.submit_value(Jacobian, q);
+    }
+
+    integrator_scalar.integrate_scatter(dealii::EvaluationFlags::values, dst_scalar_valued);
+  }
+}
+
+template class DisplacementJacobianCalculator<2, float>;
+template class DisplacementJacobianCalculator<2, double>;
+
+template class DisplacementJacobianCalculator<3, float>;
+template class DisplacementJacobianCalculator<3, double>;
+
+} // namespace ExaDG

--- a/include/exadg/operators/structure_calculators.h
+++ b/include/exadg/operators/structure_calculators.h
@@ -1,0 +1,86 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_OPERATORS_STRUCTURE_CALCULATORS_H_
+#define EXADG_OPERATORS_STRUCTURE_CALCULATORS_H_
+
+// deal.II
+#include <deal.II/lac/la_parallel_vector.h>
+
+// ExaDG
+#include <exadg/matrix_free/integrators.h>
+
+namespace ExaDG
+{
+/*
+ * Calculator for the Jacobian of the displacement field u(X) in material coordinates X defined as
+ *
+ * J = det(F) with F = I + Grad(u),
+ *
+ * where F is the deformation gradient tensor and Grad(u) is the gradient with respect to the
+ * material coordinates X of the displacement field.
+ *
+ */
+template<int dim, typename Number>
+class DisplacementJacobianCalculator
+{
+public:
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+
+  typedef DisplacementJacobianCalculator<dim, Number> This;
+
+  typedef CellIntegrator<dim, dim, Number> CellIntegratorVector;
+  typedef CellIntegrator<dim, 1, Number>   CellIntegratorScalar;
+
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+
+  DisplacementJacobianCalculator();
+
+  void
+  initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+             unsigned int const                      dof_index_vector_in,
+             unsigned int const                      dof_index_scalar_in,
+             unsigned int const                      quad_index_in);
+
+  /*
+   * Compute the right-hand side of an L2 projection of the Jacobian of the displacement field.
+   */
+  void
+  compute_projection_rhs(VectorType & dst, VectorType const & src) const;
+
+private:
+  void
+  cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
+            VectorType &                                  dst_scalar_valued,
+            VectorType const &                            src_vector_valued,
+            std::pair<unsigned int, unsigned int> const & cell_range) const;
+
+  dealii::MatrixFree<dim, Number> const * matrix_free;
+
+  unsigned int dof_index_vector;
+  unsigned int dof_index_scalar;
+  unsigned int quad_index;
+};
+
+} // namespace ExaDG
+
+#endif /* EXADG_OPERATORS_STRUCTURE_CALCULATORS_H_ */

--- a/include/exadg/structure/postprocessor/output_generator.h
+++ b/include/exadg/structure/postprocessor/output_generator.h
@@ -36,7 +36,7 @@ namespace Structure
 {
 struct OutputData : public OutputDataBase
 {
-  OutputData() : write_displacement_magnitude(false)
+  OutputData() : write_displacement_magnitude(false), write_displacement_jacobian(false)
   {
   }
 
@@ -46,10 +46,14 @@ struct OutputData : public OutputDataBase
     OutputDataBase::print(pcout, unsteady);
 
     print_parameter(pcout, "Write displacement magnitude", write_displacement_magnitude);
+    print_parameter(pcout, "Write displacement Jacobian", write_displacement_jacobian);
   }
 
   // write displacement magnitude
   bool write_displacement_magnitude;
+
+  // write Jacobian of the displacement field
+  bool write_displacement_jacobian;
 };
 
 template<int dim, typename Number>

--- a/include/exadg/structure/postprocessor/postprocessor.h
+++ b/include/exadg/structure/postprocessor/postprocessor.h
@@ -78,6 +78,7 @@ private:
 
   // Fields for derived quantities
   SolutionField<dim, Number> displacement_magnitude;
+  SolutionField<dim, Number> displacement_jacobian;
 
   // write output for visualization of results (e.g., using paraview)
   OutputGenerator<dim, Number> output_generator;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -343,6 +343,11 @@ Operator<dim, Number>::setup_calculators_for_derived_quantities()
                                            get_dof_index(),
                                            get_dof_index_scalar(),
                                            get_quad_index());
+
+    displacement_jacobian_calculator.initialize(*matrix_free,
+                                                get_dof_index(),
+                                                get_dof_index_scalar(),
+                                                get_quad_index());
   }
 }
 
@@ -708,6 +713,20 @@ Operator<dim, Number>::compute_displacement_magnitude(VectorType &       dst_sca
                                  "Cannot compute displacement magnitude."));
 
   vector_magnitude_calculator.compute(dst_scalar_valued, src_vector_valued);
+
+  inverse_mass_scalar.apply(dst_scalar_valued, dst_scalar_valued);
+}
+
+template<int dim, typename Number>
+void
+Operator<dim, Number>::compute_displacement_jacobian(VectorType &       dst_scalar_valued,
+                                                     VectorType const & src_vector_valued) const
+{
+  AssertThrow(setup_scalar_field,
+              dealii::ExcMessage("Scalar field not set up. "
+                                 "Cannot compute Jacobian of the displacement field."));
+
+  displacement_jacobian_calculator.compute_projection_rhs(dst_scalar_valued, src_vector_valued);
 
   inverse_mass_scalar.apply(dst_scalar_valued, dst_scalar_valued);
 }

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -31,6 +31,7 @@
 #include <exadg/operators/inverse_mass_operator.h>
 #include <exadg/operators/mass_operator.h>
 #include <exadg/operators/navier_stokes_calculators.h>
+#include <exadg/operators/structure_calculators.h>
 #include <exadg/solvers_and_preconditioners/newton/newton_solver.h>
 #include <exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h>
 #include <exadg/structure/spatial_discretization/interface.h>
@@ -349,6 +350,11 @@ public:
   compute_displacement_magnitude(VectorType &       dst_scalar_valued,
                                  VectorType const & src_vector_valued) const;
 
+  // compute Jacobian of the displacement field
+  void
+  compute_displacement_jacobian(VectorType &       dst_tensor_valued,
+                                VectorType const & src_vector_valued) const;
+
 private:
   /*
    * Initializes dealii::DoFHandler.
@@ -553,6 +559,8 @@ private:
    * Calculators to obtain derived quantities.
    */
   MagnitudeCalculator<dim, Number> vector_magnitude_calculator;
+
+  DisplacementJacobianCalculator<dim, Number> displacement_jacobian_calculator;
 
   /*
    * MPI communicator


### PR DESCRIPTION
add another calculator (`DisplacementJacobianCalculator`) for the structure module.
It does not enforce constraints again on the `src` vector when reading, i.e., we use `read_dof_values_plain(src)` since we are in postprocessing and the `src` has already all constraints enforced.

Here is a little test:
St Venant Kirchhoff $\nu=0.49$, showing `|J-1|` being close to 0.0:
<img width="1408" height="587" alt="StVenantKirchhoff_nu=0 49" src="https://github.com/user-attachments/assets/bd7ca0d6-efa8-46df-9d68-466c4bb5bc0c" />

and for the quasi-incompressible neo Hookean solid with $\nu=0.49$, where we enforce incompressibility with an additional penalty term:
<img width="1408" height="587" alt="quasiIncompressibleNeoHookean_nu=0 49" src="https://github.com/user-attachments/assets/10148cf2-3681-4366-8c7d-b8f39a031d7f" />

See how it is an order of magnitude less in the latter case? :rocket:

Anyways, the postprocessor seems to work.