### PR TITLE
remove solver wrappers and enums like `Solver::CG`

### DIFF
--- a/applications/aero_acoustic/co_rotating_vortex_pair/application.h
+++ b/applications/aero_acoustic/co_rotating_vortex_pair/application.h
@@ -423,8 +423,8 @@ public:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.smoother_data.smoother =
@@ -437,8 +437,7 @@ public:
       MultigridCoarseGridPreconditioner::PointJacobi;
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    this->param.solver_data_pressure_poisson = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -447,8 +446,7 @@ public:
       MultigridCoarseGridPreconditioner::AMG;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
 
@@ -460,8 +458,7 @@ public:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -479,11 +476,12 @@ public:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum = SolverMomentum::GMRES;
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
       else
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
@@ -495,11 +493,11 @@ public:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled = SolverCoupled::GMRES;
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      this->param.solver_data_coupled =
+        SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
     else
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, 100);
+      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;

--- a/applications/convection_diffusion/boundary_layer/application.h
+++ b/applications/convection_diffusion/boundary_layer/application.h
@@ -103,11 +103,10 @@ private:
 
     // SOLVER
     this->param.use_cell_based_face_loops = true;
-    this->param.solver                    = Solver::GMRES;
-    this->param.solver_data               = SolverData(1e4, 1.e-20, 1.e-8, 100);
-    this->param.preconditioner            = Preconditioner::Multigrid; // PointJacobi;
-    this->param.mg_operator_type          = MultigridOperatorType::ReactionConvectionDiffusion;
-    this->param.multigrid_data.type       = MultigridType::phMG;
+    this->param.solver_data         = SolverData(1e4, 1.e-20, 1.e-8, LinearSolver::GMRES, 100);
+    this->param.preconditioner      = Preconditioner::Multigrid; // PointJacobi;
+    this->param.mg_operator_type    = MultigridOperatorType::ReactionConvectionDiffusion;
+    this->param.multigrid_data.type = MultigridType::phMG;
     // MG smoother
     this->param.multigrid_data.smoother_data.smoother = MultigridSmoother::Jacobi; // Chebyshev;
     // MG smoother data

--- a/applications/convection_diffusion/const_rhs/application.h
+++ b/applications/convection_diffusion/const_rhs/application.h
@@ -139,8 +139,7 @@ private:
     this->param.IP_factor = 1.0;
 
     // SOLVER
-    this->param.solver         = Solver::GMRES;
-    this->param.solver_data    = SolverData(1e4, 1.e-20, 1.e-8, 100);
+    this->param.solver_data    = SolverData(1e4, 1.e-20, 1.e-8, LinearSolver::GMRES, 100);
     this->param.preconditioner = Preconditioner::Multigrid; // PointJacobi; //BlockJacobi;
     this->param.implement_block_diagonal_preconditioner_matrix_free = false;
     this->param.use_cell_based_face_loops                           = false;

--- a/applications/convection_diffusion/decaying_hill/application.h
+++ b/applications/convection_diffusion/decaying_hill/application.h
@@ -167,16 +167,15 @@ private:
     this->param.IP_factor = 1.0;
 
     // SOLVER
-    this->param.solver =
-      Solver::CG; // use FGMRES for elementwise iterative block Jacobi type preconditioners
-    this->param.solver_data      = SolverData(1e4, 1.e-20, 1.e-6, 100);
+    // use FGMRES for elementwise iterative block Jacobi type preconditioners
+    this->param.solver_data      = SolverData(1e4, 1.e-20, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner   = Preconditioner::InverseMassMatrix; // BlockJacobi; //Multigrid;
     this->param.mg_operator_type = MultigridOperatorType::ReactionDiffusion;
     this->param.multigrid_data.smoother_data.smoother = MultigridSmoother::Chebyshev; // GMRES;
     this->param.implement_block_diagonal_preconditioner_matrix_free = true;
     this->param.solver_block_diagonal                               = Elementwise::Solver::CG;
     this->param.preconditioner_block_diagonal = Elementwise::Preconditioner::InverseMassMatrix;
-    this->param.solver_data_block_diagonal    = SolverData(1000, 1.e-12, 1.e-2, 1000);
+    this->param.solver_data_block_diagonal    = SolverData(1000, 1.e-12, 1.e-2);
     this->param.use_cell_based_face_loops     = true;
     this->param.update_preconditioner         = false;
 

--- a/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
+++ b/applications/convection_diffusion/decaying_hill/tests/diffusive_implicit_time_int.output
@@ -58,7 +58,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            InverseMassMatrix
   Update preconditioner:                     false
   Block Jacobi matrix-free:                  true
@@ -67,7 +66,7 @@ Solver:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-02
-  Maximum size of Krylov space:              1000
+  Maximum size of Krylov space:              30
   Solver information:
   Interval physical time:                    1.0000e+00
   Interval wall time:                        1.7977e+308
@@ -122,7 +121,7 @@ Calculate error for all fields at time t = 1.0000e-01:
   Relative error (L2-norm): 5.27880e-11
 
 Calculate error for all fields at time t = 1.5000e-01:
-  Relative error (L2-norm): 5.28141e-11
+  Relative error (L2-norm): 5.28142e-11
 
 Calculate error for all fields at time t = 2.0000e-01:
   Relative error (L2-norm): 5.28508e-11
@@ -146,13 +145,13 @@ Calculate error for all fields at time t = 5.0000e-01:
   Relative error (L2-norm): 5.32889e-11
 
 Calculate error for all fields at time t = 5.5000e-01:
-  Relative error (L2-norm): 5.33979e-11
+  Relative error (L2-norm): 5.33980e-11
 
 Calculate error for all fields at time t = 6.0000e-01:
   Relative error (L2-norm): 5.35171e-11
 
 Calculate error for all fields at time t = 6.5000e-01:
-  Relative error (L2-norm): 5.36463e-11
+  Relative error (L2-norm): 5.36464e-11
 
 Calculate error for all fields at time t = 7.0000e-01:
   Relative error (L2-norm): 5.37856e-11
@@ -164,7 +163,7 @@ Calculate error for all fields at time t = 8.0000e-01:
   Relative error (L2-norm): 5.40938e-11
 
 Calculate error for all fields at time t = 8.5000e-01:
-  Relative error (L2-norm): 5.42625e-11
+  Relative error (L2-norm): 5.42626e-11
 
 Calculate error for all fields at time t = 9.0000e-01:
   Relative error (L2-norm): 5.44409e-11

--- a/applications/convection_diffusion/deforming_hill/application.h
+++ b/applications/convection_diffusion/deforming_hill/application.h
@@ -131,8 +131,7 @@ private:
     this->param.IP_factor = 1.0;
 
     // SOLVER
-    this->param.solver         = Solver::GMRES;
-    this->param.solver_data    = SolverData(1e4, 1.e-20, 1.e-6, 100);
+    this->param.solver_data    = SolverData(1e4, 1.e-20, 1.e-6, LinearSolver::GMRES, 100);
     this->param.preconditioner = Preconditioner::InverseMassMatrix;
 
     // output of solver information

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -185,8 +185,7 @@ private:
     this->param.IP_factor = 1.0;
 
     // SOLVER
-    this->param.solver      = Solver::GMRES;
-    this->param.solver_data = SolverData(1e3, 1.e-20, 1.e-8, 100);
+    this->param.solver_data = SolverData(1e3, 1.e-20, 1.e-8, LinearSolver::GMRES, 100);
     this->param.preconditioner =
       Preconditioner::Multigrid; // None; //InverseMassMatrix; //PointJacobi; // BlockJacobi;
                                  // //Multigrid;
@@ -196,7 +195,8 @@ private:
     this->param.implement_block_diagonal_preconditioner_matrix_free = false; // true;
     this->param.solver_block_diagonal                               = Elementwise::Solver::GMRES;
     this->param.preconditioner_block_diagonal = Elementwise::Preconditioner::InverseMassMatrix;
-    this->param.solver_data_block_diagonal    = SolverData(1000, 1.e-12, 1.e-2, 1000);
+    this->param.solver_data_block_diagonal =
+      SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000);
 
     // Multigrid
     this->param.mg_operator_type    = MultigridOperatorType::ReactionConvection;

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -115,8 +115,7 @@ private:
     this->param.IP_factor = 1.0;
 
     // SOLVER
-    this->param.solver         = Solver::GMRES;
-    this->param.solver_data    = SolverData(1e4, 1.e-20, 1.e-6, 100);
+    this->param.solver_data    = SolverData(1e4, 1.e-20, 1.e-6, LinearSolver::GMRES, 100);
     this->param.preconditioner = Preconditioner::InverseMassMatrix;
     // use default parameters of multigrid preconditioner
 

--- a/applications/convection_diffusion/throughput/application.h
+++ b/applications/convection_diffusion/throughput/application.h
@@ -107,8 +107,8 @@ private:
     this->param.IP_factor = 1.0;
 
     // SOLVER
-    this->param.solver         = Solver::GMRES;
-    this->param.preconditioner = Preconditioner::None;
+    this->param.solver_data.linear_solver = LinearSolver::GMRES;
+    this->param.preconditioner            = Preconditioner::None;
 
     // NUMERICAL PARAMETERS
     this->param.use_cell_based_face_loops               = false;

--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -210,10 +210,9 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
-    param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
-    param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
+    param.solver_data_pressure_poisson    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
+    param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
+    param.multigrid_data_pressure_poisson.type                   = MultigridType::cphMG;
     param.multigrid_data_pressure_poisson.smoother_data.smoother = MultigridSmoother::Chebyshev;
     param.multigrid_data_pressure_poisson.smoother_data.preconditioner =
       PreconditionerSmoother::PointJacobi;
@@ -223,8 +222,7 @@ private:
     param.multigrid_data_pressure_poisson.coarse_problem.solver_data.rel_tol = 1.e-3;
 
     // projection step
-    param.solver_projection         = SolverProjection::CG;
-    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -236,8 +234,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -256,11 +253,11 @@ private:
       param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      param.solver_momentum = SolverMomentum::FGMRES;
       if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+        param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
       else
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
       param.update_preconditioner_momentum = false;
       param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix; // Multigrid;
       param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
@@ -278,11 +275,11 @@ private:
     param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    param.solver_coupled = SolverCoupled::FGMRES;
     if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data_coupled =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
 
     // preconditioner linear solver
     param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -594,8 +591,7 @@ private:
     param.spatial_discretization = SpatialDiscretization::CG;
 
     // SOLVER
-    param.solver         = Poisson::LinearSolver::FGMRES;
-    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner = Preconditioner::Multigrid;
 
     param.multigrid_data.type                          = MultigridType::phMG;
@@ -664,11 +660,11 @@ private:
     param.degree = this->param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;
@@ -791,11 +787,11 @@ private:
     param.mapping_degree_coarse_grids = param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -240,8 +240,7 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    param.solver_data_pressure_poisson = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     param.multigrid_data_pressure_poisson.smoother_data.smoother = MultigridSmoother::Chebyshev;
@@ -252,8 +251,7 @@ private:
       MultigridCoarseGridPreconditioner::AMG;
 
     // projection step
-    param.solver_projection         = SolverProjection::CG;
-    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -265,8 +263,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -285,11 +282,11 @@ private:
       param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      param.solver_momentum = SolverMomentum::FGMRES;
       if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+        param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
       else
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
       param.update_preconditioner_momentum = false;
       param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
     }
@@ -302,11 +299,11 @@ private:
     param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    param.solver_coupled = SolverCoupled::FGMRES;
     if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data_coupled =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
 
     // preconditioner linear solver
     param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -621,8 +618,7 @@ private:
     param.degree                 = this->param.mapping_degree;
 
     // SOLVER
-    param.solver         = Poisson::LinearSolver::FGMRES;
-    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner = Preconditioner::Multigrid;
 
     param.multigrid_data.type                          = MultigridType::phMG;
@@ -681,11 +677,11 @@ private:
     param.degree = this->param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;
@@ -810,11 +806,11 @@ private:
     param.mapping_degree_coarse_grids = param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -203,8 +203,7 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    param.solver_data_pressure_poisson = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     param.multigrid_data_pressure_poisson.smoother_data.smoother = MultigridSmoother::Chebyshev;
@@ -215,8 +214,7 @@ private:
       MultigridCoarseGridPreconditioner::AMG;
 
     // projection step
-    param.solver_projection         = SolverProjection::CG;
-    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -228,8 +226,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::PointJacobi;
     }
 
@@ -248,11 +245,11 @@ private:
       param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      param.solver_momentum = SolverMomentum::FGMRES;
       if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+        param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
       else
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
       param.update_preconditioner_momentum = false;
       param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
     }
@@ -265,11 +262,11 @@ private:
     param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    param.solver_coupled = SolverCoupled::FGMRES;
     if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data_coupled =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
 
     // preconditioner linear solver
     param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -481,8 +478,7 @@ private:
     param.degree                 = this->param.mapping_degree;
 
     // SOLVER
-    param.solver         = Poisson::LinearSolver::FGMRES;
-    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner = Preconditioner::Multigrid;
 
     param.multigrid_data.type                          = MultigridType::phMG;
@@ -541,11 +537,11 @@ private:
     param.degree = this->param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;
@@ -669,11 +665,11 @@ public:
     param.mapping_degree_coarse_grids = param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -202,8 +202,7 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    param.solver_data_pressure_poisson = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     param.multigrid_data_pressure_poisson.smoother_data.smoother = MultigridSmoother::Chebyshev;
@@ -215,8 +214,7 @@ private:
     param.multigrid_data_pressure_poisson.coarse_problem.solver_data.rel_tol = 1.e-3;
 
     // projection step
-    param.solver_projection         = SolverProjection::CG;
-    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -228,8 +226,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -248,11 +245,11 @@ private:
       param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      param.solver_momentum = SolverMomentum::FGMRES;
       if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+        param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
       else
-        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
       param.update_preconditioner_momentum = false;
       param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix; // Multigrid;
       param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
@@ -270,11 +267,11 @@ private:
     param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    param.solver_coupled = SolverCoupled::FGMRES;
     if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data_coupled =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data_coupled = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
 
     // preconditioner linear solver
     param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -500,8 +497,7 @@ private:
     param.degree                 = this->param.mapping_degree;
 
     // SOLVER
-    param.solver         = Poisson::LinearSolver::FGMRES;
-    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+    param.solver_data    = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner = Preconditioner::Multigrid;
 
     param.multigrid_data.type                          = MultigridType::phMG;
@@ -564,11 +560,11 @@ private:
     param.degree = this->param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;
@@ -682,11 +678,11 @@ private:
     param.mapping_degree_coarse_grids = param.mapping_degree;
 
     param.newton_solver_data = Newton::SolverData(1e4, ABS_TOL, REL_TOL);
-    param.solver             = Structure::Solver::FGMRES;
     if(param.large_deformation)
-      param.solver_data = SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, 100);
+      param.solver_data =
+        SolverData(1e4, ABS_TOL_LINEARIZED, REL_TOL_LINEARIZED, LinearSolver::FGMRES, 100);
     else
-      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::FGMRES, 100);
     param.preconditioner                               = Preconditioner::AMG; // Multigrid;
     param.multigrid_data.type                          = MultigridType::phMG;
     param.multigrid_data.coarse_problem.solver         = MultigridCoarseGridSolver::CG;

--- a/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
+++ b/applications/incompressible_flow_with_transport/differentially_heated_cavity/application.h
@@ -157,8 +157,8 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -171,8 +171,7 @@ private:
       PreconditionerSmoother::PointJacobi;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -183,8 +182,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -202,11 +200,12 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum = SolverMomentum::GMRES;
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
       else
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
@@ -220,11 +219,11 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled = SolverCoupled::GMRES;
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      this->param.solver_data_coupled =
+        SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
     else
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, 100);
+      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
     // preconditioner linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -438,10 +437,9 @@ private:
     this->param.use_cell_based_face_loops                           = false;
 
     // SOLVER
-    this->param.solver                    = ConvDiff::Solver::CG;
-    this->param.solver_data               = SolverData(1e3, ABS_TOL, REL_TOL, 100);
-    this->param.preconditioner            = Preconditioner::InverseMassMatrix;
-    this->param.multigrid_data.type       = MultigridType::phMG;
+    this->param.solver_data         = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
+    this->param.preconditioner      = Preconditioner::InverseMassMatrix;
+    this->param.multigrid_data.type = MultigridType::phMG;
     this->param.multigrid_data.p_sequence = PSequenceType::Bisect;
     this->param.mg_operator_type          = MultigridOperatorType::ReactionDiffusion;
     this->param.update_preconditioner     = false;

--- a/applications/incompressible_flow_with_transport/mantle_convection/application.h
+++ b/applications/incompressible_flow_with_transport/mantle_convection/application.h
@@ -197,14 +197,13 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-30, reltol, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-30, reltol, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-30, reltol);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-30, reltol, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -215,10 +214,9 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                  = SolverMomentum::CG;
-      this->param.solver_data_momentum             = SolverData(1000, 1.e-30, reltol);
-      this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
-      this->param.multigrid_data_momentum.type     = MultigridType::cphMG;
+      this->param.solver_data_momentum         = SolverData(1000, 1.e-30, reltol, LinearSolver::CG);
+      this->param.preconditioner_momentum      = MomentumPreconditioner::Multigrid;
+      this->param.multigrid_data_momentum.type = MultigridType::cphMG;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
     }
 
@@ -236,9 +234,8 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-30, reltol);
 
       // linear solver
-      this->param.solver_momentum                  = SolverMomentum::CG;
-      this->param.solver_data_momentum             = SolverData(1e4, 1.e-30, reltol, 100);
-      this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
+      this->param.solver_data_momentum    = SolverData(1e4, 1.e-30, reltol, LinearSolver::CG, 100);
+      this->param.preconditioner_momentum = MomentumPreconditioner::Multigrid;
       this->param.multigrid_data_momentum.type     = MultigridType::cphMG;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
     }
@@ -249,8 +246,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-30, reltol);
 
     // linear solver
-    this->param.solver_coupled         = SolverCoupled::GMRES;
-    this->param.solver_data_coupled    = SolverData(1e3, 1.e-30, reltol, 100);
+    this->param.solver_data_coupled    = SolverData(1e3, 1.e-30, reltol, LinearSolver::GMRES, 100);
     this->param.use_scaling_continuity = false;
 
     // preconditioner linear solver
@@ -450,8 +446,8 @@ private:
     this->param.use_cell_based_face_loops                           = false;
 
     // SOLVER
-    this->param.solver                = ConvDiff::Solver::GMRES; // CG;
-    this->param.solver_data           = SolverData(1e4, 1.e-30, reltol, 100);
+    this->param.solver_data =
+      SolverData(1e4, 1.e-30, reltol, LinearSolver::GMRES /* LinearSolver::CG */, 100);
     this->param.preconditioner        = Preconditioner::InverseMassMatrix;
     this->param.multigrid_data.type   = MultigridType::cphMG;
     this->param.mg_operator_type      = MultigridOperatorType::ReactionDiffusion;

--- a/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
+++ b/applications/incompressible_flow_with_transport/rayleigh_benard/application.h
@@ -168,8 +168,8 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -182,8 +182,7 @@ private:
       PreconditionerSmoother::PointJacobi;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -194,8 +193,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6);
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -213,8 +211,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-20, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum         = SolverMomentum::GMRES;
-      this->param.solver_data_momentum    = SolverData(1e4, 1.e-12, 1.e-6, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -225,8 +222,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-12, 1.e-6);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::GMRES;
-    this->param.solver_data_coupled = SolverData(1e3, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_coupled = SolverData(1e3, 1.e-12, 1.e-6, LinearSolver::GMRES, 100);
 
     // preconditioner linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -445,8 +441,7 @@ private:
     this->param.use_cell_based_face_loops                           = false;
 
     // SOLVER
-    this->param.solver                    = ConvDiff::Solver::CG;
-    this->param.solver_data               = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.solver_data               = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner            = Preconditioner::InverseMassMatrix;
     this->param.multigrid_data.type       = MultigridType::pMG;
     this->param.multigrid_data.p_sequence = PSequenceType::Bisect;

--- a/applications/incompressible_flow_with_transport/rising_bubble/application.h
+++ b/applications/incompressible_flow_with_transport/rising_bubble/application.h
@@ -170,8 +170,8 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -184,8 +184,7 @@ private:
       PreconditionerSmoother::PointJacobi;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -196,8 +195,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -215,11 +213,12 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum = SolverMomentum::GMRES;
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
       else
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
@@ -231,11 +230,11 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled = SolverCoupled::GMRES;
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      this->param.solver_data_coupled =
+        SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
     else
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, 100);
+      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
     // preconditioner linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -410,10 +409,9 @@ private:
     this->param.use_cell_based_face_loops                           = false;
 
     // SOLVER
-    this->param.solver                    = ConvDiff::Solver::CG;
-    this->param.solver_data               = SolverData(1e3, ABS_TOL, REL_TOL, 100);
-    this->param.preconditioner            = Preconditioner::InverseMassMatrix;
-    this->param.multigrid_data.type       = MultigridType::phMG;
+    this->param.solver_data         = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
+    this->param.preconditioner      = Preconditioner::InverseMassMatrix;
+    this->param.multigrid_data.type = MultigridType::phMG;
     this->param.multigrid_data.p_sequence = PSequenceType::Bisect;
     this->param.mg_operator_type          = MultigridOperatorType::ReactionDiffusion;
     this->param.update_preconditioner     = false;

--- a/applications/incompressible_navier_stokes/backward_facing_step/application.h
+++ b/applications/incompressible_navier_stokes/backward_facing_step/application.h
@@ -149,10 +149,9 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
   // PROJECTION METHODS
 
   // pressure Poisson equation
-  param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-  param.solver_data_pressure_poisson         = SolverData(1e4, 1.e-12, 1.e-6, 100);
-  param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
-  param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
+  param.solver_data_pressure_poisson    = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::CG, 100);
+  param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
+  param.multigrid_data_pressure_poisson.type                   = MultigridType::cphMG;
   param.multigrid_data_pressure_poisson.smoother_data.smoother = MultigridSmoother::Chebyshev;
   param.multigrid_data_pressure_poisson.smoother_data.preconditioner =
     PreconditionerSmoother::PointJacobi;
@@ -162,17 +161,15 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
     MultigridCoarseGridPreconditioner::PointJacobi;
 
   // pressure Poisson equation
-  param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-  param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
-  param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
-  param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
+  param.solver_data_pressure_poisson    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
+  param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
+  param.multigrid_data_pressure_poisson.type                  = MultigridType::cphMG;
   param.multigrid_data_pressure_poisson.coarse_problem.solver = MultigridCoarseGridSolver::CG;
   param.multigrid_data_pressure_poisson.coarse_problem.preconditioner =
     MultigridCoarseGridPreconditioner::AMG;
 
   // projection step
-  param.solver_projection         = SolverProjection::CG;
-  param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+  param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
   param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
 
@@ -184,8 +181,7 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
 
   if(param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
-    param.solver_momentum         = SolverMomentum::CG;
-    param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+    param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
   }
 
@@ -203,11 +199,11 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
     param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    param.solver_momentum = SolverMomentum::GMRES;
     if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      param.solver_data_momentum =
+        SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
     else
-      param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+      param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
     param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
   }
@@ -219,11 +215,11 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
   param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
   // linear solver
-  param.solver_coupled = SolverCoupled::GMRES;
   if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-    param.solver_data_coupled = SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+    param.solver_data_coupled =
+      SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
   else
-    param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, 100);
+    param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
   // preconditioning linear solver
   param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/beltrami/application.h
+++ b/applications/incompressible_navier_stokes/beltrami/application.h
@@ -150,13 +150,12 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-8, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -167,9 +166,8 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                  = SolverMomentum::CG;
-      this->param.solver_data_momentum             = SolverData(1000, 1.e-12, 1.e-8);
-      this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
+      this->param.preconditioner_momentum = MomentumPreconditioner::Multigrid;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
     }
 
@@ -182,8 +180,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-10, 1.e-8);
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::GMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-12, 1.e-8, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-8, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
@@ -200,8 +197,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-12, 1.e-8);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::GMRES;
-    this->param.solver_data_coupled = SolverData(1e3, 1.e-12, 1.e-8, 100);
+    this->param.solver_data_coupled = SolverData(1e3, 1.e-12, 1.e-8, LinearSolver::GMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/cavity/application.h
+++ b/applications/incompressible_navier_stokes/cavity/application.h
@@ -109,18 +109,19 @@ private:
     // NUMERICAL PARAMETERS
     this->param.implement_block_diagonal_preconditioner_matrix_free = false;
     this->param.use_cell_based_face_loops                           = false;
-    this->param.solver_data_block_diagonal = SolverData(1000, 1.e-12, 1.e-2, 1000);
-    this->param.quad_rule_linearization    = QuadratureRuleLinearization::Overintegration32k;
+    this->param.solver_data_block_diagonal =
+      SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000);
+    this->param.quad_rule_linearization = QuadratureRuleLinearization::Overintegration32k;
 
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-8, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-8);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
 
@@ -132,8 +133,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-8);
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -147,11 +147,10 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-20, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum = SolverMomentum::GMRES; // FGMRES;
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        this->param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-2, 100);
+        this->param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-2, LinearSolver::GMRES, 100);
       else
-        this->param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-6, 100);
+        this->param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = true;
       this->param.multigrid_data_momentum.smoother_data.smoother = MultigridSmoother::Jacobi;
@@ -173,11 +172,10 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-12, 1.e-8);
 
     // linear solver
-    this->param.solver_coupled = SolverCoupled::FGMRES; // FGMRES;
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-2, 1000);
+      this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-2, LinearSolver::FGMRES, 30);
     else
-      this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-6, 1000);
+      this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::FGMRES, 30);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -198,7 +196,8 @@ private:
       MultigridCoarseGridSolver::GMRES;
 
     this->param.iterative_solve_of_velocity_block = false; // true;
-    this->param.solver_data_velocity_block        = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_velocity_block =
+      SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::FGMRES, 100);
 
     // preconditioner Schur-complement block
     this->param.preconditioner_pressure_block =
@@ -206,7 +205,7 @@ private:
     this->param.multigrid_data_pressure_block.coarse_problem.solver =
       MultigridCoarseGridSolver::Chebyshev;
     this->param.iterative_solve_of_pressure_block = false;
-    this->param.solver_data_pressure_block        = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_pressure_block = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::CG, 100);
   }
 
   void

--- a/applications/incompressible_navier_stokes/couette/application.h
+++ b/applications/incompressible_navier_stokes/couette/application.h
@@ -109,13 +109,11 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-20, 1.e-6);
+    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-20, 1.e-6, LinearSolver::CG);
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -127,9 +125,8 @@ private:
     // viscous step
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                  = SolverMomentum::CG;
-      this->param.solver_data_momentum             = SolverData(1000, 1.e-20, 1.e-6);
-      this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-20, 1.e-6, LinearSolver::CG);
+      this->param.preconditioner_momentum = MomentumPreconditioner::Multigrid;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
     }
 
@@ -143,8 +140,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-20, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::GMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-20, 1.e-4, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-20, 1.e-4, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
@@ -159,8 +155,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-14, 1.e-14);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-14, 1.e-2, 100);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-14, 1.e-2, LinearSolver::FGMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/fda_benchmark/application.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application.h
@@ -173,10 +173,9 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
   // PROJECTION METHODS
 
   // pressure Poisson equation
-  param.IP_factor_pressure                   = 1.0;
-  param.solver_data_pressure_poisson         = SolverData(1000, 1.e-12, 1.e-3, 100);
-  param.solver_pressure_poisson              = SolverPressurePoisson::CG; // FGMRES;
-  param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
+  param.IP_factor_pressure              = 1.0;
+  param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-3, LinearSolver::CG, 100);
+  param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
   param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
   if(is_precursor)
     param.multigrid_data_pressure_poisson.type = MultigridType::phMG;
@@ -188,8 +187,7 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
 
 
   // projection step
-  param.solver_projection                = SolverProjection::CG;
-  param.solver_data_projection           = SolverData(1000, 1.e-12, 1.e-3);
+  param.solver_data_projection           = SolverData(1000, 1.e-12, 1.e-3, LinearSolver::CG);
   param.preconditioner_projection        = PreconditionerProjection::InverseMassMatrix;
   param.update_preconditioner_projection = true;
 
@@ -202,8 +200,7 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
 
   if(param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
   {
-    param.solver_momentum         = SolverMomentum::CG;
-    param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-3);
+    param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-3, LinearSolver::CG);
     param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
   }
 
@@ -222,11 +219,10 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
 
     // linear solver
     if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-1, 100);
+      param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-1, LinearSolver::GMRES, 100);
     else
-      param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-3, 100);
+      param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-3, LinearSolver::GMRES, 100);
 
-    param.solver_momentum                = SolverMomentum::GMRES;
     param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
     param.update_preconditioner_momentum = false;
   }
@@ -238,11 +234,10 @@ do_set_parameters(Parameters & param, bool const is_precursor = false)
   param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-20, 1.e-3);
 
   // linear solver
-  param.solver_coupled = SolverCoupled::GMRES; // GMRES; //FGMRES;
   if(param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-    param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-1, 100);
+    param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-1, LinearSolver::GMRES, 100);
   else
-    param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-3, 100);
+    param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-3, LinearSolver::GMRES, 100);
 
   // preconditioning linear solver
   param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
+++ b/applications/incompressible_navier_stokes/fda_benchmark/application_poisson.h
@@ -52,10 +52,7 @@ private:
     this->param.IP_factor                   = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = Poisson::LinearSolver::CG;
-    this->param.solver_data.abs_tol         = 1.e-20;
-    this->param.solver_data.rel_tol         = 1.e-10;
-    this->param.solver_data.max_iter        = 1e4;
+    this->param.solver_data                 = SolverData(1e4, 1e-20, 1e-10, LinearSolver::CG);
     this->param.compute_performance_metrics = true;
     this->param.preconditioner              = Preconditioner::Multigrid;
     this->param.multigrid_data.type         = MultigridType::cphMG;

--- a/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_cylinder/application.h
@@ -226,8 +226,8 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 30);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 30);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.smoother_data.smoother =
@@ -240,9 +240,8 @@ private:
     this->param.update_preconditioner_pressure_poisson = false;
 
     // projection step
-    this->param.solver_projection                = SolverProjection::CG;
-    this->param.solver_data_projection           = SolverData(1000, ABS_TOL, REL_TOL);
-    this->param.preconditioner_projection        = PreconditionerProjection::InverseMassMatrix;
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
+    this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
     this->param.update_preconditioner_projection = false;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -253,9 +252,8 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                = SolverMomentum::CG;
-      this->param.solver_data_momentum           = SolverData(1000, ABS_TOL, REL_TOL);
-      this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
+      this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
 
@@ -272,8 +270,8 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum      = SolverMomentum::FGMRES;
-      this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      this->param.solver_data_momentum =
+        SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::FGMRES, 100);
 
       this->param.update_preconditioner_momentum                   = true;
       this->param.update_preconditioner_momentum_every_newton_iter = 10;
@@ -299,8 +297,8 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES;
-    this->param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+    this->param.solver_data_coupled =
+      SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::FGMRES, 100);
 
     this->param.update_preconditioner_coupled                   = true;
     this->param.update_preconditioner_coupled_every_newton_iter = 10;

--- a/applications/incompressible_navier_stokes/flow_past_sphere/application.h
+++ b/applications/incompressible_navier_stokes/flow_past_sphere/application.h
@@ -167,8 +167,8 @@ public:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 30);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 30);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.p_sequence = PSequenceType::Bisect;
@@ -180,9 +180,8 @@ public:
     this->param.update_preconditioner_pressure_poisson = false;
 
     // projection step
-    this->param.solver_projection                = SolverProjection::CG;
-    this->param.solver_data_projection           = SolverData(1000, ABS_TOL, REL_TOL);
-    this->param.preconditioner_projection        = PreconditionerProjection::InverseMassMatrix;
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
+    this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
     this->param.update_preconditioner_projection = false;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -193,9 +192,8 @@ public:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                = SolverMomentum::CG;
-      this->param.solver_data_momentum           = SolverData(1000, ABS_TOL, REL_TOL);
-      this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
+      this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
 
@@ -212,8 +210,8 @@ public:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum      = SolverMomentum::FGMRES;
-      this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      this->param.solver_data_momentum =
+        SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::FGMRES, 100);
 
       this->param.update_preconditioner_momentum                   = true;
       this->param.update_preconditioner_momentum_every_newton_iter = 10;
@@ -239,8 +237,8 @@ public:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES;
-    this->param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+    this->param.solver_data_coupled =
+      SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::FGMRES, 100);
 
     this->param.update_preconditioner_coupled                   = true;
     this->param.update_preconditioner_coupled_every_newton_iter = 10;

--- a/applications/incompressible_navier_stokes/free_stream/application.h
+++ b/applications/incompressible_navier_stokes/free_stream/application.h
@@ -146,8 +146,8 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-14, 1.e-14, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-14, 1.e-14, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -160,12 +160,12 @@ private:
       PreconditionerSmoother::PointJacobi;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-14, 1.e-14);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-14, 1.e-14, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
     this->param.preconditioner_block_diagonal_projection =
       Elementwise::Preconditioner::InverseMassMatrix;
-    this->param.solver_data_block_diagonal_projection = SolverData(1000, 1.e-12, 1.e-2, 1000);
+    this->param.solver_data_block_diagonal_projection =
+      SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000);
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
 
@@ -176,10 +176,9 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                  = SolverMomentum::CG;
-      this->param.solver_data_momentum             = SolverData(1000, 1.e-14, 1.e-14);
-      this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
-      this->param.multigrid_data_momentum.type     = MultigridType::hMG;
+      this->param.solver_data_momentum         = SolverData(1000, 1.e-14, 1.e-14, LinearSolver::CG);
+      this->param.preconditioner_momentum      = MomentumPreconditioner::Multigrid;
+      this->param.multigrid_data_momentum.type = MultigridType::hMG;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
       this->param.multigrid_data_momentum.smoother_data.smoother = MultigridSmoother::Chebyshev;
       this->param.multigrid_data_momentum.coarse_problem.solver =
@@ -202,8 +201,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-12, 1.e-12);
 
       // linear solver
-      this->param.solver_momentum                  = SolverMomentum::FGMRES;
-      this->param.solver_data_momentum             = SolverData(1e4, 1.e-14, 1.e-14, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-14, 1.e-14, LinearSolver::FGMRES, 100);
       this->param.update_preconditioner_momentum   = false;
       this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
       this->param.multigrid_data_momentum.type     = MultigridType::hMG;
@@ -220,8 +218,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-12, 1.e-12);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-14, 1.e-14, 100);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-14, 1.e-14, LinearSolver::FGMRES, 100);
 
     // preconditioner linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
+++ b/applications/incompressible_navier_stokes/kelvin_helmholtz/application.h
@@ -126,13 +126,12 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -143,9 +142,8 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                  = SolverMomentum::CG;
-      this->param.solver_data_momentum             = SolverData(1000, 1.e-12, 1.e-6);
-      this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
+      this->param.preconditioner_momentum = MomentumPreconditioner::Multigrid;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
     }
 
@@ -158,8 +156,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-14, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::GMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-20, 1.e-6, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-20, 1.e-6, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
@@ -175,8 +172,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-10, 1.e-6);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::GMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-6, 200);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::GMRES, 200);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/kovasznay/application.h
+++ b/applications/incompressible_navier_stokes/kovasznay/application.h
@@ -180,13 +180,12 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-20, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-20, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -197,9 +196,8 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum                  = SolverMomentum::CG;
-      this->param.solver_data_momentum             = SolverData(1000, 1.e-20, 1.e-6);
-      this->param.preconditioner_momentum          = MomentumPreconditioner::Multigrid;
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-20, 1.e-6, LinearSolver::CG);
+      this->param.preconditioner_momentum = MomentumPreconditioner::Multigrid;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
     }
 
@@ -213,8 +211,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-20, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::GMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-20, 1.e-4, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-20, 1.e-4, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
@@ -226,13 +223,10 @@ private:
     // COUPLED NAVIER-STOKES SOLVER
 
     // nonlinear solver (Newton solver)
-    this->param.newton_solver_data_coupled.abs_tol  = 1.e-12;
-    this->param.newton_solver_data_coupled.rel_tol  = 1.e-6;
-    this->param.newton_solver_data_coupled.max_iter = 1e2;
+    this->param.newton_solver_data_coupled = Newton::SolverData(1e2, 1.e-12, 1.e-6);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-3, 1000);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-3, LinearSolver::FGMRES, 1000);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -495,13 +495,11 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-8);
+    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-8);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
     this->param.update_preconditioner_projection = true;
 
@@ -513,11 +511,9 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum =
-        treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit ?
-          SolverMomentum::CG :
-          SolverMomentum::FGMRES;
-      this->param.solver_data_momentum = SolverData(1000, 1e-12, 1e-8);
+      LinearSolver const linear_solver = treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit ?
+          LinearSolver::CG : LinearSolver::FGMRES;
+      this->param.solver_data_momentum = SolverData(1000, 1e-12, 1e-8, linear_solver);
       this->param.preconditioner_momentum = spatial_discretization == SpatialDiscretization::L2 ?
                                              MomentumPreconditioner::Multigrid :
                                              MomentumPreconditioner::PointJacobi;
@@ -537,8 +533,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-14, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::GMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-12, 1.e-8, 100);
+      this->param.solver_data_momentum           = SolverData(1e4, 1.e-12, 1.e-8, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::Multigrid;
       this->param.update_preconditioner_momentum = true;
     }
@@ -557,7 +552,7 @@ private:
       this->param.multigrid_data_momentum.smoother_data.iterations_eigenvalue_estimation = 60; // Chebyshev, default: 20
 
       this->param.multigrid_data_momentum.coarse_problem.solver         = this->param.non_explicit_convective_problem() ? MultigridCoarseGridSolver::GMRES : MultigridCoarseGridSolver::CG; // MultigridCoarseGridSolver::AMG
-      this->param.multigrid_data_momentum.coarse_problem.solver_data    = SolverData(1000, 1e-12, 1e-8, 30);
+      this->param.multigrid_data_momentum.coarse_problem.solver_data    = SolverData(1000, 1e-12, 1e-8, LinearSolver::Undefined, 30);
       this->param.multigrid_data_momentum.smoother_data.preconditioner  = PreconditionerSmoother::PointJacobi;
       this->param.multigrid_data_momentum.coarse_problem.preconditioner = MultigridCoarseGridPreconditioner::PointJacobi;
 #ifdef DEAL_II_WITH_TRILINOS
@@ -575,8 +570,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-10, 1.e-6);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-8, 100);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-8, LinearSolver::FGMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
+++ b/applications/incompressible_navier_stokes/orr_sommerfeld/application.h
@@ -231,14 +231,13 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-14, 1.e-14, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-14, 1.e-14, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-14, 1.e-14);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-14, 1.e-14, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -249,8 +248,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, 1.e-14, 1.e-14);
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-14, 1.e-14, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -267,8 +265,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-14, 1.e-14);
 
       // linear solver
-      this->param.solver_momentum         = SolverMomentum::GMRES;
-      this->param.solver_data_momentum    = SolverData(1e4, 1.e-14, 1.e-14, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-14, 1.e-14, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -278,8 +275,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-14, 1.e-14);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::GMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-14, 1.e-14, 200);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-14, 1.e-14, LinearSolver::GMRES, 200);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -246,8 +246,8 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -256,9 +256,8 @@ private:
       MultigridCoarseGridPreconditioner::PointJacobi;
 
     // projection step
-    this->param.solver_projection                = SolverProjection::CG;
-    this->param.solver_data_projection           = SolverData(1000, 1.e-12, 1.e-6);
-    this->param.preconditioner_projection        = PreconditionerProjection::InverseMassMatrix;
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
+    this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
     this->param.update_preconditioner_projection = true;
 
 
@@ -268,8 +267,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    this->param.solver_momentum         = SolverMomentum::CG;
-    this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6);
+    this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
     this->param.preconditioner_momentum = spatial_discretization == SpatialDiscretization::L2 ?
                                             MomentumPreconditioner::InverseMassMatrix :
                                             MomentumPreconditioner::PointJacobi;

--- a/applications/incompressible_navier_stokes/poiseuille/application.h
+++ b/applications/incompressible_navier_stokes/poiseuille/application.h
@@ -244,13 +244,12 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-20, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-20, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-20, 1.e-12, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
 
@@ -262,8 +261,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, 1.e-20, 1.e-6);
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-20, 1.e-6, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -280,8 +278,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-14, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::GMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-20, 1.e-6, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-20, 1.e-6, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
@@ -293,8 +290,7 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-10, 1.e-6);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES; // GMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-2, 200);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-2, LinearSolver::FGMRES, 200);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow.output
@@ -109,7 +109,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
@@ -127,11 +126,10 @@ High-order dual splitting scheme:
   Maximum size of Krylov space:              30
 
   Projection step:
-  Solver projection step:                    CG
+  Solver:                                    CG
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-12
-  Maximum size of Krylov space:              30
   Preconditioner projection step:            InverseMassMatrix
   Update preconditioner projection step:     false
 
@@ -141,7 +139,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              30
   Preconditioner:                            InverseMassMatrix
   Update of preconditioner:                  false
 
@@ -193,10 +190,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0036e+01:
-  Absolute error (L2-norm): 1.13273e-15
+  Absolute error (L2-norm): 7.05304e-16
 
 Calculate error for pressure at time t = 1.0036e+01:
-  Absolute error (L2-norm): 2.14222e-15
+  Absolute error (L2-norm): 7.19311e-15
 
 ________________________________________________________________________________
 
@@ -204,10 +201,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 2.0076e+01:
-  Absolute error (L2-norm): 1.33106e-15
+  Absolute error (L2-norm): 4.94362e-16
 
 Calculate error for pressure at time t = 2.0076e+01:
-  Absolute error (L2-norm): 7.67499e-15
+  Absolute error (L2-norm): 4.00880e-15
 
 ________________________________________________________________________________
 
@@ -215,10 +212,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 3.0117e+01:
-  Absolute error (L2-norm): 1.07720e-15
+  Absolute error (L2-norm): 9.14347e-16
 
 Calculate error for pressure at time t = 3.0117e+01:
-  Absolute error (L2-norm): 4.69212e-15
+  Absolute error (L2-norm): 1.06952e-14
 
 ________________________________________________________________________________
 
@@ -226,10 +223,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 4.0017e+01:
-  Absolute error (L2-norm): 9.59174e-16
+  Absolute error (L2-norm): 7.41602e-16
 
 Calculate error for pressure at time t = 4.0017e+01:
-  Absolute error (L2-norm): 1.64174e-15
+  Absolute error (L2-norm): 4.41522e-15
 
 ________________________________________________________________________________
 
@@ -237,10 +234,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 5.0057e+01:
-  Absolute error (L2-norm): 1.34088e-15
+  Absolute error (L2-norm): 6.37358e-16
 
 Calculate error for pressure at time t = 5.0057e+01:
-  Absolute error (L2-norm): 7.76297e-15
+  Absolute error (L2-norm): 1.56074e-14
 
 ________________________________________________________________________________
 
@@ -248,10 +245,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 6.0098e+01:
-  Absolute error (L2-norm): 9.85986e-16
+  Absolute error (L2-norm): 6.33812e-16
 
 Calculate error for pressure at time t = 6.0098e+01:
-  Absolute error (L2-norm): 3.72583e-15
+  Absolute error (L2-norm): 2.96566e-15
 
 ________________________________________________________________________________
 
@@ -259,10 +256,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 7.0139e+01:
-  Absolute error (L2-norm): 1.10214e-15
+  Absolute error (L2-norm): 7.00049e-16
 
 Calculate error for pressure at time t = 7.0139e+01:
-  Absolute error (L2-norm): 8.34320e-15
+  Absolute error (L2-norm): 1.07583e-14
 
 ________________________________________________________________________________
 
@@ -270,10 +267,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 8.0038e+01:
-  Absolute error (L2-norm): 1.36045e-15
+  Absolute error (L2-norm): 6.78495e-16
 
 Calculate error for pressure at time t = 8.0038e+01:
-  Absolute error (L2-norm): 1.18094e-14
+  Absolute error (L2-norm): 1.49736e-15
 
 ________________________________________________________________________________
 
@@ -281,10 +278,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0079e+01:
-  Absolute error (L2-norm): 1.20648e-15
+  Absolute error (L2-norm): 8.54854e-16
 
 Calculate error for pressure at time t = 9.0079e+01:
-  Absolute error (L2-norm): 1.87106e-14
+  Absolute error (L2-norm): 5.93392e-15
 
 ________________________________________________________________________________
 
@@ -292,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0012e+02:
-  Absolute error (L2-norm): 1.44141e-15
+  Absolute error (L2-norm): 6.78778e-16
 
 Calculate error for pressure at time t = 1.0012e+02:
-  Absolute error (L2-norm): 2.43541e-14
+  Absolute error (L2-norm): 5.52128e-15

--- a/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/parabolic_inflow_symmetry_bc.output
@@ -109,7 +109,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
@@ -127,11 +126,10 @@ High-order dual splitting scheme:
   Maximum size of Krylov space:              30
 
   Projection step:
-  Solver projection step:                    CG
+  Solver:                                    CG
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-12
-  Maximum size of Krylov space:              30
   Preconditioner projection step:            InverseMassMatrix
   Update preconditioner projection step:     false
 
@@ -141,7 +139,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              30
   Preconditioner:                            InverseMassMatrix
   Update of preconditioner:                  false
 
@@ -193,10 +190,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0127e+01:
-  Absolute error (L2-norm): 1.07927e-15
+  Absolute error (L2-norm): 7.92090e-16
 
 Calculate error for pressure at time t = 1.0127e+01:
-  Absolute error (L2-norm): 4.70178e-15
+  Absolute error (L2-norm): 3.75970e-16
 
 ________________________________________________________________________________
 
@@ -204,10 +201,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 2.0010e+01:
-  Absolute error (L2-norm): 1.04158e-15
+  Absolute error (L2-norm): 1.00592e-15
 
 Calculate error for pressure at time t = 2.0010e+01:
-  Absolute error (L2-norm): 4.51456e-15
+  Absolute error (L2-norm): 6.61132e-16
 
 ________________________________________________________________________________
 
@@ -215,10 +212,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 3.0037e+01:
-  Absolute error (L2-norm): 8.83094e-16
+  Absolute error (L2-norm): 6.11762e-16
 
 Calculate error for pressure at time t = 3.0037e+01:
-  Absolute error (L2-norm): 7.35652e-16
+  Absolute error (L2-norm): 1.30436e-14
 
 ________________________________________________________________________________
 
@@ -226,10 +223,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 4.0064e+01:
-  Absolute error (L2-norm): 9.86093e-16
+  Absolute error (L2-norm): 6.33759e-16
 
 Calculate error for pressure at time t = 4.0064e+01:
-  Absolute error (L2-norm): 1.43495e-15
+  Absolute error (L2-norm): 5.82969e-16
 
 ________________________________________________________________________________
 
@@ -237,10 +234,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 5.0091e+01:
-  Absolute error (L2-norm): 1.16129e-15
+  Absolute error (L2-norm): 7.04313e-16
 
 Calculate error for pressure at time t = 5.0091e+01:
-  Absolute error (L2-norm): 2.70685e-15
+  Absolute error (L2-norm): 4.42552e-15
 
 ________________________________________________________________________________
 
@@ -248,10 +245,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 6.0118e+01:
-  Absolute error (L2-norm): 1.10174e-15
+  Absolute error (L2-norm): 5.90300e-16
 
 Calculate error for pressure at time t = 6.0118e+01:
-  Absolute error (L2-norm): 9.49217e-15
+  Absolute error (L2-norm): 2.11722e-15
 
 ________________________________________________________________________________
 
@@ -259,10 +256,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 7.0001e+01:
-  Absolute error (L2-norm): 9.01623e-16
+  Absolute error (L2-norm): 7.86986e-16
 
 Calculate error for pressure at time t = 7.0001e+01:
-  Absolute error (L2-norm): 6.14412e-15
+  Absolute error (L2-norm): 1.87848e-15
 
 ________________________________________________________________________________
 
@@ -270,10 +267,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 8.0028e+01:
-  Absolute error (L2-norm): 9.61386e-16
+  Absolute error (L2-norm): 8.12198e-16
 
 Calculate error for pressure at time t = 8.0028e+01:
-  Absolute error (L2-norm): 6.55332e-15
+  Absolute error (L2-norm): 6.62578e-15
 
 ________________________________________________________________________________
 
@@ -281,10 +278,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0055e+01:
-  Absolute error (L2-norm): 9.15372e-16
+  Absolute error (L2-norm): 9.40866e-16
 
 Calculate error for pressure at time t = 9.0055e+01:
-  Absolute error (L2-norm): 2.98344e-15
+  Absolute error (L2-norm): 1.96096e-14
 
 ________________________________________________________________________________
 
@@ -292,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0008e+02:
-  Absolute error (L2-norm): 1.04193e-15
+  Absolute error (L2-norm): 9.42588e-16
 
 Calculate error for pressure at time t = 1.0008e+02:
-  Absolute error (L2-norm): 2.15660e-15
+  Absolute error (L2-norm): 3.41680e-15

--- a/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/periodic_bc.output
@@ -109,7 +109,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
@@ -127,11 +126,10 @@ High-order dual splitting scheme:
   Maximum size of Krylov space:              30
 
   Projection step:
-  Solver projection step:                    CG
+  Solver:                                    CG
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-12
-  Maximum size of Krylov space:              30
   Preconditioner projection step:            InverseMassMatrix
   Update preconditioner projection step:     false
 
@@ -141,7 +139,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              30
   Preconditioner:                            InverseMassMatrix
   Update of preconditioner:                  false
 
@@ -196,7 +193,7 @@ Calculate error for velocity at time t = 1.0059e+01:
   Absolute error (L2-norm): 1.68241e-01
 
 Calculate error for pressure at time t = 1.0059e+01:
-  Absolute error (L2-norm): 3.70189e-10
+  Absolute error (L2-norm): 9.45163e-10
 
 ________________________________________________________________________________
 
@@ -207,7 +204,7 @@ Calculate error for velocity at time t = 2.0123e+01:
   Absolute error (L2-norm): 1.36953e-02
 
 Calculate error for pressure at time t = 2.0123e+01:
-  Absolute error (L2-norm): 2.15218e-11
+  Absolute error (L2-norm): 1.21150e-11
 
 ________________________________________________________________________________
 
@@ -218,7 +215,7 @@ Calculate error for velocity at time t = 3.0047e+01:
   Absolute error (L2-norm): 1.15467e-03
 
 Calculate error for pressure at time t = 3.0047e+01:
-  Absolute error (L2-norm): 1.40866e-12
+  Absolute error (L2-norm): 5.69569e-12
 
 ________________________________________________________________________________
 
@@ -229,7 +226,7 @@ Calculate error for velocity at time t = 4.0089e+01:
   Absolute error (L2-norm): 9.45165e-05
 
 Calculate error for pressure at time t = 4.0089e+01:
-  Absolute error (L2-norm): 1.06242e-13
+  Absolute error (L2-norm): 2.51179e-13
 
 ________________________________________________________________________________
 
@@ -240,7 +237,7 @@ Calculate error for velocity at time t = 5.0130e+01:
   Absolute error (L2-norm): 7.73955e-06
 
 Calculate error for pressure at time t = 5.0130e+01:
-  Absolute error (L2-norm): 1.01057e-14
+  Absolute error (L2-norm): 8.34570e-15
 
 ________________________________________________________________________________
 
@@ -251,7 +248,7 @@ Calculate error for velocity at time t = 6.0029e+01:
   Absolute error (L2-norm): 6.56494e-07
 
 Calculate error for pressure at time t = 6.0029e+01:
-  Absolute error (L2-norm): 1.29427e-15
+  Absolute error (L2-norm): 9.90430e-16
 
 ________________________________________________________________________________
 
@@ -262,7 +259,7 @@ Calculate error for velocity at time t = 7.0070e+01:
   Absolute error (L2-norm): 5.37574e-08
 
 Calculate error for pressure at time t = 7.0070e+01:
-  Absolute error (L2-norm): 2.36443e-15
+  Absolute error (L2-norm): 8.54377e-16
 
 ________________________________________________________________________________
 
@@ -273,7 +270,7 @@ Calculate error for velocity at time t = 8.0111e+01:
   Absolute error (L2-norm): 4.40196e-09
 
 Calculate error for pressure at time t = 8.0111e+01:
-  Absolute error (L2-norm): 1.91306e-15
+  Absolute error (L2-norm): 6.81998e-16
 
 ________________________________________________________________________________
 
@@ -284,7 +281,7 @@ Calculate error for velocity at time t = 9.0010e+01:
   Absolute error (L2-norm): 3.73380e-10
 
 Calculate error for pressure at time t = 9.0010e+01:
-  Absolute error (L2-norm): 1.55055e-15
+  Absolute error (L2-norm): 9.96260e-16
 
 ________________________________________________________________________________
 
@@ -292,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0005e+02:
-  Absolute error (L2-norm): 3.05689e-11
+  Absolute error (L2-norm): 3.05667e-11
 
 Calculate error for pressure at time t = 1.0005e+02:
-  Absolute error (L2-norm): 3.47967e-15
+  Absolute error (L2-norm): 2.44902e-15

--- a/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
+++ b/applications/incompressible_navier_stokes/poiseuille/tests/pressure_inflow.output
@@ -109,7 +109,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            hMG
@@ -127,11 +126,10 @@ High-order dual splitting scheme:
   Maximum size of Krylov space:              30
 
   Projection step:
-  Solver projection step:                    CG
+  Solver:                                    CG
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-12
-  Maximum size of Krylov space:              30
   Preconditioner projection step:            InverseMassMatrix
   Update preconditioner projection step:     false
 
@@ -141,7 +139,6 @@ High-order dual splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              30
   Preconditioner:                            InverseMassMatrix
   Update of preconditioner:                  false
 
@@ -196,7 +193,7 @@ Calculate error for velocity at time t = 1.0056e+01:
   Absolute error (L2-norm): 1.68135e-01
 
 Calculate error for pressure at time t = 1.0056e+01:
-  Absolute error (L2-norm): 4.11875e-10
+  Absolute error (L2-norm): 1.12673e-09
 
 ________________________________________________________________________________
 
@@ -207,7 +204,7 @@ Calculate error for velocity at time t = 2.0119e+01:
   Absolute error (L2-norm): 1.36693e-02
 
 Calculate error for pressure at time t = 2.0119e+01:
-  Absolute error (L2-norm): 1.68078e-11
+  Absolute error (L2-norm): 1.73050e-11
 
 ________________________________________________________________________________
 
@@ -218,7 +215,7 @@ Calculate error for velocity at time t = 3.0043e+01:
   Absolute error (L2-norm): 1.15089e-03
 
 Calculate error for pressure at time t = 3.0043e+01:
-  Absolute error (L2-norm): 8.23861e-13
+  Absolute error (L2-norm): 3.49392e-13
 
 ________________________________________________________________________________
 
@@ -229,7 +226,7 @@ Calculate error for velocity at time t = 4.0085e+01:
   Absolute error (L2-norm): 9.40746e-05
 
 Calculate error for pressure at time t = 4.0085e+01:
-  Absolute error (L2-norm): 9.40131e-13
+  Absolute error (L2-norm): 8.69132e-14
 
 ________________________________________________________________________________
 
@@ -240,7 +237,7 @@ Calculate error for velocity at time t = 5.0126e+01:
   Absolute error (L2-norm): 7.69248e-06
 
 Calculate error for pressure at time t = 5.0126e+01:
-  Absolute error (L2-norm): 4.66125e-15
+  Absolute error (L2-norm): 4.70131e-15
 
 ________________________________________________________________________________
 
@@ -251,7 +248,7 @@ Calculate error for velocity at time t = 6.0025e+01:
   Absolute error (L2-norm): 6.51593e-07
 
 Calculate error for pressure at time t = 6.0025e+01:
-  Absolute error (L2-norm): 1.73958e-15
+  Absolute error (L2-norm): 9.00798e-16
 
 ________________________________________________________________________________
 
@@ -262,7 +259,7 @@ Calculate error for velocity at time t = 7.0066e+01:
   Absolute error (L2-norm): 5.32807e-08
 
 Calculate error for pressure at time t = 7.0066e+01:
-  Absolute error (L2-norm): 3.15033e-15
+  Absolute error (L2-norm): 3.82877e-15
 
 ________________________________________________________________________________
 
@@ -273,7 +270,7 @@ Calculate error for velocity at time t = 8.0107e+01:
   Absolute error (L2-norm): 4.35676e-09
 
 Calculate error for pressure at time t = 8.0107e+01:
-  Absolute error (L2-norm): 1.63373e-15
+  Absolute error (L2-norm): 4.10898e-15
 
 ________________________________________________________________________________
 
@@ -281,10 +278,10 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 9.0006e+01:
-  Absolute error (L2-norm): 3.69033e-10
+  Absolute error (L2-norm): 3.69028e-10
 
 Calculate error for pressure at time t = 9.0006e+01:
-  Absolute error (L2-norm): 1.71827e-15
+  Absolute error (L2-norm): 9.48560e-16
 
 ________________________________________________________________________________
 
@@ -292,7 +289,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0005e+02:
-  Absolute error (L2-norm): 3.01722e-11
+  Absolute error (L2-norm): 3.01674e-11
 
 Calculate error for pressure at time t = 1.0005e+02:
-  Absolute error (L2-norm): 3.56495e-16
+  Absolute error (L2-norm): 4.12898e-15

--- a/applications/incompressible_navier_stokes/shear_layer/application.h
+++ b/applications/incompressible_navier_stokes/shear_layer/application.h
@@ -134,8 +134,8 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -144,8 +144,7 @@ private:
       MultigridCoarseGridPreconditioner::PointJacobi;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -154,8 +153,7 @@ private:
     this->param.order_extrapolation_pressure_nbc =
       this->param.order_time_integrator <= 2 ? this->param.order_time_integrator : 2;
 
-    this->param.solver_momentum         = SolverMomentum::CG;
-    this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6);
+    this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
     this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
   }
 

--- a/applications/incompressible_navier_stokes/stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/stokes_manufactured/application.h
@@ -179,13 +179,11 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-8);
+    this->param.solver_data_pressure_poisson    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-8);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -196,8 +194,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-8);
+      this->param.solver_data_momentum    = SolverData(1000, 1.e-12, 1.e-8, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -210,8 +207,7 @@ private:
       // Newton solver
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::GMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-12, 1.e-8, 100);
+      this->param.solver_data_momentum = SolverData(1e4, 1.e-12, 1.e-8, LinearSolver::GMRES, 100);
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
     }
@@ -226,8 +222,7 @@ private:
     // nonlinear solver (Newton solver)
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::GMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-8, 100);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-8, LinearSolver::GMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
+++ b/applications/incompressible_navier_stokes/taylor_green_vortex/application.h
@@ -234,13 +234,13 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
@@ -251,8 +251,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -265,11 +264,12 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum = SolverMomentum::GMRES;
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
       else
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
       this->param.preconditioner_momentum        = MomentumPreconditioner::InverseMassMatrix;
       this->param.update_preconditioner_momentum = false;
@@ -287,11 +287,11 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled = SolverCoupled::GMRES;
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      this->param.solver_data_coupled =
+        SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
     else
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, 100);
+      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/throughput/application.h
+++ b/applications/incompressible_navier_stokes/throughput/application.h
@@ -120,19 +120,20 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
-    this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::None;
+
+    this->param.solver_data_pressure_poisson.linear_solver = LinearSolver::CG;
+    this->param.preconditioner_pressure_poisson            = PreconditionerPressurePoisson::None;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.preconditioner_projection = PreconditionerProjection::None;
+    this->param.solver_data_projection.linear_solver = LinearSolver::CG;
+    this->param.preconditioner_projection            = PreconditionerProjection::None;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.preconditioner_momentum = MomentumPreconditioner::None;
+      this->param.solver_data_momentum.linear_solver = LinearSolver::CG;
+      this->param.preconditioner_momentum            = MomentumPreconditioner::None;
     }
 
     // PRESSURE-CORRECTION SCHEME
@@ -141,14 +142,14 @@ private:
     if(this->param.temporal_discretization == TemporalDiscretization::BDFPressureCorrection)
     {
       // linear solver
-      this->param.solver_momentum         = SolverMomentum::GMRES;
-      this->param.preconditioner_momentum = MomentumPreconditioner::None;
+      this->param.solver_data_momentum.linear_solver = LinearSolver::GMRES;
+      this->param.preconditioner_momentum            = MomentumPreconditioner::None;
     }
 
     // COUPLED NAVIER-STOKES SOLVER
 
     // linear solver
-    this->param.solver_coupled = SolverCoupled::GMRES;
+    this->param.solver_data_coupled.linear_solver = LinearSolver::GMRES;
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::None;

--- a/applications/incompressible_navier_stokes/turbulent_channel/application.h
+++ b/applications/incompressible_navier_stokes/turbulent_channel/application.h
@@ -251,14 +251,13 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
 
 
@@ -270,8 +269,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
 
@@ -289,11 +287,12 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum = SolverMomentum::GMRES;
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
       else
-        this->param.solver_data_momentum = SolverData(1e4, ABS_TOL, REL_TOL, 100);
+        this->param.solver_data_momentum =
+          SolverData(1e4, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
     }
@@ -305,11 +304,11 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled = SolverCoupled::GMRES;
     if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Implicit)
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+      this->param.solver_data_coupled =
+        SolverData(1e3, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
     else
-      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, 100);
+      this->param.solver_data_coupled = SolverData(1e3, ABS_TOL, REL_TOL, LinearSolver::GMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -335,8 +335,7 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson              = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_pressure_poisson         = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson      = PreconditionerPressurePoisson::Multigrid;
     this->param.multigrid_data_pressure_poisson.type = MultigridType::cphMG;
     this->param.multigrid_data_pressure_poisson.coarse_problem.solver =
@@ -349,12 +348,12 @@ private:
       PreconditionerSmoother::PointJacobi;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6);
+    this->param.solver_data_projection    = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
     this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
     this->param.preconditioner_block_diagonal_projection =
       Elementwise::Preconditioner::InverseMassMatrix;
-    this->param.solver_data_block_diagonal_projection = SolverData(1000, 1.e-12, 1.e-2, 1000);
+    this->param.solver_data_block_diagonal_projection =
+      SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000);
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
 
@@ -367,15 +366,13 @@ private:
     {
       if(this->param.treatment_of_convective_term == TreatmentOfConvectiveTerm::Explicit)
       {
-        this->param.solver_momentum      = SolverMomentum::CG;
-        this->param.solver_data_momentum = SolverData(1000, 1.e-12, 1.e-6);
+        this->param.solver_data_momentum = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG);
       }
       else
       {
         // Newton solver
         this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-10, 1.e-6);
-        this->param.solver_momentum             = SolverMomentum::GMRES;
-        this->param.solver_data_momentum        = SolverData(1000, 1.e-12, 1.e-6);
+        this->param.solver_data_momentum        = SolverData(1000, 1.e-12, 1.e-6, LinearSolver::GMRES);
       }
 
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix; // Multigrid;
@@ -402,8 +399,7 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, 1.e-12, 1.e-6);
 
       // linear solver
-      this->param.solver_momentum                = SolverMomentum::FGMRES;
-      this->param.solver_data_momentum           = SolverData(1e4, 1.e-12, 1.e-6, 100);
+      this->param.solver_data_momentum           = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::FGMRES, 100);
       this->param.update_preconditioner_momentum = false;
       this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix; // Multigrid;
       this->param.multigrid_operator_type_momentum = MultigridOperatorType::ReactionDiffusion;
@@ -427,12 +423,10 @@ private:
     this->param.use_scaling_continuity = false;
 
     // nonlinear solver (Newton solver)
-    this->param.newton_solver_data_coupled =
-      Newton::SolverData(100, 1.e-10, 1.e-6); // TODO did not converge with 1.e-12
+    this->param.newton_solver_data_coupled = Newton::SolverData(100, 1.e-10, 1.e-6);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::FGMRES;
-    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.solver_data_coupled = SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::FGMRES, 100);
 
     // preconditioner linear solver
     this->param.preconditioner_coupled        = PreconditionerCoupled::BlockTriangular;
@@ -601,10 +595,7 @@ private:
     this->poisson_param.IP_factor              = 1.0e0;
 
     // SOLVER
-    this->poisson_param.solver                    = Poisson::LinearSolver::CG;
-    this->poisson_param.solver_data.abs_tol       = 1.e-20;
-    this->poisson_param.solver_data.rel_tol       = 1.e-10;
-    this->poisson_param.solver_data.max_iter      = 1e4;
+    this->poisson_param.solver_data               = SolverData(1e4, 1e-20, 1e-10, LinearSolver::CG);
     this->poisson_param.preconditioner            = Preconditioner::Multigrid;
     this->poisson_param.multigrid_data.type       = MultigridType::cphMG;
     this->poisson_param.multigrid_data.p_sequence = PSequenceType::Bisect;

--- a/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting_Explicit.output
+++ b/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting_Explicit.output
@@ -108,7 +108,6 @@ Consistent splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            cphMG
@@ -127,11 +126,10 @@ Consistent splitting scheme:
   Maximum size of Krylov space:              30
 
   Projection step:
-  Solver projection step:                    CG
+  Solver:                                    CG
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              30
   Preconditioner projection step:            InverseMassMatrix
   Update preconditioner projection step:     false
 

--- a/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting_Implicit.output
+++ b/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting_Implicit.output
@@ -107,7 +107,6 @@ Consistent splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            cphMG
@@ -126,11 +125,10 @@ Consistent splitting scheme:
   Maximum size of Krylov space:              30
 
   Projection step:
-  Solver projection step:                    CG
+  Solver:                                    CG
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              30
   Preconditioner projection step:            InverseMassMatrix
   Update preconditioner projection step:     false
 

--- a/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting_LinearlyImplicit.output
+++ b/applications/incompressible_navier_stokes/vortex/tests/consistent_splitting_LinearlyImplicit.output
@@ -107,7 +107,6 @@ Consistent splitting scheme:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Update preconditioner pressure step:       false
   Multigrid type:                            cphMG
@@ -126,11 +125,10 @@ Consistent splitting scheme:
   Maximum size of Krylov space:              30
 
   Projection step:
-  Solver projection step:                    CG
+  Solver:                                    CG
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              30
   Preconditioner projection step:            InverseMassMatrix
   Update preconditioner projection step:     false
 
@@ -190,7 +188,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0000e+00:
-  Relative error (L2-norm): 5.25824e-07
+  Relative error (L2-norm): 5.25803e-07
 
 Calculate error for pressure at time t = 1.0000e+00:
-  Relative error (L2-norm): 5.19556e-06
+  Relative error (L2-norm): 5.19554e-06

--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
@@ -171,14 +171,13 @@ private:
     // PROJECTION METHODS
 
     // pressure Poisson equation
-    this->param.solver_pressure_poisson         = SolverPressurePoisson::CG;
-    this->param.solver_data_pressure_poisson    = SolverData(1000, ABS_TOL, REL_TOL, 100);
+    this->param.solver_data_pressure_poisson =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG, 100);
     this->param.preconditioner_pressure_poisson = PreconditionerPressurePoisson::Multigrid;
 
     // projection step
-    this->param.solver_projection         = SolverProjection::CG;
-    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL);
-    this->param.preconditioner_projection = PreconditionerProjection::InverseMassMatrix;
+    this->param.solver_data_projection    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
+    this->param.preconditioner_projection = PreconditionerProjection::PointJacobi;
 
     // HIGH-ORDER DUAL SPLITTING SCHEME
 
@@ -188,8 +187,7 @@ private:
 
     if(this->param.temporal_discretization == TemporalDiscretization::BDFDualSplitting)
     {
-      this->param.solver_momentum         = SolverMomentum::CG;
-      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL);
+      this->param.solver_data_momentum    = SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
       this->param.preconditioner_momentum = MomentumPreconditioner::PointJacobi;
     }
 
@@ -203,9 +201,9 @@ private:
       this->param.newton_solver_data_momentum = Newton::SolverData(100, ABS_TOL, REL_TOL);
 
       // linear solver
-      this->param.solver_momentum         = SolverMomentum::GMRES;
-      this->param.solver_data_momentum    = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
-      this->param.preconditioner_momentum = MomentumPreconditioner::InverseMassMatrix;
+      this->param.solver_data_momentum =
+        SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
+      this->param.preconditioner_momentum        = MomentumPreconditioner::PointJacobi;
       this->param.update_preconditioner_momentum = false;
     }
 
@@ -219,8 +217,8 @@ private:
     this->param.newton_solver_data_coupled = Newton::SolverData(1000, ABS_TOL, REL_TOL);
 
     // linear solver
-    this->param.solver_coupled      = SolverCoupled::GMRES;
-    this->param.solver_data_coupled = SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, 100);
+    this->param.solver_data_coupled =
+      SolverData(1e4, ABS_TOL_LINEAR, REL_TOL_LINEAR, LinearSolver::GMRES, 100);
 
     // preconditioning linear solver
     this->param.preconditioner_coupled = PreconditionerCoupled::BlockTriangular;
@@ -239,7 +237,8 @@ private:
     this->param.preconditioner_pressure_block = SchurComplementPreconditioner::CahouetChabard;
 
     // Inversion of mass operator in case of H(div)-conforming method
-    this->param.inverse_mass_operator.solver_data    = SolverData(1000, ABS_TOL, REL_TOL);
+    this->param.inverse_mass_operator.solver_data =
+      SolverData(1000, ABS_TOL, REL_TOL, LinearSolver::CG);
     this->param.inverse_mass_operator.preconditioner = PreconditionerMass::PointJacobi;
   }
 

--- a/applications/poisson/gaussian/application.h
+++ b/applications/poisson/gaussian/application.h
@@ -224,10 +224,7 @@ private:
     this->param.IP_factor              = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = LinearSolver::CG;
-    this->param.solver_data.abs_tol         = 1.e-20;
-    this->param.solver_data.rel_tol         = 1.e-10;
-    this->param.solver_data.max_iter        = 1e4;
+    this->param.solver_data                 = SolverData(1e4, 1e-20, 1e-10, LinearSolver::CG);
     this->param.compute_performance_metrics = true;
     this->param.preconditioner              = preconditioner;
     this->param.multigrid_data.type         = MultigridType::cphMG;

--- a/applications/poisson/gaussian/tests/gaussian.output
+++ b/applications/poisson/gaussian/tests/gaussian.output
@@ -41,7 +41,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -133,7 +132,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -225,7 +223,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -317,7 +314,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -409,7 +405,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -501,7 +496,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -593,7 +587,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -685,7 +678,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -777,7 +769,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -869,7 +860,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -961,7 +951,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -1053,7 +1042,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -1145,7 +1133,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -1237,7 +1224,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -1329,7 +1315,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect

--- a/applications/poisson/overset_grids/application.h
+++ b/applications/poisson/overset_grids/application.h
@@ -57,10 +57,7 @@ public:
     p.IP_factor              = 1.0e0;
 
     // SOLVER
-    p.solver                      = LinearSolver::CG;
-    p.solver_data.abs_tol         = 1.e-20;
-    p.solver_data.rel_tol         = 1.e-10;
-    p.solver_data.max_iter        = 1e4;
+    p.solver_data                 = SolverData(1e4, 1e-20, 1e-10, LinearSolver::CG);
     p.compute_performance_metrics = true;
     p.preconditioner              = Preconditioner::Multigrid;
     p.multigrid_data.type         = MultigridType::cphMG;
@@ -189,10 +186,7 @@ private:
     p.IP_factor              = 1.0e0;
 
     // SOLVER
-    p.solver                      = LinearSolver::CG;
-    p.solver_data.abs_tol         = 1.e-20;
-    p.solver_data.rel_tol         = 1.e-10;
-    p.solver_data.max_iter        = 1e4;
+    p.solver_data                 = SolverData(1e4, 1e-20, 1e-10, LinearSolver::CG);
     p.compute_performance_metrics = true;
     p.preconditioner              = Preconditioner::Multigrid;
     p.multigrid_data.type         = MultigridType::cphMG;

--- a/applications/poisson/sine/application.h
+++ b/applications/poisson/sine/application.h
@@ -161,10 +161,7 @@ private:
     this->param.IP_factor              = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = LinearSolver::CG;
-    this->param.solver_data.abs_tol         = 1.e-20;
-    this->param.solver_data.rel_tol         = 1.e-10;
-    this->param.solver_data.max_iter        = 1e4;
+    this->param.solver_data                 = SolverData(1e4, 1e-20, 1e-10, LinearSolver::CG);
     this->param.compute_performance_metrics = true;
     this->param.preconditioner              = Preconditioner::Multigrid;
     this->param.multigrid_data.type         = MultigridType::cphMG;

--- a/applications/poisson/sine/tests/cartesian.output
+++ b/applications/poisson/sine/tests/cartesian.output
@@ -41,7 +41,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -129,7 +128,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -217,7 +215,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -305,7 +302,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -393,7 +389,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -481,7 +476,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -569,7 +563,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect

--- a/applications/poisson/sine/tests/curvilinear.output
+++ b/applications/poisson/sine/tests/curvilinear.output
@@ -41,7 +41,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -129,7 +128,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -217,7 +215,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -305,7 +302,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -393,7 +389,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -481,7 +476,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -569,7 +563,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect

--- a/applications/poisson/sine/tests/curvilinear_AMG.with_trilinos=true.output
+++ b/applications/poisson/sine/tests/curvilinear_AMG.with_trilinos=true.output
@@ -41,7 +41,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -133,7 +132,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect
@@ -225,7 +223,6 @@ Solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-20
   Relative solver tolerance:                 1.0000e-10
-  Maximum size of Krylov space:              30
   Preconditioner:                            Multigrid
   Multigrid type:                            cphMG
   p-sequence:                                Bisect

--- a/applications/poisson/slit/application.h
+++ b/applications/poisson/slit/application.h
@@ -54,10 +54,7 @@ private:
     this->param.IP_factor              = 1.0e0;
 
     // SOLVER
-    this->param.solver                      = LinearSolver::CG;
-    this->param.solver_data.abs_tol         = 1.e-20;
-    this->param.solver_data.rel_tol         = 1.e-10;
-    this->param.solver_data.max_iter        = 1e4;
+    this->param.solver_data                 = SolverData(1e4, 1e-20, 1e-10, LinearSolver::CG);
     this->param.compute_performance_metrics = true;
     this->param.preconditioner              = Preconditioner::Multigrid;
     this->param.multigrid_data.type         = MultigridType::hcpMG;

--- a/applications/poisson/throughput/application.h
+++ b/applications/poisson/throughput/application.h
@@ -86,8 +86,8 @@ private:
     this->param.sparse_matrix_type        = SparseMatrixType::Trilinos;
 
     // SOLVER
-    this->param.solver         = LinearSolver::CG;
-    this->param.preconditioner = Preconditioner::None;
+    this->param.solver_data.linear_solver = LinearSolver::CG;
+    this->param.preconditioner            = Preconditioner::None;
   }
 
   void

--- a/applications/structure/bar/application.h
+++ b/applications/structure/bar/application.h
@@ -330,10 +330,11 @@ private:
 
     this->param.newton_solver_data = Newton::SolverData(1e2, 1.e-9, 1.e-9);
 
-    bool const use_iterative_solver_on_coarse_grid = false;
-    this->param.solver         = use_iterative_solver_on_coarse_grid ? Solver::FGMRES : Solver::CG;
-    this->param.solver_data    = SolverData(1e3, 1.e-12, 1.e-8, 100);
-    this->param.preconditioner = preconditioner;
+    bool const         use_iterative_solver_on_coarse_grid = false;
+    LinearSolver const linear_solver =
+      use_iterative_solver_on_coarse_grid ? LinearSolver::FGMRES : LinearSolver::CG;
+    this->param.solver_data         = SolverData(1e3, 1.e-12, 1.e-8, linear_solver, 100);
+    this->param.preconditioner      = preconditioner;
     this->param.multigrid_data.type = MultigridType::phMG;
 
     this->param.multigrid_data.smoother_data.smoother       = MultigridSmoother::Chebyshev;
@@ -348,10 +349,11 @@ private:
     this->param.multigrid_data.smoother_data.iterations_eigenvalue_estimation =
       60; // Chebyshev, default: 20
 
-    this->param.multigrid_data.coarse_problem.solver      = use_iterative_solver_on_coarse_grid ?
-                                                              MultigridCoarseGridSolver::GMRES :
-                                                              MultigridCoarseGridSolver::AMG;
-    this->param.multigrid_data.coarse_problem.solver_data = SolverData(1e3, 1.e-12, 1.e-3, 100);
+    this->param.multigrid_data.coarse_problem.solver = use_iterative_solver_on_coarse_grid ?
+                                                         MultigridCoarseGridSolver::GMRES :
+                                                         MultigridCoarseGridSolver::AMG;
+    this->param.multigrid_data.coarse_problem.solver_data =
+      SolverData(1e3, 1.e-12, 1.e-3, LinearSolver::Undefined, 100);
     this->param.multigrid_data.coarse_problem.preconditioner =
       use_iterative_solver_on_coarse_grid ? MultigridCoarseGridPreconditioner::AMG :
                                             MultigridCoarseGridPreconditioner::None;

--- a/applications/structure/bar/tests/incompressible_neo_hookean.with_trilinos=true.output
+++ b/applications/structure/bar/tests/incompressible_neo_hookean.with_trilinos=true.output
@@ -56,7 +56,6 @@ Linear solver:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-08
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                DecreaseByOne

--- a/applications/structure/bar/tests/quasistatic_large_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/quasistatic_large_strain_multigrid.with_trilinos=true.output
@@ -56,7 +56,6 @@ Linear solver:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-08
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                DecreaseByOne

--- a/applications/structure/bar/tests/steady_large_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/steady_large_strain_multigrid.with_trilinos=true.output
@@ -55,7 +55,6 @@ Linear solver:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-08
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                DecreaseByOne

--- a/applications/structure/bar/tests/steady_small_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/steady_small_strain_multigrid.with_trilinos=true.output
@@ -48,7 +48,6 @@ Linear solver:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-08
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                DecreaseByOne

--- a/applications/structure/bar/tests/unsteady_small_strain_multigrid.with_trilinos=true.output
+++ b/applications/structure/bar/tests/unsteady_small_strain_multigrid.with_trilinos=true.output
@@ -59,7 +59,6 @@ Linear solver:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-08
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                DecreaseByOne

--- a/applications/structure/bar/tests/weak_damping.with_trilinos=true.output
+++ b/applications/structure/bar/tests/weak_damping.with_trilinos=true.output
@@ -67,7 +67,6 @@ Linear solver:
   Maximum number of iterations:              1000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-08
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                DecreaseByOne

--- a/applications/structure/beam/application.h
+++ b/applications/structure/beam/application.h
@@ -162,11 +162,10 @@ private:
 
     this->param.load_increment = 0.1;
 
-    this->param.newton_solver_data                     = Newton::SolverData(1e3, 1.e-10, 1.e-6);
-    this->param.solver                                 = Solver::FGMRES;
-    this->param.solver_data                            = SolverData(1e3, 1.e-14, 1.e-6, 100);
-    this->param.preconditioner                         = Preconditioner::Multigrid;
-    this->param.update_preconditioner                  = true;
+    this->param.newton_solver_data    = Newton::SolverData(1e3, 1.e-10, 1.e-6);
+    this->param.solver_data           = SolverData(1e3, 1.e-14, 1.e-6, LinearSolver::FGMRES, 100);
+    this->param.preconditioner        = Preconditioner::Multigrid;
+    this->param.update_preconditioner = true;
     this->param.update_preconditioner_every_time_steps = 1;
     this->param.update_preconditioner_every_newton_iterations =
       this->param.newton_solver_data.max_iter;

--- a/applications/structure/can/application.h
+++ b/applications/structure/can/application.h
@@ -159,11 +159,10 @@ private:
 
     this->param.load_increment = 0.1;
 
-    this->param.newton_solver_data                     = Newton::SolverData(1e3, 1.e-10, 1.e-6);
-    this->param.solver                                 = Solver::CG;
-    this->param.solver_data                            = SolverData(1e3, 1.e-14, 1.e-6, 100);
-    this->param.preconditioner                         = Preconditioner::Multigrid;
-    this->param.update_preconditioner                  = true;
+    this->param.newton_solver_data    = Newton::SolverData(1e3, 1.e-10, 1.e-6);
+    this->param.solver_data           = SolverData(1e3, 1.e-14, 1.e-6, LinearSolver::CG, 100);
+    this->param.preconditioner        = Preconditioner::Multigrid;
+    this->param.update_preconditioner = true;
     this->param.update_preconditioner_every_time_steps = 1;
     this->param.update_preconditioner_every_newton_iterations =
       this->param.newton_solver_data.max_iter;

--- a/applications/structure/manufactured/application.h
+++ b/applications/structure/manufactured/application.h
@@ -347,7 +347,7 @@ public:
 
     prm.enter_subsection("Application");
     {
-      prm.add_parameter("Solver", solver, "Krylov solver used.");
+      prm.add_parameter("LinearSolver", linear_solver, "Krylov solver used.");
       prm.add_parameter("UseMatrixBasedOperator",
                         use_matrix_based_operator,
                         "Use matrix-based operators in global Krylov solver and Multigrid.",
@@ -383,8 +383,7 @@ private:
     this->param.mapping_degree_coarse_grids = this->param.mapping_degree;
 
     this->param.newton_solver_data  = Newton::SolverData(1e4, 1.e-10, 1.e-10);
-    this->param.solver              = solver;
-    this->param.solver_data         = SolverData(1e4, 1.e-12, 1.e-6, 100);
+    this->param.solver_data         = SolverData(1e4, 1.e-12, 1.e-6, linear_solver, 100);
     this->param.preconditioner      = Preconditioner::Multigrid;
     this->param.multigrid_data.type = MultigridType::phMG;
 
@@ -535,8 +534,9 @@ private:
   double const end_time         = 1.0;
   double const frequency        = 3.0 / 2.0 * dealii::numbers::PI / end_time;
 
-  Solver solver                    = Solver::CG;
-  bool   use_matrix_based_operator = false;
+  LinearSolver linear_solver = LinearSolver::CG;
+
+  bool use_matrix_based_operator = false;
 
   bool const prescribe_initial_acceleration_as_field_function = false;
 };

--- a/applications/structure/manufactured/input.json
+++ b/applications/structure/manufactured/input.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "10"
     },
     "Application": {
-        "Solver": "CG",
+        "LinearSolver": "CG",
         "UseMatrixBasedOperator": "false"
     },
     "Output": {

--- a/applications/structure/manufactured/tests/2d.json
+++ b/applications/structure/manufactured/tests/2d.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "8"
     },
     "Application": {
-        "Solver": "CG",
+        "LinearSolver": "CG",
         "UseMatrixBasedOperator": "false"
     },
     "Output": {

--- a/applications/structure/manufactured/tests/2d.output
+++ b/applications/structure/manufactured/tests/2d.output
@@ -66,7 +66,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -186,7 +185,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -306,7 +304,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -426,7 +423,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -546,7 +542,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -666,7 +661,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -786,7 +780,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -906,7 +899,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -1026,7 +1018,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect

--- a/applications/structure/manufactured/tests/3d.json
+++ b/applications/structure/manufactured/tests/3d.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "8"
     },
     "Application": {
-        "Solver": "CG",
+        "LinearSolver": "CG",
         "UseMatrixBasedOperator": "false"
     },
     "Output": {

--- a/applications/structure/manufactured/tests/3d.output
+++ b/applications/structure/manufactured/tests/3d.output
@@ -66,7 +66,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -186,7 +185,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -306,7 +304,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -426,7 +423,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -546,7 +542,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -666,7 +661,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -786,7 +780,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -906,7 +899,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect
@@ -1026,7 +1018,6 @@ Linear solver:
   Maximum number of iterations:              10000
   Absolute solver tolerance:                 1.0000e-12
   Relative solver tolerance:                 1.0000e-06
-  Maximum size of Krylov space:              100
   Preconditioner:                            Multigrid
   Multigrid type:                            phMG
   p-sequence:                                Bisect

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -494,24 +494,7 @@ Operator<dim, Number>::setup_solver()
   // initialize solver data
   bool constexpr compute_performance_metrics = false;
   bool constexpr compute_eigenvalues         = false;
-  bool const  use_preconditioner             = param.preconditioner != Preconditioner::None;
-  std::string name;
-  if(param.solver == Solver::CG)
-  {
-    name = "cg";
-  }
-  else if(param.solver == Solver::GMRES)
-  {
-    name = "gmres";
-  }
-  else if(param.solver == Solver::FGMRES)
-  {
-    name = "fgmres";
-  }
-  else
-  {
-    AssertThrow(false, dealii::ExcMessage("Specified solver is not implemented!"));
-  }
+  bool const use_preconditioner              = param.preconditioner != Preconditioner::None;
 
   typedef Krylov::
     KrylovSolver<CombinedOperator<dim, Number>, PreconditionerBase<Number>, VectorType>
@@ -521,7 +504,6 @@ Operator<dim, Number>::setup_solver()
   iterative_solver = std::make_shared<SolverType>(combined_operator,
                                                   *preconditioner,
                                                   param.solver_data,
-                                                  name,
                                                   use_preconditioner,
                                                   compute_performance_metrics,
                                                   compute_eigenvalues);

--- a/include/exadg/convection_diffusion/user_interface/enum_types.h
+++ b/include/exadg/convection_diffusion/user_interface/enum_types.h
@@ -174,17 +174,6 @@ enum class NumericalFluxConvectiveOperator
 /**************************************************************************************/
 
 /*
- *   Solver for linear system of equations
- */
-enum class Solver
-{
-  Undefined,
-  CG,
-  GMRES,
-  FGMRES // flexible GMRES
-};
-
-/*
  *  Preconditioner type for solution of linear system of equations
  */
 enum class Preconditioner

--- a/include/exadg/convection_diffusion/user_interface/parameters.cpp
+++ b/include/exadg/convection_diffusion/user_interface/parameters.cpp
@@ -74,15 +74,14 @@ Parameters::Parameters()
     IP_factor(1.0),
 
     // SOLVER
-    solver(Solver::Undefined),
-    solver_data(SolverData(1e4, 1.e-12, 1.e-6, 100)),
+    solver_data(SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::Undefined, 100)),
     preconditioner(Preconditioner::Undefined),
     update_preconditioner(false),
     update_preconditioner_every_time_steps(1),
     implement_block_diagonal_preconditioner_matrix_free(false),
     solver_block_diagonal(Elementwise::Solver::Undefined),
     preconditioner_block_diagonal(Elementwise::Preconditioner::InverseMassMatrix),
-    solver_data_block_diagonal(SolverData(1000, 1.e-12, 1.e-2, 1000)),
+    solver_data_block_diagonal(SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000)),
     mg_operator_type(MultigridOperatorType::Undefined),
     multigrid_data(MultigridData()),
     solver_info_data(SolverInfoData()),
@@ -282,7 +281,8 @@ Parameters::check() const
   // SOLVER
   if(temporal_discretization == TemporalDiscretization::BDF)
   {
-    AssertThrow(solver != Solver::Undefined, dealii::ExcMessage("parameter must be defined"));
+    AssertThrow(solver_data.linear_solver != LinearSolver::Undefined,
+                dealii::ExcMessage("parameter must be defined"));
 
     AssertThrow(preconditioner != Preconditioner::Undefined,
                 dealii::ExcMessage("parameter must be defined"));
@@ -545,8 +545,6 @@ void
 Parameters::print_parameters_solver(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Solver:" << std::endl;
-
-  print_parameter(pcout, "Solver", solver);
 
   solver_data.print(pcout);
 

--- a/include/exadg/convection_diffusion/user_interface/parameters.h
+++ b/include/exadg/convection_diffusion/user_interface/parameters.h
@@ -283,9 +283,6 @@ public:
   /*                                                                                    */
   /**************************************************************************************/
 
-  // description: see enum declaration
-  Solver solver;
-
   // solver data
   SolverData solver_data;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -91,20 +91,6 @@ OperatorCoupled<dim, Number>::setup_solver_coupled()
   bool constexpr compute_performance_metrics = false;
   bool constexpr compute_eigenvalues         = false;
   bool const use_preconditioner = this->param.preconditioner_coupled != PreconditionerCoupled::None;
-  std::string name;
-  if(this->param.solver_coupled == SolverCoupled::GMRES)
-  {
-    name = "gmres";
-  }
-  else if(this->param.solver_coupled == SolverCoupled::FGMRES)
-  {
-    name = "fgmres";
-  }
-  else
-  {
-    AssertThrow(false,
-                dealii::ExcMessage("Specified solver for linearized problem is not implemented."));
-  }
 
   typedef Krylov::KrylovSolver<LinearOperatorCoupled<dim, Number>, Preconditioner, BlockVectorType>
     SolverType;
@@ -113,7 +99,6 @@ OperatorCoupled<dim, Number>::setup_solver_coupled()
   linear_solver = std::make_shared<SolverType>(linear_operator,
                                                block_preconditioner,
                                                this->param.solver_data_coupled,
-                                               name,
                                                use_preconditioner,
                                                compute_performance_metrics,
                                                compute_eigenvalues);
@@ -602,8 +587,7 @@ OperatorCoupled<dim, Number>::setup_iterative_solver_momentum()
   // initialize solver data
   bool constexpr compute_performance_metrics = false;
   bool constexpr compute_eigenvalues         = false;
-  bool const        use_preconditioner       = true;
-  std::string const name                     = "fgmres";
+  bool const use_preconditioner              = true;
 
   typedef Krylov::
     KrylovSolver<MomentumOperator<dim, Number>, PreconditionerBase<Number>, VectorType>
@@ -613,7 +597,6 @@ OperatorCoupled<dim, Number>::setup_iterative_solver_momentum()
   solver_velocity_block = std::make_shared<SolverType>(this->momentum_operator,
                                                        *preconditioner_momentum,
                                                        this->param.solver_data_velocity_block,
-                                                       name,
                                                        use_preconditioner,
                                                        compute_performance_metrics,
                                                        compute_eigenvalues);
@@ -765,8 +748,7 @@ OperatorCoupled<dim, Number>::setup_iterative_solver_schur_complement()
   // initialize solver data
   bool constexpr compute_performance_metrics = false;
   bool constexpr compute_eigenvalues         = false;
-  bool const        use_preconditioner       = true;
-  std::string const name                     = "cg";
+  bool const use_preconditioner              = true;
 
   typedef Krylov::
     KrylovSolver<Poisson::LaplaceOperator<dim, Number, 1>, PreconditionerBase<Number>, VectorType>
@@ -776,7 +758,6 @@ OperatorCoupled<dim, Number>::setup_iterative_solver_schur_complement()
   solver_pressure_block = std::make_shared<SolverType>(*laplace_operator,
                                                        *multigrid_preconditioner_schur_complement,
                                                        this->param.solver_data_pressure_block,
-                                                       name,
                                                        use_preconditioner,
                                                        compute_performance_metrics,
                                                        compute_eigenvalues);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_projection_methods.cpp
@@ -219,21 +219,6 @@ OperatorProjectionMethods<dim, Number>::setup_solver_pressure_poisson()
   bool constexpr compute_eigenvalues         = false;
   bool const use_preconditioner =
     this->param.preconditioner_pressure_poisson != PreconditionerPressurePoisson::None;
-  std::string name;
-  if(this->param.solver_pressure_poisson == SolverPressurePoisson::CG)
-  {
-    name = "cg";
-  }
-  else if(this->param.solver_pressure_poisson == SolverPressurePoisson::FGMRES)
-  {
-    name = "fgmres";
-  }
-  else
-  {
-    AssertThrow(false,
-                dealii::ExcMessage(
-                  "Specified solver for pressure Poisson equation is not implemented."));
-  }
 
   typedef Krylov::
     KrylovSolver<Poisson::LaplaceOperator<dim, Number, 1>, PreconditionerBase<Number>, VectorType>
@@ -243,7 +228,6 @@ OperatorProjectionMethods<dim, Number>::setup_solver_pressure_poisson()
   pressure_poisson_solver = std::make_shared<SolverType>(laplace_operator,
                                                          *preconditioner_pressure_poisson,
                                                          this->param.solver_data_pressure_poisson,
-                                                         name,
                                                          use_preconditioner,
                                                          compute_performance_metrics,
                                                          compute_eigenvalues);
@@ -331,24 +315,6 @@ OperatorProjectionMethods<dim, Number>::setup_momentum_solver()
   bool constexpr compute_eigenvalues         = false;
   bool const use_preconditioner =
     this->param.preconditioner_momentum != MomentumPreconditioner::None;
-  std::string name;
-  if(this->param.solver_momentum == SolverMomentum::CG)
-  {
-    name = "cg";
-  }
-  else if(this->param.solver_momentum == SolverMomentum::GMRES)
-  {
-    name = "gmres";
-  }
-  else if(this->param.solver_momentum == SolverMomentum::FGMRES)
-  {
-    name = "fgmres";
-  }
-  else
-  {
-    AssertThrow(false,
-                dealii::ExcMessage("Specified solver for momentum equation is not implemented."));
-  }
 
   typedef Krylov::
     KrylovSolver<MomentumOperator<dim, Number>, PreconditionerBase<Number>, VectorType>
@@ -358,7 +324,6 @@ OperatorProjectionMethods<dim, Number>::setup_momentum_solver()
   momentum_linear_solver = std::make_shared<SolverType>(this->momentum_operator,
                                                         *momentum_preconditioner,
                                                         this->param.solver_data_momentum,
-                                                        name,
                                                         use_preconditioner,
                                                         compute_performance_metrics,
                                                         compute_eigenvalues);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1563,12 +1563,10 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
                                 dirichlet_bc_component_mask);
 
   // initialize solver data
-  SolverData solver_data;
-  solver_data.rel_tol                        = 1e-10;
+  SolverData solver_data(1e3, 1e-20, 1e-10, LinearSolver::CG);
   bool constexpr compute_performance_metrics = false;
   bool constexpr compute_eigenvalues         = false;
-  bool const        use_preconditioner       = true;
-  std::string const name                     = "cg";
+  bool const use_preconditioner              = true;
 
   typedef Krylov::KrylovSolver<Laplace, PreconditionerBase<Number>, VectorType> SolverType;
 
@@ -1576,7 +1574,6 @@ SpatialOperatorBase<dim, Number>::compute_streamfunction(VectorType &       dst,
   SolverType poisson_solver(laplace_operator,
                             *preconditioner,
                             solver_data,
-                            name,
                             use_preconditioner,
                             compute_performance_metrics,
                             compute_eigenvalues);
@@ -1956,20 +1953,6 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
     bool constexpr compute_eigenvalues         = false;
     bool const use_preconditioner =
       param.preconditioner_projection != PreconditionerProjection::None;
-    std::string name;
-    if(param.solver_projection == SolverProjection::CG)
-    {
-      name = "cg";
-    }
-    else if(param.solver_projection == SolverProjection::FGMRES)
-    {
-      name = "fgmres";
-    }
-    else
-    {
-      AssertThrow(false, dealii::ExcMessage("Specified projection solver not implemented."));
-    }
-
 
     typedef Krylov::KrylovSolver<ProjOperator, PreconditionerBase<Number>, VectorType> SolverType;
 
@@ -1977,7 +1960,6 @@ SpatialOperatorBase<dim, Number>::setup_projection_solver()
     projection_solver = std::make_shared<SolverType>(*projection_operator,
                                                      *preconditioner_projection,
                                                      param.solver_data_projection,
-                                                     name,
                                                      use_preconditioner,
                                                      compute_performance_metrics,
                                                      compute_eigenvalues);

--- a/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/enum_types.h
@@ -359,14 +359,7 @@ enum class QuadratureRuleLinearization
  *  use CG (conjugate gradient) method as default. FGMRES might be necessary
  *  if a Krylov method is used inside the preconditioner (e.g., as multigrid
  *  smoother or as multigrid coarse grid solver)
- */
-enum class SolverPressurePoisson
-{
-  CG,
-  FGMRES
-};
-
-/*
+ *
  *  Preconditioner type for solution of pressure Poisson equation:
  *
  *  use Multigrid as default
@@ -418,15 +411,7 @@ enum class PreconditionerProjection
  *
  *  - FGMRES might be necessary if a Krylov method is used inside the preconditioner
  *    (e.g., as multigrid smoother or as multigrid coarse grid solver).
- */
-enum class SolverMomentum
-{
-  CG,
-  GMRES,
-  FGMRES
-};
-
-/*
+ *
  *  Preconditioner type for solution of momentum equation:
  *
  *  see coupled solution approach below
@@ -446,14 +431,7 @@ enum class SolverMomentum
  *
  * - FGMRES might be necessary if a Krylov method is used inside the preconditioner
  *   (e.g., as multigrid smoother or as multigrid coarse grid solver).
- */
-enum class SolverCoupled
-{
-  GMRES,
-  FGMRES
-};
-
-/*
+ *
  *  Preconditioner type for linearized Navier-Stokes problem
  *
  *  - use BlockTriangular as default (typically best option in terms of time-to-solution, i.e.

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.cpp
@@ -139,34 +139,32 @@ Parameters::Parameters()
     // NUMERICAL PARAMETERS
     implement_block_diagonal_preconditioner_matrix_free(false),
     use_cell_based_face_loops(false),
-    solver_data_block_diagonal(SolverData(1000, 1.e-12, 1.e-2, 1000)),
+    solver_data_block_diagonal(SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000)),
     quad_rule_linearization(QuadratureRuleLinearization::Overintegration32k),
 
     // PROJECTION METHODS
 
     // pressure Poisson equation
     IP_factor_pressure(1.),
-    solver_pressure_poisson(SolverPressurePoisson::CG),
-    solver_data_pressure_poisson(SolverData(1e4, 1.e-12, 1.e-6, 100)),
+    solver_data_pressure_poisson(SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::CG, 100)),
     preconditioner_pressure_poisson(PreconditionerPressurePoisson::Multigrid),
     multigrid_data_pressure_poisson(MultigridData()),
     update_preconditioner_pressure_poisson(false),
     update_preconditioner_pressure_poisson_every_time_steps(1),
 
     // projection step
-    solver_projection(SolverProjection::CG),
-    solver_data_projection(SolverData(1000, 1.e-12, 1.e-6, 100)),
+    solver_data_projection(SolverData(1000, 1.e-12, 1.e-6, LinearSolver::CG, 100)),
     preconditioner_projection(PreconditionerProjection::InverseMassMatrix),
     multigrid_data_projection(MultigridData()),
     update_preconditioner_projection(false),
     update_preconditioner_projection_every_time_steps(1),
     preconditioner_block_diagonal_projection(Elementwise::Preconditioner::InverseMassMatrix),
-    solver_data_block_diagonal_projection(SolverData(1000, 1.e-12, 1.e-2, 1000)),
+    solver_data_block_diagonal_projection(
+      SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000)),
 
     // momentum step
     newton_solver_data_momentum(Newton::SolverData(1e2, 1.e-12, 1.e-6)),
-    solver_momentum(SolverMomentum::GMRES),
-    solver_data_momentum(SolverData(1e4, 1.e-12, 1.e-6, 100)),
+    solver_data_momentum(SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::GMRES, 100)),
     preconditioner_momentum(MomentumPreconditioner::InverseMassMatrix),
     update_preconditioner_momentum(false),
     update_preconditioner_momentum_every_newton_iter(1),
@@ -202,8 +200,7 @@ Parameters::Parameters()
     newton_solver_data_coupled(Newton::SolverData(1e2, 1.e-12, 1.e-6)),
 
     // linear solver
-    solver_coupled(SolverCoupled::GMRES),
-    solver_data_coupled(SolverData(1e4, 1.e-12, 1.e-6, 100)),
+    solver_data_coupled(SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::GMRES, 100)),
 
     // preconditioning linear solver
     preconditioner_coupled(PreconditionerCoupled::BlockTriangular),
@@ -216,13 +213,13 @@ Parameters::Parameters()
     multigrid_operator_type_velocity_block(MultigridOperatorType::Undefined),
     multigrid_data_velocity_block(MultigridData()),
     iterative_solve_of_velocity_block(false),
-    solver_data_velocity_block(SolverData(1e4, 1.e-12, 1.e-6, 100)),
+    solver_data_velocity_block(SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::FGMRES, 100)),
 
     // preconditioner pressure/Schur-complement block
     preconditioner_pressure_block(SchurComplementPreconditioner::PressureConvectionDiffusion),
     multigrid_data_pressure_block(MultigridData()),
     iterative_solve_of_pressure_block(false),
-    solver_data_pressure_block(SolverData(1e4, 1.e-12, 1.e-6, 100))
+    solver_data_pressure_block(SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::CG, 100))
 {
 }
 
@@ -1066,8 +1063,6 @@ Parameters::print_parameters_pressure_poisson(dealii::ConditionalOStream const &
 
   print_parameter(pcout, "interior penalty factor", IP_factor_pressure);
 
-  print_parameter(pcout, "Solver", solver_pressure_poisson);
-
   solver_data_pressure_poisson.print(pcout);
 
   print_parameter(pcout, "Preconditioner", preconditioner_pressure_poisson);
@@ -1094,8 +1089,6 @@ Parameters::print_parameters_projection_step(dealii::ConditionalOStream const & 
 {
   if(use_divergence_penalty == true)
   {
-    print_parameter(pcout, "Solver projection step", solver_projection);
-
     solver_data_projection.print(pcout);
 
     if(use_divergence_penalty == true and use_continuity_penalty == true)
@@ -1228,8 +1221,6 @@ Parameters::print_parameters_momentum_step(dealii::ConditionalOStream const & pc
   // Solver linear(ized) problem
   pcout << "  Linear solver:" << std::endl;
 
-  print_parameter(pcout, "Solver", solver_momentum);
-
   solver_data_momentum.print(pcout);
 
   print_parameter(pcout, "Preconditioner", preconditioner_momentum);
@@ -1318,8 +1309,6 @@ Parameters::print_parameters_coupled_solver(dealii::ConditionalOStream const & p
 
   // Solver linearized problem
   pcout << "Linear solver:" << std::endl;
-
-  print_parameter(pcout, "Solver", solver_coupled);
 
   solver_data_coupled.print(pcout);
 

--- a/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
+++ b/include/exadg/incompressible_navier_stokes/user_interface/parameters.h
@@ -510,9 +510,6 @@ public:
   // interior penalty parameter scaling factor for pressure Poisson equation
   double IP_factor_pressure;
 
-  // description: see enum declaration
-  SolverPressurePoisson solver_pressure_poisson;
-
   // solver data for pressure Poisson equation
   SolverData solver_data_pressure_poisson;
 
@@ -566,9 +563,6 @@ public:
 
   // Newton solver data
   Newton::SolverData newton_solver_data_momentum;
-
-  // description: see enum declaration
-  SolverMomentum solver_momentum;
 
   // Solver data for (linearized) momentum equation
   SolverData solver_data_momentum;
@@ -660,9 +654,6 @@ public:
 
   // solver tolerances Newton solver
   Newton::SolverData newton_solver_data_coupled;
-
-  // description: see enum declaration
-  SolverCoupled solver_coupled;
 
   // Solver data for coupled solver
   SolverData solver_data_coupled;

--- a/include/exadg/operators/inverse_mass_operator.cpp
+++ b/include/exadg/operators/inverse_mass_operator.cpp
@@ -163,7 +163,6 @@ InverseMassOperator<dim, n_components, Number>::initialize(
         AssertThrow(false, dealii::ExcMessage("This `PreconditionerMass` is not implemented."));
       }
 
-      std::string const name                     = "cg";
       bool constexpr compute_performance_metrics = false;
       bool constexpr compute_eigenvalues         = false;
       bool const use_preconditioner              = data.preconditioner != PreconditionerMass::None;
@@ -176,7 +175,6 @@ InverseMassOperator<dim, n_components, Number>::initialize(
       global_solver = std::make_shared<SolverType>(mass_operator,
                                                    *global_preconditioner,
                                                    data.solver_data,
-                                                   name,
                                                    use_preconditioner,
                                                    compute_performance_metrics,
                                                    compute_eigenvalues);

--- a/include/exadg/operators/inverse_mass_parameters.h
+++ b/include/exadg/operators/inverse_mass_parameters.h
@@ -57,7 +57,7 @@ struct InverseMassParameters
   InverseMassParameters()
     : implementation_type(InverseMassType::MatrixfreeOperator),
       preconditioner(PreconditionerMass::PointJacobi),
-      solver_data(SolverData()),
+      solver_data(SolverData(1e3, 1e-20, 1e-6, LinearSolver::CG)),
       amg_data(AMGData())
   {
   }

--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -69,7 +69,7 @@ struct OperatorBaseData
       implement_block_diagonal_preconditioner_matrix_free(false),
       solver_block_diagonal(Elementwise::Solver::GMRES),
       preconditioner_block_diagonal(Elementwise::Preconditioner::InverseMassMatrix),
-      solver_data_block_diagonal(SolverData(1000, 1.e-12, 1.e-2, 1000))
+      solver_data_block_diagonal(SolverData(1000, 1.e-12, 1.e-2, LinearSolver::Undefined, 1000))
   {
   }
 

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -53,7 +53,7 @@ struct GridToGridProjectionData
 {
   GridToGridProjectionData()
     : rpe_data(),
-      solver_data(),
+      solver_data(SolverData(1e3, 1e-20, 1e-6, LinearSolver::CG)),
       preconditioner(PreconditionerMass::PointJacobi),
       amg_data(AMGData()),
       additional_quadrature_points(1)

--- a/include/exadg/poisson/spatial_discretization/operator.cpp
+++ b/include/exadg/poisson/spatial_discretization/operator.cpp
@@ -385,27 +385,13 @@ Operator<dim, n_components, Number>::setup_preconditioner_and_solver()
   // initialize solver
   bool constexpr compute_performance_metrics = false;
   bool constexpr compute_eigenvalues         = false;
-  bool const  use_preconditioner = param.preconditioner != Poisson::Preconditioner::None;
-  std::string name;
-  if(param.solver == LinearSolver::CG)
-  {
-    name = "cg";
-  }
-  else if(param.solver == LinearSolver::FGMRES)
-  {
-    name = "fgmres";
-  }
-  else
-  {
-    AssertThrow(false, dealii::ExcMessage("Specified solver is not implemented!"));
-  }
+  bool const use_preconditioner = param.preconditioner != Poisson::Preconditioner::None;
 
   typedef Krylov::KrylovSolver<Laplace, PreconditionerBase<Number>, VectorType> SolverType;
 
   iterative_solver = std::make_shared<SolverType>(laplace_operator,
                                                   *preconditioner,
                                                   param.solver_data,
-                                                  name,
                                                   use_preconditioner,
                                                   compute_performance_metrics,
                                                   compute_eigenvalues);

--- a/include/exadg/poisson/user_interface/enum_types.h
+++ b/include/exadg/poisson/user_interface/enum_types.h
@@ -49,16 +49,6 @@ enum class SpatialDiscretization
 /**************************************************************************************/
 
 /*
- *   Solver for linear system of equations
- */
-enum class LinearSolver
-{
-  Undefined,
-  CG,
-  FGMRES
-};
-
-/*
  *  Preconditioner type for solution of linear system of equations
  */
 enum class Preconditioner

--- a/include/exadg/poisson/user_interface/parameters.cpp
+++ b/include/exadg/poisson/user_interface/parameters.cpp
@@ -44,8 +44,7 @@ Parameters::Parameters()
     sparse_matrix_type(SparseMatrixType::Undefined),
 
     // SOLVER
-    solver(LinearSolver::Undefined),
-    solver_data(SolverData(1e4, 1.e-20, 1.e-12)),
+    solver_data(SolverData(1e4, 1.e-20, 1.e-12, LinearSolver::CG)),
     compute_performance_metrics(false),
     preconditioner(Preconditioner::Undefined),
     multigrid_data(MultigridData()),
@@ -73,7 +72,8 @@ Parameters::check() const
   }
 
   // SOLVER
-  AssertThrow(solver != LinearSolver::Undefined, dealii::ExcMessage("parameter must be defined."));
+  AssertThrow(solver_data.linear_solver != LinearSolver::Undefined,
+              dealii::ExcMessage("Parameter must be defined."));
   AssertThrow(preconditioner != Preconditioner::Undefined,
               dealii::ExcMessage("parameter must be defined."));
 }
@@ -144,8 +144,6 @@ void
 Parameters::print_parameters_solver(dealii::ConditionalOStream const & pcout) const
 {
   pcout << std::endl << "Solver:" << std::endl;
-
-  print_parameter(pcout, "Solver", solver);
 
   solver_data.print(pcout);
 

--- a/include/exadg/poisson/user_interface/parameters.h
+++ b/include/exadg/poisson/user_interface/parameters.h
@@ -112,9 +112,6 @@ public:
   /*                                                                                    */
   /**************************************************************************************/
 
-  // description: see enum declaration
-  LinearSolver solver;
-
   // solver data
   SolverData solver_data;
   bool       compute_performance_metrics;

--- a/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/coarse_grid_solvers.h
@@ -73,7 +73,7 @@ public:
      */
     AdditionalData()
       : solver_type(MultigridCoarseGridSolver::CG),
-        solver_data(SolverData(1e4, 1.e-12, 1.e-3, 100)),
+        solver_data(SolverData(1e4, 1.e-12, 1.e-3, LinearSolver::Undefined, 100)),
         operator_is_singular(false),
         preconditioner(MultigridCoarseGridPreconditioner::None),
         amg_data(AMGData())
@@ -177,14 +177,15 @@ public:
     }
     else
     {
-      std::string name;
+      // Overwrite `linear_solver` as enum also enables non-Krylov coarse grid solvers.
+      SolverData solver_data = additional_data.solver_data;
       if(additional_data.solver_type == MultigridCoarseGridSolver::CG)
       {
-        name = "cg";
+        solver_data.linear_solver = LinearSolver::CG;
       }
       else if(additional_data.solver_type == MultigridCoarseGridSolver::GMRES)
       {
-        name = "gmres";
+        solver_data.linear_solver = LinearSolver::GMRES;
       }
       else
       {
@@ -212,8 +213,7 @@ public:
 
       SolverType solver(pde_operator,
                         *preconditioner,
-                        additional_data.solver_data,
-                        name,
+                        solver_data,
                         use_preconditioner,
                         compute_performance_metrics,
                         compute_eigenvalues);

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -591,28 +591,6 @@ void
 Operator<dim, Number>::setup_solver()
 {
   // initialize linear solver
-  std::string name;
-  if(param.solver == Solver::CG)
-  {
-    name = "cg";
-  }
-  else if(param.solver == Solver::BiCGStab)
-  {
-    name = "bicgstab";
-  }
-  else if(param.solver == Solver::GMRES)
-  {
-    name = "gmres";
-  }
-  else if(param.solver == Solver::FGMRES)
-  {
-    name = "fgmres";
-  }
-  else
-  {
-    AssertThrow(false, dealii::ExcMessage("Specified solver not implemented in structure module."));
-  }
-
   bool const use_preconditioner              = param.preconditioner != Preconditioner::None;
   bool constexpr compute_performance_metrics = false;
   bool constexpr compute_eigenvalues         = false;
@@ -625,7 +603,6 @@ Operator<dim, Number>::setup_solver()
     linear_solver = std::make_shared<SolverType>(elasticity_operator_nonlinear,
                                                  *preconditioner,
                                                  param.solver_data,
-                                                 name,
                                                  use_preconditioner,
                                                  compute_performance_metrics,
                                                  compute_eigenvalues);
@@ -638,7 +615,6 @@ Operator<dim, Number>::setup_solver()
     linear_solver = std::make_shared<SolverType>(elasticity_operator_linear,
                                                  *preconditioner,
                                                  param.solver_data,
-                                                 name,
                                                  use_preconditioner,
                                                  compute_performance_metrics,
                                                  compute_eigenvalues);

--- a/include/exadg/structure/user_interface/enum_types.h
+++ b/include/exadg/structure/user_interface/enum_types.h
@@ -97,18 +97,6 @@ enum class MaterialType
 /**************************************************************************************/
 
 /*
- *   Solver for linear system of equations
- */
-enum class Solver
-{
-  Undefined,
-  CG,
-  BiCGStab,
-  GMRES,
-  FGMRES
-};
-
-/*
  *  Preconditioner type for solution of linear system of equations
  */
 enum class Preconditioner

--- a/include/exadg/structure/user_interface/parameters.cpp
+++ b/include/exadg/structure/user_interface/parameters.cpp
@@ -71,8 +71,7 @@ Parameters::Parameters()
 
     // SOLVER
     newton_solver_data(Newton::SolverData(1e4, 1.e-12, 1.e-6)),
-    solver(Solver::Undefined),
-    solver_data(SolverData(1e4, 1.e-12, 1.e-6, 100)),
+    solver_data(SolverData(1e4, 1.e-12, 1.e-6, LinearSolver::Undefined, 100)),
     preconditioner(Preconditioner::AMG),
     update_preconditioner(false),
     update_preconditioner_every_time_steps(1),
@@ -132,7 +131,8 @@ Parameters::check() const
   }
 
   // SOLVER
-  AssertThrow(solver != Solver::Undefined, dealii::ExcMessage("Parameter must be defined."));
+  AssertThrow(solver_data.linear_solver != LinearSolver::Undefined,
+              dealii::ExcMessage("Parameter must be defined."));
 }
 
 bool
@@ -261,7 +261,6 @@ Parameters::print_parameters_solver(dealii::ConditionalOStream const & pcout) co
 
   // linear solver
   pcout << std::endl << "Linear solver:" << std::endl;
-  print_parameter(pcout, "Solver", solver);
   solver_data.print(pcout);
 
   // preconditioner for linear system of equations

--- a/include/exadg/structure/user_interface/parameters.h
+++ b/include/exadg/structure/user_interface/parameters.h
@@ -206,9 +206,6 @@ public:
   // Newton solver data (only relevant for nonlinear problems)
   Newton::SolverData newton_solver_data;
 
-  // description: see enum declaration
-  Solver solver;
-
   // solver data
   SolverData solver_data;
 

--- a/tests/solvers_and_preconditioners/elementwise_gmres.cc
+++ b/tests/solvers_and_preconditioners/elementwise_gmres.cc
@@ -178,7 +178,7 @@ gmres_test_1a()
 {
   std::cout << std::endl << "GMRES solver (double), size M=3:" << std::endl << std::endl;
 
-  SolverData solver_data(100, tol, tol, 30);
+  SolverData solver_data(100, tol, tol, LinearSolver::Undefined, 30);
 
   typedef Elementwise::PreconditionerIdentity<double>      Preconditioner;
   typedef MyMatrix<double>                                 Matrix;
@@ -228,7 +228,7 @@ gmres_test_1b()
   std::cout << std::endl << "GMRES solver (double), size M=10000:" << std::endl << std::endl;
 
   unsigned int const M_large = 10000;
-  SolverData         solver_data(100, tol, tol, 30);
+  SolverData         solver_data(100, tol, tol, LinearSolver::Undefined, 30);
 
   typedef Elementwise::PreconditionerIdentity<double>      Preconditioner;
   typedef MyMatrix<double>                                 Matrix;
@@ -295,7 +295,7 @@ gmres_test_2a()
             << std::endl
             << std::endl;
 
-  SolverData solver_data(100, tol, tol, 30);
+  SolverData solver_data(100, tol, tol, LinearSolver::Undefined, 30);
 
   typedef Elementwise::PreconditionerIdentity<dealii::VectorizedArray<double>> Preconditioner;
   typedef MyMatrix<dealii::VectorizedArray<double>>                            Matrix;
@@ -354,7 +354,7 @@ gmres_test_2b()
             << std::endl
             << std::endl;
 
-  SolverData solver_data(100, 1e-12, 1e-12, 30);
+  SolverData solver_data(100, 1e-12, 1e-12, LinearSolver::Undefined, 30);
 
   typedef Elementwise::PreconditionerIdentity<dealii::VectorizedArray<double>> Preconditioner;
   typedef MyMatrix<dealii::VectorizedArray<double>>                            Matrix;
@@ -417,7 +417,7 @@ gmres_test_2c()
             << std::endl
             << std::endl;
 
-  SolverData solver_data(100, tol, tol, 30);
+  SolverData solver_data(100, tol, tol, LinearSolver::Undefined, 30);
 
   typedef Elementwise::PreconditionerIdentity<dealii::VectorizedArray<double>> Preconditioner;
   typedef MyMatrix<dealii::VectorizedArray<double>>                            Matrix;

--- a/tests/utilities/grid_to_grid_projection.cc
+++ b/tests/utilities/grid_to_grid_projection.cc
@@ -459,9 +459,7 @@ GridToGridProjector<dim, n_components>::project()
   }
 
   GridToGridProjection::GridToGridProjectionData<dim> data;
-  data.solver_data.max_iter = 1000;
-  data.solver_data.abs_tol  = 1.0e-12;
-  data.solver_data.rel_tol  = 1.0e-8;
+  data.solver_data = SolverData(1e3, 1e-12, 1e-8, LinearSolver::CG);
 
   data.rpe_data.tolerance              = 1e-6;
   data.rpe_data.enforce_unique_mapping = false;


### PR DESCRIPTION
closes #851

move completely to `Krylov::KrylovSolver` by:
.) remove deal.ii solver wrapper classes
.) _unify_ enums that control solver choice like `SolverCG`
.) move that enum to `SolverData`
.) update the applications and tests that are affected