### PR TITLE
Fix issue 852: move `evaluate_convergence_study()` to destructor of postprocessor

### DIFF
--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -794,6 +794,7 @@ private:
     pp_data.output_data.write_higher_order = true;
 
     // calculation of velocity error
+    pp_data.error_data_u.compute_convergence_table          = false;
     pp_data.error_data_u.write_errors_to_file               = true;
     pp_data.error_data_u.time_control_data.is_active        = true;
     pp_data.error_data_u.time_control_data.start_time       = start_time;

--- a/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.cpp
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <exadg/acoustic_conservation_equations/postprocessor/postprocessor.h>
+#include <exadg/utilities/evaluate_convergence_study.h>
 
 namespace ExaDG
 {
@@ -37,6 +38,19 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & postpro
     sound_energy_calculator(comm)
 
 {
+}
+
+template<int dim, typename Number>
+PostProcessor<dim, Number>::~PostProcessor()
+{
+  // Evaluate the convergence study.
+  std::vector<std::string> error_directories;
+  if(pp_data.error_data_u.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data_u.directory);
+  if(pp_data.error_data_p.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data_p.directory);
+
+  evaluate_convergence_study(mpi_comm, error_directories);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.h
+++ b/include/exadg/acoustic_conservation_equations/postprocessor/postprocessor.h
@@ -60,6 +60,9 @@ public:
 
   PostProcessor(PostProcessorData<dim> const & postprocessor_data, MPI_Comm const & mpi_comm);
 
+  // custom destructor computing convergence tables if desired
+  virtual ~PostProcessor();
+
   void
   setup(AcousticsOperator const & pde_operator) final;
 

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -21,6 +21,7 @@
 
 #include <exadg/compressible_navier_stokes/postprocessor/postprocessor.h>
 #include <exadg/compressible_navier_stokes/spatial_discretization/operator.h>
+#include <exadg/utilities/evaluate_convergence_study.h>
 #include <exadg/utilities/numbers.h>
 
 namespace ExaDG
@@ -45,6 +46,12 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & postpro
 template<int dim, typename Number>
 PostProcessor<dim, Number>::~PostProcessor()
 {
+  // Evaluate the convergence study.
+  std::vector<std::string> error_directories;
+  if(pp_data.error_data.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data.directory);
+
+  evaluate_convergence_study(mpi_comm, error_directories);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/compressible_navier_stokes/postprocessor/postprocessor.h
@@ -56,6 +56,7 @@ public:
 
   PostProcessor(PostProcessorData<dim> const & postprocessor_data, MPI_Comm const & comm);
 
+  // custom destructor computing convergence tables if desired
   virtual ~PostProcessor();
 
   void

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor.cpp
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor.cpp
@@ -21,6 +21,7 @@
 
 #include <exadg/convection_diffusion/postprocessor/postprocessor.h>
 #include <exadg/convection_diffusion/spatial_discretization/operator.h>
+#include <exadg/utilities/evaluate_convergence_study.h>
 
 namespace ExaDG
 {
@@ -34,6 +35,17 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data
     output_generator(mpi_comm_in),
     error_calculator(mpi_comm_in)
 {
+}
+
+template<int dim, typename Number>
+PostProcessor<dim, Number>::~PostProcessor()
+{
+  // Evaluate the convergence study.
+  std::vector<std::string> error_directories;
+  if(pp_data.error_data.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data.directory);
+
+  evaluate_convergence_study(mpi_comm, error_directories);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/postprocessor/postprocessor.h
+++ b/include/exadg/convection_diffusion/postprocessor/postprocessor.h
@@ -58,6 +58,9 @@ protected:
 public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
+  // custom destructor computing convergence tables if desired
+  virtual ~PostProcessor();
+
   void
   setup(Operator<dim, Number> const & pde_operator) override;
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <exadg/incompressible_navier_stokes/postprocessor/postprocessor.h>
+#include <exadg/utilities/evaluate_convergence_study.h>
 
 namespace ExaDG
 {
@@ -46,6 +47,14 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & postpro
 template<int dim, typename Number>
 PostProcessor<dim, Number>::~PostProcessor()
 {
+  // Evaluate the convergence study.
+  std::vector<std::string> error_directories;
+  if(pp_data.error_data_u.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data_u.directory);
+  if(pp_data.error_data_p.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data_p.directory);
+
+  evaluate_convergence_study(mpi_comm, error_directories);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -72,6 +72,7 @@ public:
 
   PostProcessor(PostProcessorData<dim> const & postprocessor_data, MPI_Comm const & mpi_comm);
 
+  // custom destructor computing convergence tables if desired
   virtual ~PostProcessor();
 
   void

--- a/include/exadg/incompressible_navier_stokes/solver.h
+++ b/include/exadg/incompressible_navier_stokes/solver.h
@@ -27,7 +27,6 @@
 #include <exadg/incompressible_navier_stokes/user_interface/declare_get_application.h>
 #include <exadg/operators/resolution_parameters.h>
 #include <exadg/time_integration/resolution_parameters.h>
-#include <exadg/utilities/evaluate_convergence_study.h>
 #include <exadg/utilities/general_parameters.h>
 
 namespace ExaDG
@@ -190,9 +189,6 @@ main(int argc, char ** argv)
       }
     }
   }
-
-  // print convergence study given data in output folder defined in parameter file
-  ExaDG::evaluate_convergence_study(mpi_comm, input_file);
 
 #ifdef USE_SUB_COMMUNICATOR
   // free communicator

--- a/include/exadg/poisson/postprocessor/postprocessor.cpp
+++ b/include/exadg/poisson/postprocessor/postprocessor.cpp
@@ -21,6 +21,7 @@
 
 #include <exadg/poisson/postprocessor/postprocessor.h>
 #include <exadg/poisson/spatial_discretization/operator.h>
+#include <exadg/utilities/evaluate_convergence_study.h>
 
 namespace ExaDG
 {
@@ -34,6 +35,17 @@ PostProcessor<dim, n_components, Number>::PostProcessor(PostProcessorData<dim> c
     output_generator(mpi_comm_in),
     error_calculator(mpi_comm_in)
 {
+}
+
+template<int dim, int n_components, typename Number>
+PostProcessor<dim, n_components, Number>::~PostProcessor()
+{
+  // Evaluate the convergence study.
+  std::vector<std::string> error_directories;
+  if(pp_data.error_data.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data.directory);
+
+  evaluate_convergence_study(mpi_comm, error_directories);
 }
 
 template<int dim, int n_components, typename Number>

--- a/include/exadg/poisson/postprocessor/postprocessor.h
+++ b/include/exadg/poisson/postprocessor/postprocessor.h
@@ -59,6 +59,9 @@ protected:
 public:
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
+  // custom destructor computing convergence tables if desired
+  virtual ~PostProcessor();
+
   void
   setup(Operator<dim, n_components, Number> const & pde_operator) override;
 

--- a/include/exadg/postprocessor/error_calculation.h
+++ b/include/exadg/postprocessor/error_calculation.h
@@ -41,6 +41,7 @@ struct ErrorCalculationData
     : calculate_relative_errors(true),
       calculate_H1_seminorm_error(false),
       write_errors_to_file(false),
+      compute_convergence_table(false),
       spatially_weight_error(false),
       weight(nullptr),
       additional_quadrature_points(3),
@@ -80,6 +81,9 @@ struct ErrorCalculationData
 
   // write errors to file?
   bool write_errors_to_file;
+
+  // process computed files generating a convergence table
+  bool compute_convergence_table;
 
   // If true, a spatially weighted norm is computed.
   bool spatially_weight_error;

--- a/include/exadg/structure/postprocessor/postprocessor.cpp
+++ b/include/exadg/structure/postprocessor/postprocessor.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <exadg/structure/postprocessor/postprocessor.h>
+#include <exadg/utilities/evaluate_convergence_study.h>
 
 namespace ExaDG
 {
@@ -33,6 +34,17 @@ PostProcessor<dim, Number>::PostProcessor(PostProcessorData<dim> const & pp_data
     output_generator(OutputGenerator<dim, Number>(mpi_comm_in)),
     error_calculator(ErrorCalculator<dim, Number>(mpi_comm_in))
 {
+}
+
+template<int dim, typename Number>
+PostProcessor<dim, Number>::~PostProcessor()
+{
+  // Evaluate the convergence study.
+  std::vector<std::string> error_directories;
+  if(pp_data.error_data.compute_convergence_table)
+    error_directories.push_back(pp_data.error_data.directory);
+
+  evaluate_convergence_study(mpi_comm, error_directories);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/postprocessor/postprocessor.h
+++ b/include/exadg/structure/postprocessor/postprocessor.h
@@ -52,6 +52,9 @@ public:
 
   PostProcessor(PostProcessorData<dim> const & pp_data, MPI_Comm const & mpi_comm);
 
+  // custom destructor computing convergence tables if desired
+  virtual ~PostProcessor();
+
   void
   setup(Operator<dim, Number> const & pde_operator_in) override;
 

--- a/include/exadg/utilities/evaluate_convergence_study.h
+++ b/include/exadg/utilities/evaluate_convergence_study.h
@@ -25,12 +25,13 @@
 namespace ExaDG
 {
 /*
- * This function searches for files in the application directories created following a
+ * This function searches for files in the directories provided created following a
  * `run_<run_id>_<fieldname>_<error_type>` logic. It assumes refining in space, time or polynomial
  * degree with increasing `run_id`.
  */
 void
-evaluate_convergence_study(MPI_Comm const & mpi_comm, std::string const & input_parameter_file);
+evaluate_convergence_study(MPI_Comm const &                 mpi_comm,
+                           std::vector<std::string> const & error_directories);
 
 } // namespace ExaDG
 


### PR DESCRIPTION
fixes #849 

in a nutshell: we move the call to the destructor of the postprocessors.
Then we do not have the problem that we do not know the `directory` that was set in the application.
We would have no other way of finding out what the user did in the application on top of what is defined in the `.json` parameter file.

The `evaluate_convergence_study()` processes all files found in the folder set.
That is why there is some logic attaching folders uniquely to not be repetitive.
In the application, activating this functionality is controlled by `error_data.compute_convergence_table`.

If each `error_data` has its own directory, the data is not merged into one convergence table and tables are printed one after the other.