### PR TITLE
Fast inverse mass matrix for affine simplex elements

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -420,9 +420,16 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
   inverse_mass_operator_data_velocity_scalar.quad_index = get_quad_index_velocity_standard();
   inverse_mass_operator_data_velocity_scalar.parameters = param.inverse_mass_operator;
   // always use optimal inverse mass type for velocity scalar
+  const bool cartesian_or_affine_mapping =
+    std::all_of(matrix_free->get_mapping_info().cell_type.begin(),
+                matrix_free->get_mapping_info().cell_type.end(),
+                [](auto g) {
+                  return g <= dealii::internal::MatrixFreeFunctions::GeometryType::affine;
+                });
   inverse_mass_operator_data_velocity_scalar.parameters.implementation_type =
     inverse_mass_operator_data_velocity_scalar.get_optimal_inverse_mass_type(
-      matrix_free->get_dof_handler(get_dof_index_velocity_scalar()).get_fe());
+      matrix_free->get_dof_handler(get_dof_index_velocity_scalar()).get_fe(),
+      cartesian_or_affine_mapping);
   inverse_mass_velocity_scalar.initialize(*matrix_free, inverse_mass_operator_data_velocity_scalar);
 
   // body force operator

--- a/include/exadg/operators/inverse_mass_operator.h
+++ b/include/exadg/operators/inverse_mass_operator.h
@@ -55,11 +55,12 @@ struct InverseMassOperatorData
   // operator depending on the approximation space.
   template<int dim>
   static InverseMassType
-  get_optimal_inverse_mass_type(dealii::FiniteElement<dim> const & fe)
+  get_optimal_inverse_mass_type(dealii::FiniteElement<dim> const & fe,
+                                bool const                         use_affine_mapping)
   {
     if(fe.conforms(dealii::FiniteElementData<dim>::L2))
     {
-      if(fe.reference_cell().is_hyper_cube())
+      if(fe.reference_cell().is_hyper_cube() || use_affine_mapping)
       {
         return InverseMassType::MatrixfreeOperator;
       }
@@ -141,9 +142,19 @@ private:
                                  VectorType const & src,
                                  Range const &      cell_range) const;
 
+  void
+  cell_loop_matrix_free_operator_simplex(dealii::MatrixFree<dim, Number> const &,
+                                         VectorType &       dst,
+                                         VectorType const & src,
+                                         Range const &      cell_range) const;
+
   dealii::MatrixFree<dim, Number> const * matrix_free;
 
   unsigned int dof_index, quad_index;
+
+  bool                is_hypercube_element;
+  std::vector<Number> inverse_mass_matrix;
+
 
   InverseMassParameters data;
 

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -211,9 +211,16 @@ project_vectors(
   inverse_mass_operator_data.parameters.preconditioner = data.preconditioner;
   inverse_mass_operator_data.parameters.solver_data    = data.solver_data;
   inverse_mass_operator_data.parameters.amg_data       = data.amg_data;
+
+  const bool cartesian_or_affine_mapping =
+    std::all_of(target_matrix_free.get_mapping_info().cell_type.begin(),
+                target_matrix_free.get_mapping_info().cell_type.end(),
+                [](auto g) {
+                  return g <= dealii::internal::MatrixFreeFunctions::GeometryType::affine;
+                });
   inverse_mass_operator_data.parameters.implementation_type =
     InverseMassOperatorData<Number>::get_optimal_inverse_mass_type(
-      target_matrix_free.get_dof_handler(dof_index).get_fe());
+      target_matrix_free.get_dof_handler(dof_index).get_fe(), cartesian_or_affine_mapping);
 
   InverseMassOperator<dim, n_components, Number> inverse_mass_operator;
   inverse_mass_operator.initialize(target_matrix_free, inverse_mass_operator_data);

--- a/include/exadg/structure/spatial_discretization/operator.cpp
+++ b/include/exadg/structure/spatial_discretization/operator.cpp
@@ -328,8 +328,15 @@ Operator<dim, Number>::setup_operators()
 
     // For a continuous Galerkin discretization a global Krylov solver is needed. The default
     // `PointJacobi` preconditioner is usually sufficient.
+    const bool cartesian_or_affine_mapping =
+      std::all_of(matrix_free->get_mapping_info().cell_type.begin(),
+                  matrix_free->get_mapping_info().cell_type.end(),
+                  [](auto g) {
+                    return g <= dealii::internal::MatrixFreeFunctions::GeometryType::affine;
+                  });
+
     inverse_mass_operator_data.parameters.implementation_type =
-      inverse_mass_operator_data.get_optimal_inverse_mass_type(*fe);
+      inverse_mass_operator_data.get_optimal_inverse_mass_type(*fe, cartesian_or_affine_mapping);
     inverse_mass_operator_data.parameters.preconditioner = PreconditionerMass::PointJacobi;
 
     inverse_mass.initialize(*matrix_free, inverse_mass_operator_data, &affine_constraints);
@@ -342,8 +349,16 @@ Operator<dim, Number>::setup_operators()
     inverse_mass_operator_data_scalar.parameters.solver_data = param.solver_data;
     inverse_mass_operator_data_scalar.dof_index              = get_dof_index_scalar();
     inverse_mass_operator_data_scalar.quad_index             = get_quad_index();
+    const bool cartesian_or_affine_mapping =
+      std::all_of(matrix_free->get_mapping_info().cell_type.begin(),
+                  matrix_free->get_mapping_info().cell_type.end(),
+                  [](auto g) {
+                    return g <= dealii::internal::MatrixFreeFunctions::GeometryType::affine;
+                  });
+
     inverse_mass_operator_data_scalar.parameters.implementation_type =
-      inverse_mass_operator_data_scalar.get_optimal_inverse_mass_type(*fe_scalar);
+      inverse_mass_operator_data_scalar.get_optimal_inverse_mass_type(*fe_scalar,
+                                                                      cartesian_or_affine_mapping);
 
     inverse_mass_scalar.initialize(*matrix_free,
                                    inverse_mass_operator_data_scalar,

--- a/tests/operators/inverse_mass_matrix_free_simplex.cc
+++ b/tests/operators/inverse_mass_matrix_free_simplex.cc
@@ -1,0 +1,259 @@
+/*  ______________________________________________________________________
+ *
+ *  ExaDG - High-Order Discontinuous Galerkin for the Exa-Scale
+ *
+ *  Copyright (C) 2025 by the ExaDG authors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *  ______________________________________________________________________
+ */
+
+// deal.II
+#include <deal.II/base/function.h>
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/fe/fe_raviart_thomas.h>
+#include <deal.II/fe/mapping_fe.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+// ExaDG
+#include <exadg/matrix_free/matrix_free_data.h>
+#include <exadg/operators/finite_element.h>
+#include <exadg/operators/inverse_mass_operator.h>
+#include <exadg/operators/quadrature.h>
+
+using namespace ExaDG;
+
+
+template<int dim, int n_components>
+class Projector
+{
+  using Number     = double;
+  using VectorType = dealii::LinearAlgebra::distributed::Vector<Number>;
+  using Range      = std::pair<unsigned int, unsigned int>;
+
+public:
+  Projector(const unsigned int degree);
+
+  void
+  run();
+
+  void
+  setup();
+
+private:
+  void
+  compute();
+
+  MPI_Comm                   mpi_comm;
+  dealii::ConditionalOStream pcout;
+
+  unsigned int fe_degree;
+
+  dealii::parallel::fullydistributed::Triangulation<dim> tria;
+
+  dealii::DoFHandler<dim> dof_handler;
+
+  std::shared_ptr<dealii::FiniteElement<dim>> fe;
+
+  std::shared_ptr<dealii::Mapping<dim> const> mapping;
+
+  VectorType vector;
+};
+
+template<int dim, int n_components>
+Projector<dim, n_components>::Projector(const unsigned int degree)
+  : mpi_comm(MPI_COMM_WORLD),
+    pcout(std::cout, (dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)),
+    fe_degree(degree),
+    tria(mpi_comm)
+{
+}
+
+template<int dim, int n_components>
+void
+Projector<dim, n_components>::setup()
+{
+  // Initialize finite elements
+  pcout << "  dim          = " << dim << "\n"
+        << "  n_components = " << n_components << "\n"
+        << "  fe degree    = " << fe_degree << "\n";
+
+  fe = create_finite_element<dim>(ElementType::Simplex, true, n_components, fe_degree);
+  {
+    auto const construction_data = dealii::TriangulationDescription::Utilities::
+      create_description_from_triangulation_in_groups<dim, dim>(
+        [&](dealii::Triangulation<dim> & tria_serial) {
+          dealii::GridGenerator::subdivided_hyper_cube_with_simplices(tria_serial, 2);
+
+          tria_serial.refine_global(3);
+        },
+        [](dealii::Triangulation<dim> & tria_serial,
+           MPI_Comm const               mpi_communicator,
+           unsigned int const /* group_size */) {
+          dealii::GridTools::partition_triangulation(
+            dealii::Utilities::MPI::n_mpi_processes(mpi_communicator), tria_serial);
+        },
+        mpi_comm,
+        1);
+
+    tria.create_triangulation(construction_data);
+  }
+
+
+  mapping = std::make_shared<dealii::MappingFE<dim> const>(dealii::FE_SimplexP<dim>(1));
+
+  // Distribute DoFs.
+  dof_handler.reinit(tria);
+  dof_handler.distribute_dofs(*fe);
+
+  pcout << "  Number of degrees of freedom: " << dof_handler.n_dofs() << "\n";
+
+  // Setup vector.
+  vector.reinit(dof_handler.locally_owned_dofs(), mpi_comm);
+}
+
+template<int dim, int n_components>
+void
+Projector<dim, n_components>::compute()
+{
+  // Setup MatrixFree.
+  using Number = typename VectorType::value_type;
+  MatrixFreeData<dim, Number> matrix_free_data;
+
+  MappingFlags mapping_flags;
+  mapping_flags.cells =
+    dealii::update_quadrature_points | dealii::update_values | dealii::update_JxW_values;
+  matrix_free_data.append_mapping_flags(mapping_flags);
+
+  dealii::AffineConstraints<Number> empty_constraints;
+  empty_constraints.close();
+
+  matrix_free_data.insert_dof_handler(&dof_handler, std::to_string(0));
+  matrix_free_data.insert_constraint(&empty_constraints, std::to_string(0));
+
+  ElementType element_type = get_element_type(tria);
+
+  std::shared_ptr<dealii::Quadrature<dim>> quadrature =
+    create_quadrature<dim>(element_type, fe_degree + 1);
+
+  matrix_free_data.insert_quadrature(*quadrature, std::to_string(0));
+
+  dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> matrix_free;
+  matrix_free.reinit(*mapping,
+                     matrix_free_data.get_dof_handler_vector(),
+                     matrix_free_data.get_constraint_vector(),
+                     matrix_free_data.get_quadrature_vector(),
+                     matrix_free_data.data);
+
+  // Setup a `MassOperator` with a variable coefficient.
+  MassOperatorData<dim, Number> mass_operator_data;
+  mass_operator_data.coefficient_is_variable = false;
+
+  MassOperator<dim, n_components, Number> mass_operator;
+  mass_operator.initialize(matrix_free, empty_constraints, mass_operator_data);
+
+  // Setup an `InverseMassOperator` with a variable coefficient.
+  InverseMassOperatorData<Number> inverse_mass_operator_data;
+  inverse_mass_operator_data.dof_index               = 0;
+  inverse_mass_operator_data.quad_index              = 0;
+  inverse_mass_operator_data.coefficient_is_variable = false;
+
+  inverse_mass_operator_data.parameters.implementation_type = InverseMassType::MatrixfreeOperator;
+
+  InverseMassOperator<dim, n_components, Number> inverse_mass_operator;
+  inverse_mass_operator.initialize(matrix_free, inverse_mass_operator_data, &empty_constraints);
+
+  // Setup a vector with random values and copy to reference.
+  vector = 0;
+  for(unsigned int i = 0; i < vector.locally_owned_size(); ++i)
+  {
+    vector.local_element(i) = static_cast<Number>(std::rand()) / RAND_MAX;
+  }
+
+  pcout << "  ||ref||_infty = " << vector.linfty_norm() << "\n";
+
+  // Multiply vector by `MassOperator` and `InverseMassOperator`:
+  // M^-1 * M * v = I * v = v
+  {
+    VectorType tmp, tmp2;
+    // Note that `operator.apply()` zeroes the entries of `dst`.
+    tmp.reinit(vector, true /* omit_zeroing_entries */);
+    tmp2.reinit(vector, false /* omit_zeroing_entries */);
+    mass_operator.apply(tmp /* dst */, vector /* src */);
+
+    inverse_mass_operator.apply(tmp2, tmp);
+    tmp2 -= vector;
+    pcout << "  || vec1 - vec2||_infty = " << tmp2.linfty_norm() << "\n";
+  }
+}
+
+
+template<int dim, int n_components>
+void
+Projector<dim, n_components>::run()
+{
+  setup();
+  compute();
+  pcout << "\n\n";
+}
+
+int
+main(int argc, char * argv[])
+{
+  try
+  {
+    dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+    for(unsigned int i = 1; i < 4; ++i)
+    {
+      Projector<2 /* dim */, 1 /* n_components */> projector1(i);
+      projector1.run();
+      Projector<2 /* dim */, 2 /* n_components */> projector2(i);
+      projector2.run();
+
+      Projector<3 /* dim */, 1 /* n_components */> projector4(i);
+      projector4.run();
+
+      Projector<3 /* dim */, 3 /* n_components */> projector6(i);
+      projector6.run();
+    }
+  }
+  catch(std::exception & exc)
+  {
+    std::cerr << std::endl
+              << std::endl
+              << "----------------------------------------------------" << std::endl;
+    std::cerr << "Exception on processing: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------" << std::endl;
+
+    return 1;
+  }
+  catch(...)
+  {
+    std::cerr << std::endl
+              << std::endl
+              << "----------------------------------------------------" << std::endl;
+    std::cerr << "Unknown exception!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/tests/operators/inverse_mass_matrix_free_simplex.output
+++ b/tests/operators/inverse_mass_matrix_free_simplex.output
@@ -1,0 +1,96 @@
+  dim          = 2
+  n_components = 1
+  fe degree    = 1
+  Number of degrees of freedom: 1536
+  ||ref||_infty = 0.999994
+  || vec1 - vec2||_infty = 9.99201e-16
+
+
+  dim          = 2
+  n_components = 2
+  fe degree    = 1
+  Number of degrees of freedom: 3072
+  ||ref||_infty = 0.99966
+  || vec1 - vec2||_infty = 9.99201e-16
+
+
+  dim          = 3
+  n_components = 1
+  fe degree    = 1
+  Number of degrees of freedom: 81920
+  ||ref||_infty = 0.999992
+  || vec1 - vec2||_infty = 1.77636e-15
+
+
+  dim          = 3
+  n_components = 3
+  fe degree    = 1
+  Number of degrees of freedom: 245760
+  ||ref||_infty = 0.999998
+  || vec1 - vec2||_infty = 1.66533e-15
+
+
+  dim          = 2
+  n_components = 1
+  fe degree    = 2
+  Number of degrees of freedom: 3072
+  ||ref||_infty = 0.99988
+  || vec1 - vec2||_infty = 1.55431e-15
+
+
+  dim          = 2
+  n_components = 2
+  fe degree    = 2
+  Number of degrees of freedom: 6144
+  ||ref||_infty = 0.999858
+  || vec1 - vec2||_infty = 1.88738e-15
+
+
+  dim          = 3
+  n_components = 1
+  fe degree    = 2
+  Number of degrees of freedom: 204800
+  ||ref||_infty = 0.999997
+  || vec1 - vec2||_infty = 8.98587e-15
+
+
+  dim          = 3
+  n_components = 3
+  fe degree    = 2
+  Number of degrees of freedom: 614400
+  ||ref||_infty = 0.999997
+  || vec1 - vec2||_infty = 8.52096e-15
+
+
+  dim          = 2
+  n_components = 1
+  fe degree    = 3
+  Number of degrees of freedom: 5120
+  ||ref||_infty = 0.999864
+  || vec1 - vec2||_infty = 2.66454e-15
+
+
+  dim          = 2
+  n_components = 2
+  fe degree    = 3
+  Number of degrees of freedom: 10240
+  ||ref||_infty = 0.999853
+  || vec1 - vec2||_infty = 2.55351e-15
+
+
+  dim          = 3
+  n_components = 1
+  fe degree    = 3
+  Number of degrees of freedom: 409600
+  ||ref||_infty = 0.999998
+  || vec1 - vec2||_infty = 1.63203e-14
+
+
+  dim          = 3
+  n_components = 3
+  fe degree    = 3
+  Number of degrees of freedom: 1228800
+  ||ref||_infty = 0.999999
+  || vec1 - vec2||_infty = 1.74305e-14
+
+


### PR DESCRIPTION
This adds a matrix-free inverse mass operator for simplex elements under affine mappings. It inverts the mass matrix on the reference element in the setup and then applies the inverse mass matrix on the vector with the inverted local metric terms. This assumes the the determinant of the Jacobian is constant over the cell, i.e. it only works for affine mappings.