### PR TITLE
Introduce `GMRES` and `BiCGStab` solvers in structure module

### DIFF
--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -340,6 +340,18 @@ public:
   {
   }
 
+  void
+  add_parameters(dealii::ParameterHandler & prm) final
+  {
+    ApplicationBase<dim, Number>::add_parameters(prm);
+
+    prm.enter_subsection("Application");
+    {
+      prm.add_parameter("Solver", solver, "Krylov solver used.");
+    }
+    prm.leave_subsection();
+  }
+
 private:
   void
   set_parameters() final
@@ -365,7 +377,7 @@ private:
     this->param.mapping_degree_coarse_grids = this->param.mapping_degree;
 
     this->param.newton_solver_data  = Newton::SolverData(1e4, 1.e-10, 1.e-10);
-    this->param.solver              = Solver::CG;
+    this->param.solver              = solver;
     this->param.solver_data         = SolverData(1e4, 1.e-12, 1.e-6, 100);
     this->param.preconditioner      = Preconditioner::Multigrid;
     this->param.multigrid_data.type = MultigridType::phMG;
@@ -516,6 +528,8 @@ private:
   double const start_time       = 0.0;
   double const end_time         = 1.0;
   double const frequency        = 3.0 / 2.0 * dealii::numbers::PI / end_time;
+
+  Solver solver = Solver::CG;
 
   bool const prescribe_initial_acceleration_as_field_function = false;
 };

--- a/applications/structure/manufactured/input.json
+++ b/applications/structure/manufactured/input.json
@@ -15,6 +15,7 @@
         "RefineTimeMax": "10"
     },
     "Application": {
+        "Solver": "CG",
         "Length": "100.0",
         "Height": "10.0",
         "Width": "10.0"

--- a/applications/structure/manufactured/tests/2d.json
+++ b/applications/structure/manufactured/tests/2d.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "8"
     },
     "Application": {
-        "MaterialType": "StVenantKirchhoff",
+        "Solver": "CG",
         "Length": "100.0",
         "Height": "10.0",
         "Width": "10.0"

--- a/applications/structure/manufactured/tests/3d.json
+++ b/applications/structure/manufactured/tests/3d.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "8"
     },
     "Application": {
-        "MaterialType": "StVenantKirchhoff",
+        "Solver": "CG",
         "Length": "100.0",
         "Height": "10.0",
         "Width": "10.0"

--- a/include/exadg/operators/navier_stokes_calculators.cpp
+++ b/include/exadg/operators/navier_stokes_calculators.cpp
@@ -107,7 +107,8 @@ void
 ShearRateCalculator<dim, Number>::compute_projection_rhs(VectorType &       dst_scalar_valued,
                                                          VectorType const & src_vector_valued) const
 {
-  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued, true);
+  matrix_free->cell_loop(
+    &This::cell_loop, this, dst_scalar_valued, src_vector_valued, true /* zero_dst_vector */);
 }
 
 template<int dim, typename Number>
@@ -166,8 +167,11 @@ template<int dim, typename Number>
 void
 ViscosityCalculator<dim, Number>::compute_projection_rhs(VectorType & dst_scalar_valued) const
 {
-  matrix_free->cell_loop(
-    &This::cell_loop, this, dst_scalar_valued, dst_scalar_valued /* not used */, true);
+  matrix_free->cell_loop(&This::cell_loop,
+                         this,
+                         dst_scalar_valued,
+                         dst_scalar_valued /* not used */,
+                         true /* zero_dst_vector */);
 }
 
 template<int dim, typename Number>
@@ -283,7 +287,8 @@ void
 MagnitudeCalculator<dim, Number>::compute_projection_rhs(VectorType &       dst_scalar_valued,
                                                          VectorType const & src_vector_valued) const
 {
-  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued, true);
+  matrix_free->cell_loop(
+    &This::cell_loop, this, dst_scalar_valued, src_vector_valued, true /* zero_dst_vector */);
 }
 
 template<int dim, typename Number>
@@ -348,7 +353,8 @@ QCriterionCalculator<dim, Number>::compute_projection_rhs(
   VectorType &       dst_scalar_valued,
   VectorType const & src_vector_valued) const
 {
-  matrix_free->cell_loop(&This::cell_loop, this, dst_scalar_valued, src_vector_valued, true);
+  matrix_free->cell_loop(
+    &This::cell_loop, this, dst_scalar_valued, src_vector_valued, true /* zero_dst_vector */);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -596,6 +596,14 @@ Operator<dim, Number>::setup_solver()
   {
     name = "cg";
   }
+  else if(param.solver == Solver::BiCGStab)
+  {
+    name = "bicgstab";
+  }
+  else if(param.solver == Solver::GMRES)
+  {
+    name = "gmres";
+  }
   else if(param.solver == Solver::FGMRES)
   {
     name = "fgmres";

--- a/include/exadg/structure/user_interface/enum_types.h
+++ b/include/exadg/structure/user_interface/enum_types.h
@@ -103,6 +103,8 @@ enum class Solver
 {
   Undefined,
   CG,
+  BiCGStab,
+  GMRES,
   FGMRES
 };
 


### PR DESCRIPTION
just by adding the conversion from enums to the `dealii::SolverSelector::name`

At a later point, we can completely remove the enums if we want to.
See #851

Iterations are identical to what is posted in https://github.com/exadg/exadg/pull/845