### PR TITLE
FSI: define `MaterialType` in application files

### DIFF
--- a/applications/fluid_structure_interaction/bending_wall/application.h
+++ b/applications/fluid_structure_interaction/bending_wall/application.h
@@ -656,6 +656,7 @@ private:
     param.pull_back_body_force = false;
     param.large_deformation    = false;
     param.pull_back_traction   = false;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.degree = this->param.mapping_degree;
 
@@ -722,6 +723,9 @@ private:
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
+    AssertThrow(this->ale_elasticity_param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for ALE elasticity problem not defined."));
+
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;
 
@@ -772,6 +776,7 @@ private:
     param.pull_back_body_force = false;
     param.large_deformation    = true;
     param.pull_back_traction   = true;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.density = DENSITY_STRUCTURE;
 
@@ -904,6 +909,9 @@ private:
     using namespace Structure;
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
+
+    AssertThrow(this->param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for elasticity problem not defined."));
 
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;

--- a/applications/fluid_structure_interaction/cylinder_with_flag/application.h
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/application.h
@@ -673,6 +673,7 @@ private:
     param.pull_back_body_force = false;
     param.large_deformation    = false;
     param.pull_back_traction   = false;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.degree = this->param.mapping_degree;
 
@@ -740,6 +741,9 @@ private:
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
+    AssertThrow(this->ale_elasticity_param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for ALE elasticity problem not defined."));
+
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
@@ -791,6 +795,7 @@ private:
     param.pull_back_body_force = false;
     param.large_deformation    = true;
     param.pull_back_traction   = true;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.density = DENSITY_STRUCTURE;
 
@@ -1128,6 +1133,9 @@ private:
     using namespace Structure;
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
+
+    AssertThrow(this->param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for elasticity problem not defined."));
 
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;

--- a/applications/fluid_structure_interaction/cylinder_with_flag/input.json
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/input.json
@@ -15,7 +15,7 @@
     "FSI" : {
         "AccelerationMethod": "IQN_ILS",
         "AbsTol": "1.e-8",
-        "RelTol": "1.e-3", 
+        "RelTol": "1.e-3",
         "OmegaInit": "0.3",
         "ReusedTimeSteps": "8",
         "PartitionedIterMax": "100"

--- a/applications/fluid_structure_interaction/cylinder_with_flag/input_aitken.json
+++ b/applications/fluid_structure_interaction/cylinder_with_flag/input_aitken.json
@@ -23,8 +23,8 @@
     "Application" : {
     },
     "Output": {
-        "OutputDirectory" : "output/cylinder_with_flag/", 
-        "OutputName" : "test", 
+        "OutputDirectory" : "output/cylinder_with_flag/",
+        "OutputName" : "test",
         "WriteOutput" : "false"
   }
 }

--- a/applications/fluid_structure_interaction/perpendicular_flap/application.h
+++ b/applications/fluid_structure_interaction/perpendicular_flap/application.h
@@ -533,6 +533,7 @@ private:
     param.pull_back_body_force = false;
     param.large_deformation    = false;
     param.pull_back_traction   = false;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.degree = this->param.mapping_degree;
 
@@ -600,6 +601,9 @@ private:
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
+    AssertThrow(this->ale_elasticity_param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for ALE elasticity problem not defined."));
+
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;
 
@@ -650,6 +654,7 @@ public:
     param.pull_back_body_force = false;
     param.large_deformation    = true;
     param.pull_back_traction   = true;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.density = DENSITY_STRUCTURE;
 
@@ -804,6 +809,9 @@ public:
     using namespace Structure;
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
+
+    AssertThrow(this->param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for elasticity problem not defined."));
 
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStrain;

--- a/applications/fluid_structure_interaction/pressure_wave/application.h
+++ b/applications/fluid_structure_interaction/pressure_wave/application.h
@@ -556,6 +556,7 @@ private:
     param.pull_back_body_force = false;
     param.large_deformation    = false;
     param.pull_back_traction   = false;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.degree = this->param.mapping_degree;
 
@@ -614,6 +615,9 @@ private:
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
 
+    AssertThrow(this->ale_elasticity_param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for ALE elasticity problem not defined."));
+
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;
 
@@ -663,6 +667,7 @@ private:
     param.pull_back_body_force = false;
     param.large_deformation    = true;
     param.pull_back_traction   = true;
+    param.material_type        = MaterialType::StVenantKirchhoff;
 
     param.density = DENSITY_STRUCTURE;
 
@@ -831,6 +836,9 @@ private:
     using namespace Structure;
 
     typedef std::pair<dealii::types::material_id, std::shared_ptr<MaterialData>> Pair;
+
+    AssertThrow(this->param.material_type == MaterialType::StVenantKirchhoff,
+                dealii::ExcMessage("Material parameters for elasticity problem not defined."));
 
     MaterialType const type         = MaterialType::StVenantKirchhoff;
     Type2D const       two_dim_type = Type2D::PlaneStress;


### PR DESCRIPTION
These testcases were asserting at setup since the `this->param.material_type = Structure::MaterialType::StVenantKirchhoff` was not set. This PR sets the correct value; no function changes.

I think the `material_type` parameter in the structure module is useful info, hence I want to keep it in `Structure::Parameters`.