### PR TITLE
enable implicit boundary integrals for CG

### DIFF
--- a/include/exadg/operators/operator_base.h
+++ b/include/exadg/operators/operator_base.h
@@ -440,6 +440,7 @@ protected:
 
   virtual void
   do_boundary_integral_continuous(IntegratorFace &                   integrator,
+                                  OperatorType const &               operator_type,
                                   dealii::types::boundary_id const & boundary_id) const;
 
   // The computation of the diagonal and block-diagonal requires face integrals of type

--- a/include/exadg/poisson/spatial_discretization/laplace_operator.h
+++ b/include/exadg/poisson/spatial_discretization/laplace_operator.h
@@ -341,6 +341,7 @@ private:
   // continuous FE: calculates Neumann boundary integral
   void
   do_boundary_integral_continuous(IntegratorFace &                   integrator_m,
+                                  OperatorType const &               operator_type,
                                   dealii::types::boundary_id const & boundary_id) const final;
 
   LaplaceOperatorData<rank, dim> operator_data;

--- a/include/exadg/structure/spatial_discretization/operators/linear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/linear_operator.h
@@ -39,6 +39,7 @@ private:
   typedef typename Base::IntegratorCell IntegratorCell;
   typedef typename Base::IntegratorFace IntegratorFace;
 
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>>          vector;
   typedef dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> symmetric_tensor;
 
   /*
@@ -55,16 +56,17 @@ private:
    *  d_h denotes the displacement vector.
    */
   void
-  do_cell_integral(IntegratorCell & integrator) const override;
+  do_cell_integral(IntegratorCell & integrator) const final;
 
   /*
-   * Computes Neumann BC integral
+   * Computes the linear Neumann boundary term
    *
    *  - (v_h, t)_{Gamma_N}
    */
   void
-  do_boundary_integral_continuous(IntegratorFace &                   integrator_m,
-                                  dealii::types::boundary_id const & boundary_id) const override;
+  do_boundary_integral_continuous(IntegratorFace &                   integrator,
+                                  OperatorType const &               operator_type,
+                                  dealii::types::boundary_id const & boundary_id) const final;
 };
 
 } // namespace Structure

--- a/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
+++ b/include/exadg/structure/spatial_discretization/operators/nonlinear_operator.h
@@ -151,7 +151,7 @@ private:
   do_cell_integral_nonlinear(IntegratorCell & integrator) const;
 
   /*
-   * Computes Neumann BC integral
+   * Computes the nonlinear Neumann boundary term
    *
    *  - (v_h, t_0)_{Gamma_N}
    *
@@ -164,8 +164,8 @@ private:
    * is necessary.
    */
   void
-  do_boundary_integral_continuous(IntegratorFace &                   integrator_m,
-                                  dealii::types::boundary_id const & boundary_id) const final;
+  do_boundary_integral_continuous_nonlinear(IntegratorFace &                   integrator,
+                                            dealii::types::boundary_id const & boundary_id) const;
 
   /*
    * Linearized operator.
@@ -199,7 +199,25 @@ private:
    *  the area ratio da/dA = function(d) is neglected in the linearization.
    */
   void
-  do_cell_integral(IntegratorCell & integrator) const override;
+  do_cell_integral(IntegratorCell & integrator) const final;
+
+  /*
+   * Compute the boundary term of the linearized operator
+   *
+   *  - delta (v_h, t_0)_{Gamma_N}
+   *
+   * with traction
+   *
+   *  t_0 = da/dA t .
+   *
+   * If the traction is specified as force per surface area of the underformed
+   * body, the specified traction t is interpreted as t_0 = t, and no pull-back
+   * is necessary.
+   */
+  void
+  do_boundary_integral_continuous(IntegratorFace &                   integrator,
+                                  OperatorType const &               operator_type,
+                                  dealii::types::boundary_id const & boundary_id) const final;
 
   mutable std::shared_ptr<IntegratorCell> integrator_lin;
   mutable VectorType                      displacement_lin;


### PR DESCRIPTION
with "implicit" I mean on the left hand side of a linear system $A x = b$.

Prior to this PR we only had `do_boundary_integral_continuous()` to integrate boundary terms in the CG case.
The boundary integrals considered did not include the solution itself, but where constant containing the Neumann BC data only.

With this PR, we enable (non-)linear boundary terms, which is the first step to consider for `param.pull_back_traction_vector = true` with a consistent Jacobian or other (non-)linear integrals that have to be added to the homogeneous operator.

This is allowed by having `do_boundary_integral_continuous()` which now also has `OperatorType` (similar to the DG case) and computes the boundary integral in the linear(-ized) operator, while `do_boundary_integral_continuous_nonlinear()` evaluates the boundary term with the most recent linearization vector in the nonlinear case.

The actual Jacobian of the nonlinear scaling of the Neumann term for `pull_back_traction = true` is not included.
This PR produces identical results to `master`.
In addition to `ctest`, I tested (non-)linear iteration counts with the `bar` and `manufactured` application in the structure module with matrix-based and matrix-free variants.

For looking at the diff: make sure to hide whitespace.

~we should merge #871 before such that we can verify a greater portion of the code to be functional.~