### PR TITLE
zero ghost entries after `op.set_inhomogeneous_constraints()`

### DIFF
--- a/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/body_force_operator.cpp
@@ -62,11 +62,7 @@ BodyForceOperator<dim, Number>::evaluate_add(VectorType &       dst,
 {
   this->time = time;
 
-  src.update_ghost_values();
-
   matrix_free->cell_loop(&This::cell_loop, this, dst, src, false /*zero_dst_vector*/);
-
-  src.zero_out_ghost_values();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/elasticity_operator_base.cpp
@@ -254,6 +254,9 @@ ElasticityOperatorBase<dim, Number>::set_inhomogeneous_constrained_values(Vector
       }
     }
   }
+
+  // zero out ghost values to return to default state
+  dst.zero_out_ghost_values();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/structure/spatial_discretization/operators/mass_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/mass_operator.h
@@ -90,7 +90,8 @@ public:
       if(dst.get_partitioner()->in_local_range(m.first))
         dst[m.first] = m.second;
 
-    dst.update_ghost_values();
+    // zero out ghost values to return to default state
+    dst.zero_out_ghost_values();
   }
 
 private:

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.cpp
@@ -43,8 +43,6 @@ template<int dim, typename Number>
 void
 NonLinearOperator<dim, Number>::evaluate_nonlinear(VectorType & dst, VectorType const & src) const
 {
-  src.update_ghost_values();
-
   this->matrix_free->loop(&This::cell_loop_nonlinear,
                           &This::face_loop_nonlinear,
                           &This::boundary_face_loop_nonlinear,
@@ -52,8 +50,6 @@ NonLinearOperator<dim, Number>::evaluate_nonlinear(VectorType & dst, VectorType 
                           dst,
                           src,
                           true);
-
-  src.zero_out_ghost_values();
 }
 
 template<int dim, typename Number>


### PR DESCRIPTION
un-does #855 and fixes the real place where `update_ghost_values` is called.

Thanks @kronbichler for the help!