### PR TITLE
Tracer particles postprocessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ SET(TARGET_SRC
      include/exadg/postprocessor/pressure_difference_calculation.cpp
      include/exadg/postprocessor/kinetic_energy_spectrum.cpp
      include/exadg/postprocessor/kinetic_energy_calculation.cpp
+     include/exadg/postprocessor/particle_calculation.cpp
      include/exadg/postprocessor/statistics_manager.cpp
      include/exadg/operators/operator_base.cpp
      include/exadg/operators/mass_operator.cpp

--- a/applications/incompressible_navier_stokes/vortex/application.h
+++ b/applications/incompressible_navier_stokes/vortex/application.h
@@ -665,6 +665,24 @@ private:
     pp_data.error_data_p.calculate_relative_errors = true;
     pp_data.error_data_p.name                      = "pressure";
 
+
+    // calculation of trace particles
+    pp_data.particle_data.time_control_data.is_active        = this->output_parameters.write;
+    pp_data.particle_data.time_control_data.start_time       = start_time;
+    pp_data.particle_data.time_control_data.trigger_interval = (end_time - start_time) / 20.0;
+    pp_data.particle_data.directory = this->output_parameters.directory + "vtu/";
+    pp_data.particle_data.filename  = this->output_parameters.filename;
+
+
+    std::vector<dealii::Point<2>> starting_points_2d(100);
+    for(unsigned int i = 0; i < starting_points_2d.size(); ++i)
+    {
+      double const     rad = 2 * dealii::numbers::PI * i / starting_points_2d.size();
+      dealii::Point<2> point(left + 0.3 + 0.25 * std::cos(rad), left + 0.5 + 0.25 * std::sin(rad));
+      starting_points_2d[i] = point;
+    }
+    pp_data.particle_data.starting_points_2d = starting_points_2d;
+
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
     pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
 

--- a/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/postprocessor.h
@@ -33,6 +33,7 @@
 #include <exadg/postprocessor/error_calculation.h>
 #include <exadg/postprocessor/kinetic_energy_spectrum.h>
 #include <exadg/postprocessor/lift_and_drag_calculation.h>
+#include <exadg/postprocessor/particle_calculation.h>
 #include <exadg/postprocessor/pressure_difference_calculation.h>
 
 namespace ExaDG
@@ -54,6 +55,7 @@ struct PostProcessorData
   PressureDifferenceData<dim> pressure_difference_data;
   MassConservationData        mass_data;
   KineticEnergyData           kinetic_energy_data;
+  ParticleData                particle_data;
   KineticEnergySpectrumData   kinetic_energy_spectrum_data;
   LinePlotData<dim>           line_plot_data;
 };
@@ -140,6 +142,9 @@ private:
 
   // evaluate quantities along lines through the domain
   LinePlotCalculator<dim, Number> line_plot_calculator;
+
+  // evaluate particle transport
+  ParticleCalculator<dim, Number> particle_calculator;
 };
 
 } // namespace IncNS

--- a/include/exadg/postprocessor/particle_calculation.cpp
+++ b/include/exadg/postprocessor/particle_calculation.cpp
@@ -1,0 +1,165 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// C/C++
+#include <fstream>
+
+// DEALII
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/matrix_free/fe_point_evaluation.h>
+#include <deal.II/particles/data_out.h>
+#include <deal.II/particles/particle_handler.h>
+
+// ExaDG
+#include <exadg/postprocessor/particle_calculation.h>
+#include <exadg/utilities/create_directories.h>
+
+
+
+namespace ExaDG
+{
+template<int dim, typename Number>
+ParticleCalculator<dim, Number>::ParticleCalculator(MPI_Comm const & comm)
+  : mpi_comm(comm), old_time(0.0)
+{
+}
+
+template<int dim, typename Number>
+void
+ParticleCalculator<dim, Number>::setup(dealii::DoFHandler<dim> const & dof_handler_in,
+                                       dealii::Mapping<dim> const &    mapping_in,
+                                       ParticleData const &            data_in)
+{
+  if(data_in.time_control_data.is_active)
+  {
+    data = data_in;
+    time_control.setup(data.time_control_data);
+    create_directories(data.directory, mpi_comm);
+
+    dof_handler = &dof_handler_in;
+    mapping     = &mapping_in;
+
+    // init particle handler
+    particle_handler.initialize(dof_handler->get_triangulation(), *mapping);
+
+    // get bounding boxes to distribute globally
+    auto const my_bounding_box = dealii::GridTools::compute_mesh_predicate_bounding_box(
+      dof_handler->get_triangulation(), dealii::IteratorFilters::LocallyOwnedCell());
+    global_bounding_boxes = dealii::Utilities::MPI::all_gather(mpi_comm, my_bounding_box);
+
+    // insert particles
+    if constexpr(dim == 2)
+      particle_handler.insert_global_particles(data.starting_points_2d, global_bounding_boxes);
+    else if constexpr(dim == 3)
+      particle_handler.insert_global_particles(data.starting_points_3d, global_bounding_boxes);
+
+    // reserve space for the velocities in the cell
+    solution_values.reinit(dof_handler->get_fe().n_dofs_per_cell());
+
+    // deal with lost particles
+    particle_handler.signals.particle_lost.connect(
+      [this](const typename dealii::Particles::ParticleIterator<dim> &         particle,
+             const typename dealii::Triangulation<dim>::active_cell_iterator & cell) {
+        this->track_lost_particle(particle, cell);
+      });
+  }
+}
+
+
+template<int dim, typename Number>
+void
+ParticleCalculator<dim, Number>::track_lost_particle(
+  const typename dealii::Particles::ParticleIterator<dim> &         particle,
+  const typename dealii::Triangulation<dim>::active_cell_iterator & cell)
+{
+  (void)particle;
+  (void)cell;
+  ++lost_paticles;
+}
+
+template<int dim, typename Number>
+void
+ParticleCalculator<dim, Number>::evaluate(VectorType const & velocity,
+                                          double const       time,
+                                          bool const         print_output)
+{
+  double const dt = time - old_time;
+  old_time        = time;
+
+  dealii::FEPointEvaluation<dim, dim, dim, Number> evaluator(*mapping,
+                                                             dof_handler->get_fe(),
+                                                             dealii::update_values);
+
+  // go over all particles
+  auto particle = particle_handler.begin();
+  while(particle != particle_handler.end())
+  {
+    // get cell in which the current particle is
+    auto const cell    = particle->get_surrounding_cell();
+    auto const dh_cell = typename dealii::DoFHandler<dim>::cell_iterator(*cell, dof_handler);
+
+    // get velocity in the cell
+    solution_values = 0.;
+    dh_cell->get_dof_values(velocity, solution_values);
+
+    // collect all particles in the cell
+    auto const pic = particle_handler.particles_in_cell(cell);
+
+    // collect current reference position of particles
+    std::vector<dealii::Point<dim>> particle_positions;
+    for(auto const & p : pic)
+      particle_positions.push_back(p.get_reference_location());
+
+    // evaluate the velocities at the positions of the particles
+    evaluator.reinit(cell, particle_positions);
+    evaluator.evaluate(make_array_view(solution_values), dealii::EvaluationFlags::values);
+
+    // update position of the particles
+    for(unsigned int particle_index = 0; particle != pic.end(); ++particle, ++particle_index)
+    {
+      particle->set_location(particle->get_location() + dt * evaluator.get_value(particle_index));
+    }
+  }
+
+  // sort particles into new cells
+  particle_handler.sort_particles_into_subdomains_and_cells();
+
+
+  // write output file
+  if(print_output)
+  {
+    dealii::Particles::DataOut<dim> data_out;
+    data_out.build_patches(particle_handler);
+    data_out.write_vtu_with_pvtu_record(data.directory,
+                                        data.filename + "_particles",
+                                        time_control.get_counter(),
+                                        mpi_comm);
+  }
+}
+
+template class ParticleCalculator<2, float>;
+template class ParticleCalculator<2, double>;
+
+template class ParticleCalculator<3, float>;
+template class ParticleCalculator<3, double>;
+
+} // namespace ExaDG

--- a/include/exadg/postprocessor/particle_calculation.h
+++ b/include/exadg/postprocessor/particle_calculation.h
@@ -1,0 +1,113 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+#ifndef EXADG_POSTPROCESSOR_PARTICLE_CALCULATION_H_
+#define EXADG_POSTPROCESSOR_PARTICLE_CALCULATION_H_
+
+// deal.II
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/particles/particle_handler.h>
+
+// ExaDG
+#include <exadg/matrix_free/integrators.h>
+#include <exadg/postprocessor/time_control.h>
+#include <exadg/utilities/print_functions.h>
+
+namespace ExaDG
+{
+struct ParticleData
+{
+  ParticleData() : directory("output/"), filename("particle")
+  {
+  }
+
+  void
+  print(dealii::ConditionalOStream & pcout)
+  {
+    if(time_control_data.is_active)
+    {
+      pcout << std::endl << "  Trace particles:" << std::endl;
+
+      // only implemented for unsteady problem
+      time_control_data.print(pcout, true /*unsteady*/);
+
+      print_parameter(pcout, "Directory of output files", directory);
+      print_parameter(pcout, "Filename", filename);
+    }
+  }
+
+  TimeControlData time_control_data;
+
+  // directory and filename
+  std::string directory;
+  std::string filename;
+
+  // Starting points of particles
+  std::vector<dealii::Point<2>> starting_points_2d;
+  std::vector<dealii::Point<3>> starting_points_3d;
+};
+
+template<int dim, typename Number>
+class ParticleCalculator
+{
+public:
+  typedef dealii::LinearAlgebra::distributed::Vector<Number> VectorType;
+
+  typedef dealii::VectorizedArray<Number>                         scalar;
+  typedef dealii::Tensor<1, dim, dealii::VectorizedArray<Number>> vector;
+  typedef dealii::Tensor<2, dim, dealii::VectorizedArray<Number>> tensor;
+
+  ParticleCalculator(MPI_Comm const & comm);
+
+  void
+  setup(dealii::DoFHandler<dim> const & dof_handler_in,
+        dealii::Mapping<dim> const &    mapping_in,
+        ParticleData const &            particle_data_in);
+
+  void
+  evaluate(VectorType const & velocity, double const time, bool const print_output);
+
+  TimeControl time_control;
+
+protected:
+  void
+  track_lost_particle(const typename dealii::Particles::ParticleIterator<dim> &         particle,
+                      const typename dealii::Triangulation<dim>::active_cell_iterator & cell);
+
+
+  MPI_Comm const mpi_comm;
+
+  dealii::ObserverPointer<dealii::DoFHandler<dim> const> dof_handler;
+  dealii::ObserverPointer<dealii::Mapping<dim> const>    mapping;
+
+  ParticleData data;
+  double       old_time;
+
+  unsigned int                                       lost_paticles;
+  std::vector<std::vector<dealii::BoundingBox<dim>>> global_bounding_boxes;
+
+  dealii::Vector<Number>                  solution_values;
+  dealii::Particles::ParticleHandler<dim> particle_handler;
+};
+
+} // namespace ExaDG
+
+#endif /* EXADG_POSTPROCESSOR_PARTICLE_CALCULATION_H_ */


### PR DESCRIPTION
This PR is a proposal for a tracer particle postprocessor based on the deal.II particle infrastructure (and is largely based on the prototype application of @peterrum ). It assumes massless particles which are transported in a fluid, i.e. the particles have the same velocity as the fluid. The time integration is just a explicit Euler scheme, should be fine for now, for more involved problems with forces, this should be changed to either VV or RK.
For large problems it was faster for me to iterate over the particles compared to going over all cells.

The starting positions of the particles are given by the user in a vector, we should think of a better way to do this. @richardschu 