### PR TITLE
fix ghost states, remove `set_velocity_ptr` in iNS module

### DIFF
--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -707,7 +707,7 @@ private:
       data.dimensions[0]                  = std::abs(interval_end - interval_start);
       data.dimensions[1]                  = std::abs(interval_end - interval_start);
       data.amplitude                      = std::abs(interval_end - interval_start) / 15.0;
-      data.period                         = std::abs(end_time - start_time);
+      data.period                         = 1.0;
       data.t_start                        = start_time;
       data.t_end                          = end_time;
       data.spatial_number_of_oscillations = 1.0;

--- a/include/exadg/incompressible_navier_stokes/driver.cpp
+++ b/include/exadg/incompressible_navier_stokes/driver.cpp
@@ -426,7 +426,7 @@ Driver<dim, Number>::apply_operator(OperatorType const & operator_type,
   dealii::LinearAlgebra::distributed::Vector<Number> velocity;
   pde_operator->initialize_vector_velocity(velocity);
   velocity = 1.0;
-  pde_operator->set_velocity_ptr(velocity);
+  pde_operator->set_velocity_copy(velocity);
 
   // initialize vectors
   if(application->get_parameters().temporal_discretization ==

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -209,7 +209,7 @@ OperatorCoupled<dim, Number>::rhs_linear_problem(BlockVectorType &  dst,
   if(this->param.convective_problem() and
      this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
   {
-    this->convective_operator.set_velocity_ptr(transport_velocity);
+    this->convective_operator.set_velocity_copy(transport_velocity);
     this->convective_operator.set_time(time);
     this->convective_operator.rhs_add(dst.block(0));
   }
@@ -373,7 +373,7 @@ OperatorCoupled<dim, Number>::evaluate_linearized_residual(BlockVectorType &    
     }
     else if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
     {
-      this->convective_operator.set_velocity_ptr(transport_velocity);
+      this->convective_operator.set_velocity_copy(transport_velocity);
       this->convective_operator.apply_add(dst.block(0), src.block(0));
       this->convective_operator.rhs_add(dst.block(0));
     }
@@ -1280,7 +1280,7 @@ OperatorCoupled<dim, Number>::apply_preconditioner_pressure_block(VectorType &  
 
     if(this->param.non_explicit_convective_problem())
     {
-      pressure_conv_diff_operator->set_velocity_ptr(this->convective_kernel->get_velocity());
+      pressure_conv_diff_operator->set_velocity_copy(this->convective_kernel->get_velocity());
     }
 
     pressure_conv_diff_operator->apply(dst, tmp_scp_pressure);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -108,7 +108,7 @@ public:
   void
   set_solution_linearization(BlockVectorType const & solution_linearization) const
   {
-    pde_operator->set_velocity_ptr(solution_linearization.block(0));
+    pde_operator->set_velocity_copy(solution_linearization.block(0));
   }
 
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -429,7 +429,7 @@ OperatorProjectionMethods<dim, Number>::rhs_add_convective_term(
   VectorType const & transport_velocity,
   double const       time) const
 {
-  this->convective_operator.set_velocity_ptr(transport_velocity);
+  this->convective_operator.set_velocity_copy(transport_velocity);
   this->convective_operator.set_time(time);
   this->convective_operator.rhs_add(dst);
 }
@@ -596,7 +596,7 @@ OperatorProjectionMethods<dim, Number>::evaluate_linearized_residual(
     }
     else if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::LinearlyImplicit)
     {
-      this->convective_operator.set_velocity_ptr(transport_velocity);
+      this->convective_operator.set_velocity_copy(transport_velocity);
       this->convective_operator.apply_add(dst, src);
       this->convective_operator.rhs_add(dst);
     }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.cpp
@@ -34,13 +34,6 @@ ConvectiveOperator<dim, Number>::set_velocity_copy(VectorType const & src) const
 }
 
 template<int dim, typename Number>
-void
-ConvectiveOperator<dim, Number>::set_velocity_ptr(VectorType const & src) const
-{
-  kernel->set_velocity_ptr(src);
-}
-
-template<int dim, typename Number>
 dealii::LinearAlgebra::distributed::Vector<Number> const &
 ConvectiveOperator<dim, Number>::get_velocity() const
 {
@@ -72,21 +65,15 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator(VectorType &       
 {
   this->time = time;
 
-  kernel->update_ghost_values_velocity();
-  kernel->update_ghost_values_grid_velocity();
-
   this->matrix_free->loop(&This::cell_loop_nonlinear_operator,
                           &This::face_loop_nonlinear_operator,
                           &This::boundary_face_loop_nonlinear_operator,
                           this,
                           dst,
                           src,
-                          true /*zero_dst_vector = true*/,
+                          true /* zero_dst_vector */,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
-
-  kernel->zero_out_ghost_values_velocity();
-  kernel->zero_out_ghost_values_grid_velocity();
 }
 
 template<int dim, typename Number>
@@ -97,21 +84,15 @@ ConvectiveOperator<dim, Number>::evaluate_nonlinear_operator_add(VectorType &   
 {
   this->time = time;
 
-  kernel->update_ghost_values_velocity();
-  kernel->update_ghost_values_grid_velocity();
-
   this->matrix_free->loop(&This::cell_loop_nonlinear_operator,
                           &This::face_loop_nonlinear_operator,
                           &This::boundary_face_loop_nonlinear_operator,
                           this,
                           dst,
                           src,
-                          false /*zero_dst_vector = false*/,
+                          false /* zero_dst_vector */,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values,
                           dealii::MatrixFree<dim, Number>::DataAccessOnFaces::values);
-
-  kernel->zero_out_ghost_values_velocity();
-  kernel->zero_out_ghost_values_grid_velocity();
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/convective_operator.h
@@ -112,6 +112,9 @@ public:
     {
       matrix_free.initialize_dof_vector(grid_velocity.own(), dof_index);
 
+      // grid velocity vector needs to be ghosted
+      grid_velocity->update_ghost_values();
+
       AssertThrow(data.formulation == FormulationConvectiveTerm::ConvectiveFormulation,
                   dealii::ExcMessage(
                     "ALE formulation can only be used in combination with ConvectiveFormulation"));
@@ -179,50 +182,20 @@ public:
   set_velocity_copy(VectorType const & src)
   {
     velocity.own() = src;
-  }
-
-  void
-  set_velocity_ptr(VectorType const & src)
-  {
-    velocity.reset(src);
+    velocity->update_ghost_values();
   }
 
   void
   set_grid_velocity_ptr(VectorType const & src)
   {
     grid_velocity.reset(src);
+    grid_velocity->update_ghost_values();
   }
 
   VectorType const &
   get_grid_velocity() const
   {
     return *grid_velocity;
-  }
-
-  void
-  update_ghost_values_velocity()
-  {
-    velocity->update_ghost_values();
-  }
-
-  void
-  update_ghost_values_grid_velocity()
-  {
-    if(data.ale)
-      grid_velocity->update_ghost_values();
-  }
-
-  void
-  zero_out_ghost_values_velocity()
-  {
-    velocity->zero_out_ghost_values();
-  }
-
-  void
-  zero_out_ghost_values_grid_velocity()
-  {
-    if(data.ale)
-      grid_velocity->zero_out_ghost_values();
   }
 
   inline DEAL_II_ALWAYS_INLINE //
@@ -1025,9 +998,6 @@ public:
 
   void
   set_velocity_copy(VectorType const & src) const;
-
-  void
-  set_velocity_ptr(VectorType const & src) const;
 
   dealii::LinearAlgebra::distributed::Vector<Number> const &
   get_velocity() const;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -182,7 +182,7 @@ template<int dim, typename Number>
 void
 MomentumOperator<dim, Number>::set_solution_linearization(VectorType const & velocity)
 {
-  this->set_velocity_ptr(velocity);
+  this->set_velocity_copy(velocity);
 }
 
 template<int dim, typename Number>
@@ -202,21 +202,10 @@ MomentumOperator<dim, Number>::set_velocity_copy(VectorType const & velocity) co
   {
     convective_kernel->set_velocity_copy(velocity);
   }
-  else
+  else if(viscous_kernel->get_use_velocity_own_storage())
   {
-    AssertThrow(viscous_kernel->get_use_velocity_own_storage(),
-                dealii::ExcMessage("No velocity stored in `viscous_kernel`."));
-
     viscous_kernel->set_velocity_copy(velocity);
   }
-}
-
-template<int dim, typename Number>
-void
-MomentumOperator<dim, Number>::set_velocity_ptr(VectorType const & velocity) const
-{
-  if(operator_data.convective_problem)
-    convective_kernel->set_velocity_ptr(velocity);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.h
@@ -120,9 +120,6 @@ public:
   void
   set_velocity_copy(VectorType const & velocity) const;
 
-  void
-  set_velocity_ptr(VectorType const & velocity) const;
-
   Number
   get_scaling_factor_mass_operator() const;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -118,19 +118,19 @@ public:
   ViscousKernelData const &
   get_data() const
   {
-    return this->data;
+    return data;
   }
 
   bool
   get_use_velocity_own_storage() const
   {
-    return this->use_velocity_own_storage;
+    return use_velocity_own_storage;
   }
 
   VectorType const &
   get_velocity() const
   {
-    AssertThrow(this->use_velocity_own_storage,
+    AssertThrow(use_velocity_own_storage,
                 dealii::ExcMessage("Velocity vector not stored in the viscous kernel."));
 
     return velocity;
@@ -139,10 +139,11 @@ public:
   void
   set_velocity_copy(VectorType const & src)
   {
-    AssertThrow(this->use_velocity_own_storage,
+    AssertThrow(use_velocity_own_storage,
                 dealii::ExcMessage("Velocity vector not stored in the viscous kernel."));
 
-    this->velocity = src;
+    velocity = src;
+    velocity.update_ghost_values();
   }
 
   VariableCoefficients<dealii::VectorizedArray<Number>> const *
@@ -154,13 +155,13 @@ public:
   unsigned int
   get_quad_index() const
   {
-    return this->quad_index;
+    return quad_index;
   }
 
   unsigned int
   get_degree() const
   {
-    return this->degree;
+    return degree;
   }
 
   void

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -921,9 +921,9 @@ SpatialOperatorBase<dim, Number>::get_container_interface_data()
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::set_velocity_ptr(VectorType const & velocity) const
+SpatialOperatorBase<dim, Number>::set_velocity_copy(VectorType const & velocity) const
 {
-  convective_kernel->set_velocity_ptr(velocity);
+  convective_kernel->set_velocity_copy(velocity);
 }
 
 template<int dim, typename Number>
@@ -1771,9 +1771,9 @@ SpatialOperatorBase<dim, Number>::update_after_grid_motion(bool const update_mat
 
 template<int dim, typename Number>
 void
-SpatialOperatorBase<dim, Number>::set_grid_velocity(VectorType const & u_grid_in)
+SpatialOperatorBase<dim, Number>::set_grid_velocity(VectorType const & grid_velocity_in)
 {
-  convective_kernel->set_grid_velocity_ptr(u_grid_in);
+  convective_kernel->set_grid_velocity_ptr(grid_velocity_in);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -213,7 +213,7 @@ public:
   get_container_interface_data();
 
   void
-  set_velocity_ptr(VectorType const & velocity) const;
+  set_velocity_copy(VectorType const & velocity) const;
 
   /*
    * Initialization of vectors.
@@ -443,7 +443,7 @@ public:
    * Sets the grid velocity.
    */
   void
-  set_grid_velocity(VectorType const & velocity);
+  set_grid_velocity(VectorType const & grid_velocity_in);
 
   /*
    *  Calls constraint_u.distribute(u) and updates the constrained DoFs of the velocity field


### PR DESCRIPTION
this fixes the problem of some ghost access in the `grid_velocity` and `velocity` in the `ConvectiveOperator` of the Navier-Stokes module.

The initial problem was, that the linearization vector is for linear schemes stored as a copy in the `ConvectiveOperator`, but for nonlinear schemes, a pointer to the lineaerization vector is stored. 

We removed some `rhs = 0.;` in the convective operator, which was silently zeroing out ghost entries.
This was a side effect that made everything fall in place and work nicely.
I found this very hard to see and I think we should not rely on some operator correcting the ghost state we forgot to set correctly to the zero ghost state somewhere else. 

The `grid_velocity` and `velocity` ghost state was a mess before this PR (printed it randomly in the time integrator and Newton scheme, etc.). Now we always have zero ghost everywhere, but the linearization vector and `grid_velocity` are always ghosted just as for the structure module.

I think it is actually way easier to understand what is going on and who is responsible, if we always make a copy.

There might be an alternative having a bunch of
`solution.update_ghost_values();`
and
`solution.zero_out_ghost_values();`
after `opereator.set_solution_linearization(solution);`
I have not tried this option, not sure if it actually possible.
But one would for the case that the operator stored a pointer to `solution` and not a copy control the ghost state in the Newton solver and hope it actually works.
I would find this very confusing, but it might work.
I do not have the time for this rn, but the present PR brings us into a state where all solvers are functional again.