### PR TITLE
Refactor calculators

### DIFF
--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -686,7 +686,7 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::compute_vorticity(VectorType & dst, VectorType const & src) const
 {
-  vorticity_calculator.compute_vorticity(dst, src);
+  vorticity_calculator.compute_projection_rhs(dst, src);
   inverse_mass_vector.apply(dst, dst);
 }
 
@@ -694,7 +694,7 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::compute_divergence(VectorType & dst, VectorType const & src) const
 {
-  divergence_calculator.compute_divergence(dst, src);
+  divergence_calculator.compute_projection_rhs(dst, src);
   inverse_mass_scalar.apply(dst, dst);
 }
 
@@ -702,7 +702,7 @@ template<int dim, typename Number>
 void
 Operator<dim, Number>::compute_shear_rate(VectorType & dst, VectorType const & src) const
 {
-  shear_rate_calculator.compute_shear_rate(dst, src);
+  shear_rate_calculator.compute_projection_rhs(dst, src);
   inverse_mass_scalar.apply(dst, dst);
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1413,7 +1413,7 @@ template<int dim, typename Number>
 void
 SpatialOperatorBase<dim, Number>::compute_vorticity(VectorType & dst, VectorType const & src) const
 {
-  vorticity_calculator.compute_vorticity(dst, src);
+  vorticity_calculator.compute_projection_rhs(dst, src);
   this->apply_inverse_mass_operator(dst, dst);
 }
 
@@ -1421,8 +1421,7 @@ template<int dim, typename Number>
 void
 SpatialOperatorBase<dim, Number>::compute_divergence(VectorType & dst, VectorType const & src) const
 {
-  divergence_calculator.compute_divergence(dst, src);
-
+  divergence_calculator.compute_projection_rhs(dst, src);
   inverse_mass_velocity_scalar.apply(dst, dst);
 }
 
@@ -1430,8 +1429,7 @@ template<int dim, typename Number>
 void
 SpatialOperatorBase<dim, Number>::compute_shear_rate(VectorType & dst, VectorType const & src) const
 {
-  shear_rate_calculator.compute_shear_rate(dst, src);
-
+  shear_rate_calculator.compute_projection_rhs(dst, src);
   inverse_mass_velocity_scalar.apply(dst, dst);
 }
 
@@ -1441,7 +1439,7 @@ SpatialOperatorBase<dim, Number>::access_viscosity(VectorType & dst) const
 {
   if(param.viscosity_is_variable())
   {
-    viscosity_calculator.access_viscosity(dst);
+    viscosity_calculator.compute_projection_rhs(dst);
     inverse_mass_velocity_scalar.apply(dst, dst);
   }
   else
@@ -1455,8 +1453,7 @@ void
 SpatialOperatorBase<dim, Number>::compute_velocity_magnitude(VectorType &       dst,
                                                              VectorType const & src) const
 {
-  magnitude_calculator.compute(dst, src);
-
+  magnitude_calculator.compute_projection_rhs(dst, src);
   inverse_mass_velocity_scalar.apply(dst, dst);
 }
 
@@ -1465,8 +1462,7 @@ void
 SpatialOperatorBase<dim, Number>::compute_vorticity_magnitude(VectorType &       dst,
                                                               VectorType const & src) const
 {
-  magnitude_calculator.compute(dst, src);
-
+  magnitude_calculator.compute_projection_rhs(dst, src);
   inverse_mass_velocity_scalar.apply(dst, dst);
 }
 
@@ -1573,8 +1569,7 @@ void
 SpatialOperatorBase<dim, Number>::compute_q_criterion(VectorType &       dst,
                                                       VectorType const & src) const
 {
-  q_criterion_calculator.compute(dst, src);
-
+  q_criterion_calculator.compute_projection_rhs(dst, src);
   inverse_mass_velocity_scalar.apply(dst, dst);
 }
 

--- a/include/exadg/operators/navier_stokes_calculators.h
+++ b/include/exadg/operators/navier_stokes_calculators.h
@@ -31,6 +31,11 @@
 
 namespace ExaDG
 {
+/*
+ * Calculator for the divergence of a vector field u(x) defined as the scalar quantity
+
+ * div(u) := sum_i=1,...,dim { d u(i) / d x(i) }.
+ */
 template<int dim, typename Number>
 class DivergenceCalculator
 {
@@ -51,14 +56,19 @@ public:
              unsigned int const                      dof_index_vector_in,
              unsigned int const                      dof_index_scalar_in,
              unsigned int const                      quad_index_in);
+
+  /*
+   * Compute the right-hand side of an L2 projection of the divergence of the vector field.
+   */
   void
-  compute_divergence(VectorType & dst, VectorType const & src) const;
+  compute_projection_rhs(VectorType &       dst_scalar_valued,
+                         VectorType const & src_vector_valued) const;
 
 private:
   void
   cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
-            VectorType &                                  dst,
-            VectorType const &                            src,
+            VectorType &                                  dst_scalar_valued,
+            VectorType const &                            src_vector_valued,
             std::pair<unsigned int, unsigned int> const & cell_range) const;
 
   dealii::MatrixFree<dim, Number> const * matrix_free;
@@ -68,6 +78,17 @@ private:
   unsigned int quad_index;
 };
 
+/*
+ * Calculator for the shear rate according to
+ * [Galdi et al., 2008, Hemodynamical Flows: Modeling, Analysis and Simulation]
+ * of a vector field u(x) defined as the scalar quantity
+ *
+ * sqrt(2 * trace(sym_grad(u)^2)) = sqrt(2 * sym_grad(u) : sym_grad(u))
+ * where
+ * sym_grad(u) := 0.5 * (grad(u) + grad(u)^T)
+ *
+ * is the symmetric part of the vector field's gradient.
+ */
 template<int dim, typename Number>
 class ShearRateCalculator
 {
@@ -77,7 +98,7 @@ private:
   typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
 
   typedef dealii::VectorizedArray<Number>                                  scalar;
-  typedef dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> symmetrictensor;
+  typedef dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> symmetric_tensor;
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
@@ -89,27 +110,47 @@ public:
 
   void
   initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const                      dof_index_u_in,
-             unsigned int const                      dof_index_u_scalar_in,
+             unsigned int const                      dof_index_vector_in,
+             unsigned int const                      dof_index_scalar_in,
              unsigned int const                      quad_index_in);
 
+  /*
+   * Compute the right-hand side of an L2 projection of the shear rate of the vector field.
+   */
   void
-  compute_shear_rate(VectorType & dst, VectorType const & src) const;
+  compute_projection_rhs(VectorType &       dst_scalar_valued,
+                         VectorType const & src_vector_valued) const;
 
 private:
   void
   cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                            dst,
-            VectorType const &                      src,
+            VectorType &                            dst_scalar_valued,
+            VectorType const &                      src_vector_valued,
             Range const &                           cell_range) const;
 
   dealii::MatrixFree<dim, Number> const * matrix_free;
 
-  unsigned int dof_index_u;
-  unsigned int dof_index_u_scalar;
+  unsigned int dof_index_vector;
+  unsigned int dof_index_scalar;
   unsigned int quad_index;
 };
 
+/*
+ * Calculator for the vorticity of a vector field u(x) defined as
+ *
+ * omega := curl(u)
+ *
+ * 2D : omega = - d u(1) / d x(2) + d u(2) / d x(1)
+ *
+ * 3D : omega(1) = d u(3) / d x(2) - d u(2) / d x(3)
+ *      omega(2) = d u(1) / d x(3) - d u(3) / d x(1)
+ *      omega(3) = d u(2) / d x(1) - d u(1) / d x(2)
+ *
+ * which is scalar-valued in 2D and vector-valued in 3D. Therefore, we always write into a
+ * vector-valued destination vector with `dim` components, filling only the first component in 2D.
+ * The second component in the solution vector in the 2D case corresponds to projecting the zero
+ * function into the finite element space.
+ */
 template<int dim, typename Number>
 class VorticityCalculator
 {
@@ -128,24 +169,32 @@ public:
 
   void
   initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const                      dof_index_in,
+             unsigned int const                      dof_index_vector_in,
              unsigned int const                      quad_index_in);
 
+  /*
+   * Compute the right-hand side of an L2 projection of the vorticity of the vector field.
+   */
   void
-  compute_vorticity(VectorType & dst, VectorType const & src) const;
+  compute_projection_rhs(VectorType &       dst_vector_valued,
+                         VectorType const & src_vector_valued) const;
 
 private:
   void
   cell_loop(dealii::MatrixFree<dim, Number> const &       matrix_free,
-            VectorType &                                  dst,
-            VectorType const &                            src,
+            VectorType &                                  dst_vector_valued,
+            VectorType const &                            src_vector_valued,
             std::pair<unsigned int, unsigned int> const & cell_range) const;
 
   dealii::MatrixFree<dim, Number> const * matrix_free;
-  unsigned int                            dof_index;
+  unsigned int                            dof_index_vector;
   unsigned int                            quad_index;
 };
 
+/*
+ * Calculator to project the viscosity coefficients stored in the `ViscousKernel` into the finite
+ * element space. Note that the viscosity is *not updated* but only accessed.
+ */
 template<int dim, typename Number>
 class ViscosityCalculator
 {
@@ -165,23 +214,26 @@ public:
 
   void
   initialize(dealii::MatrixFree<dim, Number> const &              matrix_free_in,
-             unsigned int const                                   dof_index_u_scalar_in,
+             unsigned int const                                   dof_index_scalar_in,
              unsigned int const                                   quad_index_in,
              IncNS::Operators::ViscousKernel<dim, Number> const & viscous_kernel_in);
 
+  /*
+   * Compute the right-hand side of an L2 projection of the stored viscosity.
+   */
   void
-  access_viscosity(VectorType & dst) const;
+  compute_projection_rhs(VectorType & dst_scalar_valued) const;
 
 private:
   void
   cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                            dst,
-            VectorType const &                      src,
+            VectorType &                            dst_scalar_valued,
+            VectorType const &                      src_scalar_valued,
             Range const &                           cell_range) const;
 
   dealii::MatrixFree<dim, Number> const * matrix_free;
 
-  unsigned int dof_index_u_scalar;
+  unsigned int dof_index_scalar;
   unsigned int quad_index;
 
   IncNS::Operators::ViscousKernel<dim, Number> const * viscous_kernel;
@@ -207,27 +259,34 @@ public:
 
   void
   initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const                      dof_index_u_in,
-             unsigned int const                      dof_index_u_scalar_in,
+             unsigned int const                      dof_index_vector_in,
+             unsigned int const                      dof_index_scalar_in,
              unsigned int const                      quad_index_in);
 
+  /*
+   * Compute the right-hand side of an L2 projection of the magnitude of the vector field.
+   */
   void
-  compute(VectorType & dst, VectorType const & src) const;
+  compute_projection_rhs(VectorType &       dst_scalar_valued,
+                         VectorType const & src_vector_valued) const;
 
 private:
   void
   cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                            dst,
-            VectorType const &                      src,
+            VectorType &                            dst_scalar_valued,
+            VectorType const &                      src_vector_valued,
             Range const &                           cell_range) const;
 
   dealii::MatrixFree<dim, Number> const * matrix_free;
 
-  unsigned int dof_index_u;
-  unsigned int dof_index_u_scalar;
+  unsigned int dof_index_vector;
+  unsigned int dof_index_scalar;
   unsigned int quad_index;
 };
 
+/*
+ * Calculator to project the Q-criterion into the finite element space.
+ */
 template<int dim, typename Number>
 class QCriterionCalculator
 {
@@ -249,25 +308,29 @@ public:
 
   void
   initialize(dealii::MatrixFree<dim, Number> const & matrix_free_in,
-             unsigned int const                      dof_index_u_in,
-             unsigned int const                      dof_index_u_scalar_in,
+             unsigned int const                      dof_index_vector_in,
+             unsigned int const                      dof_index_scalar_in,
              unsigned int const                      quad_index_in,
              bool const                              compressible_flow);
 
+  /*
+   * Compute the right-hand side of an L2 projection of the QCriterion of the vector field.
+   */
   void
-  compute(VectorType & dst, VectorType const & src) const;
+  compute_projection_rhs(VectorType &       dst_scalar_valued,
+                         VectorType const & src_vector_valued) const;
 
 private:
   void
   cell_loop(dealii::MatrixFree<dim, Number> const & matrix_free,
-            VectorType &                            dst,
-            VectorType const &                      src,
+            VectorType &                            dst_scalar_valued,
+            VectorType const &                      src_vector_valued,
             Range const &                           cell_range) const;
 
   dealii::MatrixFree<dim, Number> const * matrix_free;
 
-  unsigned int dof_index_u;
-  unsigned int dof_index_u_scalar;
+  unsigned int dof_index_vector;
+  unsigned int dof_index_scalar;
   unsigned int quad_index;
   bool         compressible_flow;
 };

--- a/include/exadg/operators/structure_calculators.cpp
+++ b/include/exadg/operators/structure_calculators.cpp
@@ -70,10 +70,8 @@ DisplacementJacobianCalculator<dim, Number>::cell_loop(
   for(unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
   {
     integrator_vector.reinit(cell);
-    // Do not enforce constraints on the `src` vector, as constraints are already applied and
-    // `dealii::MatrixFree` object stores constraints relevant in linear systemes, not necessarily
-    // constraints suitable for a DoF vector corresponding to the solution (e.g., in Newton's
-    // method).
+    // Do not enforce constraints on the `src` vector, as constraints are already applied and the
+    // `dealii::MatrixFree` object might store different constraints.
     integrator_vector.read_dof_values_plain(src_vector_valued);
     integrator_vector.evaluate(dealii::EvaluationFlags::gradients);
 

--- a/include/exadg/operators/structure_calculators.h
+++ b/include/exadg/operators/structure_calculators.h
@@ -31,12 +31,11 @@
 namespace ExaDG
 {
 /*
- * Calculator for the Jacobian of the displacement field u(X) in material coordinates X defined as
+ * Calculator for the Jacobian of the vector field u(x) defined as
  *
- * J = det(F) with F = I + Grad(u),
+ * J := det(F) with F := I + grad(u),
  *
- * where F is the deformation gradient tensor and Grad(u) is the gradient with respect to the
- * material coordinates X of the displacement field.
+ * where F is the deformation gradient tensor and grad(u) is the gradient of the vector field.
  *
  */
 template<int dim, typename Number>
@@ -62,7 +61,7 @@ public:
              unsigned int const                      quad_index_in);
 
   /*
-   * Compute the right-hand side of an L2 projection of the Jacobian of the displacement field.
+   * Compute the right-hand side of an L2 projection of the Jacobian of the vector field.
    */
   void
   compute_projection_rhs(VectorType & dst, VectorType const & src) const;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -712,7 +712,7 @@ Operator<dim, Number>::compute_displacement_magnitude(VectorType &       dst_sca
               dealii::ExcMessage("Scalar field not set up. "
                                  "Cannot compute displacement magnitude."));
 
-  vector_magnitude_calculator.compute(dst_scalar_valued, src_vector_valued);
+  vector_magnitude_calculator.compute_projection_rhs(dst_scalar_valued, src_vector_valued);
 
   inverse_mass_scalar.apply(dst_scalar_valued, dst_scalar_valued);
 }


### PR DESCRIPTION
0) use `integrator.read_dof_values_plain()` to ignore any constraints stored in the `MatrixFree` object such that we can reuse the calculators for any kind of problem where the constraints stored in the `MatrixFree` object might not be the same as for the DG case that we used in the Navier-Stokes module. Since this is in postprocessing, the `src` vector being the solution already has all constraints enforced. This is the only functional change, the rest is cosmetics for better readability.

1) the calculators have some main method, e.g., `compute_divergence()` for the `DivergenceCalculator`.
But these methods actually compute the right-hand side of an L2 projection.
Since the output `dst` already has the right size to be a DoF vector of an appropriately sized FE space, I renamed the function to `compute_projection_rhs()`.

2) rename the `src` and `dst` vectors to make clear which function space thy belong to.
E.g. for the `DivergenceCalculator` we have:
`src_vector_valued` ... which is the velocity
`dst_scalar_valued` ... which is the divergence of the velocity

3) make the calculators and naming used more generic and not tailored to the Navier-Stokes case. Also add some docu on the quantities that are computed.