### PR TITLE
restart RPE failure: write points not found to multiple files

### DIFF
--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -240,8 +240,10 @@ project_vectors(
 
   if(not rpe_source.all_points_found())
   {
+    MPI_Comm const     mpi_comm         = source_dof_handler.get_mpi_communicator();
+    unsigned int const this_mpi_process = dealii::Utilities::MPI::this_mpi_process(mpi_comm);
     write_points_in_dummy_triangulation(
-      integration_points_target, "./", "points_all", 0, source_dof_handler.get_mpi_communicator());
+      integration_points_target, "./", "points_all", this_mpi_process, mpi_comm);
 
     std::vector<dealii::Point<dim>> points_not_found;
     points_not_found.reserve(integration_points_target.size());
@@ -254,7 +256,7 @@ project_vectors(
     }
 
     write_points_in_dummy_triangulation(
-      points_not_found, "./", "points_not_found", 0, source_dof_handler.get_mpi_communicator());
+      points_not_found, "./", "points_not_found", this_mpi_process, mpi_comm);
 
     AssertThrow(
       rpe_source.all_points_found(),


### PR DESCRIPTION
when one cannot find all points at grid-to-grid-projection, e.g., used in restart, the points are collected and written to a pvtu file. 
Pre this PR, we gave the file identical indices across all MPI ranks, such that some random rank writes into file last, overwriting all other output. Then we only see part of the problem, which does not help. So now we give an index derived from `dealii::Utilities::MPI::this_mpi_rank()`.