### PR TITLE
wrap Trilinos ML includes in `DEAL_II_DISABLE_EXTRA_DIAGNOSTICS`

### DIFF
--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -32,7 +32,9 @@
 
 // Trilinos
 #ifdef DEAL_II_WITH_TRILINOS
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <ml_MultiLevelPreconditioner.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 // ExaDG


### PR DESCRIPTION
with this and https://github.com/dealii/dealii/pull/19043 we have suppressed all the warnings (at least on my machines).

Note that this is only a workaround until we have fixed a path towards resolving #809 

but we can avoid getting spammed (rightfully so :laughing: ) by Trilinos' deprecation warnings. 