### PR TITLE
Fix compilation

### DIFF
--- a/include/exadg/utilities/evaluate_convergence_study.cpp
+++ b/include/exadg/utilities/evaluate_convergence_study.cpp
@@ -22,6 +22,7 @@
 // C++
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 
 // deal.II


### PR DESCRIPTION
Fixes an issue that came up due after merging #368, my compiler is missing the `iostream` headers for `std::cout`.