### PR TITLE
remove `Structure::LinearizedOperator::vmult()`

### DIFF
--- a/include/exadg/structure/spatial_discretization/operator.h
+++ b/include/exadg/structure/spatial_discretization/operator.h
@@ -154,16 +154,6 @@ public:
     pde_operator->update_elasticity_operator(scaling_factor_mass, time);
   }
 
-  /*
-   * The implementation of linear solvers in deal.ii requires that a function called 'vmult' is
-   * provided.
-   */
-  void
-  vmult(VectorType & dst, VectorType const & src) const
-  {
-    pde_operator->apply_linearized_operator(dst, src);
-  }
-
 private:
   PDEOperator const * pde_operator;
 


### PR DESCRIPTION
it is not needed in the Newton solver, and just rather confusing to have it defined at all.

in the Newton solver (and individual steps therein), we use:
`Structure::LinearizedOperator::initialize()`
`Structure::LinearizedOperator::update()`
`Structure::LinearizedOperator::set_solution_linearization()`

we do not need `Structure::LinearizedOperator::vmult()`, as we call `linear_solver.solve()`, which has already has access to the underlying `Operator`. We hence use `OperatorBase::vmult`, i.e., `OperatorBase::apply()`.