### PR TITLE
choose zero initial guess for solves w `&src==&dst`

### DIFF
--- a/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
+++ b/include/exadg/solvers_and_preconditioners/solvers/iterative_solvers_dealii_wrapper.h
@@ -134,7 +134,9 @@ public:
     // chosen.
     if(dealii::PointerComparison::equal(&dst, &rhs) == true)
     {
-      VectorType tmp_dst(dst);
+      // Start from a zero initial guess.
+      VectorType tmp_dst;
+      tmp_dst.reinit(dst, false /* omit_zeroing_entries */);
       if(solver_data.use_preconditioner == false)
       {
         solver.solve(underlying_operator, tmp_dst, rhs, dealii::PreconditionIdentity());
@@ -239,7 +241,9 @@ public:
     // chosen.
     if(dealii::PointerComparison::equal(&dst, &rhs) == true)
     {
-      VectorType tmp_dst(dst);
+      // Start from a zero initial guess.
+      VectorType tmp_dst;
+      tmp_dst.reinit(dst, false /* omit_zeroing_entries */);
       if(solver_data.use_preconditioner == false)
       {
         solver.solve(underlying_operator, tmp_dst, rhs, dealii::PreconditionIdentity());
@@ -340,7 +344,9 @@ public:
     // chosen.
     if(dealii::PointerComparison::equal(&dst, &rhs) == true)
     {
-      VectorType tmp_dst(dst);
+      // Start from a zero initial guess.
+      VectorType tmp_dst;
+      tmp_dst.reinit(dst, false /* omit_zeroing_entries */);
       if(solver_data.use_preconditioner == false)
       {
         solver.solve(underlying_operator, tmp_dst, rhs, dealii::PreconditionIdentity());
@@ -472,7 +478,9 @@ public:
     // chosen.
     if(dealii::PointerComparison::equal(&dst, &rhs) == true)
     {
-      VectorType tmp_dst(dst);
+      // Start from a zero initial guess.
+      VectorType tmp_dst;
+      tmp_dst.reinit(dst, false /* omit_zeroing_entries */);
       if(use_preconditioner == false)
       {
         solver.solve(underlying_operator, tmp_dst, rhs, dealii::PreconditionIdentity());


### PR DESCRIPTION
see https://github.com/exadg/exadg/pull/854#discussion_r2590766407 :

we want to start with an initial guess `dst=0` for the case `&src==&dst`

so this is essentially #843, but for all solver types.