### PR TITLE
enable GMRES in structure module

### DIFF
--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -340,6 +340,18 @@ public:
   {
   }
 
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+      prm.add_parameter("Solver", solver, "Krylov solver used.");
+    }
+    prm.leave_subsection();
+  }
+
 private:
   void
   set_parameters() final
@@ -365,7 +377,7 @@ private:
     this->param.mapping_degree_coarse_grids = this->param.mapping_degree;
 
     this->param.newton_solver_data  = Newton::SolverData(1e4, 1.e-10, 1.e-10);
-    this->param.solver              = Solver::CG;
+    this->param.solver              = solver;
     this->param.solver_data         = SolverData(1e4, 1.e-12, 1.e-6, 100);
     this->param.preconditioner      = Preconditioner::Multigrid;
     this->param.multigrid_data.type = MultigridType::phMG;
@@ -516,6 +528,8 @@ private:
   double const start_time       = 0.0;
   double const end_time         = 1.0;
   double const frequency        = 3.0 / 2.0 * dealii::numbers::PI / end_time;
+
+  Solver solver = Solver::CG;
 
   bool const prescribe_initial_acceleration_as_field_function = false;
 };

--- a/applications/structure/manufactured/input.json
+++ b/applications/structure/manufactured/input.json
@@ -15,6 +15,7 @@
         "RefineTimeMax": "10"
     },
     "Application": {
+        "Solver": "CG",
         "Length": "100.0",
         "Height": "10.0",
         "Width": "10.0"

--- a/applications/structure/manufactured/tests/2d.json
+++ b/applications/structure/manufactured/tests/2d.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "8"
     },
     "Application": {
-        "MaterialType": "StVenantKirchhoff",
+        "Solver": "CG",
         "Length": "100.0",
         "Height": "10.0",
         "Width": "10.0"

--- a/applications/structure/manufactured/tests/3d.json
+++ b/applications/structure/manufactured/tests/3d.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "8"
     },
     "Application": {
-        "MaterialType": "StVenantKirchhoff",
+        "Solver": "CG",
         "Length": "100.0",
         "Height": "10.0",
         "Width": "10.0"

--- a/include/exadg/structure/user_interface/enum_types.h
+++ b/include/exadg/structure/user_interface/enum_types.h
@@ -103,6 +103,7 @@ enum class Solver
 {
   Undefined,
   CG,
+  GMRES,
   FGMRES
 };
 


### PR DESCRIPTION
For a problem w 350k DoFs in the 3D manufactured application I get:
(Error norms are identical. )

FGMRES
<img width="493" height="810" alt="image" src="https://github.com/user-attachments/assets/947abcc3-f099-47f5-8f06-f26d315a29de" />

CG
<img width="493" height="810" alt="image" src="https://github.com/user-attachments/assets/ca989346-d566-4c63-8094-4eee90a81b0a" />

GMRES
<img width="493" height="810" alt="image" src="https://github.com/user-attachments/assets/8d527125-9632-4f99-a862-440706d458ec" />

So here it barely pays off in this simple example, but if we had closer to 30 iterations, having `GMRES` is an easily achieved performance improvement (requires less memory, has lower orthogonalization cost, has a less expensive restart, etc.).
