### PR TITLE
fix viscosity restart for iNS

### DIFF
--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -352,6 +352,8 @@ TimeIntBDF<dim, Number>::read_restart_vectors()
   }
 
   this->set_vectors_deserialization(vectors_velocity_add, vectors_pressure_add);
+
+  this->update_after_deserialization();
 }
 
 template<int dim, typename Number>
@@ -421,6 +423,13 @@ TimeIntBDF<dim, Number>::set_vectors_deserialization(
   // deserialization.
   (void)vectors_velocity;
   (void)vectors_pressure;
+}
+
+template<int dim, typename Number>
+void
+TimeIntBDF<dim, Number>::update_after_deserialization()
+{
+  // Overwrite this method in the derived class to update data structures after deserialization.
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -125,6 +125,9 @@ protected:
   set_vectors_deserialization(std::vector<VectorType> const & vectors_velocity,
                               std::vector<VectorType> const & vectors_pressure);
 
+  virtual void
+  update_after_deserialization();
+
   void
   prepare_vectors_for_next_timestep() override;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -80,6 +80,14 @@ TimeIntBDFCoupled<dim, Number>::initialize_current_solution()
 
 template<int dim, typename Number>
 void
+TimeIntBDFCoupled<dim, Number>::update_after_deserialization()
+{
+  // Update the stored viscosity parameter.
+  pde_operator->update_viscosity(solution[0].block(0));
+}
+
+template<int dim, typename Number>
+void
 TimeIntBDFCoupled<dim, Number>::initialize_former_multistep_dof_vectors()
 {
   // note that the loop begins with i=1! (we could also start with i=0 but this is not necessary)

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.h
@@ -88,6 +88,9 @@ private:
   initialize_former_multistep_dof_vectors() final;
 
   void
+  update_after_deserialization() final;
+
+  void
   do_timestep_solve() final;
 
   void

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -117,6 +117,14 @@ TimeIntBDFDualSplitting<dim, Number>::set_vectors_deserialization(
 
 template<int dim, typename Number>
 void
+TimeIntBDFDualSplitting<dim, Number>::update_after_deserialization()
+{
+  // Update the stored viscosity parameter.
+  pde_operator->update_viscosity(velocity[0]);
+}
+
+template<int dim, typename Number>
+void
 TimeIntBDFDualSplitting<dim, Number>::allocate_vectors()
 {
   Base::allocate_vectors();

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.h
@@ -92,6 +92,9 @@ private:
                               std::vector<VectorType> const & vectors_pressure) final;
 
   void
+  update_after_deserialization() final;
+
+  void
   do_timestep_solve() final;
 
   void

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.cpp
@@ -126,6 +126,14 @@ TimeIntBDFPressureCorrection<dim, Number>::set_vectors_deserialization(
 
 template<int dim, typename Number>
 void
+TimeIntBDFPressureCorrection<dim, Number>::update_after_deserialization()
+{
+  // Update the stored viscosity parameter.
+  pde_operator->update_viscosity(velocity[0]);
+}
+
+template<int dim, typename Number>
+void
 TimeIntBDFPressureCorrection<dim, Number>::allocate_vectors()
 {
   Base::allocate_vectors();

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_pressure_correction.h
@@ -101,6 +101,9 @@ private:
                               std::vector<VectorType> const & vectors_pressure) final;
 
   void
+  update_after_deserialization() final;
+
+  void
   initialize_pressure_on_boundary();
 
   void


### PR DESCRIPTION
we forgot to setup the viscosity after restart.

I did not realize this as one needs to look at the viscosity that is exported.

The errors were not affected at all, because we always update the viscosity using the extrapolation before any solve.
So it was only visible in the output for the previous solver form, but it would have been wrong if we accessed the viscosity straight after restart. 

I could not put the functionality into `TimeIntBDF::udpate_after_grid_motion()` as the call `pde_operator->update_viscosity(velocity)` requires a `pde_operator` to work on, which live in the child classes.