### PR TITLE
check `boundary_type` before integration, do not submit zeros

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_dual_splitting.cpp
@@ -117,8 +117,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_div_term_body_forces_boundary_
         integrator.submit_value(-flux_times_normal, q);
       }
 
-      integrator.integrate(dealii::EvaluationFlags::values);
-      integrator.distribute_local_to_global(dst);
+      integrator.integrate_scatter(dealii::EvaluationFlags::values, dst);
     }
     else if(boundary_type == BoundaryTypeU::Neumann or boundary_type == BoundaryTypeU::Symmetry)
     {
@@ -298,8 +297,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_numerical_time_derivative_
         integrator_pressure.submit_value(h, q);
       }
 
-      integrator_pressure.integrate(dealii::EvaluationFlags::values);
-      integrator_pressure.distribute_local_to_global(dst);
+      integrator_pressure.integrate_scatter(dealii::EvaluationFlags::values, dst);
     }
     else if(boundary_type == BoundaryTypeP::Dirichlet)
     {
@@ -369,8 +367,7 @@ OperatorDualSplitting<dim, Number>::local_rhs_ppe_nbc_body_force_term_add_bounda
         integrator.submit_value(h, q);
       }
 
-      integrator.integrate(dealii::EvaluationFlags::values);
-      integrator.distribute_local_to_global(dst);
+      integrator.integrate_scatter(dealii::EvaluationFlags::values, dst);
     }
     else if(boundary_type == BoundaryTypeP::Dirichlet)
     {


### PR DESCRIPTION
functionality unchanged, but less setup on faces we do not want to integrate over in the `BDFDualSplitting` method.
`do_not_merge` as I want to check it once again with a completely fresh brain tomorrow :)