### PR TITLE
fix ghost updates in structure Newton solve

### DIFF
--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -353,6 +353,8 @@ private:
 
     this->param.density = density;
 
+    this->param.load_increment = 0.1;
+
     this->param.start_time                           = start_time;
     this->param.end_time                             = end_time;
     this->param.time_step_size                       = end_time;

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -973,7 +973,7 @@ Operator<dim, Number>::evaluate_nonlinear_residual(VectorType &       dst,
 
   // To ensure convergence of the Newton solver, the residual has to be zero
   // for constrained degrees of freedom as well, which might not be the case
-  // in general, e.g. due to const_vector. Hence, we set the constrained
+  // in general, e.g. due to `const_vector`. Hence, we set the constrained
   // degrees of freedom explicitly to zero.
   elasticity_operator_nonlinear.set_constrained_dofs_to_zero(dst);
 }

--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -92,7 +92,7 @@ public:
 
   /*
    * The implementation of the Newton solver requires a function called
-   * 'evaluate_residual'.
+   * 'evaluate_residual()'.
    */
   void
   evaluate_residual(VectorType & dst, VectorType const & src) const

--- a/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
@@ -62,7 +62,11 @@ BodyForceOperator<dim, Number>::evaluate_add(VectorType &       dst,
 {
   this->time = time;
 
+  src.update_ghost_values();
+
   matrix_free->cell_loop(&This::cell_loop, this, dst, src, false /*zero_dst_vector*/);
+
+  src.zero_out_ghost_values();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -43,6 +43,8 @@ template<int dim, typename Number>
 void
 NonLinearOperator<dim, Number>::evaluate_nonlinear(VectorType & dst, VectorType const & src) const
 {
+  src.update_ghost_values();
+
   this->matrix_free->loop(&This::cell_loop_nonlinear,
                           &This::face_loop_nonlinear,
                           &This::boundary_face_loop_nonlinear,
@@ -50,6 +52,8 @@ NonLinearOperator<dim, Number>::evaluate_nonlinear(VectorType & dst, VectorType 
                           dst,
                           src,
                           true);
+
+  src.zero_out_ghost_values();
 }
 
 template<int dim, typename Number>


### PR DESCRIPTION
with 7be6940, we changed the ghost entry handling according to the rule
*default state == zeroed ghost values*
and previously, a simple `vector = 0.0` saved us from some trouble of improper handling in the Newton solver routines.
I tested this again for the structure module and found the following spots.
Note that I did not get an assertion, but divergence, which is much more difficult to track.

Functions to check again for the iNS module are `evaluate_residual()` and `set_solution_linearization()`, which are called in the Newton solver.