### PR TITLE
Structure: use inverse mass operator

### DIFF
--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -549,11 +549,10 @@ private:
   std::shared_ptr<Krylov::SolverBase<VectorType>> linear_solver;
 
   /*
-   * Mass (inverse) operator(s) and solvers
+   * Inverse mass operators for initial acceleration problem and postprocessing.
    */
-  std::shared_ptr<PreconditionerBase<Number>>            mass_preconditioner;
-  std::shared_ptr<Krylov::SolverBase<VectorType>>        mass_solver;
-  InverseMassOperator<dim, 1 /* n_components */, Number> inverse_mass_scalar;
+  InverseMassOperator<dim, dim /* n_components */, Number> inverse_mass;
+  InverseMassOperator<dim, 1 /* n_components */, Number>   inverse_mass_scalar;
 
   /*
    * Calculators to obtain derived quantities.


### PR DESCRIPTION
Motivation for using the `InverseMassOperator` is that we can use the preconditioners implemented there immediately.

Also, once we have postprocessors/calculators for vector quantities, we will use it there as well.
One could think about introducing the functionality to give the `InverseMassOperator` a pointer to a `MassOperator`, then we only have one set up overall. The scaling has to be managed then as well, will do this after #821.