### PR TITLE
zero ghost values before adding into vector

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/continuity_penalty_operator.h
@@ -206,6 +206,8 @@ public:
         array_penalty_parameter[cell] = data.penalty_factor * (tau_convective + tau_viscous);
       }
     }
+
+    velocity.zero_out_ghost_values();
   }
 
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -72,6 +72,9 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator(VectorType &       
 {
   this->time = time;
 
+  kernel->update_ghost_values_velocity();
+  kernel->update_ghost_values_grid_velocity();
+
   this->matrix_free->loop(&This::cell_loop_nonlinear_operator,
                           &This::face_loop_nonlinear_operator,
                           &This::boundary_face_loop_nonlinear_operator,
@@ -81,6 +84,9 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator(VectorType &       
                           true /*zero_dst_vector = true*/,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
+
+  kernel->zero_out_ghost_values_velocity();
+  kernel->zero_out_ghost_values_grid_velocity();
 }
 
 template<int dim, typename Number>
@@ -91,6 +97,9 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator_add(VectorType &   
 {
   this->time = time;
 
+  kernel->update_ghost_values_velocity();
+  kernel->update_ghost_values_grid_velocity();
+
   this->matrix_free->loop(&This::cell_loop_nonlinear_operator,
                           &This::face_loop_nonlinear_operator,
                           &This::boundary_face_loop_nonlinear_operator,
@@ -100,6 +109,9 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator_add(VectorType &   
                           false /*zero_dst_vector = false*/,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
+
+  kernel->zero_out_ghost_values_velocity();
+  kernel->zero_out_ghost_values_grid_velocity();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -179,30 +179,50 @@ public:
   set_velocity_copy(VectorType const & src)
   {
     velocity.own() = src;
-
-    velocity->update_ghost_values();
   }
 
   void
   set_velocity_ptr(VectorType const & src)
   {
     velocity.reset(src);
-
-    velocity->update_ghost_values();
   }
 
   void
   set_grid_velocity_ptr(VectorType const & src)
   {
     grid_velocity.reset(src);
-
-    grid_velocity->update_ghost_values();
   }
 
   VectorType const &
   get_grid_velocity() const
   {
     return *grid_velocity;
+  }
+
+  void
+  update_ghost_values_velocity()
+  {
+    velocity->update_ghost_values();
+  }
+
+  void
+  update_ghost_values_grid_velocity()
+  {
+    if(data.ale)
+      grid_velocity->update_ghost_values();
+  }
+
+  void
+  zero_out_ghost_values_velocity()
+  {
+    velocity->zero_out_ghost_values();
+  }
+
+  void
+  zero_out_ghost_values_grid_velocity()
+  {
+    if(data.ale)
+      grid_velocity->zero_out_ghost_values();
   }
 
   inline DEAL_II_ALWAYS_INLINE //

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/divergence_penalty_operator.h
@@ -197,6 +197,8 @@ public:
         array_penalty_parameter[cell] = data.penalty_factor * (tau_convective + tau_viscous);
       }
     }
+
+    velocity.zero_out_ghost_values();
   }
 
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1299,6 +1299,9 @@ SpatialOperatorBase<dim, Number>::calculate_time_step_cfl(VectorType const & vel
                                                     param.cfl_exponent_fe_degree_velocity,
                                                     param.adaptive_time_stepping_cfl_type,
                                                     mpi_comm);
+
+  if(param.spatial_discretization == SpatialDiscretization::HDIV)
+    velocity.zero_out_ghost_values();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
+++ b/include/exadg/solvers_and_preconditioners/newton/newton_solver.h
@@ -56,9 +56,9 @@ public:
     unsigned int newton_iterations = 0, linear_iterations = 0;
 
     VectorType residual, increment, temporary;
-    residual.reinit(solution);
-    increment.reinit(solution);
-    temporary.reinit(solution);
+    residual.reinit(solution, true /* omit_zeroing_entries */);
+    increment.reinit(solution, true /* omit_zeroing_entries */);
+    temporary.reinit(solution, true /* omit_zeroing_entries */);
 
     // evaluate residual using initial guess of solution
     nonlinear_operator.evaluate_residual(residual, solution);
@@ -97,7 +97,7 @@ public:
       do
       {
         // add increment to solution vector but scale by a factor omega <= 1
-        temporary = solution;
+        temporary.copy_locally_owned_data_from(solution);
         temporary.add(omega, increment);
 
         // evaluate residual using the temporary solution
@@ -118,8 +118,8 @@ public:
                                      "Maximum number of iterations exceeded!"));
 
       // update solution and residual
-      solution = temporary;
-      norm_r   = norm_r_damp;
+      solution.copy_locally_owned_data_from(temporary);
+      norm_r = norm_r_damp;
 
       // increment iteration counter
       ++newton_iterations;


### PR DESCRIPTION
before the recent rounds of improvements, we set
`velocity_np = 0;`
in the beginning of the convective step.
We made that dependent on `this->param.convective_problem()`.

Now running it in debug mode, I found that
`pde_operator->evaluate_add_body_force_term(velocity_np, this->get_next_time());`
raises an assertion that ghost values are present in `velocity_np` and that one cannot add into it.

I do not think that this fixes #832 as we have no ghost values for a serial run and I did not use a convective term for these tests.