### PR TITLE
Fix Navier-Stokes calculators

### DIFF
--- a/include/exadg/operators/navier_stokes_calculators.cpp
+++ b/include/exadg/operators/navier_stokes_calculators.cpp
@@ -49,9 +49,7 @@ DivergenceCalculator<dim, Number>::compute_projection_rhs(
   VectorType &       dst_scalar_valued,
   VectorType const & src_vector_valued) const
 {
-  dst_scalar_valued = 0.0;
-
-  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued);
+  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued, true);
 }
 
 template<int dim, typename Number>
@@ -109,9 +107,7 @@ void
 ShearRateCalculator<dim, Number>::compute_projection_rhs(VectorType &       dst_scalar_valued,
                                                          VectorType const & src_vector_valued) const
 {
-  dst_scalar_valued = 0.0;
-
-  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued);
+  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued, true);
 }
 
 template<int dim, typename Number>
@@ -170,12 +166,8 @@ template<int dim, typename Number>
 void
 ViscosityCalculator<dim, Number>::compute_projection_rhs(VectorType & dst_scalar_valued) const
 {
-  dst_scalar_valued = 0.0;
-
-  matrix_free->cell_loop(&This::cell_loop,
-                         this,
-                         dst_scalar_valued,
-                         dst_scalar_valued /* not used */);
+  matrix_free->cell_loop(
+    &This::cell_loop, this, dst_scalar_valued, dst_scalar_valued /* not used */, true);
 }
 
 template<int dim, typename Number>
@@ -226,7 +218,7 @@ void
 VorticityCalculator<dim, Number>::compute_projection_rhs(VectorType &       dst_vector_valued,
                                                          VectorType const & src_vector_valued) const
 {
-  matrix_free->cell_loop(&This::cell_loop, this, dst_vector_valued, src_vector_valued);
+  matrix_free->cell_loop(&This::cell_loop, this, dst_vector_valued, src_vector_valued, true);
 }
 
 template<int dim, typename Number>
@@ -291,9 +283,7 @@ void
 MagnitudeCalculator<dim, Number>::compute_projection_rhs(VectorType &       dst_scalar_valued,
                                                          VectorType const & src_vector_valued) const
 {
-  dst_scalar_valued = 0.0;
-
-  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued);
+  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued, true);
 }
 
 template<int dim, typename Number>
@@ -358,10 +348,7 @@ QCriterionCalculator<dim, Number>::compute_projection_rhs(
   VectorType &       dst_scalar_valued,
   VectorType const & src_vector_valued) const
 {
-  dst_scalar_valued = 0;
-
-  matrix_free->cell_loop(
-    &This::cell_loop, this, dst_scalar_valued, src_vector_valued, compressible_flow);
+  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued, true);
 }
 
 template<int dim, typename Number>


### PR DESCRIPTION
I tried to look into a case with H(div) and the vorticity was off, because we forgot to set the vectors to zero before adding into them in `MatrixFree::cell_loop`. We should let `MatrixFree` do that. And once there, do it uniformly for all calculators.