### PR TITLE
add structure max principal stress calculator

### DIFF
--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -709,6 +709,7 @@ private:
     pp_data.output_data.filename                     = this->output_parameters.filename;
     pp_data.output_data.write_displacement_magnitude = true;
     pp_data.output_data.write_displacement_jacobian  = true;
+    pp_data.output_data.write_max_principal_stress   = true;
     pp_data.output_data.write_higher_order           = true;
     pp_data.output_data.degree                       = this->param.degree;
 

--- a/include/exadg/operators/structure_calculators.cpp
+++ b/include/exadg/operators/structure_calculators.cpp
@@ -21,7 +21,7 @@
 
 // ExaDG
 #include <exadg/operators/structure_calculators.h>
-#include <exadg/structure/spatial_discretization/operators/continuum_mechanics.h>
+#include <exadg/structure/material/material_handler.h>
 
 namespace ExaDG
 {
@@ -90,10 +90,113 @@ DisplacementJacobianCalculator<dim, Number>::cell_loop(
   }
 }
 
+template<int dim, typename Number>
+MaxPrincipalStressCalculator<dim, Number>::MaxPrincipalStressCalculator()
+  : matrix_free(nullptr),
+    dof_index_vector(0),
+    dof_index_scalar(0),
+    quad_index(0),
+    elasticity_operator_base(nullptr)
+{
+}
+
+template<int dim, typename Number>
+void
+MaxPrincipalStressCalculator<dim, Number>::initialize(
+  dealii::MatrixFree<dim, Number> const &                matrix_free_in,
+  unsigned int const                                     dof_index_vector_in,
+  unsigned int const                                     dof_index_scalar_in,
+  unsigned int const                                     quad_index_in,
+  Structure::ElasticityOperatorBase<dim, Number> const & elasticity_operator_base_in)
+{
+  matrix_free              = &matrix_free_in;
+  dof_index_vector         = dof_index_vector_in;
+  dof_index_scalar         = dof_index_scalar_in;
+  quad_index               = quad_index_in;
+  elasticity_operator_base = &elasticity_operator_base_in;
+}
+
+template<int dim, typename Number>
+void
+MaxPrincipalStressCalculator<dim, Number>::compute_projection_rhs(
+  VectorType &       dst_scalar_valued,
+  VectorType const & src_vector_valued) const
+{
+  dst_scalar_valued = 0;
+
+  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued);
+}
+
+template<int dim, typename Number>
+void
+MaxPrincipalStressCalculator<dim, Number>::cell_loop(
+  dealii::MatrixFree<dim, Number> const &       matrix_free,
+  VectorType &                                  dst_scalar_valued,
+  VectorType const &                            src_vector_valued,
+  std::pair<unsigned int, unsigned int> const & cell_range) const
+{
+  CellIntegratorVector integrator_vector(matrix_free, dof_index_vector, quad_index, 0);
+  CellIntegratorScalar integrator_scalar(matrix_free, dof_index_scalar, quad_index, 0);
+
+  for(unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
+  {
+    // material_handler->reinit(matrix_free, cell);
+    // std::shared_ptr<Material<dim, Number>> material = material_handler.get_material();
+
+    Structure::Material<dim, Number> const & material =
+      elasticity_operator_base->get_material_in_cell(matrix_free, cell);
+
+    integrator_vector.reinit(cell);
+    // Do not enforce constraints on the `src` vector, as constraints are already applied and the
+    // `dealii::MatrixFree` object might store different constraints.
+    integrator_vector.read_dof_values_plain(src_vector_valued);
+    integrator_vector.evaluate(dealii::EvaluationFlags::gradients);
+
+    integrator_scalar.reinit(cell);
+
+    for(unsigned int q = 0; q < integrator_vector.n_q_points; q++)
+    {
+      tensor const           gradient_displacement = integrator_vector.get_gradient(q);
+      tensor const           F                     = Structure::get_F(gradient_displacement);
+      scalar const           Jacobian              = determinant(F);
+      symmetric_tensor const S =
+        material.second_piola_kirchhoff_stress(gradient_displacement, cell, q);
+      symmetric_tensor const sigma = Structure::compute_push_forward(Jacobian, S, F);
+
+      // Loop over vectorization length to use `dealii::eigenvalues()`.
+      scalar max_eigenvalue;
+      for(unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); v++)
+      {
+        dealii::SymmetricTensor<2, dim, Number> sigma_v;
+        for(unsigned int i = 0; i < dim; ++i)
+        {
+          for(unsigned int j = 0; j < dim; ++j)
+          {
+            sigma_v[i][j] = sigma[i][j][v];
+          }
+        }
+        std::array<Number, dim> eigenvalues_v = dealii::eigenvalues(sigma_v);
+
+        max_eigenvalue[v] = eigenvalues_v[0];
+      }
+
+      integrator_scalar.submit_value(max_eigenvalue, q);
+    }
+
+    integrator_scalar.integrate_scatter(dealii::EvaluationFlags::values, dst_scalar_valued);
+  }
+}
+
 template class DisplacementJacobianCalculator<2, float>;
 template class DisplacementJacobianCalculator<2, double>;
 
 template class DisplacementJacobianCalculator<3, float>;
 template class DisplacementJacobianCalculator<3, double>;
+
+template class MaxPrincipalStressCalculator<2, float>;
+template class MaxPrincipalStressCalculator<2, double>;
+
+template class MaxPrincipalStressCalculator<3, float>;
+template class MaxPrincipalStressCalculator<3, double>;
 
 } // namespace ExaDG

--- a/include/exadg/structure/postprocessor/output_generator.h
+++ b/include/exadg/structure/postprocessor/output_generator.h
@@ -36,7 +36,10 @@ namespace Structure
 {
 struct OutputData : public OutputDataBase
 {
-  OutputData() : write_displacement_magnitude(false), write_displacement_jacobian(false)
+  OutputData()
+    : write_displacement_magnitude(false),
+      write_displacement_jacobian(false),
+      write_max_principal_stress(false)
   {
   }
 
@@ -47,6 +50,7 @@ struct OutputData : public OutputDataBase
 
     print_parameter(pcout, "Write displacement magnitude", write_displacement_magnitude);
     print_parameter(pcout, "Write displacement Jacobian", write_displacement_jacobian);
+    print_parameter(pcout, "Write maximum principal stress", write_max_principal_stress);
   }
 
   // write displacement magnitude
@@ -54,6 +58,9 @@ struct OutputData : public OutputDataBase
 
   // write Jacobian of the displacement field
   bool write_displacement_jacobian;
+
+  // write maximum principal stress
+  bool write_max_principal_stress;
 };
 
 template<int dim, typename Number>

--- a/include/exadg/structure/postprocessor/postprocessor.h
+++ b/include/exadg/structure/postprocessor/postprocessor.h
@@ -79,6 +79,7 @@ private:
   // Fields for derived quantities
   SolutionField<dim, Number> displacement_magnitude;
   SolutionField<dim, Number> displacement_jacobian;
+  SolutionField<dim, Number> max_principal_stress;
 
   // write output for visualization of results (e.g., using paraview)
   OutputGenerator<dim, Number> output_generator;

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -352,8 +352,13 @@ public:
 
   // compute Jacobian of the displacement field
   void
-  compute_displacement_jacobian(VectorType &       dst_tensor_valued,
+  compute_displacement_jacobian(VectorType &       dst_scalar_valued,
                                 VectorType const & src_vector_valued) const;
+
+  // compute maximum principal stress
+  void
+  compute_max_principal_stress(VectorType &       dst_scalar_valued,
+                               VectorType const & src_vector_valued) const;
 
 private:
   /*
@@ -560,6 +565,8 @@ private:
   MagnitudeCalculator<dim, Number> vector_magnitude_calculator;
 
   DisplacementJacobianCalculator<dim, Number> displacement_jacobian_calculator;
+
+  MaxPrincipalStressCalculator<dim, Number> max_principal_stress_calculator;
 
   /*
    * MPI communicator

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -100,6 +100,22 @@ ElasticityOperatorBase<dim, Number>::get_data() const
 }
 
 template<int dim, typename Number>
+Material<dim, Number> const &
+ElasticityOperatorBase<dim, Number>::get_material_in_cell(
+  dealii::MatrixFree<dim, Number> const & matrix_free_in,
+  unsigned int const                      cell) const
+{
+  AssertThrow(
+    &matrix_free_in == &(*this->matrix_free),
+    dealii::ExcMessage(
+      "`MatrixFree` object underlying this `ElasticityOperatorBase` does not match the one provided."));
+
+  material_handler.reinit(matrix_free_in, cell);
+
+  return *(material_handler.get_material());
+}
+
+template<int dim, typename Number>
 void
 ElasticityOperatorBase<dim, Number>::get_constant_modes(
   std::vector<std::vector<bool>> &   constant_modes,

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.h
@@ -101,6 +101,10 @@ public:
   OperatorData<dim> const &
   get_data() const;
 
+  Material<dim, Number> const &
+  get_material_in_cell(dealii::MatrixFree<dim, Number> const & matrix_free_in,
+                       unsigned int const                      cell) const;
+
   /*
    * Provide near null space basis vectors, i.e., rigid body modes used in AMG setup.
    */

--- a/include/exadg/structure/spatial_discretization/operators/linear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/linear_operator.cpp
@@ -36,7 +36,7 @@ LinearOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) const
   for(unsigned int q = 0; q < integrator.n_q_points; ++q)
   {
     // Cauchy stresses, only valid for linear elasticity
-    tensor const sigma =
+    symmetric_tensor const sigma =
       material->second_piola_kirchhoff_stress(integrator.get_gradient(q),
                                               integrator.get_current_cell_index(),
                                               q);

--- a/include/exadg/structure/spatial_discretization/operators/linear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/linear_operator.h
@@ -39,7 +39,7 @@ private:
   typedef typename Base::IntegratorCell IntegratorCell;
   typedef typename Base::IntegratorFace IntegratorFace;
 
-  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+  typedef dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> symmetric_tensor;
 
   /*
    * Calculates the integral

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -250,7 +250,7 @@ NonLinearOperator<dim, Number>::do_cell_integral_nonlinear(IntegratorCell & inte
     tensor const F = get_F<dim, Number>(Grad_d);
 
     // 2nd Piola-Kirchhoff stresses
-    tensor const S =
+    symmetric_tensor const S =
       material->second_piola_kirchhoff_stress(Grad_d, integrator.get_current_cell_index(), q);
 
     // 1st Piola-Kirchhoff stresses P = F * S
@@ -326,7 +326,7 @@ NonLinearOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) co
     tensor const F_lin = get_F<dim, Number>(Grad_d_lin);
 
     // 2nd Piola-Kirchhoff stresses
-    tensor const S_lin =
+    symmetric_tensor const S_lin =
       material->second_piola_kirchhoff_stress(Grad_d_lin, integrator.get_current_cell_index(), q);
 
     // directional derivative of 1st Piola-Kirchhoff stresses P

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -43,9 +43,10 @@ private:
 
   typedef std::pair<unsigned int, unsigned int> Range;
 
-  typedef dealii::VectorizedArray<Number>                         scalar;
-  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
-  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+  typedef dealii::VectorizedArray<Number>                                  scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>          vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>>          tensor;
+  typedef dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> symmetric_tensor;
 
 private:
   /**


### PR DESCRIPTION
Adds a calculator to compute the maximum eigenvalue of the push-forward of the `material.second_piola_kirchhoff_stress_tensor()`.

checking the result ($\lambda_I \approx 129.279$) for the `structure/bar` application:
<img width="1385" height="1111" alt="image" src="https://github.com/user-attachments/assets/f6d54037-7845-4acf-9c78-0dd1cab552a1" />

$\lambda_I = f_x A_0 / A$
where $f_x = 100$ ... traction on Neumann boundary on the right
$A_0 = 10^2$ ... cross-sectional area _undeformed_ configuration
$A = 8.79509^2$ ... cross-sectional area in _deformed_ configuration

--> Perfect match :sunglasses: 

side note:

I could not do
```
    for(unsigned int q = 0; q < integrator_vector.n_q_points; q++)
    {
      tensor const           gradient_displacement = integrator_vector.get_gradient(q);
      tensor const           F                     = Structure::get_F(gradient_displacement);
      scalar const           Jacobian              = determinant(F);
      symmetric_tensor const S =
        material.second_piola_kirchhoff_stress(gradient_displacement, cell, q);
      symmetric_tensor const sigma = Structure::compute_push_forward(Jacobian, S, F);

      std::array<scalar, dim> eigenvalues = dealii::eigenvalues(S);

      integrator_scalar.submit_value(eigenvalues[0], q);
    }
```
because it gave me a linking error:
<img width="1255" height="402" alt="image" src="https://github.com/user-attachments/assets/7b2a77c0-d37e-4f76-b1b3-82dc846b8a08" />

so i had to loop over vectorization length. Since this is for the `rhs` in the L2 projection in postprocessing only, I do not think this is critical at the moment.