### PR TITLE
extract `estimate_eigenvalues_gmres` from SolverGMRES

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -294,7 +294,7 @@ public:
     coarse_operator.calculate_inverse_diagonal(diagonal_vector);
 
     std::pair<double, double> eigenvalues =
-      compute_eigenvalues(coarse_operator, diagonal_vector, operator_is_singular);
+      estimate_eigenvalues_cg(coarse_operator, diagonal_vector, operator_is_singular);
 
     double const factor = 1.1;
 

--- a/include/exadg/solvers_and_preconditioners/solvers/solver_data.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/solver_data.h
@@ -59,6 +59,71 @@ struct SolverData
   // only relevant for GMRES type solvers
   unsigned int max_krylov_size;
 };
+
+// `SolverData` structs for deal.II wrapper classes
+namespace Krylov
+{
+struct SolverDataCG
+{
+  SolverDataCG()
+    : max_iter(1e4),
+      solver_tolerance_abs(1.e-20),
+      solver_tolerance_rel(1.e-6),
+      use_preconditioner(false),
+      compute_performance_metrics(false)
+  {
+  }
+
+  unsigned int max_iter;
+  double       solver_tolerance_abs;
+  double       solver_tolerance_rel;
+  bool         use_preconditioner;
+  bool         compute_performance_metrics;
+};
+
+struct SolverDataGMRES
+{
+  SolverDataGMRES()
+    : max_iter(1e4),
+      solver_tolerance_abs(1.e-20),
+      solver_tolerance_rel(1.e-6),
+      use_preconditioner(false),
+      max_n_tmp_vectors(30),
+      compute_eigenvalues(false),
+      compute_performance_metrics(false)
+  {
+  }
+
+  unsigned int max_iter;
+  double       solver_tolerance_abs;
+  double       solver_tolerance_rel;
+  bool         use_preconditioner;
+  unsigned int max_n_tmp_vectors;
+  bool         compute_eigenvalues;
+  bool         compute_performance_metrics;
+};
+
+struct SolverDataFGMRES
+{
+  SolverDataFGMRES()
+    : max_iter(1e4),
+      solver_tolerance_abs(1.e-20),
+      solver_tolerance_rel(1.e-6),
+      use_preconditioner(false),
+      max_n_tmp_vectors(30),
+      compute_performance_metrics(false)
+  {
+  }
+
+  unsigned int max_iter;
+  double       solver_tolerance_abs;
+  double       solver_tolerance_rel;
+  bool         use_preconditioner;
+  unsigned int max_n_tmp_vectors;
+  bool         compute_performance_metrics;
+};
+
+} // namespace Krylov
 } // namespace ExaDG
 
 #endif /* EXADG_SOLVERS_AND_PRECONDITIONERS_SOLVERS_SOLVER_DATA_H_ */

--- a/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
+++ b/include/exadg/solvers_and_preconditioners/utilities/compute_eigenvalues.h
@@ -25,21 +25,27 @@
 // deal.II
 #include <deal.II/numerics/vector_tools_mean_value.h>
 
+// ExaDG
+#include <exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h>
+#include <exadg/solvers_and_preconditioners/solvers/solver_data.h>
+
 namespace ExaDG
 {
-// manually compute eigenvalues for the coarsest level for proper setup of the
-// Chebyshev iteration
+/*
+ * Utility function to estimate the Eigenvalues of `Operator` via a
+ * conjugate gradient solve preconditioned by the inverse diagonal.
+ */
 template<typename Operator, typename VectorType>
 std::pair<double, double>
-compute_eigenvalues(Operator const &   op,
-                    VectorType const & inverse_diagonal,
-                    bool const         operator_is_singular,
-                    unsigned int const eig_n_iter = 10000)
+estimate_eigenvalues_cg(Operator const &   underlying_operator,
+                        VectorType const & inverse_diagonal,
+                        bool const         operator_is_singular,
+                        unsigned int const eig_n_iter = 10000)
 {
   VectorType solution, rhs;
   solution.reinit(inverse_diagonal);
   rhs.reinit(inverse_diagonal, true);
-  // NB: initialize rand in order to obtain "reproducible" results!
+  // seed `rand` in order to obtain reproducible results
   srand(1);
   for(unsigned int i = 0; i < rhs.locally_owned_size(); ++i)
     rhs.local_element(i) = (double)rand() / RAND_MAX;
@@ -53,45 +59,106 @@ compute_eigenvalues(Operator const &   op,
 
   solver.connect_eigenvalues_slot(std::bind(&dealii::internal::EigenvalueTracker::slot,
                                             &eigenvalue_tracker,
-                                            std::placeholders::_1));
+                                            std::placeholders::_1),
+                                  false /* every_iteration */);
 
-  JacobiPreconditioner<Operator> preconditioner(op, true /* initialize */);
+  JacobiPreconditioner<Operator> preconditioner(underlying_operator, true /* initialize */);
 
   try
   {
-    solver.solve(op, solution, rhs, preconditioner);
+    solver.solve(underlying_operator, solution, rhs, preconditioner);
   }
   catch(dealii::SolverControl::NoConvergence &)
   {
+    // accept the current estimates despite non-convergence
   }
 
-  std::pair<double, double> eigenvalues;
+  std::pair<double, double> eigenvalues_min_max;
   if(eigenvalue_tracker.values.empty())
   {
-    eigenvalues.first = eigenvalues.second = 1.;
+    eigenvalues_min_max.first = eigenvalues_min_max.second = 1.;
   }
   else
   {
-    eigenvalues.first  = eigenvalue_tracker.values.front();
-    eigenvalues.second = eigenvalue_tracker.values.back();
+    eigenvalues_min_max.first  = eigenvalue_tracker.values.front();
+    eigenvalues_min_max.second = eigenvalue_tracker.values.back();
   }
 
-  return eigenvalues;
+  return eigenvalues_min_max;
 }
 
-template<typename Number>
+// Struct to track complex eigenvalues similar to `dealii::internals::EigenValueTracker`.
 struct EigenvalueTracker
 {
 public:
   void
-  slot(const std::vector<Number> & eigenvalues)
+  slot(std::vector<std::complex<double>> const & eigenvalues)
   {
     values = eigenvalues;
   }
 
-  std::vector<Number> values;
+  std::vector<std::complex<double>> values;
 };
 
+/*
+ * Utility function to estimate and print the Eigenvalues of `Operator` via a preconditioned GMRES
+ * solve. This function is used for debugging only and assumes a previous solve such that `solution`
+ * and `rhs` solve the system up to tolerance already.
+ */
+template<typename Operator, typename Preconditioner, typename VectorType>
+std::vector<std::complex<double>>
+estimate_eigenvalues_gmres(Operator const &                underlying_operator,
+                           Preconditioner const &          preconditioner,
+                           VectorType const &              solution,
+                           VectorType const &              rhs,
+                           Krylov::SolverDataGMRES const & solver_data,
+                           bool const                      print)
+{
+  // initial guess
+  VectorType tmp(solution);
+
+  dealii::ReductionControl solver_control(solver_data.max_iter,
+                                          solver_data.solver_tolerance_abs,
+                                          solver_data.solver_tolerance_rel);
+
+  typename dealii::SolverGMRES<VectorType>::AdditionalData additional_data;
+  additional_data.max_n_tmp_vectors     = solver_data.max_n_tmp_vectors;
+  additional_data.right_preconditioning = true;
+  dealii::SolverGMRES<VectorType> solver(solver_control, additional_data);
+
+  EigenvalueTracker eigenvalue_tracker;
+  solver.connect_eigenvalues_slot(std::bind(&EigenvalueTracker::slot,
+                                            &eigenvalue_tracker,
+                                            std::placeholders::_1),
+                                  true /* every_iteration */);
+
+  try
+  {
+    solver.solve(underlying_operator, tmp, rhs, preconditioner);
+  }
+  catch(dealii::SolverControl::NoConvergence &)
+  {
+    // accept the current estimates despite non-convergence
+  }
+
+  std::vector<std::complex<double>> const & eigenvalues = eigenvalue_tracker.values;
+
+  if(print)
+  {
+    MPI_Comm const & mpi_comm = solution.get_mpi_communicator();
+    if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+    {
+      std::cout << "Approximate eigenvalues:\n";
+      for(unsigned int j = 0; j < eigenvalues.size(); ++j)
+      {
+        std::cout << ' ' << eigenvalues[j] << "\n";
+      }
+      std::cout << "\n";
+    }
+  }
+
+  return eigenvalues;
+}
 } // namespace ExaDG
 
 #endif /* EXADG_SOLVERS_AND_PRECONDITIONERS_UTILITIES_COMPUTE_EIGENVALUES_H_ */


### PR DESCRIPTION
this is inspired by the discussion in https://github.com/exadg/exadg/pull/846#issuecomment-3600611303

the idea is:
use `dealii::SolverSelector` https://dealii.org/current/doxygen/deal.II/classSolverSelector.html
the problem: we cannot use the `solver.connect_eigenvalues_slot()` to get the eigenvalue estimates i we work with `dealii::SolverSelector`.

`SolverGMRES` has as the only additional functionality to get eigenvalue estimates.
This functionality is only used for debugging or for presentation in papers, where performance is in that step not the focus. We can also provide this functionality for all operators, not just when using GMRES as primary solve.

So I think we should do the following:
1) extract the functionality of estimating eigenvalues from `SolverGMRES` into `estimate_eigenvalues_gmres()` (this PR)
-> this is essentially a *second* system solve, during which the eigenvalues are estimated. I experimented with passing in the solution from the first solve, but then the estimate is not computed :cry:. I think for the purpose we have (debugging only!), we do not care about the second solve.

2) we can unify all the solvers we have into a tighter wrapper class that also allows us to estimate eigenvalues independent of which first solver we use (as the debug eigenvalue estimation is a second GMRES solve anyways!)

3) we can close #845 #846 and can simplify the setup of the linear solvers everywhere.

I want to this in a few PRs though. will push the other parts soon.